### PR TITLE
fix: implement maskSecret and fix wallet test case mismatch

### DIFF
--- a/src/api/wallet.test.ts
+++ b/src/api/wallet.test.ts
@@ -261,7 +261,7 @@ describe("EVM key validation", () => {
     const badKey = `0x${"g".repeat(64)}`;
     const result = validateEvmPrivateKey(badKey);
     expect(result.valid).toBe(false);
-    expect(result.error).toContain("invalid hex characters");
+    expect(result.error).toContain("Invalid hex characters");
   });
 
   it("rejects an empty string", () => {

--- a/src/api/wallet.ts
+++ b/src/api/wallet.ts
@@ -505,6 +505,12 @@ export async function fetchSolanaNfts(address: string, heliusKey: string): Promi
 
 // Utility
 
+/** Mask a secret string for safe display (e.g. logs, UI). */
+export function maskSecret(value: string): string {
+  if (value.length <= 8) return "****";
+  return `${value.slice(0, 4)}...${value.slice(-4)}`;
+}
+
 function formatWei(wei: bigint, decimals: number): string {
   if (wei <= 0n || decimals <= 0) return wei <= 0n ? "0" : wei.toString();
   const divisor = 10n ** BigInt(decimals);


### PR DESCRIPTION
## Summary

- Implement missing `maskSecret()` utility in `src/api/wallet.ts` — tests existed but the function was never written
- Fix case mismatch in EVM validation test (`"invalid"` → `"Invalid"` to match source)

## Details

**`maskSecret(value)`:**
- Strings > 8 chars → `first4...last4` (e.g. `"0xac...ff80"`)
- Strings ≤ 8 chars or empty → `"****"`

This was referenced in the test file header as a covered feature but never implemented, causing 4 `TypeError: maskSecret is not a function` failures and 1 assertion failure from the case mismatch.

## Test plan

- [x] All 53 wallet tests pass (was 48/53)
- [x] No other test files affected

Relates to #5 (Wallet Onboarding & Key Management)

🤖 Generated with [Claude Code](https://claude.com/claude-code)