### PR TITLE
Guard plugin uninstall paths

### DIFF
--- a/src/services/plugin-installer.test.ts
+++ b/src/services/plugin-installer.test.ts
@@ -181,12 +181,13 @@ describe("plugin-installer", () => {
     });
 
     it("succeeds even if install directory doesn't exist on disk", async () => {
+      const ghostDir = path.join(configDir, "plugins", "installed", "_elizaos_plugin-ghost");
       writeConfig({
         plugins: {
           installs: {
             "@elizaos/plugin-ghost": {
               source: "npm",
-              installPath: "/nonexistent/path/that/doesnt/exist",
+              installPath: ghostDir,
               version: "1.0.0",
             },
           },
@@ -197,6 +198,26 @@ describe("plugin-installer", () => {
       const result = await uninstallPlugin("@elizaos/plugin-ghost");
 
       expect(result.success).toBe(true);
+    });
+
+    it("refuses to remove install paths outside the plugins directory", async () => {
+      writeConfig({
+        plugins: {
+          installs: {
+            "@elizaos/plugin-escape": {
+              source: "npm",
+              installPath: "/",
+              version: "1.0.0",
+            },
+          },
+        },
+      });
+
+      const { uninstallPlugin } = await loadInstaller();
+      const result = await uninstallPlugin("@elizaos/plugin-escape");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Refusing to remove plugin outside");
     });
   });
 

--- a/src/services/plugin-installer.ts
+++ b/src/services/plugin-installer.ts
@@ -134,6 +134,13 @@ function pluginsBaseDir(): string {
   return path.join(base, "plugins", "installed");
 }
 
+function isWithinPluginsDir(targetPath: string): boolean {
+  const base = path.resolve(pluginsBaseDir());
+  const resolved = path.resolve(targetPath);
+  if (resolved === base) return false;
+  return resolved.startsWith(`${base}${path.sep}`);
+}
+
 function sanitisePackageName(name: string): string {
   return name.replace(/[^a-zA-Z0-9._-]/g, "_");
 }
@@ -337,7 +344,18 @@ async function _uninstallPlugin(pluginName: string): Promise<UninstallResult> {
   }
 
   const record = installs[pluginName];
-  const dirToRemove = record.installPath || pluginDir(pluginName);
+  const candidatePath = record.installPath || pluginDir(pluginName);
+
+  if (!isWithinPluginsDir(candidatePath)) {
+    return {
+      success: false,
+      pluginName,
+      requiresRestart: false,
+      error: `Refusing to remove plugin outside ${pluginsBaseDir()}`,
+    };
+  }
+
+  const dirToRemove = candidatePath;
 
   // Remove from disk
   try {


### PR DESCRIPTION
## Summary\n- Refuse uninstall when installPath resolves outside plugins install dir\n- Add helper to validate uninstall target path\n- Add test coverage for out-of-tree install paths\n\n## Security impact\nIf an attacker can tamper with the config (e.g. via the unauthenticated /api/config endpoint or local config edit), they can set plugins.installs.<name>.installPath to an arbitrary path and trigger /api/plugins/uninstall, which will recursively delete that path. This patch prevents deletion outside the plugin install root.\n\n## Testing\n- npm test (fails on main due to existing wallet.test.ts failures unrelated to this change)