### PR TITLE
Sanitize screenshot filenames

### DIFF
--- a/apps/app/electron/src/native/screencapture.ts
+++ b/apps/app/electron/src/native/screencapture.ts
@@ -183,8 +183,15 @@ export class ScreenCaptureManager {
     filename?: string
   ): Promise<{ path: string }> {
     const dir = app.getPath("pictures");
-    const name = filename || `screenshot-${Date.now()}.${screenshot.format}`;
-    const filePath = path.join(dir, name);
+    const name = filename?.trim() || `screenshot-${Date.now()}.${screenshot.format}`;
+    const baseName = path.basename(name);
+    const safeName = baseName.replace(/[^a-zA-Z0-9._-]/g, "_");
+    const filePath = path.join(dir, safeName);
+    const resolvedDir = path.resolve(dir);
+    const resolvedFile = path.resolve(filePath);
+    if (!resolvedFile.startsWith(`${resolvedDir}${path.sep}`)) {
+      throw new Error("Invalid screenshot path");
+    }
 
     const buffer = Buffer.from(screenshot.base64, "base64");
     await writeFile(filePath, buffer);


### PR DESCRIPTION
## Summary
- Sanitize screenshot filenames to prevent path traversal
- Enforce output path stays within the Pictures directory

## Security impact
The screencapture:saveScreenshot IPC handler accepts an arbitrary filename and joins it with the Pictures directory without sanitization. A renderer-controlled filename like ../../.bashrc can escape the Pictures directory and enable arbitrary file writes. If the renderer is compromised (XSS or malicious navigation), this can lead to local code execution or data loss.

## Testing
- Not run (Electron-only change)