### PR TITLE
fix(app): standardize plugin exports and resolve from source

### DIFF
--- a/apps/app/plugins/agent/package.json
+++ b/apps/app/plugins/agent/package.json
@@ -2,9 +2,16 @@
   "name": "@milaidy/capacitor-agent",
   "version": "1.0.0",
   "description": "Milaidy Agent Plugin for Capacitor — agent lifecycle management",
-  "main": "dist/plugin.cjs.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
+ "main": "./dist/plugin.cjs.js",
+  "module": "./src/index.ts",
+  "types": "./dist/plugin.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/plugin.d.ts",
+      "import": "./dist/plugin.js",
+      "require": "./dist/plugin.cjs.js"
+    }
+  },
   "unpkg": "dist/plugin.js",
   "files": [
     "dist/"

--- a/apps/app/plugins/agent/src/index.ts
+++ b/apps/app/plugins/agent/src/index.ts
@@ -1,11 +1,10 @@
 import { registerPlugin } from "@capacitor/core";
 import type { AgentPlugin } from "./definitions";
 
-const Agent = registerPlugin<AgentPlugin>("Agent", {
+export const Agent = registerPlugin<AgentPlugin>("Agent", {
   web: () => import("./web").then((m) => new m.AgentWeb()),
   // Electron uses IPC via the preload bridge (agent:start, agent:stop, etc.)
   // iOS/Android will use the web fallback (HTTP to API server) for now
 });
 
 export * from "./definitions";
-export { Agent };

--- a/apps/app/plugins/camera/package.json
+++ b/apps/app/plugins/camera/package.json
@@ -2,9 +2,9 @@
   "name": "@milaidy/capacitor-camera",
   "version": "1.0.0",
   "description": "Milaidy Camera Plugin for Capacitor - Photo and video capture with advanced controls",
-  "main": "dist/plugin.cjs.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
+  "main": "./dist/plugin.cjs.js",
+  "module": "./src/index.ts",
+  "types": "./dist/plugin.d.ts",
   "unpkg": "dist/plugin.js",
   "files": [
     "android/src/main/",

--- a/apps/app/plugins/camera/src/index.ts
+++ b/apps/app/plugins/camera/src/index.ts
@@ -4,7 +4,7 @@ import type { CameraPlugin } from "./definitions";
 
 const electronModulePath = "../electron/src/index";
 
-const Camera = registerPlugin<CameraPlugin>("MilaidyCamera", {
+export const Camera = registerPlugin<CameraPlugin>("MilaidyCamera", {
   web: () => import("./web").then((m) => new m.CameraWeb()),
   electron: () => {
     // Use Electron-specific implementation for macOS/Windows/Linux
@@ -17,4 +17,3 @@ const Camera = registerPlugin<CameraPlugin>("MilaidyCamera", {
 });
 
 export * from "./definitions";
-export { Camera };

--- a/apps/app/plugins/canvas/package.json
+++ b/apps/app/plugins/canvas/package.json
@@ -2,9 +2,9 @@
   "name": "@milaidy/capacitor-canvas",
   "version": "1.0.0",
   "description": "Milaidy Canvas Plugin for Capacitor - A2UI integration and canvas rendering",
-  "main": "dist/plugin.cjs.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
+  "main": "./dist/plugin.cjs.js",
+  "module": "./src/index.ts",
+  "types": "./dist/plugin.d.ts",
   "unpkg": "dist/plugin.js",
   "files": [
     "android/src/main/",

--- a/apps/app/plugins/canvas/src/index.ts
+++ b/apps/app/plugins/canvas/src/index.ts
@@ -4,7 +4,7 @@ import type { CanvasPlugin } from "./definitions";
 
 const electronModulePath = "../electron/src/index";
 
-const Canvas = registerPlugin<CanvasPlugin>("MilaidyCanvas", {
+export const Canvas = registerPlugin<CanvasPlugin>("MilaidyCanvas", {
   web: () => import("./web").then((m) => new m.CanvasWeb()),
   electron: () => {
     // Use Electron-specific implementation for macOS/Windows/Linux
@@ -17,4 +17,3 @@ const Canvas = registerPlugin<CanvasPlugin>("MilaidyCanvas", {
 });
 
 export * from "./definitions";
-export { Canvas };

--- a/apps/app/plugins/desktop/package.json
+++ b/apps/app/plugins/desktop/package.json
@@ -2,9 +2,9 @@
   "name": "@milaidy/capacitor-desktop",
   "version": "1.0.0",
   "description": "Milaidy Desktop Plugin for Capacitor - System tray, global shortcuts, auto-launch for Electron",
-  "main": "dist/plugin.cjs.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
+  "main": "./dist/plugin.cjs.js",
+  "module": "./src/index.ts",
+  "types": "./dist/plugin.d.ts",
   "unpkg": "dist/plugin.js",
   "files": [
     "dist/",

--- a/apps/app/plugins/desktop/src/index.ts
+++ b/apps/app/plugins/desktop/src/index.ts
@@ -4,7 +4,7 @@ import type { DesktopPlugin } from "./definitions";
 
 const electronModulePath = "../electron/src/index";
 
-const Desktop = registerPlugin<DesktopPlugin>("Desktop", {
+export const Desktop = registerPlugin<DesktopPlugin>("Desktop", {
   web: () => import("./web").then((m) => new m.DesktopWeb()),
   electron: () => {
     // Use Electron-specific implementation for macOS/Windows/Linux
@@ -17,4 +17,3 @@ const Desktop = registerPlugin<DesktopPlugin>("Desktop", {
 });
 
 export * from "./definitions";
-export { Desktop };

--- a/apps/app/plugins/gateway/package.json
+++ b/apps/app/plugins/gateway/package.json
@@ -2,9 +2,16 @@
   "name": "@milaidy/capacitor-gateway",
   "version": "1.0.0",
   "description": "Milaidy Gateway Plugin for Capacitor - WebSocket connection to Milaidy Gateway",
-  "main": "dist/plugin.cjs.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
+"main": "./dist/plugin.cjs.js",
+  "module": "./src/index.ts",
+  "types": "./dist/plugin.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/plugin.d.ts",
+      "import": "./dist/plugin.js",
+      "require": "./dist/plugin.cjs.js"
+    }
+  },
   "unpkg": "dist/plugin.js",
   "files": [
     "android/src/main/",

--- a/apps/app/plugins/gateway/src/index.ts
+++ b/apps/app/plugins/gateway/src/index.ts
@@ -1,24 +1,18 @@
 import { registerPlugin, Capacitor } from "@capacitor/core";
-
 import type { GatewayPlugin } from "./definitions";
 
-// Electron path kept as a string to prevent tsc from resolving the file
-// under a different rootDir. The actual path is resolved at runtime by the bundler.
 const electronModulePath = "../electron/src/index";
 
-const Gateway = registerPlugin<GatewayPlugin>("Gateway", {
+export const Gateway = registerPlugin<GatewayPlugin>("Gateway", {
   web: () => import("./web").then((m) => new m.GatewayWeb()),
   electron: () => {
-    // Use Electron-specific implementation for macOS/Windows/Linux
     if (Capacitor.getPlatform() === "electron") {
       return import(/* @vite-ignore */ electronModulePath).then(
         (m: { Gateway: GatewayPlugin }) => m.Gateway
       );
     }
-    // Fallback to web implementation
     return import("./web").then((m) => new m.GatewayWeb());
   },
 });
 
 export * from "./definitions";
-export { Gateway };

--- a/apps/app/plugins/location/package.json
+++ b/apps/app/plugins/location/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.0",
   "private": true,
   "description": "Location services plugin for Milaidy Capacitor app",
-  "main": "dist/plugin.cjs.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
+  "main": "./dist/plugin.cjs.js",
+  "module": "./src/index.ts",
+  "types": "./dist/plugin.d.ts",
   "unpkg": "dist/plugin.js",
   "files": [
     "android/src/main/",

--- a/apps/app/plugins/location/src/index.ts
+++ b/apps/app/plugins/location/src/index.ts
@@ -4,7 +4,7 @@ import type { LocationPlugin } from "./definitions";
 
 const electronModulePath = "../electron/src/index";
 
-const Location = registerPlugin<LocationPlugin>("MilaidyLocation", {
+export const Location = registerPlugin<LocationPlugin>("MilaidyLocation", {
   web: () => import("./web").then((m) => new m.LocationWeb()),
   electron: () => {
     // Use Electron-specific implementation for macOS/Windows/Linux
@@ -17,4 +17,3 @@ const Location = registerPlugin<LocationPlugin>("MilaidyLocation", {
 });
 
 export * from "./definitions";
-export { Location };

--- a/apps/app/plugins/screencapture/package.json
+++ b/apps/app/plugins/screencapture/package.json
@@ -2,9 +2,9 @@
   "name": "@milaidy/capacitor-screencapture",
   "version": "1.0.0",
   "description": "Milaidy Screen Capture Plugin for Capacitor - Screen recording and screenshots",
-  "main": "dist/plugin.cjs.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
+  "main": "./dist/plugin.cjs.js",
+  "module": "./src/index.ts",
+  "types": "./dist/plugin.d.ts",
   "unpkg": "dist/plugin.js",
   "files": [
     "android/src/main/",

--- a/apps/app/plugins/screencapture/src/index.ts
+++ b/apps/app/plugins/screencapture/src/index.ts
@@ -4,7 +4,7 @@ import type { ScreenCapturePlugin } from "./definitions";
 
 const electronModulePath = "../electron/src/index";
 
-const ScreenCapture = registerPlugin<ScreenCapturePlugin>("ScreenCapture", {
+export const ScreenCapture = registerPlugin<ScreenCapturePlugin>("ScreenCapture", {
   web: () => import("./web").then((m) => new m.ScreenCaptureWeb()),
   electron: () => {
     // Use Electron-specific implementation for macOS/Windows/Linux
@@ -17,4 +17,3 @@ const ScreenCapture = registerPlugin<ScreenCapturePlugin>("ScreenCapture", {
 });
 
 export * from "./definitions";
-export { ScreenCapture };

--- a/apps/app/plugins/swabble/package.json
+++ b/apps/app/plugins/swabble/package.json
@@ -2,9 +2,9 @@
   "name": "@milaidy/capacitor-swabble",
   "version": "1.0.0",
   "description": "Milaidy Swabble Plugin for Capacitor - Voice wake word detection and speech-to-text",
-  "main": "dist/plugin.cjs.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
+  "main": "./dist/plugin.cjs.js",
+  "module": "./src/index.ts",
+  "types": "./dist/plugin.d.ts",
   "unpkg": "dist/plugin.js",
   "files": [
     "android/src/main/",

--- a/apps/app/plugins/swabble/src/index.ts
+++ b/apps/app/plugins/swabble/src/index.ts
@@ -4,7 +4,7 @@ import type { SwabblePlugin } from "./definitions";
 
 const electronModulePath = "../electron/src/index";
 
-const Swabble = registerPlugin<SwabblePlugin>("Swabble", {
+export const Swabble = registerPlugin<SwabblePlugin>("Swabble", {
   web: () => import("./web").then((m) => new m.SwabbleWeb()),
   electron: () => {
     // Use Electron-specific implementation for macOS/Windows/Linux
@@ -17,4 +17,3 @@ const Swabble = registerPlugin<SwabblePlugin>("Swabble", {
 });
 
 export * from "./definitions";
-export { Swabble };

--- a/apps/app/plugins/talkmode/package.json
+++ b/apps/app/plugins/talkmode/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.0",
   "private": true,
   "description": "Talk mode plugin with STT, chat, and TTS for Milaidy",
-  "main": "dist/plugin.cjs.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
+  "main": "./dist/plugin.cjs.js",
+  "module": "./src/index.ts",
+  "types": "./dist/plugin.d.ts",
   "unpkg": "dist/plugin.js",
   "files": [
     "android/src/main/",

--- a/apps/app/plugins/talkmode/src/index.ts
+++ b/apps/app/plugins/talkmode/src/index.ts
@@ -3,7 +3,7 @@ import type { TalkModePlugin } from "./definitions";
 
 const electronModulePath = "../electron/src/index";
 
-const TalkMode = registerPlugin<TalkModePlugin>("TalkMode", {
+export const TalkMode = registerPlugin<TalkModePlugin>("TalkMode", {
   web: () => import("./web").then((m) => new m.TalkModeWeb()),
   electron: () => {
     // Use Electron-specific implementation for macOS/Windows/Linux
@@ -16,4 +16,3 @@ const TalkMode = registerPlugin<TalkModePlugin>("TalkMode", {
 });
 
 export * from "./definitions";
-export { TalkMode };

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -122,6 +122,15 @@ export default defineConfig({
     // Ensure dependencies are deduplicated
     dedupe: ["lit", "marked", "dompurify", "@noble/ed25519", "@lit/reactive-element"],
     alias: [
+      /**
+       * GEMINI_FIX: Map @milaidy/capacitor-* packages directly to their TS source.
+       * This bypasses resolution issues with local workspace symlinks and 
+       * outdated bundle exports in the plugins' dist folders.
+       */
+      {
+        find: /^@milaidy\/capacitor-(.*)/,
+        replacement: path.resolve(here, "plugins/$1/src/index.ts"),
+      },
       // Rewrite the UI's relative imports to milaidy/src/gateway
       // The UI uses paths like "../../../../src/gateway/device-auth.js"
       // from files in milaidy/apps/ui/src/ui/


### PR DESCRIPTION
This fixes the 'Gateway is not exported' build error by aliasing capacitor plugins to their TS source and updating export syntax.