### PR TITLE
feat: add plugin hot-reload support

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -1583,6 +1583,63 @@ async function handleRequest(
     plugin.validationErrors = updated.errors;
     plugin.validationWarnings = updated.warnings;
 
+    // Update config.plugins.allow for hot-reload
+    if (body.enabled !== undefined) {
+      const packageName = `@elizaos/plugin-${pluginId}`;
+
+      // Initialize plugins.allow if it doesn't exist
+      if (!state.config.plugins) {
+        state.config.plugins = {};
+      }
+      if (!state.config.plugins.allow) {
+        state.config.plugins.allow = [];
+      }
+
+      const allowList = state.config.plugins.allow as string[];
+      const index = allowList.indexOf(packageName);
+
+      if (body.enabled && index === -1) {
+        // Add plugin to allow list
+        allowList.push(packageName);
+        addLog("info", `Enabled plugin: ${packageName}`, "milaidy-api");
+      } else if (!body.enabled && index !== -1) {
+        // Remove plugin from allow list
+        allowList.splice(index, 1);
+        addLog("info", `Disabled plugin: ${packageName}`, "milaidy-api");
+      }
+
+      // Save updated config
+      try {
+        saveMilaidyConfig(state.config);
+      } catch (err) {
+        logger.warn(
+          `[milaidy-api] Failed to save config: ${err instanceof Error ? err.message : err}`,
+        );
+      }
+
+      // Trigger runtime restart if available
+      if (callCtx.onRestart) {
+        addLog("info", "Triggering runtime restart...", "milaidy-api");
+        callCtx
+          .onRestart()
+          .then((newRuntime) => {
+            if (newRuntime) {
+              updateRuntime(newRuntime);
+              addLog("info", "Runtime restarted successfully", "milaidy-api");
+            } else {
+              addLog("warn", "Runtime restart returned null", "milaidy-api");
+            }
+          })
+          .catch((err) => {
+            addLog(
+              "error",
+              `Runtime restart failed: ${err instanceof Error ? err.message : err}`,
+              "milaidy-api",
+            );
+          });
+      }
+    }
+
     json(res, { ok: true, plugin });
     return;
   }

--- a/src/runtime/eliza.ts
+++ b/src/runtime/eliza.ts
@@ -246,6 +246,16 @@ function extractPlugin(mod: PluginModuleShape): Plugin | null {
  */
 /** @internal Exported for testing. */
 export function collectPluginNames(config: MilaidyConfig): Set<string> {
+  // Check for explicit allow list first
+  const allowList = config.plugins?.allow;
+  const hasExplicitAllowList = allowList && allowList.length > 0;
+
+  // If there's an explicit allow list, respect it and skip auto-detection
+  if (hasExplicitAllowList) {
+    return new Set<string>(allowList);
+  }
+
+  // Otherwise, proceed with auto-detection
   const pluginsToLoad = new Set<string>(CORE_PLUGINS);
 
   // Channel plugins — load when channel has config entries
@@ -1204,7 +1214,7 @@ export async function startEliza(
   // Workspace skills directory (highest precedence for overrides)
   const workspaceSkillsDir = workspaceDir ? `${workspaceDir}/skills` : null;
 
-  const runtime = new AgentRuntime({
+  let runtime = new AgentRuntime({
     character,
     plugins: [milaidyPlugin, ...otherPlugins.map((p) => p.plugin)],
     ...(runtimeLogLevel ? { logLevel: runtimeLogLevel } : {}),
@@ -1329,6 +1339,47 @@ export async function startEliza(
     const { port: actualApiPort } = await startApiServer({
       port: apiPort,
       runtime,
+      onRestart: async () => {
+        logger.info("[milaidy] Hot-reload: Restarting runtime...");
+        try {
+          // Reload config from disk (updated by API)
+          const freshConfig = loadMilaidyConfig();
+
+          // Resolve plugins using same function as startup
+          const resolvedPlugins = await resolvePlugins(freshConfig);
+
+          // Recreate Milaidy plugin with fresh workspace
+          const freshMilaidyPlugin = createMilaidyPlugin({
+            workspaceDir:
+              freshConfig.agents?.defaults?.workspace ?? workspaceDir,
+            bootstrapMaxChars:
+              freshConfig.agents?.defaults?.bootstrapMaxChars,
+            agentId:
+              runtime.character.name?.toLowerCase().replace(/\s+/g, "-") ??
+              "main",
+          });
+
+          // Create new runtime with updated plugins
+          const newRuntime = new AgentRuntime({
+            character: runtime.character,
+            plugins: [
+              freshMilaidyPlugin,
+              ...resolvedPlugins.map((p) => p.plugin),
+            ],
+            ...(runtimeLogLevel ? { logLevel: runtimeLogLevel } : {}),
+            enableAutonomy: true,
+            settings: runtime.settings,
+          });
+
+          await newRuntime.initialize();
+          runtime = newRuntime;
+          logger.info("[milaidy] Hot-reload: Runtime restarted successfully");
+          return newRuntime;
+        } catch (err) {
+          logger.error(`[milaidy] Hot-reload failed: ${formatError(err)}`);
+          return null;
+        }
+      },
     });
     logger.info(
       `[milaidy] API server listening on http://localhost:${actualApiPort}`,


### PR DESCRIPTION
Implemented plugin hot-reload system that allows toggling plugins via UI without requiring manual server restart. When a plugin is enabled or disabled, the runtime automatically restarts with the new configuration.

Changes:
- Modified collectPluginNames() to respect explicit allow list
- Added early return when config.plugins.allow is set
- Updated PUT /api/plugins/:id to persist changes to config
- Added onRestart callback to startApiServer
- Implemented runtime recreation logic with fresh plugin resolution
- Changed runtime from const to let for hot-swap support

Benefits:
- No manual server restart needed when toggling plugins
- Config persists across sessions
- Plugin state accurately reflects runtime
- Better developer experience
- Foundation for other hot-reload features

Workflow:
1. User toggles plugin in UI
2. API updates config.plugins.allow and saves to disk
3. API triggers onRestart callback
4. Runtime reloads config, resolves plugins, recreates runtime
5. UI updates after ~10 seconds to reflect new state