### PR TITLE
fix: WebSocket status broadcast field mismatch causes UI to revert to not_started

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -4758,12 +4758,10 @@ export async function startApiServer(opts?: {
   const broadcastStatus = () => {
     const statusData = {
       type: "status",
-      data: {
-        agentState: state.agentState,
-        agentName: state.agentName,
-        model: state.model,
-        startedAt: state.startedAt,
-      },
+      state: state.agentState,
+      agentName: state.agentName,
+      model: state.model,
+      startedAt: state.startedAt,
     };
     const message = JSON.stringify(statusData);
     for (const client of wsClients) {


### PR DESCRIPTION
## Summary

- The `broadcastStatus()` function in the API server was sending status fields nested under a `data` key with `agentState` as the field name: `{ type: "status", data: { agentState: "running", ... } }`
- The UI's WebSocket event handler receives the full parsed message object and reads `.state` directly from the top level, falling back to `"not_started"` when `.state` is `undefined`
- This caused the agent status to flip back to "not_started" every 5 seconds on the WebSocket poll, making the UI unusable — clicking "Start Agent" would briefly show "running" then immediately revert

**Fix:** Flatten the status fields to the top level and rename `agentState` to `state` so the message shape matches the UI's `AgentStatus` interface.

## Test plan

- [ ] Start the API server and open the Control UI
- [ ] Click "Start Agent" and verify it stays in "running" state
- [ ] Verify the status does not revert to "not_started" after 5 seconds
- [ ] Test pause/resume/stop/restart lifecycle buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)