### PR TITLE
fix: prevent path traversal via skill ID in API endpoints

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -894,10 +894,10 @@ function validateSkillId(
     !skillId ||
     !SAFE_SKILL_ID_RE.test(skillId) ||
     skillId === "." ||
-    skillId === ".." ||
     skillId.includes("..")
   ) {
-    error(res, `Invalid skill ID: "${skillId}"`, 400);
+    const safeDisplay = skillId.slice(0, 80).replace(/[^\x20-\x7e]/g, "?");
+    error(res, `Invalid skill ID: "${safeDisplay}"`, 400);
     return null;
   }
   return skillId;
@@ -2847,13 +2847,16 @@ async function handleRequest(
       return;
     }
 
+    const uninstallId = validateSkillId(body.id.trim(), res);
+    if (!uninstallId) return;
+
     try {
       const workspaceDir =
         state.config.agents?.defaults?.workspace ??
         resolveDefaultAgentWorkspaceDir();
       const result = await uninstallMarketplaceSkill(
         workspaceDir,
-        body.id.trim(),
+        uninstallId,
       );
       json(res, { ok: true, skill: result });
     } catch (err) {


### PR DESCRIPTION
## Summary

- Skill IDs from URL parameters (`/api/skills/:id`) were used directly in `path.join()` for filesystem operations (`rmSync`, `existsSync`, `cpSync`, `readFileSync`) without sanitization
- An attacker could send `DELETE /api/skills/..%2F..%2F..%2Fetc` to recursively delete arbitrary directories, or use similar traversals in scan/open/enable endpoints for arbitrary file reads and directory copies
- Adds `validateSkillId()` guard that rejects any ID not matching `/^[a-zA-Z0-9._-]+$/` (aligned with `safeName()` in `skill-marketplace.ts`), applied to all 5 skill API endpoints

## Affected endpoints

| Method | Path | Risk |
|--------|------|------|
| `DELETE` | `/api/skills/:id` | **Arbitrary recursive directory deletion** via `rmSync` |
| `POST` | `/api/skills/:id/open` | Directory escape + `exec`/`execFile` with traversed path |
| `GET` | `/api/skills/:id/scan` | Arbitrary `.scan-results.json` reads outside workspace |
| `POST` | `/api/skills/:id/acknowledge` | Scan report reads from arbitrary paths |
| `PUT` | `/api/skills/:id` | Path used in `loadScanReportFromDisk` |

## Test plan

- [ ] Verify normal skill operations still work with valid IDs (e.g. `my-skill`, `weather_v2`)
- [ ] Verify `DELETE /api/skills/..%2F..%2Ffoo` returns 400 `Invalid skill ID`
- [ ] Verify `GET /api/skills/..%2Fetc/scan` returns 400
- [ ] Verify `POST /api/skills/foo%3Brm+-rf+%2F/open` returns 400
