### PR TITLE
fix: add model selection for OpenRouter and fix plugin version skew

### DIFF
--- a/apps/ui/src/ui/api-client.ts
+++ b/apps/ui/src/ui/api-client.ts
@@ -144,6 +144,12 @@ export interface InventoryProviderOption {
   rpcProviders: RpcProviderOption[];
 }
 
+export interface OpenRouterModelOption {
+  id: string;
+  name: string;
+  description: string;
+}
+
 export interface OnboardingOptions {
   names: string[];
   styles: StylePreset[];
@@ -153,6 +159,7 @@ export interface OnboardingOptions {
     small: ModelOption[];
     large: ModelOption[];
   };
+  openrouterModels?: OpenRouterModelOption[];
   inventoryProviders: InventoryProviderOption[];
   sharedStyleRules: string;
 }
@@ -178,6 +185,7 @@ export interface OnboardingData {
   // Local-specific
   provider?: string;
   providerApiKey?: string;
+  openrouterModel?: string;
   // Inventory / wallet setup
   inventoryProviders?: Array<{
     chain: string;

--- a/apps/ui/src/ui/app.ts
+++ b/apps/ui/src/ui/app.ts
@@ -196,6 +196,7 @@ export class MilaidyApp extends LitElement {
   @state() onboardingLargeModel = "claude-sonnet-4-5";
   @state() onboardingProvider = "";
   @state() onboardingApiKey = "";
+  @state() onboardingOpenRouterModel = "anthropic/claude-sonnet-4";
   @state() anthropicAuthMode: "oauth" | "token" = "oauth";
   @state() onboardingSelectedChains: Set<string> = new Set(["evm", "solana"]);
   @state() onboardingRpcSelections: Record<string, string> = {};
@@ -3756,6 +3757,7 @@ export class MilaidyApp extends LitElement {
         largeModel: this.onboardingRunMode === "cloud" ? this.onboardingLargeModel : undefined,
         provider: this.onboardingRunMode === "local" ? this.onboardingProvider || undefined : undefined,
         providerApiKey: this.onboardingRunMode === "local" ? this.onboardingApiKey || undefined : undefined,
+        openrouterModel: this.onboardingRunMode === "local" && this.onboardingProvider === "openrouter" ? this.onboardingOpenRouterModel || undefined : undefined,
         inventoryProviders: inventoryProviders.length > 0 ? inventoryProviders : undefined,
       });
     } catch (err) {
@@ -7232,6 +7234,27 @@ export class MilaidyApp extends LitElement {
                 @input=${(e: Event) => { this.onboardingApiKey = (e.target as HTMLInputElement).value; }}
                 style="margin-top:0;"
               />
+            </div>
+          `
+        : ""}
+      ${this.onboardingProvider === "openrouter" && this.onboardingApiKey.trim() && opts.openrouterModels
+        ? html`
+            <div style="margin-top:12px;padding:12px 14px;border:1px solid var(--border);background:var(--card);">
+              <label style="display:block;font-size:11px;text-transform:uppercase;letter-spacing:0.05em;color:var(--muted);margin-bottom:6px;">Select Model</label>
+              <div style="display:grid;gap:6px;">
+                ${(opts.openrouterModels as Array<{id: string; name: string; description: string}>).map(
+                  (model) => html`
+                    <div
+                      class="onboarding-option ${this.onboardingOpenRouterModel === model.id ? "selected" : ""}"
+                      @click=${() => { this.onboardingOpenRouterModel = model.id; }}
+                      style="padding:8px 12px;"
+                    >
+                      <div class="label" style="font-size:13px;">${model.name}</div>
+                      <div class="hint" style="font-size:11px;">${model.description}</div>
+                    </div>
+                  `,
+                )}
+              </div>
             </div>
           `
         : ""}

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "@elizaos/plugin-msteams": "next",
     "@elizaos/plugin-ollama": "2.0.0-alpha.4",
     "@elizaos/plugin-openai": "2.0.0-alpha.4",
-    "@elizaos/plugin-openrouter": "2.0.0-alpha.4",
+    "@elizaos/plugin-openrouter": "2.0.0-alpha.3",
     "@elizaos/plugin-pdf": "next",
     "@elizaos/plugin-personality": "next",
     "@elizaos/plugin-plugin-manager": "next",

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -1292,6 +1292,40 @@ function getModelOptions(): {
   };
 }
 
+function getOpenRouterModelOptions(): Array<{
+  id: string;
+  name: string;
+  description: string;
+}> {
+  return [
+    {
+      id: "anthropic/claude-sonnet-4",
+      name: "Claude Sonnet 4",
+      description: "Balanced speed & intelligence (recommended)",
+    },
+    {
+      id: "anthropic/claude-opus-4",
+      name: "Claude Opus 4",
+      description: "Most capable, slower",
+    },
+    {
+      id: "openai/gpt-4o",
+      name: "GPT-4o",
+      description: "OpenAI's flagship model",
+    },
+    {
+      id: "google/gemini-2.5-pro-preview",
+      name: "Gemini 2.5 Pro",
+      description: "Google's latest model",
+    },
+    {
+      id: "deepseek/deepseek-chat-v3",
+      name: "DeepSeek V3",
+      description: "Cost-effective alternative",
+    },
+  ];
+}
+
 function getInventoryProviderOptions(): Array<{
   id: string;
   name: string;
@@ -1806,6 +1840,7 @@ async function handleRequest(
       providers: getProviderOptions(),
       cloudProviders: getCloudProviderOptions(),
       models: getModelOptions(),
+      openrouterModels: getOpenRouterModelOptions(),
       inventoryProviders: getInventoryProviderOptions(),
       sharedStyleRules: "Keep responses brief. Be helpful and concise.",
     });
@@ -1885,6 +1920,14 @@ async function handleRequest(
             body.providerApiKey as string;
           process.env[providerOpt.envKey] = body.providerApiKey as string;
         }
+      }
+
+      // OpenRouter requires explicit model selection — persist the chosen model
+      if (body.provider === "openrouter" && body.openrouterModel) {
+        (config as Record<string, unknown>).agent = {
+          ...((config as Record<string, unknown>).agent as Record<string, unknown> || {}),
+          model: `openrouter/${body.openrouterModel}`,
+        };
       }
     }
 


### PR DESCRIPTION
- Add model selection step when OpenRouter is chosen in onboarding (CLI + UI)
- Fix config path: save model to agent.model instead of agents.defaults.model.primary
- Downgrade @elizaos/plugin-openrouter to 2.0.0-alpha.3 to match @elizaos/core

Without this fix, selecting OpenRouter would save the API key but no model, causing 'No handler found for delegate type: TEXT_LARGE' errors.

Closes #10