### PR TITLE
fix: add model selection for OpenRouter and fix plugin version skew

### DIFF
--- a/apps/app/src/AppContext.tsx
+++ b/apps/app/src/AppContext.tsx
@@ -271,6 +271,7 @@ export interface AppState {
   onboardingLargeModel: string;
   onboardingProvider: string;
   onboardingApiKey: string;
+  onboardingOpenRouterModel: string;
   onboardingSelectedChains: Set<string>;
   onboardingRpcSelections: Record<string, string>;
   onboardingRpcKeys: Record<string, string>;
@@ -574,6 +575,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const [onboardingLargeModel, setOnboardingLargeModel] = useState("claude-sonnet-4-5");
   const [onboardingProvider, setOnboardingProvider] = useState("");
   const [onboardingApiKey, setOnboardingApiKey] = useState("");
+  const [onboardingOpenRouterModel, setOnboardingOpenRouterModel] = useState("anthropic/claude-sonnet-4");
   const [onboardingSelectedChains, setOnboardingSelectedChains] = useState<Set<string>>(new Set(["evm", "solana"]));
   const [onboardingRpcSelections, setOnboardingRpcSelections] = useState<Record<string, string>>({});
   const [onboardingRpcKeys, setOnboardingRpcKeys] = useState<Record<string, string>>({});
@@ -1556,6 +1558,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
         largeModel: onboardingRunMode === "cloud" ? onboardingLargeModel : undefined,
         provider: onboardingRunMode === "local" ? onboardingProvider || undefined : undefined,
         providerApiKey: onboardingRunMode === "local" ? onboardingApiKey || undefined : undefined,
+        openrouterModel: onboardingRunMode === "local" && onboardingProvider === "openrouter" ? onboardingOpenRouterModel || undefined : undefined,
         inventoryProviders: inventoryProviders.length > 0 ? inventoryProviders : undefined,
       });
     } catch (err) {
@@ -1572,7 +1575,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
   }, [
     onboardingOptions, onboardingStyle, onboardingName, onboardingTheme,
     onboardingRunMode, onboardingCloudProvider, onboardingSmallModel,
-    onboardingLargeModel, onboardingProvider, onboardingApiKey,
+    onboardingLargeModel, onboardingProvider, onboardingApiKey, onboardingOpenRouterModel,
     onboardingSelectedChains, onboardingRpcSelections, onboardingRpcKeys,
   ]);
 
@@ -1755,6 +1758,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
       onboardingLargeModel: setOnboardingLargeModel as (v: never) => void,
       onboardingProvider: setOnboardingProvider as (v: never) => void,
       onboardingApiKey: setOnboardingApiKey as (v: never) => void,
+      onboardingOpenRouterModel: setOnboardingOpenRouterModel as (v: never) => void,
       onboardingSelectedChains: setOnboardingSelectedChains as (v: never) => void,
       onboardingRpcSelections: setOnboardingRpcSelections as (v: never) => void,
       onboardingRpcKeys: setOnboardingRpcKeys as (v: never) => void,
@@ -1964,7 +1968,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
     importBusy, importPassword, importFile, importError, importSuccess,
     onboardingStep, onboardingOptions, onboardingName, onboardingStyle, onboardingTheme,
     onboardingRunMode, onboardingCloudProvider, onboardingSmallModel, onboardingLargeModel,
-    onboardingProvider, onboardingApiKey, onboardingSelectedChains,
+    onboardingProvider, onboardingApiKey, onboardingOpenRouterModel, onboardingSelectedChains,
     onboardingRpcSelections, onboardingRpcKeys,
     commandPaletteOpen, commandQuery, commandActiveIndex,
     mcpConfiguredServers, mcpServerStatuses, mcpMarketplaceQuery, mcpMarketplaceResults,

--- a/apps/app/src/api-client.ts
+++ b/apps/app/src/api-client.ts
@@ -144,6 +144,12 @@ export interface InventoryProviderOption {
   rpcProviders: RpcProviderOption[];
 }
 
+export interface OpenRouterModelOption {
+  id: string;
+  name: string;
+  description: string;
+}
+
 export interface OnboardingOptions {
   names: string[];
   styles: StylePreset[];
@@ -153,6 +159,7 @@ export interface OnboardingOptions {
     small: ModelOption[];
     large: ModelOption[];
   };
+  openrouterModels?: OpenRouterModelOption[];
   inventoryProviders: InventoryProviderOption[];
   sharedStyleRules: string;
 }
@@ -178,6 +185,7 @@ export interface OnboardingData {
   // Local-specific
   provider?: string;
   providerApiKey?: string;
+  openrouterModel?: string;
   // Inventory / wallet setup
   inventoryProviders?: Array<{
     chain: string;

--- a/apps/app/src/components/OnboardingWizard.tsx
+++ b/apps/app/src/components/OnboardingWizard.tsx
@@ -4,7 +4,7 @@
 
 import { useEffect } from "react";
 import { useApp, THEMES, type OnboardingStep } from "../AppContext.js";
-import type { StylePreset, ProviderOption, CloudProviderOption, ModelOption, InventoryProviderOption, RpcProviderOption } from "../api-client";
+import type { StylePreset, ProviderOption, CloudProviderOption, ModelOption, InventoryProviderOption, RpcProviderOption, OpenRouterModelOption } from "../api-client";
 
 export function OnboardingWizard() {
   const {
@@ -19,6 +19,7 @@ export function OnboardingWizard() {
     onboardingLargeModel,
     onboardingProvider,
     onboardingApiKey,
+    onboardingOpenRouterModel,
     onboardingSelectedChains,
     onboardingRpcSelections,
     onboardingRpcKeys,
@@ -74,6 +75,10 @@ export function OnboardingWizard() {
 
   const handleApiKeyChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setState("onboardingApiKey", e.target.value);
+  };
+
+  const handleOpenRouterModelSelect = (modelId: string) => {
+    setState("onboardingOpenRouterModel", modelId);
   };
 
   const handleChainToggle = (chain: string) => {
@@ -368,6 +373,27 @@ export function OnboardingWizard() {
                   placeholder="Enter your API key"
                   className="w-full px-3 py-2 border border-border bg-card text-sm mt-2 focus:border-accent focus:outline-none"
                 />
+              </div>
+            )}
+            {onboardingProvider === "openrouter" && onboardingApiKey.trim() && onboardingOptions?.openrouterModels && (
+              <div className="max-w-[360px] mx-auto mt-4">
+                <label className="text-[13px] font-bold text-txt-strong block mb-2 text-left">Select Model:</label>
+                <div className="flex flex-col gap-2">
+                  {onboardingOptions.openrouterModels.map((model: OpenRouterModelOption) => (
+                    <div
+                      key={model.id}
+                      className={`px-4 py-3 border cursor-pointer transition-colors text-left ${
+                        onboardingOpenRouterModel === model.id
+                          ? "border-accent bg-card"
+                          : "border-border bg-card hover:border-accent/50"
+                      }`}
+                      onClick={() => handleOpenRouterModelSelect(model.id)}
+                    >
+                      <div className="font-bold text-sm">{model.name}</div>
+                      {model.description && <div className="text-xs text-muted mt-0.5">{model.description}</div>}
+                    </div>
+                  ))}
+                </div>
               </div>
             )}
           </div>

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@elizaos/plugin-msteams": "next",
     "@elizaos/plugin-ollama": "2.0.0-alpha.4",
     "@elizaos/plugin-openai": "2.0.0-alpha.4",
-    "@elizaos/plugin-openrouter": "2.0.0-alpha.4",
+    "@elizaos/plugin-openrouter": "2.0.0-alpha.3",
     "@elizaos/plugin-pdf": "next",
     "@elizaos/plugin-personality": "next",
     "@elizaos/plugin-plugin-manager": "next",

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -1296,6 +1296,40 @@ function getModelOptions(): {
   };
 }
 
+function getOpenRouterModelOptions(): Array<{
+  id: string;
+  name: string;
+  description: string;
+}> {
+  return [
+    {
+      id: "anthropic/claude-sonnet-4",
+      name: "Claude Sonnet 4",
+      description: "Balanced speed & intelligence (recommended)",
+    },
+    {
+      id: "anthropic/claude-opus-4",
+      name: "Claude Opus 4",
+      description: "Most capable, slower",
+    },
+    {
+      id: "openai/gpt-4o",
+      name: "GPT-4o",
+      description: "OpenAI's flagship model",
+    },
+    {
+      id: "google/gemini-2.5-pro-preview",
+      name: "Gemini 2.5 Pro",
+      description: "Google's latest model",
+    },
+    {
+      id: "deepseek/deepseek-chat-v3",
+      name: "DeepSeek V3",
+      description: "Cost-effective alternative",
+    },
+  ];
+}
+
 function getInventoryProviderOptions(): Array<{
   id: string;
   name: string;
@@ -1852,6 +1886,7 @@ async function handleRequest(
       providers: getProviderOptions(),
       cloudProviders: getCloudProviderOptions(),
       models: getModelOptions(),
+      openrouterModels: getOpenRouterModelOptions(),
       inventoryProviders: getInventoryProviderOptions(),
       sharedStyleRules: "Keep responses brief. Be helpful and concise.",
     });
@@ -1937,6 +1972,14 @@ async function handleRequest(
             body.providerApiKey as string;
           process.env[providerOpt.envKey] = body.providerApiKey as string;
         }
+      }
+
+      // OpenRouter requires explicit model selection — persist the chosen model
+      if (body.provider === "openrouter" && body.openrouterModel) {
+        (config as Record<string, unknown>).agent = {
+          ...((config as Record<string, unknown>).agent as Record<string, unknown> || {}),
+          model: `openrouter/${body.openrouterModel}`,
+        };
       }
     }
 

--- a/src/runtime/eliza.ts
+++ b/src/runtime/eliza.ts
@@ -1156,6 +1156,7 @@ async function runFirstTimeSetup(
 
   let providerEnvKey: string | undefined;
   let providerApiKey: string | undefined;
+  let selectedOpenRouterModel: string | undefined;
 
   // In cloud mode, skip provider selection entirely.
   if (runMode === "cloud") {
@@ -1207,6 +1208,44 @@ async function runFirstTimeSetup(
           if (clack.isCancel(apiKeyInput)) cancelOnboarding();
 
           providerApiKey = apiKeyInput.trim();
+        }
+
+        // OpenRouter requires explicit model selection (it's a gateway to many models)
+        if (chosen.id === "openrouter" && providerApiKey) {
+          const modelChoice = await clack.select({
+            message: `${name}: Which model should I use via OpenRouter?`,
+            options: [
+              {
+                value: "anthropic/claude-sonnet-4",
+                label: "Claude Sonnet 4",
+                hint: "balanced speed & intelligence (recommended)",
+              },
+              {
+                value: "anthropic/claude-opus-4",
+                label: "Claude Opus 4",
+                hint: "most capable, slower",
+              },
+              {
+                value: "openai/gpt-4o",
+                label: "GPT-4o",
+                hint: "OpenAI's flagship model",
+              },
+              {
+                value: "google/gemini-2.5-pro-preview",
+                label: "Gemini 2.5 Pro",
+                hint: "Google's latest model",
+              },
+              {
+                value: "deepseek/deepseek-chat-v3",
+                label: "DeepSeek V3",
+                hint: "cost-effective alternative",
+              },
+            ],
+          });
+
+          if (clack.isCancel(modelChoice)) cancelOnboarding();
+
+          selectedOpenRouterModel = modelChoice as string;
         }
       }
     }
@@ -1373,6 +1412,15 @@ async function runFirstTimeSetup(
     // Also set immediately in process.env for the current run
     process.env[providerEnvKey] = providerApiKey;
   }
+
+  // Persist the selected OpenRouter model in config.agent.model
+  if (selectedOpenRouterModel) {
+    (updated as Record<string, unknown>).agent = {
+      ...((updated as Record<string, unknown>).agent as Record<string, unknown> || {}),
+      model: `openrouter/${selectedOpenRouterModel}`,
+    };
+  }
+
   if (process.env.EVM_PRIVATE_KEY && !hasEvmKey) {
     envBucket.EVM_PRIVATE_KEY = process.env.EVM_PRIVATE_KEY;
   }


### PR DESCRIPTION
- Add model selection step when OpenRouter is chosen in onboarding (CLI + UI)
- Fix config path: save model to agent.model
- Downgrade @elizaos/plugin-openrouter to 2.0.0-alpha.3 to match @elizaos/core

Without this fix, selecting OpenRouter would save the API key but no model, causing 'No handler found for delegate type: TEXT_LARGE' errors.