### PR TITLE
test: update config round-trip tests for config overwrite guard

### DIFF
--- a/test/agent-runtime.e2e.test.ts
+++ b/test/agent-runtime.e2e.test.ts
@@ -593,10 +593,10 @@ describe("Agent Runtime E2E", () => {
     it.skipIf(!hasModelProvider)("PUT /api/config round-trips", async () => {
       const original = (await http$(server?.port, "GET", "/api/config")).data;
       await http$(server?.port, "PUT", "/api/config", {
-        agent: { name: "TempCfg" },
+        wizard: { lastRunCommand: "TempCfg" },
       });
       const { data } = await http$(server?.port, "GET", "/api/config");
-      expect((data as Record<string, Record<string, string>>).agent?.name).toBe(
+      expect((data as Record<string, Record<string, string>>).wizard?.lastRunCommand).toBe(
         "TempCfg",
       );
       await http$(server?.port, "PUT", "/api/config", original); // restore

--- a/test/api-server.e2e.test.ts
+++ b/test/api-server.e2e.test.ts
@@ -353,12 +353,12 @@ describe("API Server E2E (no runtime)", () => {
     it("PUT /api/config → GET /api/config round-trips", async () => {
       const original = (await req(port, "GET", "/api/config")).data;
 
-      // Write new config
-      await req(port, "PUT", "/api/config", { test: { roundTrip: true } });
+      // Write new config (use an allowed top-level key per config allowlist)
+      await req(port, "PUT", "/api/config", { wizard: { lastRunCommand: "round-trip-test" } });
       const { data } = await req(port, "GET", "/api/config");
       expect(
-        (data as Record<string, Record<string, boolean>>).test?.roundTrip,
-      ).toBe(true);
+        (data as Record<string, Record<string, string>>).wizard?.lastRunCommand,
+      ).toBe("round-trip-test");
 
       // Restore
       await req(port, "PUT", "/api/config", original);


### PR DESCRIPTION
## Summary

Follow-up to PR #53 (config overwrite guard). The config allowlist rejects arbitrary top-level keys, which breaks 5 existing tests that used invented keys like `test`, `agent`, `concurrent_test`, `deadlock_test`, and `rapid_test`.

Updated all config round-trip tests to use `wizard` (an allowed `MilaidyConfig` key) with its `lastRunCommand` field for assertions.

**Files changed:**
- `test/api-server.e2e.test.ts` — `test.roundTrip` → `wizard.lastRunCommand`
- `test/agent-runtime.e2e.test.ts` — `agent.name` → `wizard.lastRunCommand`
- `test/e2e-validation.e2e.test.ts` — `test_integrity`, `concurrent_test`, `deadlock_test`, `rapid_test` → `wizard.*`

## Test plan

- [ ] All modified tests pass with the config overwrite guard in place
- [ ] No other tests reference arbitrary config keys via PUT /api/config

🤖 Generated with [Claude Code](https://claude.com/claude-code)