### PR TITLE
fix: prevent shell injection in browser open and self-updater

### DIFF
--- a/src/runtime/eliza.ts
+++ b/src/runtime/eliza.ts
@@ -996,13 +996,28 @@ async function runFirstTimeSetup(
         // Try to open the browser automatically; fall back to showing URL
         import("node:child_process")
           .then((cp) => {
-            const cmd =
-              process.platform === "darwin"
-                ? "open"
-                : process.platform === "win32"
-                  ? "start"
-                  : "xdg-open";
-            cp.exec(`${cmd} "${url}"`);
+            // Validate URL protocol to prevent shell injection via crafted
+            // cloud.baseUrl values containing shell metacharacters.
+            let safeUrl: string;
+            try {
+              const parsed = new URL(url);
+              if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+                throw new Error("Invalid protocol");
+              }
+              safeUrl = parsed.href;
+            } catch {
+              clack.log.message(`Open this URL in your browser:\n  ${url}`);
+              return;
+            }
+
+            // Use execFile (not exec) to avoid shell interpretation.
+            // On Windows, "start" is a cmd built-in so we invoke via cmd.exe.
+            if (process.platform === "win32") {
+              cp.execFile("cmd", ["/c", "start", "", safeUrl]);
+            } else {
+              const cmd = process.platform === "darwin" ? "open" : "xdg-open";
+              cp.execFile(cmd, [safeUrl]);
+            }
           })
           .catch(() => {
             clack.log.message(`Open this URL in your browser:\n  ${url}`);

--- a/src/services/self-updater.ts
+++ b/src/services/self-updater.ts
@@ -133,7 +133,8 @@ function runCommand(
   return new Promise((resolve) => {
     const child = spawn(command, args, {
       stdio: ["inherit", "inherit", "pipe"],
-      shell: true,
+      // shell:true removed — all update commands are safe to run directly.
+      // The apt case uses sh -c explicitly, so no shell wrapper is needed.
     });
 
     let stderr = "";


### PR DESCRIPTION
## Summary
Two related shell injection fixes in child process spawning:

### 1. Browser open RCE via `exec()` (CRITICAL)
**File:** `src/runtime/eliza.ts` line 1005  
**Before:** `cp.exec(\`${cmd} "${url}"\`)`  
**Attack:** Set `config.cloud.baseUrl` to `https://evil.com"; rm -rf / #` → shell executes injected command when opening browser during cloud login.

**Fix:**
- Validate URL with `new URL()` — rejects malformed input, percent-encodes metacharacters
- Restrict protocol to `http:` / `https:` only (blocks `file:`, `javascript:`, etc.)
- Replace `exec()` with `execFile()` which never invokes a shell
- Windows handled via `execFile("cmd", ["/c", "start", "", safeUrl])` with pre-validated URL
- Falls back to printing the URL if validation fails

### 2. Self-updater `shell:true` removal (HIGH)
**File:** `src/services/self-updater.ts` line 136  
**Before:** `spawn(command, args, { shell: true })`

**Fix:** Removed `shell: true`. All update commands (`npm`, `bun`, `brew`, `sudo`, `sh`, `flatpak`) are real binaries that work without a shell wrapper. The apt case already uses `sh -c` explicitly.

## Test plan
- [x] TypeScript compiles cleanly (pre-existing errors unrelated)
- [x] Self-updater tests: 37/37 pass
- [x] No tests assert `shell: true` — zero breakage
- [x] Verified `new URL()` percent-encodes shell metacharacters in `.href`
- [x] Verified all self-updater commands work without shell (npm, bun, brew, sudo, sh -c, flatpak)
- [x] No upstream changes to eliza.ts or self-updater.ts since branch point

🤖 Generated with [Claude Code](https://claude.com/claude-code)