### PR TITLE
fix: return 200 with ConnectionTestResult when pg is not installed

### DIFF
--- a/src/api/database.ts
+++ b/src/api/database.ts
@@ -534,11 +534,13 @@ async function handleTestConnection(
     const pgModule = await import("pg");
     Pool = pgModule.default?.Pool ?? pgModule.Pool;
   } catch {
-    errorResponse(
-      res,
-      "PostgreSQL client library (pg) is not available. Ensure @elizaos/plugin-sql is installed.",
-      500,
-    );
+    jsonResponse(res, {
+      success: false,
+      serverVersion: null,
+      error:
+        "PostgreSQL client library (pg) is not available. Ensure @elizaos/plugin-sql is installed.",
+      durationMs: Date.now() - start,
+    } satisfies ConnectionTestResult);
     return;
   }
 


### PR DESCRIPTION
## Summary

- `POST /api/database/test` was returning HTTP 500 when `pg` is not installed, breaking the endpoint's contract of always returning 200 with success/failure in the body
- Changed the missing-`pg` catch block from `errorResponse(res, ..., 500)` to `jsonResponse(res, { success: false, serverVersion: null, error: "...", durationMs })` matching the `ConnectionTestResult` type
- Fixes 3 e2e test failures in `test/database-api.e2e.test.ts`

## Test plan

- [x] `pnpm vitest run test/database-api.e2e.test.ts --config vitest.e2e.config.ts` — 36/36 passing
- [x] `pnpm vitest run --config vitest.e2e.config.ts` — 9 files passed, 327 tests passing
- [x] `pnpm vitest run --config vitest.unit.config.ts` — 42 files, 1033/1033 passing

Fixes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)