### PR TITLE
fix: harden cloud login browser open

### DIFF
--- a/src/runtime/eliza.ts
+++ b/src/runtime/eliza.ts
@@ -996,13 +996,33 @@ async function runFirstTimeSetup(
         // Try to open the browser automatically; fall back to showing URL
         import("node:child_process")
           .then((cp) => {
-            const cmd =
-              process.platform === "darwin"
-                ? "open"
-                : process.platform === "win32"
-                  ? "start"
-                  : "xdg-open";
-            cp.exec(`${cmd} "${url}"`);
+            // Validate URL protocol to prevent shell injection via crafted
+            // cloud.baseUrl values containing shell metacharacters.
+            let safeUrl: string;
+            try {
+              const parsed = new URL(url);
+              if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+                throw new Error("Invalid protocol");
+              }
+              safeUrl = parsed.href;
+            } catch {
+              clack.log.message(`Open this URL in your browser:\n  ${url}`);
+              return;
+            }
+
+            // Use execFile (not exec) to avoid shell interpretation.
+            // On Windows, "start" is a cmd built-in so we invoke via cmd.exe.
+            const child = process.platform === "win32"
+              ? cp.execFile("cmd", ["/c", "start", "", safeUrl])
+              : cp.execFile(
+                  process.platform === "darwin" ? "open" : "xdg-open",
+                  [safeUrl],
+                );
+            // Handle missing binary (e.g. xdg-open on minimal Linux) to
+            // avoid an unhandled error crash — fall back to printing the URL.
+            child.on("error", () => {
+              clack.log.message(`Open this URL in your browser:\n  ${safeUrl}`);
+            });
           })
           .catch(() => {
             clack.log.message(`Open this URL in your browser:\n  ${url}`);

--- a/src/services/self-updater.ts
+++ b/src/services/self-updater.ts
@@ -133,7 +133,8 @@ function runCommand(
   return new Promise((resolve) => {
     const child = spawn(command, args, {
       stdio: ["inherit", "inherit", "pipe"],
-      shell: true,
+      // shell:true removed — all update commands are safe to run directly.
+      // The apt case uses sh -c explicitly, so no shell wrapper is needed.
     });
 
     let stderr = "";


### PR DESCRIPTION
**Summary**
- Prevent shell injection when opening Eliza Cloud login URL.
- Remove shell wrapper from self-updater spawn.

**Changes**
- Validate URL protocol and open via execFile; handle missing opener binary.
- Remove shell:true from self-updater (apt path already uses sh -c explicitly).

**Testing**
- Not run (not requested).

**Risk**
- Low: change limited to browser-open flow and update process spawn.