### PR TITLE
fix: merge security and API contract fixes (#81, #82, #83)

### DIFF
--- a/src/api/database.ts
+++ b/src/api/database.ts
@@ -534,11 +534,13 @@ async function handleTestConnection(
     const pgModule = await import("pg");
     Pool = pgModule.default?.Pool ?? pgModule.Pool;
   } catch {
-    errorResponse(
-      res,
-      "PostgreSQL client library (pg) is not available. Ensure @elizaos/plugin-sql is installed.",
-      500,
-    );
+    jsonResponse(res, {
+      success: false,
+      serverVersion: null,
+      error:
+        "PostgreSQL client library (pg) is not available. Ensure @elizaos/plugin-sql is installed.",
+      durationMs: Date.now() - start,
+    } satisfies ConnectionTestResult);
     return;
   }
 

--- a/src/services/self-updater.ts
+++ b/src/services/self-updater.ts
@@ -133,7 +133,8 @@ function runCommand(
   return new Promise((resolve) => {
     const child = spawn(command, args, {
       stdio: ["inherit", "inherit", "pipe"],
-      shell: true,
+      // shell:true removed — all update commands are safe to run directly.
+      // The apt case uses sh -c explicitly, so no shell wrapper is needed.
     });
 
     let stderr = "";


### PR DESCRIPTION
## Summary

Combines three reviewed PRs with biome formatting fixes applied:

- **#81** (lawyered0): Validate hook handler module paths to prevent RCE via config-injected `import()` paths. Restricts `extraDirs` to `~/.milaidy/` and legacy handler modules to known hook roots.
- **#82** (wbaxterh): Return HTTP 200 with `ConnectionTestResult` body when `pg` is not installed, instead of HTTP 500. Aligns with the endpoint's API contract.
- **#83** (lawyered0): Harden cloud login browser open — validate URL protocol, use `execFile` instead of `exec`, add error handler for missing binaries, remove `shell:true` from self-updater.

## Why combined

All three PRs had valid fixes but were blocked by CI — #81 and #83 had minor biome formatting issues, #82 had a pre-existing flaky Windows e2e test. This PR applies all changes with formatting fixes so CI passes cleanly.

Closes #81, closes #82, closes #83

Co-authored-by: Lawyered <lawyered0@users.noreply.github.com>
Co-authored-by: Wes Huber <wbaxterh@users.noreply.github.com>

Made with [Cursor](https://cursor.com)