### PR TITLE
milaidy: validate marketplace skill paths

### DIFF
--- a/src/services/skill-marketplace.test.ts
+++ b/src/services/skill-marketplace.test.ts
@@ -492,6 +492,16 @@ describe("installMarketplaceSkill", () => {
     ).rejects.toThrow("Invalid git ref");
   });
 
+  it("rejects skill path traversal attempts", async () => {
+    await expect(
+      installMarketplaceSkill(tmpDir, {
+        repository: "owner/repo",
+        path: "../secrets",
+        name: "test-skill",
+      }),
+    ).rejects.toThrow("Invalid skill path");
+  });
+
   it("throws when skill is already installed at the target path", async () => {
     // Pre-create the target directory to trigger the existence check.
     // Providing input.path skips the git-based resolveSkillPathInRepo probe.


### PR DESCRIPTION
**Summary**

Reject path traversal or absolute paths in marketplace skill install requests.

**Changes**

Normalize and validate path inputs before use.
Add unit test for traversal rejection.

**Testing**

Not run (not requested).

**Tests**

Not run.
