### PR TITLE
fix: correct ILIKE ESCAPE clause for database table search

### DIFF
--- a/src/api/database.ts
+++ b/src/api/database.ts
@@ -707,8 +707,11 @@ async function handleGetRows(
   // Build search clause: search across all text-castable columns
   let whereClause = "";
   if (search.trim()) {
+    // Escape ILIKE special characters: backslash first (since it becomes
+    // the escape character), then the ILIKE wildcards % and _.
     const escapedSearch = search
       .replace(/'/g, "''")
+      .replace(/\\/g, "\\\\")
       .replace(/%/g, "\\%")
       .replace(/_/g, "\\_");
     const textColumns = columnNames.filter((col) => {
@@ -729,7 +732,7 @@ async function handleGetRows(
     if (textColumns.length > 0) {
       const conditions = textColumns.map(
         (col) =>
-          `${quoteIdent(col)}::text ILIKE '%${escapedSearch}%' ESCAPE ''`,
+          `${quoteIdent(col)}::text ILIKE '%${escapedSearch}%' ESCAPE '\\'`,
       );
       whereClause = `WHERE (${conditions.join(" OR ")})`;
     }


### PR DESCRIPTION
## Summary
`ESCAPE ''` (empty string) declares no escape character, so the backslash escaping of `%` and `_` wildcards had no effect — wildcards remained active in search terms. Fixed to `ESCAPE '\'` and added backslash escaping so literal backslashes in search input aren't misinterpreted.

**Before:** searching `100%` matched `1000`, `100x`, etc.  
**After:** searching `100%` matches only `100%`

## Test plan
- [x] TypeScript compiles (pre-existing errors unrelated)
- [x] No existing search tests to break
- [x] Reviewed by Codex — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)