### PR TITLE
milaidy: handle database JSON parse errors

### DIFF
--- a/src/api/database.ts
+++ b/src/api/database.ts
@@ -106,6 +106,36 @@ function readBody(req: http.IncomingMessage): Promise<string> {
 }
 
 /**
+ * Read and parse a JSON request body with size limits and error handling.
+ * Returns null (and sends a 4xx response) if reading or parsing fails.
+ */
+async function readJsonBody<T = Record<string, unknown>>(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+): Promise<T | null> {
+  let raw: string;
+  try {
+    raw = await readBody(req);
+  } catch (err) {
+    const msg =
+      err instanceof Error ? err.message : "Failed to read request body";
+    errorResponse(res, msg, 413);
+    return null;
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      errorResponse(res, "Request body must be a JSON object", 400);
+      return null;
+    }
+    return parsed as T;
+  } catch {
+    errorResponse(res, "Invalid JSON in request body", 400);
+    return null;
+  }
+}
+
+/**
  * Safely quote a SQL identifier (table or column name).
  * Postgres uses double-quote escaping: embedded " becomes "".
  */
@@ -442,7 +472,8 @@ async function handlePutConfig(
   req: http.IncomingMessage,
   res: http.ServerResponse,
 ): Promise<void> {
-  const body = JSON.parse(await readBody(req)) as DatabaseConfig;
+  const body = await readJsonBody<DatabaseConfig>(req, res);
+  if (!body) return;
 
   // Validate
   if (
@@ -517,7 +548,8 @@ async function handleTestConnection(
   req: http.IncomingMessage,
   res: http.ServerResponse,
 ): Promise<void> {
-  const body = JSON.parse(await readBody(req)) as PostgresCredentials;
+  const body = await readJsonBody<PostgresCredentials>(req, res);
+  if (!body) return;
 
   const hostError = await validateDbHost(body);
   if (hostError) {
@@ -772,9 +804,10 @@ async function handleInsertRow(
   runtime: AgentRuntime,
   tableName: string,
 ): Promise<void> {
-  const body = JSON.parse(await readBody(req)) as {
+  const body = await readJsonBody<{
     data: Record<string, unknown>;
-  };
+  }>(req, res);
+  if (!body) return;
 
   if (
     !body.data ||
@@ -813,10 +846,11 @@ async function handleUpdateRow(
   runtime: AgentRuntime,
   tableName: string,
 ): Promise<void> {
-  const body = JSON.parse(await readBody(req)) as {
+  const body = await readJsonBody<{
     where: Record<string, unknown>;
     data: Record<string, unknown>;
-  };
+  }>(req, res);
+  if (!body) return;
 
   if (!body.where || Object.keys(body.where).length === 0) {
     errorResponse(
@@ -866,9 +900,10 @@ async function handleDeleteRow(
   runtime: AgentRuntime,
   tableName: string,
 ): Promise<void> {
-  const body = JSON.parse(await readBody(req)) as {
+  const body = await readJsonBody<{
     where: Record<string, unknown>;
-  };
+  }>(req, res);
+  if (!body) return;
 
   if (!body.where || Object.keys(body.where).length === 0) {
     errorResponse(
@@ -906,10 +941,11 @@ async function handleQuery(
   res: http.ServerResponse,
   runtime: AgentRuntime,
 ): Promise<void> {
-  const body = JSON.parse(await readBody(req)) as {
+  const body = await readJsonBody<{
     sql: string;
     readOnly?: boolean;
-  };
+  }>(req, res);
+  if (!body) return;
 
   if (
     !body.sql ||


### PR DESCRIPTION
**Summary**
- Handle invalid JSON bodies in database API routes with 4xx responses instead of throwing.

**Changes**
- Add `readJsonBody` helper in database API.
- Use it across config, test, query, and row CRUD handlers.

**Testing**
- `bunx vitest run --config vitest.unit.config.ts`

**Notes**
- Full `bun run test` timed out due to network-dependent e2e/plugin-installer steps.