### PR TITLE
Fix/config changes require manual restart

### DIFF
--- a/apps/app/src/components/ConfigView.tsx
+++ b/apps/app/src/components/ConfigView.tsx
@@ -392,6 +392,7 @@ export function ConfigView() {
       await client.updateConfig({
         models: { small: currentSmallModel, large: currentLargeModel },
       });
+      await client.restartAgent();
       setModelSaveSuccess(true);
       setTimeout(() => setModelSaveSuccess(false), 2000);
     } catch { /* ignore */ }


### PR DESCRIPTION
## Problem

API key and model configuration changes were not taking effect until manual restart. Discovered when changing Anthropic API key - had to restart manually for it to work.

This was inconsistent with cloud mode selection which already auto-restarts on save.

## Solution

Config changes now apply immediately when saving:
- Model selection (small/large models)
- AI provider API keys (Anthropic, OpenAI, etc.)
- Wallet/RPC provider keys (Alchemy, Infura, Ankr, Helius, Birdeye)

## Implementation

Added `client.restartAgent()` calls to 3 handlers:
- `handleModelSave` in ConfigView.tsx
- `handlePluginConfigSave` in AppContext.tsx (conditional on AI provider)
- `handleWalletApiKeySave` in AppContext.tsx

Non-AI plugin configs continue to save without restart.

## Testing

✅ Model selection changes apply immediately
✅ AI provider API keys apply immediately  
✅ Wallet RPC keys apply immediately
✅ Non-AI plugin configs save without restart