### PR TITLE
fix: remove debug console.log and duplicate db adapter init

### DIFF
--- a/src/runtime/eliza.ts
+++ b/src/runtime/eliza.ts
@@ -1668,7 +1668,6 @@ export async function startEliza(
   //     this.adapter is undefined, so plugins that use runtime.db will fail.
   if (sqlPlugin) {
     await runtime.registerPlugin(sqlPlugin.plugin);
-    console.log("sqlPlugin", sqlPlugin);
 
     // 7c. Eagerly initialize the database adapter so it's fully ready (connection
     //     open, schema bootstrapped) BEFORE other plugins run their init().
@@ -1690,18 +1689,6 @@ export async function startEliza(
     throw new Error(
       "@elizaos/plugin-sql is required but was not loaded. " +
         "Ensure the package is installed and built (check for import errors above).",
-    );
-  }
-
-  // 7c. Eagerly initialize the database adapter so it's fully ready (connection
-  //     open, schema bootstrapped) BEFORE other plugins run their init().
-  //     runtime.initialize() also calls adapter.init() but that happens AFTER
-  //     all plugin inits — too late for plugins that need runtime.db during init.
-  //     The call is idempotent (runtime.initialize checks adapter.isReady()).
-  if (runtime.adapter && !(await runtime.adapter.isReady())) {
-    await runtime.adapter.init();
-    logger.info(
-      "[milaidy] Database adapter initialized early (before plugin inits)",
     );
   }
 


### PR DESCRIPTION
## Summary

- Remove stray `console.log("sqlPlugin", sqlPlugin)` on line 1671 that prints plugin internals to stdout on every agent startup
- Remove verbatim duplicate of the "7c" database adapter initialization block (lines 1696-1706) — the same code already runs inside the `if (sqlPlugin)` branch at lines 1673-1683

Both are copy-paste artifacts from the merge-security-fixes PR.

## Test plan

- [x] `pnpm vitest run --config vitest.unit.config.ts` — 42 files, 1033/1033 passing

Fixes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)