### PR TITLE
fix: handle malformed .scan-results.json without crashing

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -628,7 +628,12 @@ async function loadScanReportFromDisk(
 
     if (!fsSync.existsSync(resolved)) continue;
     const content = fsSync.readFileSync(resolved, "utf-8");
-    const parsed = JSON.parse(content);
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(content);
+    } catch {
+      continue;
+    }
     if (
       typeof parsed.scannedAt === "string" &&
       typeof parsed.status === "string" &&
@@ -729,8 +734,12 @@ async function discoverSkills(
               const reportPath = path.join(s.path, ".scan-results.json");
               if (fs.existsSync(reportPath)) {
                 const raw = fs.readFileSync(reportPath, "utf-8");
-                const parsed = JSON.parse(raw);
-                if (parsed?.status) scanStatus = parsed.status;
+                try {
+                  const parsed = JSON.parse(raw);
+                  if (parsed?.status) scanStatus = parsed.status;
+                } catch {
+                  // Malformed scan report — treat as unscanned
+                }
               }
             }
 


### PR DESCRIPTION
## Summary
- Wraps two unguarded `JSON.parse` calls in `src/api/server.ts` with try-catch
- `findSkillScanReport()` (line ~631): a corrupt `.scan-results.json` no longer crashes the scan report lookup — it skips the bad file and continues checking other candidates
- `discoverSkills()` (line ~732): a malformed scan report for one skill no longer aborts the entire skill listing — that skill is treated as unscanned

Closes #113

## Test plan
- [x] All 1033 unit tests pass
- [x] All 327 e2e tests pass
- [ ] Manual: corrupt a `.scan-results.json` file and verify the API still returns skill listings

🤖 Generated with [Claude Code](https://claude.com/claude-code)