### PR TITLE
fix: handle malformed SSE events in cloud bridge message stream

### DIFF
--- a/src/cloud/bridge-client.ts
+++ b/src/cloud/bridge-client.ts
@@ -177,10 +177,13 @@ export class ElizaCloudClient {
         }
 
         if (eventData) {
-          yield {
-            type: eventType,
-            data: JSON.parse(eventData) as Record<string, unknown>,
-          };
+          let data: Record<string, unknown>;
+          try {
+            data = JSON.parse(eventData) as Record<string, unknown>;
+          } catch {
+            continue;
+          }
+          yield { type: eventType, data };
         }
       }
     }


### PR DESCRIPTION
## Summary
- Wraps `JSON.parse(eventData)` in `sendMessageStream()` (`src/cloud/bridge-client.ts:182`) with try-catch
- A malformed SSE event from the cloud bridge now skips the bad event instead of crashing the entire async generator
- Without this fix, a single truncated/corrupt SSE event kills the message stream silently

Closes #116

## Test plan
- [x] All 1033 unit tests pass
- [x] All 327 e2e tests pass
- [x] Existing `sendMessageStream` tests in `bridge-client.test.ts` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)