### PR TITLE
milaidy: block IPv6 ULA targets in DB host validation

### DIFF
--- a/src/api/database.ts
+++ b/src/api/database.ts
@@ -187,7 +187,7 @@ const PRIVATE_IP_PATTERNS: RegExp[] = [
   /^172\.(1[6-9]|2\d|3[01])\./, // RFC 1918 Class B
   /^192\.168\./, // RFC 1918 Class C
   /^::1$/, // IPv6 loopback
-  /^fc00:/i, // IPv6 ULA
+  /^f[cd][0-9a-f]{2}:/i, // IPv6 ULA (fc00::/7)
 ];
 
 /**


### PR DESCRIPTION
## Summary
- harden database SSRF protections for IPv6 private network ranges
- block the full ULA range (`fc00::/7`) instead of only the narrow `fc00:` literal prefix
- add e2e regression coverage for non-loopback API bind behavior

## Security impact
When the API is remotely reachable (`MILAIDY_API_BIND` non-loopback), `/api/database/test` and `/api/database/config` are intended to reject private/internal targets. The previous check only matched `fc00:` exactly, allowing many ULA targets (for example `fc12::1`, `fd12::1`) to bypass the private-range block.

## Changes
- update ULA matcher in `src/api/database.ts` from `^fc00:` to `^f[cd][0-9a-f]{2}:`
- add e2e test in `test/database-api.e2e.test.ts` that verifies `fc12::1` and `fd12::1` are blocked with non-loopback bind

## Testing
- `bun run test:e2e -- test/database-api.e2e.test.ts`

## Risk
- low: isolated to DB host-validation guardrail; covered by regression test
