### PR TITLE
milaidy: secure websocket upgrades with auth and origin checks

### DIFF
--- a/apps/app/src/api-client.ts
+++ b/apps/app/src/api-client.ts
@@ -1336,7 +1336,11 @@ export class MilaidyClient {
     if (!host) return;
 
     const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-    const url = `${protocol}//${host}/ws`;
+    let url = `${protocol}//${host}/ws`;
+    const token = this.apiToken;
+    if (token) {
+      url += `?token=${encodeURIComponent(token)}`;
+    }
 
     this.ws = new WebSocket(url);
 


### PR DESCRIPTION
## Summary
- Enforce API token authentication on WebSocket (`/ws`) upgrade requests.
- Enforce the existing HTTP CORS origin allowlist on WebSocket upgrades.
- Update the app client to send the API token in the WebSocket URL query for browser compatibility.

## Security issue
`/ws` upgrades previously accepted unauthenticated connections and skipped origin checks. This allowed:
- token bypass for real-time status/log stream access when API auth was enabled
- cross-site WebSocket connections from untrusted origins (browser `Origin` not validated)

## Changes
- `src/api/server.ts`
  - Added `isWebSocketAuthorized()` using:
    - existing auth headers (`Authorization`, `X-Milaidy-Token`, `X-Api-Key`)
    - query fallback (`token`, `apiKey`, `api_key`) for browser WebSocket clients
  - Added `rejectWebSocketUpgrade()` with explicit 401/403 HTTP responses.
  - In `server.on("upgrade")`:
    - reject non-`/ws` paths (existing behavior)
    - reject disallowed origins via `resolveCorsOrigin()` (new)
    - reject unauthorized upgrades when token is required (new)
- `apps/app/src/api-client.ts`
  - `connectWs()` now appends `?token=...` when an API token is available.
- `test/api-auth.e2e.test.ts`
  - Added WebSocket auth test: reject without token in token-gated mode.
  - Added WebSocket auth test: accept with query token.
  - Added WebSocket origin tests: reject `https://evil.example.com`, allow localhost origin.

## Testing
- `bun run test:e2e -- test/api-auth.e2e.test.ts`

## Risk
- Low to medium.
- WebSocket handshake behavior is stricter by design; clients now need valid auth when token auth is enabled.
