### PR TITLE
milaidy: guard MCP config keys against prototype pollution

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -997,6 +997,35 @@ function error(res: http.ServerResponse, message: string, status = 400): void {
 const SENSITIVE_KEY_RE =
   /password|secret|api.?key|private.?key|seed.?phrase|authorization|connection.?string|credential|(?<!max)tokens?$/i;
 
+const BLOCKED_OBJECT_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+function hasBlockedObjectKeyDeep(value: unknown): boolean {
+  if (value === null || value === undefined) return false;
+  if (Array.isArray(value)) return value.some(hasBlockedObjectKeyDeep);
+  if (typeof value !== "object") return false;
+
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    if (BLOCKED_OBJECT_KEYS.has(key)) return true;
+    if (hasBlockedObjectKeyDeep(child)) return true;
+  }
+  return false;
+}
+
+function cloneWithoutBlockedObjectKeys<T>(value: T): T {
+  if (value === null || value === undefined) return value;
+  if (Array.isArray(value)) {
+    return value.map((item) => cloneWithoutBlockedObjectKeys(item)) as T;
+  }
+  if (typeof value !== "object") return value;
+
+  const out: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    if (BLOCKED_OBJECT_KEYS.has(key)) continue;
+    out[key] = cloneWithoutBlockedObjectKeys(child);
+  }
+  return out as T;
+}
+
 /**
  * Replace any non-empty value with "[REDACTED]".  For arrays, each string
  * element is individually redacted; for objects, all string leaves are
@@ -4688,8 +4717,6 @@ async function handleRequest(
     ]);
 
     // Keys that could enable prototype pollution.
-    const BLOCKED_KEYS = new Set(["__proto__", "constructor", "prototype"]);
-
     /**
      * Deep-merge `src` into `target`, only touching keys present in `src`.
      * Prevents prototype pollution by rejecting dangerous key names at every
@@ -4701,7 +4728,7 @@ async function handleRequest(
       src: Record<string, unknown>,
     ): void {
       for (const key of Object.keys(src)) {
-        if (BLOCKED_KEYS.has(key)) continue;
+        if (BLOCKED_OBJECT_KEYS.has(key)) continue;
         const srcVal = src[key];
         const tgtVal = target[key];
         if (
@@ -4725,7 +4752,7 @@ async function handleRequest(
     // Filter to allowed top-level keys, then deep-merge.
     const filtered: Record<string, unknown> = {};
     for (const key of Object.keys(body)) {
-      if (ALLOWED_TOP_KEYS.has(key) && !BLOCKED_KEYS.has(key)) {
+      if (ALLOWED_TOP_KEYS.has(key) && !BLOCKED_OBJECT_KEYS.has(key)) {
         filtered[key] = body[key];
       }
     }
@@ -5711,10 +5738,26 @@ async function handleRequest(
       error(res, "Server name is required", 400);
       return;
     }
+    if (BLOCKED_OBJECT_KEYS.has(serverName)) {
+      error(
+        res,
+        'Invalid server name: "__proto__", "constructor", and "prototype" are reserved',
+        400,
+      );
+      return;
+    }
 
     const config = body.config as Record<string, unknown> | undefined;
     if (!config || typeof config !== "object") {
       error(res, "Server config object is required", 400);
+      return;
+    }
+    if (hasBlockedObjectKeyDeep(config)) {
+      error(
+        res,
+        'Invalid server config: "__proto__", "constructor", and "prototype" are not allowed',
+        400,
+      );
       return;
     }
 
@@ -5746,7 +5789,8 @@ async function handleRequest(
 
     if (!state.config.mcp) state.config.mcp = {};
     if (!state.config.mcp.servers) state.config.mcp.servers = {};
-    state.config.mcp.servers[serverName] = config as NonNullable<
+    const sanitized = cloneWithoutBlockedObjectKeys(config);
+    state.config.mcp.servers[serverName] = sanitized as NonNullable<
       NonNullable<typeof state.config.mcp>["servers"]
     >[string];
 
@@ -5767,6 +5811,14 @@ async function handleRequest(
     const serverName = decodeURIComponent(
       pathname.slice("/api/mcp/config/server/".length),
     );
+    if (BLOCKED_OBJECT_KEYS.has(serverName)) {
+      error(
+        res,
+        'Invalid server name: "__proto__", "constructor", and "prototype" are reserved',
+        400,
+      );
+      return;
+    }
 
     if (state.config.mcp?.servers?.[serverName]) {
       delete state.config.mcp.servers[serverName];
@@ -5792,7 +5844,16 @@ async function handleRequest(
 
     if (!state.config.mcp) state.config.mcp = {};
     if (body.servers && typeof body.servers === "object") {
-      state.config.mcp.servers = body.servers as NonNullable<
+      if (hasBlockedObjectKeyDeep(body.servers)) {
+        error(
+          res,
+          'Invalid servers config: "__proto__", "constructor", and "prototype" are not allowed',
+          400,
+        );
+        return;
+      }
+      const sanitized = cloneWithoutBlockedObjectKeys(body.servers);
+      state.config.mcp.servers = sanitized as NonNullable<
         NonNullable<typeof state.config.mcp>["servers"]
       >;
     }

--- a/test/api-server.e2e.test.ts
+++ b/test/api-server.e2e.test.ts
@@ -657,6 +657,14 @@ describe("API Server E2E (no runtime)", () => {
       expect(status).toBe(400);
     });
 
+    it("POST /api/mcp/config/server rejects reserved server names", async () => {
+      const { status } = await req(port, "POST", "/api/mcp/config/server", {
+        name: "__proto__",
+        config: { type: "stdio", command: "npx" },
+      });
+      expect(status).toBe(400);
+    });
+
     it("POST /api/mcp/config/server validates config type", async () => {
       const { status } = await req(port, "POST", "/api/mcp/config/server", {
         name: "bad-type",
@@ -677,6 +685,20 @@ describe("API Server E2E (no runtime)", () => {
       const { status } = await req(port, "POST", "/api/mcp/config/server", {
         name: "no-url",
         config: { type: "streamable-http" },
+      });
+      expect(status).toBe(400);
+    });
+
+    it("POST /api/mcp/config/server rejects reserved keys in nested config", async () => {
+      const { status } = await req(port, "POST", "/api/mcp/config/server", {
+        name: "bad-nested-keys",
+        config: {
+          type: "stdio",
+          command: "npx",
+          env: {
+            constructor: { polluted: "yes" },
+          },
+        },
       });
       expect(status).toBe(400);
     });
@@ -752,6 +774,27 @@ describe("API Server E2E (no runtime)", () => {
       const servers = configData.servers as Record<string, unknown>;
       expect(servers["bulk-a"]).toBeDefined();
       expect(servers["bulk-b"]).toBeDefined();
+    });
+
+    it("PUT /api/mcp/config rejects reserved keys in servers payload", async () => {
+      const { status } = await req(port, "PUT", "/api/mcp/config", {
+        servers: {
+          constructor: {
+            type: "stdio",
+            command: "npx",
+          },
+        },
+      });
+      expect(status).toBe(400);
+    });
+
+    it("DELETE /api/mcp/config/server/:name rejects reserved server names", async () => {
+      const { status } = await req(
+        port,
+        "DELETE",
+        "/api/mcp/config/server/__proto__",
+      );
+      expect(status).toBe(400);
     });
   });
 


### PR DESCRIPTION
## Summary
- Block reserved object keys (`__proto__`, `constructor`, `prototype`) in MCP config endpoints.
- Apply deep key validation for `POST /api/mcp/config/server` and `PUT /api/mcp/config`.
- Reject reserved server names on `POST`/`DELETE /api/mcp/config/server/:name`.
- Sanitize stored MCP server config objects before persistence.

## Why
`/api/config` already guards against prototype-pollution keys, but `/api/mcp/config*` accepted unsanitized payloads. This created an inconsistent security boundary on a privileged config surface.

## Changes
- `src/api/server.ts`
  - Added shared blocked-key helpers:
    - `hasBlockedObjectKeyDeep()`
    - `cloneWithoutBlockedObjectKeys()`
  - Hardened MCP config routes to reject/strip reserved keys.
- `test/api-server.e2e.test.ts`
  - Added regression coverage for reserved names and nested reserved keys.

## Testing
- `bun run test:e2e -- test/api-server.e2e.test.ts`
- `bunx biome check src/api/server.ts test/api-server.e2e.test.ts`

## Risk
Low: change is scoped to MCP config route validation and adds tests for behavior lock-in.
