### PR TITLE
milaidy: handle malformed MCP route encoding as 400

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -1592,6 +1592,19 @@ function isAuthorized(req: http.IncomingMessage): boolean {
   return crypto.timingSafeEqual(a, b);
 }
 
+function decodePathComponent(
+  raw: string,
+  res: http.ServerResponse,
+  fieldName: string,
+): string | null {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    error(res, `Invalid ${fieldName}: malformed URL encoding`, 400);
+    return null;
+  }
+}
+
 async function handleRequest(
   req: http.IncomingMessage,
   res: http.ServerResponse,
@@ -5663,9 +5676,12 @@ async function handleRequest(
     method === "GET" &&
     pathname.startsWith("/api/mcp/marketplace/details/")
   ) {
-    const serverName = decodeURIComponent(
+    const serverName = decodePathComponent(
       pathname.slice("/api/mcp/marketplace/details/".length),
+      res,
+      "server name",
     );
+    if (serverName === null) return;
     if (!serverName.trim()) {
       error(res, "Server name is required", 400);
       return;
@@ -5764,9 +5780,12 @@ async function handleRequest(
 
   // ── DELETE /api/mcp/config/server/:name ──────────────────────────────
   if (method === "DELETE" && pathname.startsWith("/api/mcp/config/server/")) {
-    const serverName = decodeURIComponent(
+    const serverName = decodePathComponent(
       pathname.slice("/api/mcp/config/server/".length),
+      res,
+      "server name",
     );
+    if (serverName === null) return;
 
     if (state.config.mcp?.servers?.[serverName]) {
       delete state.config.mcp.servers[serverName];

--- a/test/api-server.e2e.test.ts
+++ b/test/api-server.e2e.test.ts
@@ -736,6 +736,16 @@ describe("API Server E2E (no runtime)", () => {
       expect(data.ok).toBe(true);
     });
 
+    it("DELETE /api/mcp/config/server/:name returns 400 for malformed encoding", async () => {
+      const { status, data } = await req(
+        port,
+        "DELETE",
+        "/api/mcp/config/server/%E0%A4%A",
+      );
+      expect(status).toBe(400);
+      expect(typeof data.error).toBe("string");
+    });
+
     it("PUT /api/mcp/config replaces entire config", async () => {
       const newServers = {
         "bulk-a": { type: "stdio", command: "npx", args: ["-y", "@test/a"] },


### PR DESCRIPTION
## Summary
- Fix malformed URL-encoded path handling in MCP routes so invalid path encoding returns a client `400` instead of a server `500`.

## Bug
`decodeURIComponent(...)` can throw on malformed encodings (for example `%E0%A4%A`). In MCP path routes this bubbled to the top-level handler and returned `500`.

## Changes
- `src/api/server.ts`
  - Added `decodePathComponent(...)` helper that catches decode errors and returns a `400` response.
  - Applied it to:
    - `GET /api/mcp/marketplace/details/:name`
    - `DELETE /api/mcp/config/server/:name`
- `test/api-server.e2e.test.ts`
  - Added regression test:
    - `DELETE /api/mcp/config/server/:name returns 400 for malformed encoding`

## Testing
- `bun run test:e2e -- test/api-server.e2e.test.ts`
- `bunx biome check src/api/server.ts test/api-server.e2e.test.ts`

## Risk
Low: scoped to path decoding error handling in MCP routes.
