### PR TITLE
milaidy: harden API path decoding against malformed encoding

### DIFF
--- a/src/api/database.test.ts
+++ b/src/api/database.test.ts
@@ -1,0 +1,54 @@
+import type http from "node:http";
+import { describe, expect, it } from "vitest";
+import { handleDatabaseRoute } from "./database.js";
+
+type MockResponse = http.ServerResponse & {
+  body: string;
+  headers: Record<string, string>;
+};
+
+function createMockResponse(): MockResponse {
+  const headers: Record<string, string> = {};
+  const response: Partial<MockResponse> = {
+    statusCode: 200,
+    body: "",
+    headers,
+    setHeader(name: string, value: number | string | readonly string[]) {
+      headers[name.toLowerCase()] = Array.isArray(value)
+        ? value.join(",")
+        : String(value);
+      return response as MockResponse;
+    },
+    end(chunk?: unknown) {
+      if (typeof chunk === "string") {
+        response.body = chunk;
+      } else if (Buffer.isBuffer(chunk)) {
+        response.body = chunk.toString("utf8");
+      } else if (chunk != null) {
+        response.body = String(chunk);
+      }
+      return response as MockResponse;
+    },
+  };
+  return response as MockResponse;
+}
+
+describe("handleDatabaseRoute", () => {
+  it("returns 400 for malformed table name encoding", async () => {
+    const req = { method: "PATCH" } as http.IncomingMessage;
+    const res = createMockResponse();
+
+    const handled = await handleDatabaseRoute(
+      req,
+      res,
+      { adapter: {} } as never,
+      "/api/database/tables/%E0%A4%A/rows",
+    );
+
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({
+      error: "Invalid table name: malformed URL encoding",
+    });
+  });
+});

--- a/test/api-server.e2e.test.ts
+++ b/test/api-server.e2e.test.ts
@@ -609,6 +609,16 @@ describe("API Server E2E (no runtime)", () => {
       );
       expect(status).toBe(400);
     });
+
+    it("GET /api/mcp/marketplace/details/:name returns 400 for malformed encoding", async () => {
+      const { status, data } = await req(
+        port,
+        "GET",
+        "/api/mcp/marketplace/details/%E0%A4%A",
+      );
+      expect(status).toBe(400);
+      expect(data.error).toBe("Invalid server name: malformed URL encoding");
+    });
   });
 
   describe("MCP config endpoints", () => {
@@ -734,6 +744,16 @@ describe("API Server E2E (no runtime)", () => {
       );
       expect(status).toBe(200);
       expect(data.ok).toBe(true);
+    });
+
+    it("DELETE /api/mcp/config/server/:name returns 400 for malformed encoding", async () => {
+      const { status, data } = await req(
+        port,
+        "DELETE",
+        "/api/mcp/config/server/%E0%A4%A",
+      );
+      expect(status).toBe(400);
+      expect(data.error).toBe("Invalid server name: malformed URL encoding");
     });
 
     it("PUT /api/mcp/config replaces entire config", async () => {


### PR DESCRIPTION
## Summary
- Prevent decodeURIComponent exceptions from surfacing as 500 errors on malformed encoded path components.
- Return deterministic 400 responses with field-specific error messages for malformed URL encoding.

## Changes
- Added shared decode guard in src/api/server.ts and applied it to decoded route params.
- Added the same guard in src/api/database.ts for /api/database/tables/:table/rows.
- Added regression tests for malformed encoding in MCP details and MCP config delete routes.
- Added a database route unit test for malformed table-name decoding.

## Testing
- bunx vitest run src/api/database.test.ts
- bun run test:e2e -- test/api-server.e2e.test.ts
- bun run test:e2e -- test/database-api.e2e.test.ts
- bunx biome check src/api/server.ts src/api/database.ts src/api/database.test.ts test/api-server.e2e.test.ts

## Risk
- Low: changes are limited to path-decoding error handling and preserve normal route behavior.