### PR TITLE
Bugfix/websocket webgl error handling

### DIFF
--- a/apps/app/src/components/ChatAvatar.tsx
+++ b/apps/app/src/components/ChatAvatar.tsx
@@ -36,6 +36,10 @@ export function ChatAvatar({ mouthOpen = 0, isSpeaking = false }: ChatAvatarProp
     setAvatarReady(true);
   }, []);
 
+  const handleError = useCallback((_error: string) => {
+    // Error will be shown in modal, no need to update avatar state
+  }, []);
+
   return (
     <div
       className="absolute inset-0 pointer-events-none"
@@ -59,6 +63,7 @@ export function ChatAvatar({ mouthOpen = 0, isSpeaking = false }: ChatAvatarProp
           mouthOpen={mouthOpen}
           isSpeaking={isSpeaking}
           onEngineReady={handleEngineReady}
+          onError={handleError}
         />
       </div>
     </div>

--- a/apps/app/src/components/avatar/VrmEngine.ts
+++ b/apps/app/src/components/avatar/VrmEngine.ts
@@ -92,7 +92,36 @@ export class VrmEngine {
     this.onUpdate = onUpdate;
     this.loadingAborted = false;
 
-    const renderer = new THREE.WebGLRenderer({ canvas, alpha: true, antialias: true });
+    // Try to create WebGL renderer with error handling
+    let renderer: THREE.WebGLRenderer;
+
+    // Dev helper: force WebGL error for testing
+    const forceWebGLError = typeof window !== "undefined"
+      && localStorage.getItem("__forceWebGLError") === "true";
+
+    if (forceWebGLError) {
+      throw new Error("WebGL is not available or disabled in your browser.");
+    }
+
+    try {
+      // Suppress THREE.js console warnings during WebGL initialization
+      const originalWarn = console.warn;
+      const originalError = console.error;
+      console.warn = () => {};
+      console.error = () => {};
+
+      try {
+        renderer = new THREE.WebGLRenderer({ canvas, alpha: true, antialias: true });
+      } finally {
+        // Restore console methods
+        console.warn = originalWarn;
+        console.error = originalError;
+      }
+    } catch (err) {
+      // Provide a user-friendly error (no need for technical details in the message)
+      throw new Error("WebGL is not available or disabled in your browser.");
+    }
+
     renderer.setPixelRatio(window.devicePixelRatio);
     renderer.setClearColor(0x000000, 0);
     this.renderer = renderer;

--- a/apps/app/src/components/avatar/VrmViewer.tsx
+++ b/apps/app/src/components/avatar/VrmViewer.tsx
@@ -5,7 +5,8 @@
  * the `mouthOpen` prop. Sized to fill its parent container.
  */
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { VrmEngine, type VrmEngineState } from "./VrmEngine";
 
 const DEFAULT_VRM_PATH = "/vrms/1.vrm";
@@ -18,6 +19,7 @@ export type VrmViewerProps = {
   isSpeaking?: boolean;
   onEngineState?: (state: VrmEngineState) => void;
   onEngineReady?: (engine: VrmEngine) => void;
+  onError?: (error: string) => void;
 };
 
 export function VrmViewer(props: VrmViewerProps) {
@@ -28,9 +30,57 @@ export function VrmViewer(props: VrmViewerProps) {
   const lastStateEmitMsRef = useRef<number>(0);
   const mountedRef = useRef(true);
   const currentVrmPathRef = useRef<string>("");
+  const [webglError, setWebglError] = useState<string | null>(null);
+  const errorShownRef = useRef(false);
 
   mouthOpenRef.current = props.mouthOpen;
   isSpeakingRef.current = props.isSpeaking ?? false;
+
+  // Check if user already dismissed the WebGL error
+  const webglErrorDismissed = typeof window !== "undefined"
+    && localStorage.getItem("webgl-error-dismissed") === "true";
+
+  const dismissWebglError = () => {
+    setWebglError(null);
+    if (typeof window !== "undefined") {
+      localStorage.setItem("webgl-error-dismissed", "true");
+    }
+  };
+
+  // Dev helper: expose function to test modal
+  useEffect(() => {
+    if (typeof window !== "undefined" && import.meta.env.DEV) {
+      (window as any).__testWebGLModal = () => {
+        if (webglError) {
+          return;
+        }
+        localStorage.removeItem("webgl-error-dismissed");
+        errorShownRef.current = false;
+        setWebglError("WebGL is not available or disabled in your browser.");
+      };
+      (window as any).__clearWebGLDismissed = () => {
+        localStorage.removeItem("webgl-error-dismissed");
+      };
+      (window as any).__enableForceWebGLError = () => {
+        localStorage.setItem("__forceWebGLError", "true");
+        localStorage.removeItem("webgl-error-dismissed"); // Clear dismissed flag
+        alert("WebGL error will be forced on next page load. Reload now.");
+      };
+      (window as any).__disableForceWebGLError = () => {
+        localStorage.removeItem("__forceWebGLError");
+        alert("WebGL error forcing disabled. Reload to see avatar.");
+      };
+      (window as any).__debugWebGLModal = () => {
+        console.log("=== WebGL Modal Debug Info ===");
+        console.log("webglError:", webglError);
+        console.log("webglErrorDismissed:", webglErrorDismissed);
+        console.log("errorShownRef.current:", errorShownRef.current);
+        console.log("localStorage webgl-error-dismissed:", localStorage.getItem("webgl-error-dismissed"));
+        console.log("localStorage __forceWebGLError:", localStorage.getItem("__forceWebGLError"));
+        console.log("Modal should show:", !!(webglError && !webglErrorDismissed));
+      };
+    }
+  }, [webglError]);
 
   // Setup engine once
   useEffect(() => {
@@ -45,19 +95,34 @@ export function VrmViewer(props: VrmViewerProps) {
       engineRef.current = engine;
     }
 
-    engine.setup(canvas, () => {
-      engine.setMouthOpen(mouthOpenRef.current);
-      engine.setSpeaking(isSpeakingRef.current);
-      if (props.onEngineState && mountedRef.current) {
-        const now = performance.now();
-        if (now - lastStateEmitMsRef.current >= 250) {
-          lastStateEmitMsRef.current = now;
-          props.onEngineState(engine.getState());
+    try {
+      engine.setup(canvas, () => {
+        engine.setMouthOpen(mouthOpenRef.current);
+        engine.setSpeaking(isSpeakingRef.current);
+        if (props.onEngineState && mountedRef.current) {
+          const now = performance.now();
+          if (now - lastStateEmitMsRef.current >= 250) {
+            lastStateEmitMsRef.current = now;
+            props.onEngineState(engine.getState());
+          }
         }
-      }
-    });
+      });
 
-    props.onEngineReady?.(engine);
+      setWebglError(null);
+      errorShownRef.current = false;
+      props.onEngineReady?.(engine);
+    } catch (err) {
+      // Only process the error once to avoid duplicate modals
+      if (errorShownRef.current || webglErrorDismissed) {
+        return;
+      }
+      errorShownRef.current = true;
+
+      const errorMessage = err instanceof Error ? err.message : "Unknown error initializing 3D renderer";
+      setWebglError(errorMessage);
+      props.onError?.(errorMessage);
+      return;
+    }
 
     const resize = () => {
       const el = canvasRef.current;
@@ -110,15 +175,96 @@ export function VrmViewer(props: VrmViewerProps) {
     return () => { abortController.abort(); };
   }, [props.vrmPath]);
 
-  return (
-    <canvas
-      ref={canvasRef}
+  // Render modal using Portal (outside component hierarchy)
+  const modalElement = webglError && !webglErrorDismissed ? (
+    <div
       style={{
-        display: "block",
-        width: "100%",
-        height: "100%",
-        background: "transparent",
+        position: "fixed",
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        backgroundColor: "rgba(0, 0, 0, 0.75)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 10000,
+        pointerEvents: "auto",
       }}
-    />
+      onClick={dismissWebglError}
+    >
+      {/* Modal */}
+      <div
+        style={{
+          backgroundColor: "#1a1a1a",
+          borderRadius: "12px",
+          padding: "32px",
+          maxWidth: "420px",
+          width: "90%",
+          boxShadow: "0 8px 32px rgba(0, 0, 0, 0.6)",
+          border: "1px solid rgba(255, 255, 255, 0.1)",
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3
+          style={{
+            margin: "0 0 16px 0",
+            fontSize: "20px",
+            fontWeight: "600",
+            color: "#ffffff",
+          }}
+        >
+          3D Avatar Unavailable
+        </h3>
+        <p
+          style={{
+            margin: "0 0 24px 0",
+            fontSize: "15px",
+            lineHeight: "1.6",
+            color: "rgba(255, 255, 255, 0.7)",
+          }}
+        >
+          WebGL is disabled or not supported in your browser. The chat will work normally without the 3D avatar.
+        </p>
+        <button
+          onClick={dismissWebglError}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.backgroundColor = "#2563eb";
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.backgroundColor = "#3b82f6";
+          }}
+          style={{
+            width: "100%",
+            padding: "12px 20px",
+            backgroundColor: "#3b82f6",
+            color: "white",
+            border: "none",
+            borderRadius: "8px",
+            fontSize: "15px",
+            fontWeight: "600",
+            cursor: "pointer",
+            transition: "background-color 0.2s",
+          }}
+        >
+          OK
+        </button>
+      </div>
+    </div>
+  ) : null;
+
+  return (
+    <>
+      <canvas
+        ref={canvasRef}
+        style={{
+          display: "block",
+          width: "100%",
+          height: "100%",
+          background: "transparent",
+        }}
+      />
+      {modalElement && typeof document !== "undefined" && createPortal(modalElement, document.body)}
+    </>
   );
 }

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -66,6 +66,19 @@ export default defineConfig({
       "/ws": {
         target: `ws://localhost:${apiPort}`,
         ws: true,
+        changeOrigin: true,
+        rewrite: (path) => path,
+        configure: (proxy, _options) => {
+          proxy.on('error', (err, _req, _res) => {
+            console.log('[vite] proxy error:', err);
+          });
+          proxy.on('proxyReq', (proxyReq, req, _res) => {
+            console.log('[vite] Sending Request to the Target:', req.method, req.url);
+          });
+          proxy.on('proxyRes', (proxyRes, req, _res) => {
+            console.log('[vite] Received Response from the Target:', proxyRes.statusCode, req.url);
+          });
+        },
       },
     },
     fs: {


### PR DESCRIPTION
## Problem
- Vite WebSocket proxy was throwing `ECONNABORTED` errors
- THREE.js WebGL initialization warnings cluttered console
- No user-friendly error handling when WebGL unavailable

## Solution
### WebSocket Fixes
- Configured Vite proxy with `changeOrigin: true` and error handlers
- Added HTTP server timeouts (keepAliveTimeout: 120s, headersTimeout: 120s)
- Improved WebSocket upgrade error handling to prevent crashes on client disconnect

### WebGL Error Handling
- Suppress THREE.js warnings during WebGLRenderer initialization (warnings restored immediately after)
- Added graceful error modal using React Portal when WebGL fails
- Modal dismissal persists in localStorage (shows only once)
- Chat functionality works normally without 3D avatar

### Development Tools
Added console helpers for testing:
- `__testWebGLModal()` - Test modal appearance
- `__enableForceWebGLError()` - Force WebGL error
- `__debugWebGLModal()` - Debug modal state

## Testing
1. WebSocket proxy works without errors
2. Avatar loads normally with WebGL enabled
3. Modal appears gracefully when WebGL unavailable
4. Chat works without avatar when WebGL disabled