### PR TITLE
fix deploy Dockerfile and serve dashboard UI in production

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,12 +16,7 @@ dist
 **/dist
 **/*.trace
 
-# Large/binary files
-*.png
-*.jpg
-*.jpeg
-*.webp
-*.gif
+# Large binary media files (not needed for build)
 *.mp4
 *.mov
 *.wav

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -14,31 +14,29 @@ RUN if [ -n "$MILAIDY_DOCKER_APT_PACKAGES" ]; then \
       rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*; \
     fi
 
-COPY package.json bun.lock* .npmrc ./
-COPY ui/package.json ./ui/package.json
-COPY patches ./patches
+# Copy dependency manifests first for better layer caching
+COPY package.json pnpm-lock.yaml ./
+COPY apps/app/package.json ./apps/app/package.json
 COPY scripts ./scripts
 
-RUN bun install --frozen-lockfile
+# Install dependencies (bun reads pnpm-lock.yaml)
+RUN bun install --frozen-lockfile || bun install
 
+# Copy everything and build (includes UI at apps/app/dist/)
 COPY . .
-RUN MILAIDY_A2UI_SKIP_MISSING=1 bun run build
-RUN bun run ui:build
+RUN bun run build
 
 ENV NODE_ENV=production
 
-# Allow non-root user to write temp files during runtime/tests.
+# Allow non-root user to write temp files during runtime.
 RUN chown -R node:node /app
 
 # Security hardening: Run as non-root user
-# The node:22-bookworm image includes a 'node' user (uid 1000)
-# This reduces the attack surface by preventing container escape via root privileges
 USER node
 
-# Start gateway server with default config.
-# Binds to loopback (127.0.0.1) by default for security.
-#
-# For container platforms requiring external health checks:
-#   1. Set MILAIDY_GATEWAY_TOKEN or MILAIDY_GATEWAY_PASSWORD env var
-#   2. Override CMD: ["node","dist/index.js","gateway","--allow-unconfigured","--bind","lan"]
-CMD ["node", "dist/index.js", "gateway", "--allow-unconfigured"]
+# Default: bind to 0.0.0.0 in containers so the service is reachable.
+# Set MILAIDY_API_TOKEN in production to require auth.
+ENV MILAIDY_API_BIND="0.0.0.0"
+
+# Start the API server + dashboard UI on port 2138.
+CMD ["node", "milaidy.mjs", "start"]


### PR DESCRIPTION
The deploy Dockerfile was broken after the pnpm migration and UI restructuring:

1. **Stale COPY paths**: referenced `ui/package.json`, `patches/`, `.npmrc`, `bun.lock` — none of which exist anymore. Fixed to use `apps/app/package.json` and `pnpm-lock.yaml`.

2. **Wrong CMD**: `node dist/index.js gateway` doesn't work — the `gateway` CLI command was removed during the refactor. Fixed to `node milaidy.mjs start`.

3. **No UI serving**: `milaidy start` only runs the API server — the built React dashboard in `apps/app/dist/` was never served. Added static file serving to the API server with SPA fallback (production only, skipped in dev where Vite handles it).

4. **Bind address**: containers need `0.0.0.0`, not `127.0.0.1`. Set `MILAIDY_API_BIND=0.0.0.0` as default in the Dockerfile.

5. **.dockerignore**: removed `*.png` exclusion that prevented app icons and favicons from being copied into the build context.