### PR TITLE
fix(api): enforce auth + origin checks on websocket upgrade

### DIFF
--- a/src/api/server.websocket-auth.test.ts
+++ b/src/api/server.websocket-auth.test.ts
@@ -1,0 +1,62 @@
+import type http from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveWebSocketUpgradeRejection } from "./server.js";
+
+type ReqLike = Pick<http.IncomingMessage, "headers">;
+
+function req(headers: http.IncomingHttpHeaders = {}): ReqLike {
+  return { headers };
+}
+
+describe("resolveWebSocketUpgradeRejection", () => {
+  const prevToken = process.env.MILAIDY_API_TOKEN;
+
+  afterEach(() => {
+    if (prevToken === undefined) delete process.env.MILAIDY_API_TOKEN;
+    else process.env.MILAIDY_API_TOKEN = prevToken;
+  });
+
+  it("rejects non-/ws paths", () => {
+    const rejection = resolveWebSocketUpgradeRejection(
+      req() as http.IncomingMessage,
+      "/not-ws",
+    );
+    expect(rejection).toEqual({ status: 404, reason: "Not found" });
+  });
+
+  it("rejects disallowed origins", () => {
+    delete process.env.MILAIDY_API_TOKEN;
+    const rejection = resolveWebSocketUpgradeRejection(
+      req({ origin: "https://evil.example" }) as http.IncomingMessage,
+      "/ws",
+    );
+    expect(rejection).toEqual({ status: 403, reason: "Origin not allowed" });
+  });
+
+  it("rejects unauthenticated upgrades when API token is enabled", () => {
+    process.env.MILAIDY_API_TOKEN = "test-token";
+    const rejection = resolveWebSocketUpgradeRejection(
+      req() as http.IncomingMessage,
+      "/ws",
+    );
+    expect(rejection).toEqual({ status: 401, reason: "Unauthorized" });
+  });
+
+  it("accepts valid bearer token", () => {
+    process.env.MILAIDY_API_TOKEN = "test-token";
+    const rejection = resolveWebSocketUpgradeRejection(
+      req({ authorization: "Bearer test-token" }) as http.IncomingMessage,
+      "/ws",
+    );
+    expect(rejection).toBeNull();
+  });
+
+  it("accepts when token auth is disabled and origin is local", () => {
+    delete process.env.MILAIDY_API_TOKEN;
+    const rejection = resolveWebSocketUpgradeRejection(
+      req({ origin: "http://localhost:5173" }) as http.IncomingMessage,
+      "/ws",
+    );
+    expect(rejection).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Fix a security gap where WebSocket upgrades to `/ws` bypassed API token auth and origin validation.

## What changed
- Added `resolveWebSocketUpgradeRejection()` to apply path, origin, and token checks to WS upgrades.
- Added `rejectWebSocketUpgrade()` to return explicit HTTP rejection responses (`401`, `403`, `404`) before socket close.
- Updated `server.on("upgrade", ...)` to enforce the same auth boundary as HTTP routes.

## Files changed
- `src/api/server.ts`
- `src/api/server.websocket-auth.test.ts`

## Tests
- `bun x vitest run src/api/server.websocket-auth.test.ts`

Covers:
- reject non-`/ws` path (`404`)
- reject disallowed origin (`403`)
- reject missing token when `MILAIDY_API_TOKEN` is set (`401`)
- accept valid bearer token
- accept local-origin upgrade when token auth is disabled
