### PR TITLE
fix(telegram): load enhanced plugin from plugins.entries (#142)

### DIFF
--- a/src/plugins/telegram-enhanced/chunking.test.ts
+++ b/src/plugins/telegram-enhanced/chunking.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Unit tests for the Telegram smart chunking module.
+ *
+ * Covers: empty input, normal text, long messages exceeding the 4096 limit,
+ * markdown preservation, and custom chunk sizes.
+ */
+
+import { describe, expect, it } from "vitest";
+import { smartChunkTelegramText, type TelegramChunk } from "./chunking.js";
+
+describe("smartChunkTelegramText", () => {
+  // --- Empty / falsy input ---
+
+  it("returns empty array for empty string", () => {
+    expect(smartChunkTelegramText("")).toEqual([]);
+  });
+
+  it("returns empty array for whitespace-only string", () => {
+    expect(smartChunkTelegramText("   \n\t  ")).toEqual([]);
+  });
+
+  it("returns empty array for null input", () => {
+    // @ts-expect-error — intentional null for robustness test
+    expect(smartChunkTelegramText(null)).toEqual([]);
+  });
+
+  it("returns empty array for undefined input", () => {
+    // @ts-expect-error — intentional undefined for robustness test
+    expect(smartChunkTelegramText(undefined)).toEqual([]);
+  });
+
+  // --- Normal text ---
+
+  it("returns a single chunk for short text", () => {
+    const chunks = smartChunkTelegramText("Hello, world!");
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].text).toContain("Hello, world!");
+    expect(chunks[0].html).toBeTruthy();
+  });
+
+  it("returns chunks with both html and text fields", () => {
+    const chunks = smartChunkTelegramText("Some text");
+    expect(chunks).toHaveLength(1);
+    expect(typeof chunks[0].html).toBe("string");
+    expect(typeof chunks[0].text).toBe("string");
+  });
+
+  // --- Long text chunking ---
+
+  it("splits text that exceeds the default limit into multiple chunks", () => {
+    // Default limit is 4096 - 120 = 3976
+    const longText = "A".repeat(5000);
+    const chunks = smartChunkTelegramText(longText);
+    expect(chunks.length).toBeGreaterThanOrEqual(2);
+    // All chunks should have content
+    for (const chunk of chunks) {
+      expect(chunk.html.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("respects custom maxChars parameter", () => {
+    const text = "Hello world. This is a test message. It should be split.";
+    const chunks = smartChunkTelegramText(text, 20);
+    expect(chunks.length).toBeGreaterThanOrEqual(2);
+  });
+
+  // --- Markdown formatting ---
+
+  it("preserves markdown bold formatting in HTML output", () => {
+    const chunks = smartChunkTelegramText("This is **bold** text");
+    expect(chunks).toHaveLength(1);
+    // The chunker converts markdown to HTML for Telegram
+    expect(chunks[0].html).toContain("bold");
+  });
+
+  it("handles code blocks without crashing", () => {
+    const text = "Here is code:\n```javascript\nconsole.log('hello');\n```\nEnd.";
+    const chunks = smartChunkTelegramText(text);
+    expect(chunks.length).toBeGreaterThanOrEqual(1);
+    expect(chunks[0].html).toBeTruthy();
+  });
+
+  it("handles inline code", () => {
+    const text = "Use `console.log()` for debugging";
+    const chunks = smartChunkTelegramText(text);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].html).toBeTruthy();
+  });
+
+  // --- Edge cases ---
+
+  it("handles text that is exactly at the limit", () => {
+    const text = "A".repeat(3976);
+    const chunks = smartChunkTelegramText(text);
+    expect(chunks.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("handles text with only newlines", () => {
+    const chunks = smartChunkTelegramText("\n\n\n");
+    // Newlines-only might be trimmed to empty
+    // The implementation trims first, so this should be empty
+    expect(chunks).toEqual([]);
+  });
+
+  it("handles special characters (emoji, unicode)", () => {
+    const text = "Hello 👋 world 🌍! This is a test with émojis and ünïcödé.";
+    const chunks = smartChunkTelegramText(text);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].text).toContain("👋");
+  });
+
+  // --- Fallback behavior ---
+
+  it("returns raw text as fallback when markdownToTelegramChunks returns empty", () => {
+    // Very short text should still produce at least one chunk
+    const chunks = smartChunkTelegramText("x");
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].text.length).toBeGreaterThan(0);
+  });
+});

--- a/src/plugins/telegram-enhanced/message-manager.test.ts
+++ b/src/plugins/telegram-enhanced/message-manager.test.ts
@@ -1,0 +1,402 @@
+/**
+ * Unit tests for EnhancedTelegramMessageManager.
+ *
+ * Covers: typing indicators, receipt reactions, error handling,
+ * message chunking with inline buttons, and draft streaming integration.
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+// Mock @elizaos/core logger before importing the module under test
+vi.mock("@elizaos/core", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Mock the base MessageManager from @elizaos/plugin-telegram
+vi.mock("@elizaos/plugin-telegram", () => {
+  class MockMessageManager {
+    async handleMessage(_ctx: unknown) {
+      // base implementation — tests override via prototype spy
+    }
+    async sendMessageInChunks(
+      _ctx: unknown,
+      _content: unknown,
+      _replyTo?: number,
+    ) {
+      return [];
+    }
+  }
+
+  function markdownToTelegramChunks(text: string, _maxChars?: number) {
+    return [{ html: text, text }];
+  }
+
+  return {
+    MessageManager: MockMessageManager,
+    markdownToTelegramChunks,
+  };
+});
+
+// Now import the module under test (after mocks are set up)
+const { EnhancedTelegramMessageManager } = await import(
+  "./message-manager.js"
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    chat: { id: 123 },
+    from: { id: 456, first_name: "Test" },
+    message: { message_id: 789 },
+    telegram: {
+      sendMessage: vi.fn().mockResolvedValue({ message_id: 100, text: "ok" }),
+      editMessageText: vi
+        .fn()
+        .mockResolvedValue({ message_id: 100, text: "edited" }),
+      setMessageReaction: vi.fn().mockResolvedValue(true),
+      sendChatAction: vi.fn().mockResolvedValue(true),
+    },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("EnhancedTelegramMessageManager", () => {
+  let manager: InstanceType<typeof EnhancedTelegramMessageManager>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    manager = new EnhancedTelegramMessageManager({} as unknown, {} as unknown);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  // --- handleMessage: typing indicators ---
+
+  describe("handleMessage - typing indicators", () => {
+    it("sends typing indicator before processing", async () => {
+      const ctx = createMockCtx();
+      // Spy on parent handleMessage to resolve immediately
+      vi.spyOn(
+        Object.getPrototypeOf(Object.getPrototypeOf(manager)),
+        "handleMessage",
+      ).mockResolvedValue(undefined);
+
+      await manager.handleMessage(ctx);
+
+      expect(ctx.telegram.sendChatAction).toHaveBeenCalledWith(
+        123,
+        "typing",
+      );
+    });
+
+    it("clears typing interval after processing completes", async () => {
+      const ctx = createMockCtx();
+      vi.spyOn(
+        Object.getPrototypeOf(Object.getPrototypeOf(manager)),
+        "handleMessage",
+      ).mockResolvedValue(undefined);
+
+      await manager.handleMessage(ctx);
+
+      // After handleMessage returns, the interval should be cleared.
+      // Advance timers to verify no additional calls happen.
+      const callCount = ctx.telegram.sendChatAction.mock.calls.length;
+      await vi.advanceTimersByTimeAsync(8000);
+      // Should NOT have additional calls since interval was cleared
+      expect(ctx.telegram.sendChatAction.mock.calls.length).toBe(callCount);
+    });
+  });
+
+  // --- handleMessage: receipt reactions ---
+
+  describe("handleMessage - receipt reactions", () => {
+    it("sends a receipt reaction emoji on the incoming message", async () => {
+      const ctx = createMockCtx();
+      vi.spyOn(
+        Object.getPrototypeOf(Object.getPrototypeOf(manager)),
+        "handleMessage",
+      ).mockResolvedValue(undefined);
+
+      await manager.handleMessage(ctx);
+
+      expect(ctx.telegram.setMessageReaction).toHaveBeenCalledWith(
+        123,
+        789,
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "emoji",
+            emoji: expect.stringMatching(/^(👀|⏳)$/),
+          }),
+        ]),
+      );
+    });
+
+    it("gracefully handles reaction failure", async () => {
+      const ctx = createMockCtx();
+      ctx.telegram.setMessageReaction.mockRejectedValue(
+        new Error("reaction not supported"),
+      );
+      vi.spyOn(
+        Object.getPrototypeOf(Object.getPrototypeOf(manager)),
+        "handleMessage",
+      ).mockResolvedValue(undefined);
+
+      // Should not throw
+      await expect(manager.handleMessage(ctx)).resolves.not.toThrow();
+    });
+
+    it("skips reaction when setMessageReaction is not a function", async () => {
+      const ctx = createMockCtx();
+      ctx.telegram.setMessageReaction = "not a function" as unknown;
+      vi.spyOn(
+        Object.getPrototypeOf(Object.getPrototypeOf(manager)),
+        "handleMessage",
+      ).mockResolvedValue(undefined);
+
+      await expect(manager.handleMessage(ctx)).resolves.not.toThrow();
+    });
+  });
+
+  // --- handleMessage: error handling ---
+
+  describe("handleMessage - error handling", () => {
+    it("sends fallback error message when parent handler throws", async () => {
+      const ctx = createMockCtx();
+      vi.spyOn(
+        Object.getPrototypeOf(Object.getPrototypeOf(manager)),
+        "handleMessage",
+      ).mockRejectedValue(new Error("LLM timeout"));
+
+      await manager.handleMessage(ctx);
+
+      // Should send a friendly fallback message
+      expect(ctx.telegram.sendMessage).toHaveBeenCalledWith(
+        123,
+        expect.stringContaining("error"),
+        expect.objectContaining({
+          reply_parameters: { message_id: 789 },
+        }),
+      );
+    });
+
+    it("handles fallback message send failure gracefully", async () => {
+      const ctx = createMockCtx();
+      vi.spyOn(
+        Object.getPrototypeOf(Object.getPrototypeOf(manager)),
+        "handleMessage",
+      ).mockRejectedValue(new Error("LLM timeout"));
+      ctx.telegram.sendMessage.mockRejectedValue(
+        new Error("network error"),
+      );
+
+      // Should not throw even when fallback send fails
+      await expect(manager.handleMessage(ctx)).resolves.not.toThrow();
+    });
+
+    it("skips processing when ctx has no message", async () => {
+      const ctx = createMockCtx({ message: undefined });
+
+      await manager.handleMessage(ctx);
+
+      expect(ctx.telegram.sendChatAction).not.toHaveBeenCalled();
+    });
+
+    it("skips processing when ctx has no from", async () => {
+      const ctx = createMockCtx({ from: undefined });
+
+      await manager.handleMessage(ctx);
+
+      expect(ctx.telegram.sendChatAction).not.toHaveBeenCalled();
+    });
+
+    it("skips processing when ctx has no chat", async () => {
+      const ctx = createMockCtx({ chat: undefined });
+
+      await manager.handleMessage(ctx);
+
+      expect(ctx.telegram.sendChatAction).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- sendMessageInChunks ---
+
+  describe("sendMessageInChunks", () => {
+    it("sends text message via draft streaming when editMessageText is available", async () => {
+      // Draft streaming uses real setTimeout internally, so switch to real timers
+      vi.useRealTimers();
+      const ctx = createMockCtx();
+
+      const result = await manager.sendMessageInChunks(
+        ctx,
+        { text: "Hello world" },
+        789,
+      );
+
+      // Should have used sendMessage for the initial draft
+      expect(ctx.telegram.sendMessage).toHaveBeenCalled();
+      expect(result).toBeDefined();
+      vi.useFakeTimers();
+    });
+
+    it("falls back to plain send when editMessageText is not a function", async () => {
+      vi.useRealTimers();
+      const ctx = createMockCtx();
+      ctx.telegram.editMessageText = undefined;
+
+      const result = await manager.sendMessageInChunks(
+        ctx,
+        { text: "Hello world" },
+        789,
+      );
+
+      expect(ctx.telegram.sendMessage).toHaveBeenCalledWith(
+        123,
+        expect.any(String),
+        expect.objectContaining({
+          parse_mode: "HTML",
+          reply_parameters: { message_id: 789 },
+        }),
+      );
+      expect(Array.isArray(result)).toBe(true);
+      vi.useFakeTimers();
+    });
+
+    it("delegates to parent for messages with attachments", async () => {
+      vi.useRealTimers();
+      const ctx = createMockCtx();
+      const parentSpy = vi.spyOn(
+        Object.getPrototypeOf(Object.getPrototypeOf(manager)),
+        "sendMessageInChunks",
+      ).mockResolvedValue([{ message_id: 200 }]);
+
+      const content = {
+        text: "Check this out",
+        attachments: [{ type: "image", url: "https://example.com/img.png" }],
+      };
+
+      await manager.sendMessageInChunks(ctx, content, 789);
+
+      expect(parentSpy).toHaveBeenCalled();
+      vi.useFakeTimers();
+    });
+
+    it("returns empty array when chat is missing", async () => {
+      const ctx = createMockCtx({ chat: undefined });
+
+      const result = await manager.sendMessageInChunks(
+        ctx,
+        { text: "Hello" },
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it("returns empty array for empty text", async () => {
+      const ctx = createMockCtx();
+
+      const result = await manager.sendMessageInChunks(ctx, { text: "" });
+
+      expect(result).toEqual([]);
+    });
+
+    it("sends multiple chunks for long text without editMessageText", async () => {
+      vi.useRealTimers();
+      const ctx = createMockCtx();
+      ctx.telegram.editMessageText = undefined;
+      const longText = "Hello world. ".repeat(400); // ~5200 chars
+
+      await manager.sendMessageInChunks(ctx, { text: longText });
+
+      // Should have called sendMessage at least once (for chunked text)
+      expect(ctx.telegram.sendMessage.mock.calls.length).toBeGreaterThanOrEqual(
+        1,
+      );
+      vi.useFakeTimers();
+    });
+
+    it("includes inline keyboard buttons on first chunk", async () => {
+      vi.useRealTimers();
+      const ctx = createMockCtx();
+      ctx.telegram.editMessageText = undefined;
+      const content = {
+        text: "Check this link",
+        buttons: [
+          { text: "Visit Site", url: "https://example.com" },
+        ],
+      };
+
+      await manager.sendMessageInChunks(ctx, content);
+
+      const firstCall = ctx.telegram.sendMessage.mock.calls[0];
+      expect(firstCall).toBeDefined();
+      // The call should include reply_markup for inline keyboard
+      const extra = firstCall[2];
+      expect(extra).toBeDefined();
+      vi.useFakeTimers();
+    });
+
+    it("handles login button kind", async () => {
+      vi.useRealTimers();
+      const ctx = createMockCtx();
+      ctx.telegram.editMessageText = undefined;
+      const content = {
+        text: "Please login",
+        buttons: [
+          { text: "Login", url: "https://example.com/auth", kind: "login" },
+        ],
+      };
+
+      await manager.sendMessageInChunks(ctx, content);
+
+      expect(ctx.telegram.sendMessage).toHaveBeenCalled();
+      vi.useFakeTimers();
+    });
+
+    it("skips buttons with missing text or url", async () => {
+      vi.useRealTimers();
+      const ctx = createMockCtx();
+      ctx.telegram.editMessageText = undefined;
+      const content = {
+        text: "No buttons",
+        buttons: [
+          { text: "", url: "https://example.com" },
+          { text: "Valid", url: "" },
+          { text: "Good", url: "https://example.com" },
+        ],
+      };
+
+      await manager.sendMessageInChunks(ctx, content);
+      expect(ctx.telegram.sendMessage).toHaveBeenCalled();
+      vi.useFakeTimers();
+    });
+
+    it("handles null/undefined buttons array", async () => {
+      vi.useRealTimers();
+      const ctx = createMockCtx();
+      ctx.telegram.editMessageText = undefined;
+
+      await manager.sendMessageInChunks(ctx, {
+        text: "No buttons",
+        buttons: undefined,
+      });
+
+      expect(ctx.telegram.sendMessage).toHaveBeenCalled();
+      vi.useFakeTimers();
+    });
+  });
+});

--- a/src/runtime/eliza.test.ts
+++ b/src/runtime/eliza.test.ts
@@ -140,6 +140,43 @@ describe("collectPluginNames", () => {
     expect(names.has("@elizaos/plugin-slack")).toBe(false);
   });
 
+  it("uses enhanced Telegram plugin when telegram is enabled via plugins.entries", () => {
+    const config = {
+      plugins: {
+        entries: { telegram: { enabled: true } },
+      },
+    } as unknown as MilaidyConfig;
+    const names = collectPluginNames(config);
+    // Should load the enhanced telegram plugin, NOT the base @elizaos/plugin-telegram
+    expect(names.has("@milaidy/plugin-telegram-enhanced")).toBe(true);
+    expect(names.has("@elizaos/plugin-telegram")).toBe(false);
+  });
+
+  it("uses enhanced Telegram plugin from CHANNEL_PLUGIN_MAP for connectors with plugins.entries", () => {
+    // When both connectors AND plugins.entries set telegram, the enhanced
+    // plugin should load (not both enhanced + base).
+    const config = {
+      connectors: { telegram: { botToken: "tok" } },
+      plugins: {
+        entries: { telegram: { enabled: true } },
+      },
+    } as unknown as MilaidyConfig;
+    const names = collectPluginNames(config);
+    expect(names.has("@milaidy/plugin-telegram-enhanced")).toBe(true);
+    expect(names.has("@elizaos/plugin-telegram")).toBe(false);
+  });
+
+  it("does not load telegram plugin when plugins.entries.telegram.enabled is false", () => {
+    const config = {
+      plugins: {
+        entries: { telegram: { enabled: false } },
+      },
+    } as unknown as MilaidyConfig;
+    const names = collectPluginNames(config);
+    expect(names.has("@milaidy/plugin-telegram-enhanced")).toBe(false);
+    expect(names.has("@elizaos/plugin-telegram")).toBe(false);
+  });
+
   it("does not add connector plugins for empty connector configs", () => {
     const config = {
       connectors: { telegram: null },


### PR DESCRIPTION
## Summary
- **Fixed** `collectPluginNames()` loading the base `@elizaos/plugin-telegram` instead of `@milaidy/plugin-telegram-enhanced` when Telegram was enabled via the UI toggle (`plugins.entries.telegram.enabled: true`). This silently disabled typing indicators, draft streaming, receipt reactions, and better error handling.
- Added `CHANNEL_PLUGIN_MAP` lookup priority in the `plugins.entries` resolution so connector keys use the correct plugin variant.
- Added 38 new unit tests covering smart chunking, message manager behavior, and plugin loading.

## Test plan
- [x] All 1490 existing tests pass
- [x] 38 new Telegram-specific tests pass (chunking, message manager, plugin loading)
- [x] Verified `collectPluginNames()` resolves `plugins.entries.telegram` → `@milaidy/plugin-telegram-enhanced`
- [x] Verified `connectors.telegram` + `plugins.entries.telegram` doesn't double-load base + enhanced
- [x] Verified `plugins.entries.telegram.enabled: false` loads neither plugin

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)