### PR TITLE
fix(runtime): block vulnerable pdf plugin enablement

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -5787,6 +5787,25 @@ async function handleRequest(
     );
     if (!body || !body.npmName) return;
 
+    const {
+      CORE_PLUGINS,
+      OPTIONAL_CORE_PLUGINS,
+      getSecurityBlockedPluginReason,
+    } = await import(
+      "../runtime/eliza.js"
+    );
+
+    if (body.enabled) {
+      const blockedReason = getSecurityBlockedPluginReason(body.npmName);
+      if (blockedReason) {
+        error(
+          res,
+          `Plugin is temporarily disabled for security reasons: ${blockedReason}`,
+          409,
+        );
+        return;
+      }
+    }
     // Only allow toggling optional plugins, not core
     const isCorePlugin = (CORE_PLUGINS as readonly string[]).includes(
       body.npmName,

--- a/src/runtime/eliza.test.ts
+++ b/src/runtime/eliza.test.ts
@@ -19,6 +19,7 @@ import {
   buildCharacterFromConfig,
   CUSTOM_PLUGINS_DIRNAME,
   collectPluginNames,
+  getSecurityBlockedPluginReason,
   mergeDropInPlugins,
   resolvePackageEntry,
   resolvePrimaryModel,
@@ -147,6 +148,20 @@ describe("collectPluginNames", () => {
     } as unknown as MilaidyConfig;
     const names = collectPluginNames(config);
     expect(names.has("@elizaos/plugin-telegram")).toBe(false);
+  });
+
+  it("blocks @elizaos/plugin-pdf even when explicitly allow-listed", () => {
+    const config = {
+      plugins: { allow: ["@elizaos/plugin-pdf"] },
+    } as unknown as MilaidyConfig;
+    const names = collectPluginNames(config);
+    expect(names.has("@elizaos/plugin-pdf")).toBe(false);
+    expect(names.has("@elizaos/plugin-sql")).toBe(true);
+  });
+
+  it("provides a block reason for @elizaos/plugin-pdf", () => {
+    const reason = getSecurityBlockedPluginReason("@elizaos/plugin-pdf");
+    expect(reason).toContain("pdfjs-dist");
   });
 
   it("adds ElizaCloud plugin when cloud is enabled in config", () => {

--- a/src/runtime/eliza.ts
+++ b/src/runtime/eliza.ts
@@ -155,6 +155,31 @@ const CHANNEL_ENV_MAP: Readonly<
 export { CORE_PLUGINS, OPTIONAL_CORE_PLUGINS };
 
 /**
+ * Security blocklist for plugins that are temporarily disabled due to known
+ * high-severity vulnerabilities in their dependency chain.
+ *
+ * NOTE: Keep entries minimal and remove once upstream ships patched versions.
+ */
+const SECURITY_BLOCKED_PLUGINS: Readonly<Record<string, string>> = {
+  "@elizaos/plugin-pdf":
+    "Temporarily disabled: vulnerable pdfjs-dist chain (GHSA-wgrm-67xf-hhpq).",
+};
+
+export function getSecurityBlockedPluginReason(
+  pluginName: string,
+): string | null {
+  return SECURITY_BLOCKED_PLUGINS[pluginName] ?? null;
+}
+
+function applySecurityPluginBlocklist(pluginsToLoad: Set<string>): void {
+  for (const [pluginName, reason] of Object.entries(SECURITY_BLOCKED_PLUGINS)) {
+    if (pluginsToLoad.delete(pluginName)) {
+      logger.warn(`[milaidy] Blocking plugin ${pluginName}: ${reason}`);
+    }
+  }
+}
+
+/**
  * Optional plugins that require native binaries or specific config.
  * These are only loaded when explicitly enabled via features config,
  * NOT by default — they crash if their prerequisites are missing.
@@ -271,6 +296,7 @@ export function collectPluginNames(config: MilaidyConfig): Set<string> {
         names.delete(p);
       }
     }
+    applySecurityPluginBlocklist(names);
     return names;
   }
 
@@ -361,6 +387,7 @@ export function collectPluginNames(config: MilaidyConfig): Set<string> {
     }
   }
 
+  applySecurityPluginBlocklist(pluginsToLoad);
   return pluginsToLoad;
 }
 


### PR DESCRIPTION
## Summary
Temporarily block enabling/loading `@elizaos/plugin-pdf` due to a known high-severity vulnerable dependency chain (`pdfjs-dist`, GHSA-wgrm-67xf-hhpq).

## What changed
- Added a runtime security blocklist for temporarily disabled plugins.
- Added `getSecurityBlockedPluginReason(pluginName)` in runtime plugin resolution.
- Applied the blocklist to plugin selection so blocked plugins are removed even if explicitly allow-listed.
- Updated `POST /api/plugins/core/toggle` to reject enabling blocked plugins with `409` and an explicit reason.
- Added unit coverage for block behavior and reason lookup.

## Files changed
- `src/runtime/eliza.ts`
- `src/api/server.ts`
- `src/runtime/eliza.test.ts`

## Validation
- `bun x vitest run src/runtime/eliza.test.ts`
- `bun audit | rg "pdfjs-dist|GHSA-wgrm-67xf-hhpq|@elizaos/plugin-pdf"`

## Notes
This is a mitigation to reduce exposure while upstream dependency remediation is pending.
