### PR TITLE
fix(release): electron TS6059 rootDir in desktop builds

### DIFF
--- a/apps/app/electron/src/native/permissions-darwin.ts
+++ b/apps/app/electron/src/native/permissions-darwin.ts
@@ -16,7 +16,7 @@
 import { exec } from "child_process";
 import { promisify } from "util";
 import { systemPreferences, desktopCapturer, shell } from "electron";
-import type { PermissionCheckResult, SystemPermissionId } from "../../../../../src/permissions/types.js";
+import type { PermissionCheckResult, SystemPermissionId } from "./permissions-shared.js";
 
 const execAsync = promisify(exec);
 

--- a/apps/app/electron/src/native/permissions-linux.ts
+++ b/apps/app/electron/src/native/permissions-linux.ts
@@ -19,7 +19,7 @@ import { exec } from "child_process";
 import { promisify } from "util";
 import { access, constants } from "fs/promises";
 import { shell } from "electron";
-import type { PermissionCheckResult, SystemPermissionId } from "../../../../../src/permissions/types.js";
+import type { PermissionCheckResult, SystemPermissionId } from "./permissions-shared.js";
 
 const execAsync = promisify(exec);
 

--- a/apps/app/electron/src/native/permissions-shared.ts
+++ b/apps/app/electron/src/native/permissions-shared.ts
@@ -1,0 +1,107 @@
+/**
+ * Shared permission types and registry for Electron main-process code.
+ *
+ * This keeps Electron's TypeScript program self-contained under
+ * apps/app/electron to avoid cross-root imports during compilation.
+ */
+
+export type SystemPermissionId =
+  | "accessibility"
+  | "screen-recording"
+  | "microphone"
+  | "camera"
+  | "shell";
+
+export type PermissionStatus =
+  | "granted"
+  | "denied"
+  | "not-determined"
+  | "restricted"
+  | "not-applicable";
+
+export type Platform = "darwin" | "win32" | "linux";
+
+export interface SystemPermissionDefinition {
+  id: SystemPermissionId;
+  name: string;
+  description: string;
+  icon: string;
+  platforms: Platform[];
+  requiredForFeatures: string[];
+}
+
+export interface PermissionState {
+  id: SystemPermissionId;
+  status: PermissionStatus;
+  lastChecked: number;
+  canRequest: boolean;
+}
+
+export interface PermissionCheckResult {
+  status: PermissionStatus;
+  canRequest: boolean;
+}
+
+export interface AllPermissionsState {
+  accessibility: PermissionState;
+  "screen-recording": PermissionState;
+  microphone: PermissionState;
+  camera: PermissionState;
+  shell: PermissionState;
+}
+
+export const SYSTEM_PERMISSIONS: SystemPermissionDefinition[] = [
+  {
+    id: "accessibility",
+    name: "Accessibility",
+    description:
+      "Control mouse, keyboard, and interact with other applications",
+    icon: "cursor",
+    platforms: ["darwin"],
+    requiredForFeatures: ["computeruse", "browser"],
+  },
+  {
+    id: "screen-recording",
+    name: "Screen Recording",
+    description: "Capture screen content for screenshots and vision",
+    icon: "monitor",
+    platforms: ["darwin"],
+    requiredForFeatures: ["computeruse", "vision"],
+  },
+  {
+    id: "microphone",
+    name: "Microphone",
+    description: "Voice input for talk mode and speech recognition",
+    icon: "mic",
+    platforms: ["darwin", "win32", "linux"],
+    requiredForFeatures: ["talkmode", "voice"],
+  },
+  {
+    id: "camera",
+    name: "Camera",
+    description: "Video input for vision and video capture",
+    icon: "camera",
+    platforms: ["darwin", "win32", "linux"],
+    requiredForFeatures: ["camera", "vision"],
+  },
+  {
+    id: "shell",
+    name: "Shell Access",
+    description: "Execute terminal commands and scripts",
+    icon: "terminal",
+    platforms: ["darwin", "win32", "linux"],
+    requiredForFeatures: ["shell"],
+  },
+];
+
+const PERMISSION_MAP = new Map<SystemPermissionId, SystemPermissionDefinition>(
+  SYSTEM_PERMISSIONS.map((permission) => [permission.id, permission]),
+);
+
+export function isPermissionApplicable(
+  id: SystemPermissionId,
+  platform: Platform,
+): boolean {
+  const definition = PERMISSION_MAP.get(id);
+  return definition ? definition.platforms.includes(platform) : false;
+}

--- a/apps/app/electron/src/native/permissions-win32.ts
+++ b/apps/app/electron/src/native/permissions-win32.ts
@@ -15,7 +15,7 @@
 import { exec } from "child_process";
 import { promisify } from "util";
 import { shell } from "electron";
-import type { PermissionCheckResult, SystemPermissionId } from "../../../../../src/permissions/types.js";
+import type { PermissionCheckResult, SystemPermissionId } from "./permissions-shared.js";
 
 const execAsync = promisify(exec);
 

--- a/apps/app/electron/src/native/permissions.ts
+++ b/apps/app/electron/src/native/permissions.ts
@@ -13,8 +13,8 @@ import type {
   PermissionState,
   AllPermissionsState,
   PermissionCheckResult,
-} from "../../../../../src/permissions/types.js";
-import { SYSTEM_PERMISSIONS, isPermissionApplicable } from "../../../../../src/permissions/registry.js";
+} from "./permissions-shared.js";
+import { SYSTEM_PERMISSIONS, isPermissionApplicable } from "./permissions-shared.js";
 import * as darwin from "./permissions-darwin.js";
 import * as win32 from "./permissions-win32.js";
 import * as linux from "./permissions-linux.js";


### PR DESCRIPTION
Cherry-picks fd49f3e from develop to main to unblock release builds on macOS/Linux/Windows.\n\nRoot cause: electron TS compile pulled root src/permissions files outside apps/app/electron rootDir.