### PR TITLE
fix(api): validate sandbox audio-play format and harden exec

### DIFF
--- a/src/api/__tests__/sandbox-routes.test.ts
+++ b/src/api/__tests__/sandbox-routes.test.ts
@@ -334,6 +334,36 @@ describe("handleSandboxRoute", () => {
       });
       expect(res._status).toBe(400);
     });
+
+    it("POST /api/sandbox/audio/play should reject invalid format characters", async () => {
+      const req = createMockReq(
+        "POST",
+        JSON.stringify({
+          data: Buffer.from("abc").toString("base64"),
+          format: "wav;$(touch /tmp/pwned)",
+        }),
+      );
+      const res = createMockRes();
+      await handleSandboxRoute(req, res, "/api/sandbox/audio/play", "POST", {
+        sandboxManager: mgr,
+      });
+      expect(res._status).toBe(400);
+    });
+
+    it("POST /api/sandbox/audio/play should reject unsupported formats", async () => {
+      const req = createMockReq(
+        "POST",
+        JSON.stringify({
+          data: Buffer.from("abc").toString("base64"),
+          format: "exe",
+        }),
+      );
+      const res = createMockRes();
+      await handleSandboxRoute(req, res, "/api/sandbox/audio/play", "POST", {
+        sandboxManager: mgr,
+      });
+      expect(res._status).toBe(400);
+    });
   });
 
   describe("Computer use bridge", () => {


### PR DESCRIPTION
## Summary
Fix a high-severity command-injection risk in `POST /api/sandbox/audio/play` by validating untrusted `format` input and using argument-safe process execution for playback commands.

## What changed
- Added strict JSON/body validation for `POST /api/sandbox/audio/play`.
- Added `resolveAudioFormat()` allowlist guard for format values (`wav`, `mp3`, `ogg`, `flac`, `m4a`).
- Rejected malformed or unsupported format values with `400`.
- Switched audio playback execution to argument-safe process invocation (`execFileSync`) to avoid user-influenced shell-string execution.

## Files changed
- `src/api/sandbox-routes.ts`
- `src/api/__tests__/sandbox-routes.test.ts`

## Tests
- Added regression tests covering:
  - invalid format characters rejected
  - unsupported formats rejected
- Local Vitest execution from this environment is constrained; Biome checks on changed files pass.

## Follow-up note
- Known overlap with #183: this branch adds `runProcess()` while #183 adds `runCommand()`; whichever merges second should deduplicate to a single helper.
