### PR TITLE
fix(api): hard-pin postgres host query params after validation

### DIFF
--- a/src/api/database.ts
+++ b/src/api/database.ts
@@ -173,6 +173,10 @@ function withPinnedHost(
     try {
       const parsed = new URL(next.connectionString);
       parsed.hostname = normalizedPinned;
+      // Preserve DNS pinning even when libpq-style query params are present.
+      // `host` / `hostaddr` can override URI hostname; force both to pinned IP.
+      parsed.searchParams.set("host", normalizedPinned);
+      parsed.searchParams.set("hostaddr", normalizedPinned);
       next.connectionString = parsed.toString();
     } catch {
       // Validation has already parsed this once, but if URL rewriting fails,


### PR DESCRIPTION
## Summary
Fix a database SSRF hardening gap where validated Postgres connection strings could still carry libpq override params (`host`, `hostaddr`) that bypass hostname pinning.

## What changed
- Updated `withPinnedHost()` in `src/api/database.ts` to also pin `host` and `hostaddr` query params to the validated IP.
- Added a regression test in `src/api/database.security.test.ts` verifying hostname + `host` + `hostaddr` are all rewritten to the pinned value.

## Security impact
Prevents bypass of DNS pinning through connection string override parameters, reducing risk of database-target SSRF toward internal or metadata addresses after config save.

## Files changed
- `src/api/database.ts`
- `src/api/database.security.test.ts`

## Tests
- `bun x vitest run src/api/database.security.test.ts`
