### PR TITLE
fix(api): harden agent reset state-dir safety checks

### DIFF
--- a/src/api/server.reset-state-dir-safety.test.ts
+++ b/src/api/server.reset-state-dir-safety.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { isSafeResetStateDir } from "./server.js";
+
+describe("isSafeResetStateDir", () => {
+  it("accepts default state dir under home", () => {
+    expect(isSafeResetStateDir("/Users/alice/.milaidy", "/Users/alice")).toBe(
+      true,
+    );
+  });
+
+  it("accepts nested paths under .milaidy", () => {
+    expect(
+      isSafeResetStateDir(
+        "/Users/alice/.milaidy/workspace/snapshots",
+        "/Users/alice",
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects root path", () => {
+    expect(isSafeResetStateDir("/", "/Users/alice")).toBe(false);
+  });
+
+  it("rejects the home directory itself", () => {
+    expect(isSafeResetStateDir("/Users/alice", "/Users/alice")).toBe(false);
+  });
+
+  it("rejects paths outside home even if they contain milaidy", () => {
+    expect(isSafeResetStateDir("/tmp/milaidy-state", "/Users/alice")).toBe(
+      false,
+    );
+  });
+
+  it("rejects substring-only matches without a milaidy segment", () => {
+    expect(
+      isSafeResetStateDir("/Users/alice/not-milaidy-backup", "/Users/alice"),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Harden `POST /api/agent/reset` path safety checks before recursive deletion.

## What changed
- Added `isSafeResetStateDir()` to validate reset targets using strict rules.
- Replaced substring-based reset safety logic with the new validator.
- Added regression tests for allowed and rejected reset paths.

## Security impact
Prevents destructive reset operations against crafted state directory paths that are outside the intended Milaidy state scope.

## Files changed
- `src/api/server.ts`
- `src/api/server.reset-state-dir-safety.test.ts`

## Tests
- `bun x vitest run src/api/server.reset-state-dir-safety.test.ts`

Covers:
- allow canonical/nested state dirs under home
- reject root and home directory targets
- reject outside-home paths even with "milaidy" in the name
- reject substring-only path matches (no actual milaidy segment)
