### PR TITLE
feat(settings): improve export/import password UX contract

### DIFF
--- a/apps/app/src/AppContext.tsx
+++ b/apps/app/src/AppContext.tsx
@@ -97,6 +97,7 @@ export const THEMES: ReadonlyArray<{
 ];
 
 const VALID_THEMES = new Set<string>(THEMES.map((t) => t.id));
+const AGENT_TRANSFER_MIN_PASSWORD_LENGTH = 4;
 
 function loadTheme(): ThemeName {
   try {
@@ -2472,7 +2473,19 @@ export function AppProvider({ children }: { children: ReactNode }) {
   // ── Agent export/import ────────────────────────────────────────────
 
   const handleAgentExport = useCallback(async () => {
-    if (exportBusy || exportPassword.length < 4) return;
+    if (exportBusy) return;
+    if (!exportPassword) {
+      setExportError("Password is required.");
+      setExportSuccess(null);
+      return;
+    }
+    if (exportPassword.length < AGENT_TRANSFER_MIN_PASSWORD_LENGTH) {
+      setExportError(
+        `Password must be at least ${AGENT_TRANSFER_MIN_PASSWORD_LENGTH} characters.`,
+      );
+      setExportSuccess(null);
+      return;
+    }
     setExportBusy(true);
     setExportError(null);
     setExportSuccess(null);
@@ -2500,7 +2513,24 @@ export function AppProvider({ children }: { children: ReactNode }) {
   }, [exportBusy, exportPassword, exportIncludeLogs]);
 
   const handleAgentImport = useCallback(async () => {
-    if (importBusy || !importFile || importPassword.length < 4) return;
+    if (importBusy) return;
+    if (!importFile) {
+      setImportError("Select an export file before importing.");
+      setImportSuccess(null);
+      return;
+    }
+    if (!importPassword) {
+      setImportError("Password is required.");
+      setImportSuccess(null);
+      return;
+    }
+    if (importPassword.length < AGENT_TRANSFER_MIN_PASSWORD_LENGTH) {
+      setImportError(
+        `Password must be at least ${AGENT_TRANSFER_MIN_PASSWORD_LENGTH} characters.`,
+      );
+      setImportSuccess(null);
+      return;
+    }
     setImportBusy(true);
     setImportError(null);
     setImportSuccess(null);
@@ -2572,8 +2602,12 @@ export function AppProvider({ children }: { children: ReactNode }) {
       inventorySort: setInventorySort,
       exportPassword: setExportPassword,
       exportIncludeLogs: setExportIncludeLogs,
+      exportError: setExportError,
+      exportSuccess: setExportSuccess,
       importPassword: setImportPassword,
       importFile: setImportFile,
+      importError: setImportError,
+      importSuccess: setImportSuccess,
       onboardingName: setOnboardingName,
       onboardingStyle: setOnboardingStyle,
       onboardingTheme: setOnboardingTheme,

--- a/apps/app/src/api-client.ts
+++ b/apps/app/src/api-client.ts
@@ -1488,6 +1488,7 @@ declare global {
 
 const GENERIC_NO_RESPONSE_TEXT =
   "Sorry, I couldn't generate a response right now. Please try again.";
+const AGENT_TRANSFER_MIN_PASSWORD_LENGTH = 4;
 
 export class MilaidyClient {
   private _baseUrl: string;
@@ -2153,6 +2154,11 @@ export class MilaidyClient {
    * Returns the raw Response so the caller can stream the binary body.
    */
   async exportAgent(password: string, includeLogs = false): Promise<Response> {
+    if (password.length < AGENT_TRANSFER_MIN_PASSWORD_LENGTH) {
+      throw new Error(
+        `Password must be at least ${AGENT_TRANSFER_MIN_PASSWORD_LENGTH} characters.`,
+      );
+    }
     if (!this.apiAvailable) {
       throw new Error("API not available (no HTTP origin)");
     }
@@ -2199,6 +2205,11 @@ export class MilaidyClient {
     agentName: string;
     counts: Record<string, number>;
   }> {
+    if (password.length < AGENT_TRANSFER_MIN_PASSWORD_LENGTH) {
+      throw new Error(
+        `Password must be at least ${AGENT_TRANSFER_MIN_PASSWORD_LENGTH} characters.`,
+      );
+    }
     if (!this.apiAvailable) {
       throw new Error("API not available (no HTTP origin)");
     }

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -1530,6 +1530,8 @@ function scanSkillsDir(
 /** Maximum request body size (1 MB) — prevents memory-based DoS. */
 const MAX_BODY_BYTES = 1_048_576;
 const MAX_IMPORT_BYTES = 512 * 1_048_576; // 512 MB for agent imports
+const AGENT_TRANSFER_MIN_PASSWORD_LENGTH = 4;
+const AGENT_TRANSFER_MAX_PASSWORD_LENGTH = 1024;
 
 function readBody(req: http.IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -5151,12 +5153,21 @@ async function handleRequest(
     }>(req, res);
     if (!body) return;
 
-    if (
-      !body.password ||
-      typeof body.password !== "string" ||
-      body.password.length < 4
-    ) {
-      error(res, "A password of at least 4 characters is required.", 400);
+    if (!body.password || typeof body.password !== "string") {
+      error(
+        res,
+        `A password of at least ${AGENT_TRANSFER_MIN_PASSWORD_LENGTH} characters is required.`,
+        400,
+      );
+      return;
+    }
+
+    if (body.password.length < AGENT_TRANSFER_MIN_PASSWORD_LENGTH) {
+      error(
+        res,
+        `A password of at least ${AGENT_TRANSFER_MIN_PASSWORD_LENGTH} characters is required.`,
+        400,
+      );
       return;
     }
 
@@ -5239,8 +5250,20 @@ async function handleRequest(
 
     // Parse binary envelope: [4 bytes password length][password][file data]
     const passwordLength = rawBody.readUInt32BE(0);
-    if (passwordLength < 4 || passwordLength > 1024) {
-      error(res, "Invalid password length in request envelope.", 400);
+    if (passwordLength < AGENT_TRANSFER_MIN_PASSWORD_LENGTH) {
+      error(
+        res,
+        `Password must be at least ${AGENT_TRANSFER_MIN_PASSWORD_LENGTH} characters.`,
+        400,
+      );
+      return;
+    }
+    if (passwordLength > AGENT_TRANSFER_MAX_PASSWORD_LENGTH) {
+      error(
+        res,
+        `Password is too long (max ${AGENT_TRANSFER_MAX_PASSWORD_LENGTH} bytes).`,
+        400,
+      );
       return;
     }
     if (rawBody.length < 4 + passwordLength + 1) {

--- a/src/services/agent-export.test.ts
+++ b/src/services/agent-export.test.ts
@@ -731,7 +731,14 @@ describe("agent-export", () => {
     it("rejects export with empty password", async () => {
       populateDb(sourceDb);
       await expect(exportAgent(sourceRuntime, "")).rejects.toThrow(
-        /password.*required/i,
+        /at least 4|password.*required/i,
+      );
+    });
+
+    it("rejects export with a short password", async () => {
+      populateDb(sourceDb);
+      await expect(exportAgent(sourceRuntime, "abc")).rejects.toThrow(
+        /at least 4/i,
       );
     });
 
@@ -744,7 +751,20 @@ describe("agent-export", () => {
       const targetRuntime = createMockRuntime(targetDb);
 
       await expect(importAgent(targetRuntime, fileBuffer, "")).rejects.toThrow(
-        /password.*required/i,
+        /at least 4|password.*required/i,
+      );
+    });
+
+    it("rejects import with a short password", async () => {
+      populateDb(sourceDb);
+      const fileBuffer = await exportAgent(sourceRuntime, "valid-pass");
+
+      const targetDb = createMockDb();
+      targetDb.agents.set(AGENT_ID, makeAgent());
+      const targetRuntime = createMockRuntime(targetDb);
+
+      await expect(importAgent(targetRuntime, fileBuffer, "abc")).rejects.toThrow(
+        /at least 4/i,
       );
     });
   });

--- a/src/services/agent-export.ts
+++ b/src/services/agent-export.ts
@@ -49,6 +49,7 @@ const SALT_LEN = 32;
 const IV_LEN = 12; // AES-256-GCM standard nonce
 const TAG_LEN = 16; // AES-GCM authentication tag
 const KEY_LEN = 32; // AES-256
+const MIN_PASSWORD_LENGTH = 4;
 const HEADER_SIZE = MAGIC_BYTES.length + 4 + SALT_LEN + IV_LEN + TAG_LEN; // 15 + 4 + 32 + 12 + 16 = 79
 const EXPORT_VERSION = 1;
 const MAX_IMPORT_DECOMPRESSED_BYTES = 16 * 1024 * 1024; // 16 MiB safety cap
@@ -761,8 +762,10 @@ export async function exportAgent(
   password: string,
   options: AgentExportOptions = {},
 ): Promise<Buffer> {
-  if (!password || password.length < 1) {
-    throw new AgentExportError("A password is required to encrypt the export.");
+  if (!password || password.length < MIN_PASSWORD_LENGTH) {
+    throw new AgentExportError(
+      `A password of at least ${MIN_PASSWORD_LENGTH} characters is required to encrypt the export.`,
+    );
   }
 
   if (!runtime.adapter) {
@@ -802,8 +805,10 @@ export async function importAgent(
   fileBuffer: Buffer,
   password: string,
 ): Promise<ImportResult> {
-  if (!password || password.length < 1) {
-    throw new AgentExportError("A password is required to decrypt the import.");
+  if (!password || password.length < MIN_PASSWORD_LENGTH) {
+    throw new AgentExportError(
+      `A password of at least ${MIN_PASSWORD_LENGTH} characters is required to decrypt the import.`,
+    );
   }
 
   if (!runtime.adapter) {


### PR DESCRIPTION
## Summary
Improve agent export/import UX by enforcing a clear password contract and returning actionable feedback instead of silent failures.

## What changed
- Require export/import password input in the settings flow and surface explicit validation errors to the user.
- Added export size estimate UI to help users understand export scope before running it.
- Added missing `AppContext` state setters for export/import success and error fields so UI state updates consistently.
- Aligned client + server + service validation for transfer passwords (minimum length and clearer messages).
- Added/updated tests for short-password rejection.

## Files changed
- `apps/app/src/AppContext.tsx`
- `apps/app/src/api-client.ts`
- `apps/app/src/components/SettingsView.tsx`
- `src/api/server.ts`
- `src/services/agent-export.ts`
- `src/services/agent-export.test.ts`

## Tests
- `bun x vitest run src/services/agent-export.test.ts src/api/server.websocket-auth.test.ts src/api/server.wallet-export-auth.test.ts`
