### PR TITLE
feat(chat): persist conversation titles across restarts

### DIFF
--- a/src/api/server.conversation-title.test.ts
+++ b/src/api/server.conversation-title.test.ts
@@ -1,0 +1,76 @@
+import type { AgentRuntime, UUID } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { persistConversationRoomTitle } from "./server.js";
+
+const conversation = {
+  id: "conv-1",
+  title: "Renamed Conversation",
+  roomId: "00000000-0000-0000-0000-000000000001" as UUID,
+};
+
+describe("persistConversationRoomTitle", () => {
+  it("returns false when runtime is missing", async () => {
+    const updated = await persistConversationRoomTitle(null, conversation);
+    expect(updated).toBe(false);
+  });
+
+  it("returns false when room cannot be found", async () => {
+    const runtime = {
+      getRoom: vi.fn().mockResolvedValue(null),
+      adapter: {},
+    } as unknown as Pick<AgentRuntime, "getRoom" | "adapter">;
+
+    const updated = await persistConversationRoomTitle(runtime, conversation);
+
+    expect(updated).toBe(false);
+    expect(runtime.getRoom).toHaveBeenCalledWith(conversation.roomId);
+  });
+
+  it("returns false when room already has the same title", async () => {
+    const runtime = {
+      getRoom: vi.fn().mockResolvedValue({
+        id: conversation.roomId,
+        name: conversation.title,
+      }),
+      adapter: { updateRoom: vi.fn() },
+    } as unknown as Pick<AgentRuntime, "getRoom" | "adapter">;
+
+    const updated = await persistConversationRoomTitle(runtime, conversation);
+
+    expect(updated).toBe(false);
+    expect(runtime.adapter.updateRoom).not.toHaveBeenCalled();
+  });
+
+  it("returns false when adapter cannot update rooms", async () => {
+    const runtime = {
+      getRoom: vi.fn().mockResolvedValue({
+        id: conversation.roomId,
+        name: "Old title",
+      }),
+      adapter: {},
+    } as unknown as Pick<AgentRuntime, "getRoom" | "adapter">;
+
+    const updated = await persistConversationRoomTitle(runtime, conversation);
+
+    expect(updated).toBe(false);
+  });
+
+  it("updates the room name when title changed", async () => {
+    const updateRoom = vi.fn().mockResolvedValue(undefined);
+    const runtime = {
+      getRoom: vi.fn().mockResolvedValue({
+        id: conversation.roomId,
+        name: "Old title",
+      }),
+      adapter: { updateRoom },
+    } as unknown as Pick<AgentRuntime, "getRoom" | "adapter">;
+
+    const updated = await persistConversationRoomTitle(runtime, conversation);
+
+    expect(updated).toBe(true);
+    expect(updateRoom).toHaveBeenCalledWith({
+      id: conversation.roomId,
+      name: conversation.title,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Persist conversation title changes across restarts and improve conversation action reliability feedback in the app.

## What changed
- Added `persistConversationRoomTitle()` to sync conversation titles to room names in runtime storage.
- Hooked title sync on conversation create and rename so restored conversations keep user-edited titles.
- Added focused tests for room-title persistence behavior.
- Improved conversation action handlers in app state (`select`, `delete`, `clear`, `rename`) to handle not-found and failure cases with explicit notices and recovery paths.

## Files changed
- `src/api/server.ts`
- `src/api/server.conversation-title.test.ts`
- `apps/app/src/AppContext.tsx`

## Tests
- `bun x vitest run src/api/server.conversation-title.test.ts src/api/server.websocket-auth.test.ts src/api/server.wallet-export-auth.test.ts`
- `bun x vitest run --config apps/app/vitest.config.ts apps/app/test/app/lifecycle.test.ts apps/app/test/app/startup-chat.e2e.test.ts`
