### PR TITLE
feat(plugins): add restart-aware toggle feedback

### DIFF
--- a/apps/app/src/AppContext.tsx
+++ b/apps/app/src/AppContext.tsx
@@ -1688,20 +1688,41 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const handlePluginToggle = useCallback(
     async (pluginId: string, enabled: boolean) => {
       const plugin = plugins.find((p: PluginInfo) => p.id === pluginId);
+      const pluginName = plugin?.name ?? pluginId;
       if (enabled && plugin?.validationErrors && plugin.validationErrors.length > 0) {
         setPluginSettingsOpen((prev) => new Set([...prev, pluginId]));
+        setActionNotice(
+          `${pluginName} has required settings. Configure them after enabling.`,
+          "info",
+          3400,
+        );
       }
       try {
-        await client.updatePlugin(pluginId, { enabled });
-        // Optimistic update for immediate feedback
-        setPlugins((prev: PluginInfo[]) =>
-          prev.map((p: PluginInfo) => (p.id === pluginId ? { ...p, enabled } : p)),
+        setActionNotice(
+          `${enabled ? "Enabling" : "Disabling"} ${pluginName}. Restarting agent...`,
+          "info",
+          4200,
         );
+        await client.updatePlugin(pluginId, { enabled });
         // The server schedules a restart after toggle — wait for it then refresh
         await client.restartAndWait();
         await loadPlugins();
-      } catch {
-        /* ignore */
+        setActionNotice(
+          `${pluginName} ${enabled ? "enabled" : "disabled"}.`,
+          "success",
+          2800,
+        );
+      } catch (err) {
+        await loadPlugins().catch(() => {
+          /* ignore */
+        });
+        setActionNotice(
+          `Failed to ${enabled ? "enable" : "disable"} ${pluginName}: ${
+            err instanceof Error ? err.message : "unknown error"
+          }`,
+          "error",
+          4200,
+        );
       }
     },
     [plugins, loadPlugins, setActionNotice],
@@ -1720,15 +1741,20 @@ export function AppProvider({ children }: { children: ReactNode }) {
 
         // Restart agent if AI provider (API keys need restart to take effect)
         if (isAiProvider) {
-          await client.restartAgent();
+          setActionNotice(
+            "Saving provider settings. Restarting agent to apply changes...",
+            "info",
+            4200,
+          );
+          await client.restartAndWait();
         }
 
         await loadPlugins();
         setActionNotice(
           isAiProvider
-            ? "Plugin settings saved and agent restarted."
+            ? "Provider settings saved and agent restarted."
             : "Plugin settings saved.",
-          "success"
+          "success",
         );
         setPluginSaveSuccess((prev) => new Set([...prev, pluginId]));
         setTimeout(() => {

--- a/apps/app/src/components/PluginsView.tsx
+++ b/apps/app/src/components/PluginsView.tsx
@@ -726,6 +726,8 @@ function PluginListView({ label, mode = "all" }: PluginListViewProps) {
   const [addDirLoading, setAddDirLoading] = useState(false);
   const [installingPlugins, setInstallingPlugins] = useState<Set<string>>(new Set());
   const [installProgress, setInstallProgress] = useState<Map<string, { phase: string; message: string }>>(new Map());
+  const [togglingPlugins, setTogglingPlugins] = useState<Set<string>>(new Set());
+  const hasPluginToggleInFlight = togglingPlugins.size > 0;
 
   // ── Drag-to-reorder state ────────────────────────────────────────
   const [pluginOrder, setPluginOrder] = useState<string[]>(() => {
@@ -955,6 +957,29 @@ function PluginListView({ label, mode = "all" }: PluginListViewProps) {
     }
   };
 
+  const handleTogglePlugin = useCallback(
+    async (pluginId: string, enabled: boolean) => {
+      let shouldStart = false;
+      setTogglingPlugins((prev) => {
+        if (prev.has(pluginId) || prev.size > 0) return prev;
+        shouldStart = true;
+        return new Set(prev).add(pluginId);
+      });
+      if (!shouldStart) return;
+
+      try {
+        await handlePluginToggle(pluginId, enabled);
+      } finally {
+        setTogglingPlugins((prev) => {
+          const next = new Set(prev);
+          next.delete(pluginId);
+          return next;
+        });
+      }
+    },
+    [handlePluginToggle],
+  );
+
   // ── Add from directory ──────────────────────────────────────────────
 
   const handleAddFromDirectory = async () => {
@@ -1060,6 +1085,8 @@ function PluginListView({ label, mode = "all" }: PluginListViewProps) {
           ? "border-l-[3px] border-l-warn"
           : "border-l-[3px] border-l-accent"
         : "";
+    const isToggleBusy = togglingPlugins.has(p.id);
+    const toggleDisabled = isToggleBusy || (hasPluginToggleInFlight && !isToggleBusy);
 
     const isDragging = draggingId === p.id;
     const isDragOver = dragOverId === p.id && draggingId !== p.id;
@@ -1103,17 +1130,22 @@ function PluginListView({ label, mode = "all" }: PluginListViewProps) {
             <button
               type="button"
               data-plugin-toggle={p.id}
-              className={`text-[10px] font-bold tracking-wider px-2.5 py-[2px] border cursor-pointer transition-colors duration-150 shrink-0 ${
+              className={`text-[10px] font-bold tracking-wider px-2.5 py-[2px] border transition-colors duration-150 shrink-0 ${
                 p.enabled
                   ? "bg-accent text-accent-fg border-accent"
                   : "bg-transparent text-muted border-border hover:text-txt"
+              } ${
+                toggleDisabled
+                  ? "opacity-60 cursor-not-allowed"
+                  : "cursor-pointer"
               }`}
               onClick={(e) => {
                 e.stopPropagation();
-                handlePluginToggle(p.id, !p.enabled);
+                void handleTogglePlugin(p.id, !p.enabled);
               }}
+              disabled={toggleDisabled}
             >
-              {p.enabled ? "ON" : "OFF"}
+              {isToggleBusy ? "APPLYING" : p.enabled ? "ON" : "OFF"}
             </button>
           )}
         </div>
@@ -1136,6 +1168,11 @@ function PluginListView({ label, mode = "all" }: PluginListViewProps) {
               title={p.loadError || "Plugin is enabled but not loaded in the runtime"}
             >
               {p.loadError ? "load failed" : "not installed"}
+            </span>
+          )}
+          {isToggleBusy && (
+            <span className="text-[10px] px-1.5 py-px border border-accent bg-accent-subtle text-accent lowercase tracking-wide whitespace-nowrap">
+              restarting...
             </span>
           )}
         </div>
@@ -1307,6 +1344,12 @@ function PluginListView({ label, mode = "all" }: PluginListViewProps) {
           + Add Plugin
         </button>
       </div>
+
+      {hasPluginToggleInFlight && (
+        <div className="mb-3 px-3 py-2 border border-accent bg-accent-subtle text-[11px] text-accent">
+          Applying plugin change and waiting for agent restart...
+        </div>
+      )}
 
       {/* Tag filters */}
       {showSubgroupFilters && (

--- a/apps/app/test/app/plugins-view-toggle-restart.test.ts
+++ b/apps/app/test/app/plugins-view-toggle-restart.test.ts
@@ -1,0 +1,129 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import TestRenderer, { act } from "react-test-renderer";
+
+const mockUseApp = vi.fn();
+const mockOnWsEvent = vi.fn(() => () => {});
+const mockHandlePluginToggle = vi.fn();
+const mockLoadPlugins = vi.fn(async () => {});
+const mockHandlePluginConfigSave = vi.fn(async () => {});
+const mockSetActionNotice = vi.fn();
+const mockSetState = vi.fn();
+
+vi.mock("../../src/AppContext", () => ({
+  useApp: () => mockUseApp(),
+}));
+
+vi.mock("../../src/api-client", () => ({
+  client: {
+    onWsEvent: (...args: unknown[]) => mockOnWsEvent(...args),
+    installRegistryPlugin: vi.fn(),
+    testPluginConnection: vi.fn(),
+    restartAndWait: vi.fn(),
+  },
+}));
+
+import { PluginsView } from "../../src/components/PluginsView";
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function baseContext() {
+  return {
+    plugins: [
+      {
+        id: "test-plugin",
+        name: "Test Plugin",
+        description: "Plugin for toggle UX tests",
+        enabled: false,
+        configured: true,
+        envKey: null,
+        category: "feature" as const,
+        source: "bundled" as const,
+        parameters: [],
+        validationErrors: [],
+        validationWarnings: [],
+      },
+    ],
+    pluginStatusFilter: "all" as const,
+    pluginSearch: "",
+    pluginSettingsOpen: new Set<string>(),
+    pluginSaving: new Set<string>(),
+    pluginSaveSuccess: new Set<string>(),
+    loadPlugins: mockLoadPlugins,
+    handlePluginToggle: mockHandlePluginToggle,
+    handlePluginConfigSave: mockHandlePluginConfigSave,
+    setActionNotice: mockSetActionNotice,
+    setState: mockSetState,
+  };
+}
+
+describe("PluginsView restart-aware toggles", () => {
+  beforeEach(() => {
+    mockUseApp.mockReset();
+    mockOnWsEvent.mockReset();
+    mockHandlePluginToggle.mockReset();
+    mockLoadPlugins.mockReset();
+    mockHandlePluginConfigSave.mockReset();
+    mockSetActionNotice.mockReset();
+    mockSetState.mockReset();
+    mockOnWsEvent.mockReturnValue(() => {});
+    mockLoadPlugins.mockResolvedValue(undefined);
+    mockHandlePluginConfigSave.mockResolvedValue(undefined);
+    mockSetState.mockImplementation(() => {});
+    mockUseApp.mockReturnValue(baseContext());
+  });
+
+  it("locks plugin toggles while a restart-causing toggle is in flight", async () => {
+    const deferred = createDeferred<void>();
+    mockHandlePluginToggle.mockReturnValue(deferred.promise);
+
+    let tree: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      tree = TestRenderer.create(React.createElement(PluginsView));
+    });
+
+    const getToggle = () =>
+      tree!.root.find(
+        (node) =>
+          node.type === "button" &&
+          node.props["data-plugin-toggle"] === "test-plugin",
+      );
+
+    expect(getToggle().props.disabled).toBe(false);
+
+    await act(async () => {
+      getToggle().props.onClick({ stopPropagation: () => {} });
+    });
+
+    expect(mockHandlePluginToggle).toHaveBeenCalledTimes(1);
+    expect(getToggle().props.disabled).toBe(true);
+    expect(String(getToggle().props.children)).toContain("APPLYING");
+    expect(
+      tree!.root
+        .findAll((node) =>
+          typeof node.props.className === "string" &&
+          node.props.className.includes("border-accent") &&
+          node.children.join("").includes("Applying plugin change"),
+        )
+        .length,
+    ).toBeGreaterThan(0);
+
+    await act(async () => {
+      getToggle().props.onClick({ stopPropagation: () => {} });
+    });
+    expect(mockHandlePluginToggle).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      deferred.resolve();
+      await deferred.promise;
+    });
+
+    expect(getToggle().props.disabled).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Improve plugin and provider toggle UX by making restart/application state explicit and preventing conflicting toggle actions while a restart-triggering change is in flight.

## What changed
- Added restart-aware plugin toggle handling with visible in-flight state (`APPLYING`, `restarting...`) and a global “waiting for restart” banner.
- Disabled additional plugin toggles while a restart-triggering toggle is processing to avoid conflicting actions.
- Improved notices for enable/disable success and failure cases instead of silent behavior.
- Updated provider config save flow to use restart-and-wait behavior with clearer user feedback.
- Added a UI regression test that verifies toggle locking while restart is in flight.

## Files changed
- `apps/app/src/AppContext.tsx`
- `apps/app/src/components/PluginsView.tsx`
- `apps/app/test/app/plugins-view-toggle-restart.test.ts`

## Tests
- `bun x vitest run --config apps/app/vitest.config.ts apps/app/test/app/plugins-view-toggle-restart.test.ts apps/app/test/app/lifecycle.test.ts`
- `bun x vitest run --config apps/app/vitest.config.ts apps/app/test/app/startup-chat.e2e.test.ts`
