### PR TITLE
ci: skip Claude OIDC jobs on fork pull requests

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   claude-review:
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||
@@ -41,4 +42,3 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   claude:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -44,4 +45,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-


### PR DESCRIPTION
## Summary
Prevent deterministic merge-check failures on fork-origin pull requests by gating Claude jobs to same-repo PR contexts.

## Root Cause
For fork PR `pull_request` events, Claude jobs can run without `ACTIONS_ID_TOKEN_REQUEST_URL`, causing OIDC token acquisition to fail (`Could not fetch an OIDC token`).

## Change
- Added a job-level guard in `.github/workflows/claude.yml` to skip fork `pull_request` runs while preserving other triggers.
- Added a job-level guard in `.github/workflows/claude-code-review.yml` to run review only for same-repo PRs.

## Expected Behavior
- Fork PRs: `claude` / `claude-review` are skipped (not failed).
- Same-repo PRs: Claude automation continues to run as before.

## Scope
Workflow-only change. No runtime/API code changes.
