### PR TITLE
fix(ui): prevent duplicate cloud login attempts

### DIFF
--- a/apps/app/src/AppContext.tsx
+++ b/apps/app/src/AppContext.tsx
@@ -2662,6 +2662,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
           clearInterval(cloudLoginPollTimer.current);
           cloudLoginPollTimer.current = null;
         }
+        cloudLoginBusyRef.current = false;
         setCloudLoginBusy(false);
         setCloudLoginError(null);
         break;


### PR DESCRIPTION
## Summary
Prevent duplicate Eliza Cloud login attempts from rapid clicks and ensure the login lock is released when users back out of the cloud login onboarding step.

## What changed
- Added a synchronous lock (`cloudLoginBusyRef`) in `handleCloudLogin` to prevent same-tick duplicate login starts.
- Released the lock on all terminal paths (timeout, authenticated, expired/error, top-level failure).
- Fixed onboarding back-navigation path (`cloudLogin` step) to clear the lock when users cancel/back out.
- Added regression tests for:
  - same-tick duplicate cloud login de-duplication
  - lock release after failed login (retry allowed)
  - lock release after onboarding back-path cancel (retry allowed)

## Files changed
- `apps/app/src/AppContext.tsx`
- `apps/app/test/app/cloud-login-lock.test.ts`

## Tests
- `bun x vitest run --config apps/app/vitest.config.ts apps/app/test/app/cloud-login-lock.test.ts apps/app/test/app/lifecycle-lock.test.ts`
