### PR TITLE
fix(ui): prevent duplicate pairing submissions

### DIFF
--- a/apps/app/src/AppContext.tsx
+++ b/apps/app/src/AppContext.tsx
@@ -991,6 +991,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const prevAgentStateRef = useRef<string | null>(null);
   const lifecycleBusyRef = useRef(false);
   const lifecycleActionRef = useRef<LifecycleAction | null>(null);
+  const pairingBusyRef = useRef(false);
   /** Guards against double-greeting when both init and state-transition paths fire. */
   const greetingFiredRef = useRef(false);
   const chatAbortRef = useRef<AbortController | null>(null);
@@ -2018,12 +2019,14 @@ export function AppProvider({ children }: { children: ReactNode }) {
   // ── Pairing ────────────────────────────────────────────────────────
 
   const handlePairingSubmit = useCallback(async () => {
+    if (pairingBusyRef.current || pairingBusy) return;
     const code = pairingCodeInput.trim();
     if (!code) {
       setPairingError("Enter the pairing code from the server logs.");
       return;
     }
     setPairingError(null);
+    pairingBusyRef.current = true;
     setPairingBusy(true);
     try {
       const { token } = await client.pair(code);
@@ -2035,9 +2038,10 @@ export function AppProvider({ children }: { children: ReactNode }) {
       else if (status === 429) setPairingError("Too many attempts. Try again later.");
       else setPairingError("Pairing failed. Check the code and try again.");
     } finally {
+      pairingBusyRef.current = false;
       setPairingBusy(false);
     }
-  }, [pairingCodeInput]);
+  }, [pairingBusy, pairingCodeInput]);
 
   // ── Plugin actions ─────────────────────────────────────────────────
 

--- a/apps/app/test/app/pairing-lock.test.ts
+++ b/apps/app/test/app/pairing-lock.test.ts
@@ -1,0 +1,245 @@
+import React, { useEffect } from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockClient } = vi.hoisted(() => ({
+  mockClient: {
+    hasToken: vi.fn(() => false),
+    getAuthStatus: vi.fn(async () => ({
+      required: false,
+      pairingEnabled: true,
+      expiresAt: null,
+    })),
+    getOnboardingStatus: vi.fn(async () => ({ complete: true })),
+    listConversations: vi.fn(async () => ({
+      conversations: [
+        {
+          id: "conv-1",
+          title: "Chat",
+          roomId: "room-1",
+          createdAt: "2026-02-01T00:00:00.000Z",
+          updatedAt: "2026-02-01T00:00:00.000Z",
+        },
+      ],
+    })),
+    getConversationMessages: vi.fn(async () => ({
+      messages: [
+        {
+          id: "msg-1",
+          role: "assistant",
+          text: "hello",
+          timestamp: Date.now(),
+        },
+      ],
+    })),
+    sendWsMessage: vi.fn(),
+    connectWs: vi.fn(),
+    disconnectWs: vi.fn(),
+    onWsEvent: vi.fn(() => () => {}),
+    getAgentEvents: vi.fn(async () => ({ events: [], latestEventId: null })),
+    getStatus: vi.fn(async () => ({
+      state: "running",
+      agentName: "Milaidy",
+      model: undefined,
+      startedAt: undefined,
+      uptime: undefined,
+    })),
+    getWalletAddresses: vi.fn(async () => null),
+    getConfig: vi.fn(async () => ({})),
+    getCloudStatus: vi.fn(async () => ({ enabled: false, connected: false })),
+    getWorkbenchOverview: vi.fn(async () => ({
+      tasks: [],
+      triggers: [],
+      todos: [],
+    })),
+    pair: vi.fn(async () => ({ token: "tok" })),
+    setToken: vi.fn(),
+  },
+}));
+
+vi.mock("../../src/api-client", () => ({
+  client: mockClient,
+  SkillScanReportSummary: {},
+}));
+
+import { AppProvider, useApp } from "../../src/AppContext";
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+type ProbeApi = {
+  setPairingCodeInput: (code: string) => void;
+  handlePairingSubmit: () => Promise<void>;
+};
+
+function Probe(props: { onReady: (api: ProbeApi) => void }) {
+  const { onReady } = props;
+  const app = useApp();
+
+  useEffect(() => {
+    onReady({
+      setPairingCodeInput: (code: string) => app.setState("pairingCodeInput", code),
+      handlePairingSubmit: app.handlePairingSubmit,
+    });
+  }, [app, onReady]);
+
+  return null;
+}
+
+describe("pairing submit locking", () => {
+  beforeEach(() => {
+    Object.assign(window.location, {
+      protocol: "file:",
+      pathname: "/chat",
+      reload: vi.fn(),
+    });
+    Object.assign(window, {
+      setTimeout: globalThis.setTimeout,
+      clearTimeout: globalThis.clearTimeout,
+      setInterval: globalThis.setInterval,
+      clearInterval: globalThis.clearInterval,
+    });
+    Object.assign(document.documentElement, { setAttribute: vi.fn() });
+
+    for (const fn of Object.values(mockClient)) {
+      if (typeof fn === "function" && "mockReset" in fn) {
+        (fn as { mockReset: () => void }).mockReset();
+      }
+    }
+
+    mockClient.hasToken.mockReturnValue(false);
+    mockClient.getAuthStatus.mockResolvedValue({
+      required: false,
+      pairingEnabled: true,
+      expiresAt: null,
+    });
+    mockClient.getOnboardingStatus.mockResolvedValue({ complete: true });
+    mockClient.listConversations.mockResolvedValue({
+      conversations: [
+        {
+          id: "conv-1",
+          title: "Chat",
+          roomId: "room-1",
+          createdAt: "2026-02-01T00:00:00.000Z",
+          updatedAt: "2026-02-01T00:00:00.000Z",
+        },
+      ],
+    });
+    mockClient.getConversationMessages.mockResolvedValue({
+      messages: [
+        {
+          id: "msg-1",
+          role: "assistant",
+          text: "hello",
+          timestamp: Date.now(),
+        },
+      ],
+    });
+    mockClient.sendWsMessage.mockImplementation(() => {});
+    mockClient.connectWs.mockImplementation(() => {});
+    mockClient.disconnectWs.mockImplementation(() => {});
+    mockClient.onWsEvent.mockReturnValue(() => {});
+    mockClient.getAgentEvents.mockResolvedValue({ events: [], latestEventId: null });
+    mockClient.getStatus.mockResolvedValue({
+      state: "running",
+      agentName: "Milaidy",
+      model: undefined,
+      startedAt: undefined,
+      uptime: undefined,
+    });
+    mockClient.getWalletAddresses.mockResolvedValue(null);
+    mockClient.getConfig.mockResolvedValue({});
+    mockClient.getCloudStatus.mockResolvedValue({ enabled: false, connected: false });
+    mockClient.getWorkbenchOverview.mockResolvedValue({
+      tasks: [],
+      triggers: [],
+      todos: [],
+    });
+    mockClient.pair.mockResolvedValue({ token: "tok" });
+    mockClient.setToken.mockImplementation(() => {});
+  });
+
+  it("allows only one same-tick pairing submit", async () => {
+    const deferred = createDeferred<{ token: string }>();
+    mockClient.pair.mockReturnValue(deferred.promise);
+
+    let api: ProbeApi | null = null;
+    let tree: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      tree = TestRenderer.create(
+        React.createElement(
+          AppProvider,
+          null,
+          React.createElement(Probe, {
+            onReady: (nextApi) => {
+              api = nextApi;
+            },
+          }),
+        ),
+      );
+    });
+
+    expect(api).not.toBeNull();
+
+    await act(async () => {
+      api!.setPairingCodeInput("abcd");
+    });
+
+    await act(async () => {
+      void api!.handlePairingSubmit();
+      void api!.handlePairingSubmit();
+    });
+
+    expect(mockClient.pair).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      tree!.unmount();
+    });
+  });
+
+  it("releases lock after failed pairing so retry can run", async () => {
+    mockClient.pair
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockRejectedValueOnce(new Error("boom-2"));
+
+    let api: ProbeApi | null = null;
+    let tree: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      tree = TestRenderer.create(
+        React.createElement(
+          AppProvider,
+          null,
+          React.createElement(Probe, {
+            onReady: (nextApi) => {
+              api = nextApi;
+            },
+          }),
+        ),
+      );
+    });
+
+    expect(api).not.toBeNull();
+
+    await act(async () => {
+      api!.setPairingCodeInput("abcd");
+    });
+
+    await act(async () => {
+      await api!.handlePairingSubmit();
+    });
+    await act(async () => {
+      await api!.handlePairingSubmit();
+    });
+
+    expect(mockClient.pair).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      tree!.unmount();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Prevent duplicate pairing submissions caused by same-tick double clicks in the pairing UI.

## What changed
- Added a synchronous pairing lock (`pairingBusyRef`) in `handlePairingSubmit`.
- Guard now checks ref + UI state to prevent duplicate submit starts before React state settles.
- Lock is acquired before async `client.pair` and always released in `finally`.
- Added regression tests for:
  - same-tick duplicate submit de-duplication
  - lock release after failed pairing (retry allowed)

## Files changed
- `apps/app/src/AppContext.tsx`
- `apps/app/test/app/pairing-lock.test.ts`

## Tests
- `bun x vitest run --config apps/app/vitest.config.ts apps/app/test/app/pairing-lock.test.ts apps/app/test/app/lifecycle-lock.test.ts`
