### PR TITLE
milaidy: OpenAI + Anthropic compatible endpoints

### DIFF
--- a/src/api/compat-utils.test.ts
+++ b/src/api/compat-utils.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractAnthropicSystemAndLastUser,
+  extractCompatTextContent,
+  extractOpenAiSystemAndLastUser,
+  resolveCompatRoomKey,
+} from "./compat-utils.js";
+
+describe("extractCompatTextContent", () => {
+  it("returns string content directly", () => {
+    expect(extractCompatTextContent("hello")).toBe("hello");
+  });
+
+  it("extracts concatenated text parts", () => {
+    expect(
+      extractCompatTextContent([
+        { type: "text", text: "a" },
+        { type: "text", text: "b" },
+      ]),
+    ).toBe("ab");
+  });
+
+  it("ignores non-text parts", () => {
+    expect(
+      extractCompatTextContent([
+        { type: "image_url", image_url: { url: "https://example.com/x.png" } },
+        { type: "text", text: "ok" },
+      ]),
+    ).toBe("ok");
+  });
+
+  it("extracts object .text string", () => {
+    expect(extractCompatTextContent({ text: "hello" })).toBe("hello");
+  });
+});
+
+describe("extractOpenAiSystemAndLastUser", () => {
+  it("returns null when messages is not an array", () => {
+    expect(extractOpenAiSystemAndLastUser({})).toBeNull();
+  });
+
+  it("returns null when there is no user message", () => {
+    expect(
+      extractOpenAiSystemAndLastUser([{ role: "system", content: "x" }]),
+    ).toBeNull();
+  });
+
+  it("extracts joined system and last user", () => {
+    expect(
+      extractOpenAiSystemAndLastUser([
+        { role: "system", content: "s1" },
+        { role: "developer", content: "s2" },
+        { role: "user", content: "u1" },
+        { role: "assistant", content: "a1" },
+        { role: "user", content: "u2" },
+      ]),
+    ).toEqual({ system: "s1\n\ns2", user: "u2" });
+  });
+});
+
+describe("extractAnthropicSystemAndLastUser", () => {
+  it("returns null when messages is not an array", () => {
+    expect(
+      extractAnthropicSystemAndLastUser({ system: "x", messages: {} }),
+    ).toBeNull();
+  });
+
+  it("returns null when no user message exists", () => {
+    expect(
+      extractAnthropicSystemAndLastUser({
+        system: "x",
+        messages: [{ role: "assistant", content: "a" }],
+      }),
+    ).toBeNull();
+  });
+
+  it("extracts system and last user", () => {
+    expect(
+      extractAnthropicSystemAndLastUser({
+        system: "sys",
+        messages: [
+          { role: "user", content: "u1" },
+          { role: "assistant", content: "a1" },
+          { role: "user", content: "u2" },
+        ],
+      }),
+    ).toEqual({ system: "sys", user: "u2" });
+  });
+});
+
+describe("resolveCompatRoomKey", () => {
+  it("prefers OpenAI user field", () => {
+    expect(resolveCompatRoomKey({ user: "alice" })).toBe("alice");
+  });
+
+  it("uses metadata conversation_id", () => {
+    expect(resolveCompatRoomKey({ metadata: { conversation_id: "c1" } })).toBe(
+      "c1",
+    );
+  });
+
+  it("uses metadata user_id", () => {
+    expect(resolveCompatRoomKey({ metadata: { user_id: "u1" } })).toBe("u1");
+  });
+
+  it("falls back when nothing is provided", () => {
+    expect(resolveCompatRoomKey({})).toBe("default");
+    expect(resolveCompatRoomKey({}, "x")).toBe("x");
+  });
+});

--- a/src/api/compat-utils.ts
+++ b/src/api/compat-utils.ts
@@ -1,0 +1,154 @@
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function readString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+/**
+ * Extract a best-effort text string from OpenAI/Anthropic "content" fields.
+ * Supports:
+ * - string
+ * - array of parts: [{ type: "text", text: "..." }, ...]
+ * - objects with a `text` string field
+ */
+export function extractCompatTextContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    const chunks: string[] = [];
+    for (const item of content) {
+      const obj = asRecord(item);
+      if (!obj) continue;
+      const type = readString(obj.type);
+      if (type && type !== "text") continue;
+      const text = readString(obj.text);
+      if (text) chunks.push(text);
+    }
+    return chunks.join("");
+  }
+  const obj = asRecord(content);
+  if (obj) return readString(obj.text);
+  return "";
+}
+
+export type OpenAiChatRole =
+  | "system"
+  | "developer"
+  | "user"
+  | "assistant"
+  | "tool"
+  | "function";
+
+export interface OpenAiChatMessage {
+  role: OpenAiChatRole;
+  content?: unknown;
+}
+
+/**
+ * For OpenAI-compatible requests, we intentionally reduce "messages" to:
+ * - all system/developer messages (joined)
+ * - the last user message
+ *
+ * This keeps the server-side room memory coherent (so stateless clients that
+ * resend full history do not cause runaway duplication).
+ */
+export function extractOpenAiSystemAndLastUser(
+  messages: unknown,
+): { system: string; user: string } | null {
+  if (!Array.isArray(messages)) return null;
+
+  let system = "";
+  let user = "";
+
+  for (const item of messages) {
+    const msg = asRecord(item);
+    if (!msg) continue;
+    const role = readString(msg.role) as OpenAiChatRole;
+    const contentText = extractCompatTextContent(msg.content);
+    if (!contentText.trim()) continue;
+
+    if (role === "system" || role === "developer") {
+      system = system
+        ? `${system}\n\n${contentText.trim()}`
+        : contentText.trim();
+      continue;
+    }
+    if (role === "user") {
+      user = contentText.trim();
+    }
+  }
+
+  if (!user) return null;
+  return { system, user };
+}
+
+export type AnthropicRole = "user" | "assistant";
+
+export interface AnthropicMessage {
+  role: AnthropicRole;
+  content?: unknown;
+}
+
+export function extractAnthropicSystemAndLastUser(args: {
+  system?: unknown;
+  messages: unknown;
+}): { system: string; user: string } | null {
+  if (!Array.isArray(args.messages)) return null;
+
+  const system = readString(args.system).trim();
+  let user = "";
+
+  for (const item of args.messages) {
+    const msg = asRecord(item);
+    if (!msg) continue;
+    const role = readString(msg.role) as AnthropicRole;
+    if (role !== "user") continue;
+    const contentText = extractCompatTextContent(msg.content);
+    if (!contentText.trim()) continue;
+    user = contentText.trim();
+  }
+
+  if (!user) return null;
+  return { system, user };
+}
+
+function readNestedString(
+  obj: Record<string, unknown>,
+  key: string,
+): string | null {
+  const raw = obj[key];
+  if (typeof raw === "string" && raw.trim()) return raw.trim();
+  return null;
+}
+
+/**
+ * Resolve a stable room key for compatibility endpoints so manual testing can
+ * keep conversation memory when the client provides an identifier.
+ *
+ * We accept a few common fields without requiring any one client:
+ * - OpenAI: body.user (string)
+ * - OpenAI: body.metadata.conversation_id
+ * - Anthropic: body.metadata.user_id
+ * - Anthropic: body.metadata.conversation_id
+ */
+export function resolveCompatRoomKey(
+  body: Record<string, unknown>,
+  fallback = "default",
+): string {
+  const direct = readNestedString(body, "user");
+  if (direct) return direct;
+
+  const metadata = asRecord(body.metadata);
+  if (metadata) {
+    const conv =
+      readNestedString(metadata, "conversation_id") ??
+      readNestedString(metadata, "conversationId");
+    if (conv) return conv;
+    const userId = readNestedString(metadata, "user_id");
+    if (userId) return userId;
+  }
+
+  return fallback;
+}

--- a/testing-plan.md
+++ b/testing-plan.md
@@ -77,6 +77,73 @@ cd apps/ui && bun run dev
 
 ---
 
+### 1.7 OpenAI + Anthropic Compatibility API
+- [ ] `GET /v1/models` returns a list of models
+- [ ] `POST /v1/chat/completions` returns an OpenAI-shaped response
+- [ ] `POST /v1/chat/completions` supports `stream: true` (SSE)
+- [ ] `POST /v1/messages` returns an Anthropic-shaped response
+- [ ] `POST /v1/messages` supports `stream: true` (SSE)
+
+**How to test**:
+```bash
+# Terminal 1
+bun run start
+
+# If you have MILAIDY_API_TOKEN set, add this to curl:
+#   -H "Authorization: Bearer $MILAIDY_API_TOKEN"
+
+curl -sS http://localhost:2138/v1/models | jq .
+
+curl -sS http://localhost:2138/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "milaidy",
+    "messages": [
+      { "role": "system", "content": "You are a helpful assistant." },
+      { "role": "user", "content": "Say hello in one sentence." }
+    ]
+  }' | jq .
+
+curl -N http://localhost:2138/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "milaidy",
+    "stream": true,
+    "messages": [
+      { "role": "user", "content": "Stream a short haiku." }
+    ]
+  }'
+
+curl -sS http://localhost:2138/v1/messages \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "milaidy",
+    "max_tokens": 256,
+    "system": "You are a helpful assistant.",
+    "messages": [
+      { "role": "user", "content": "What is 2+2?" }
+    ]
+  }' | jq .
+
+curl -N http://localhost:2138/v1/messages \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "milaidy",
+    "stream": true,
+    "max_tokens": 256,
+    "messages": [
+      { "role": "user", "content": "Stream the answer to 2+2." }
+    ]
+  }'
+```
+
+**Expected**:
+- OpenAI route returns `{ id, object, created, model, choices: [...] }`
+- Anthropic route returns `{ id, type: \"message\", role: \"assistant\", content: [{type:\"text\", text:\"...\"}] }`
+- Streaming routes produce `data:` SSE chunks and complete without hanging
+
+---
+
 ## Phase 2: Desktop App Testing (Windows)
 
 ### 2.1 Build Desktop App


### PR DESCRIPTION
Adds OpenAI- and Anthropic-compatible HTTP endpoints to the Milaidy API server.

Endpoints:
- GET /v1/models
- GET /v1/models/:id
- POST /v1/chat/completions (supports stream: true SSE)
- POST /v1/messages (supports stream: true SSE)

Notes:
- Reuses existing chat pipeline and supports cloud proxy + local runtime.
- Adds request parsing utilities + unit tests.
- Documents manual curl testing in testing-plan.md.

Testing:
- bun run check
- bunx vitest run src/api/compat-utils.test.ts