### PR TITLE
fix(ui): prevent duplicate release channel updates

### DIFF
--- a/apps/app/test/app/update-channel-lock.test.ts
+++ b/apps/app/test/app/update-channel-lock.test.ts
@@ -1,0 +1,248 @@
+import React, { useEffect } from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockClient } = vi.hoisted(() => ({
+  mockClient: {
+    hasToken: vi.fn(() => false),
+    getAuthStatus: vi.fn(async () => ({
+      required: false,
+      pairingEnabled: false,
+      expiresAt: null,
+    })),
+    getOnboardingStatus: vi.fn(async () => ({ complete: true })),
+    listConversations: vi.fn(async () => ({
+      conversations: [
+        {
+          id: "conv-1",
+          title: "Chat",
+          roomId: "room-1",
+          createdAt: "2026-02-01T00:00:00.000Z",
+          updatedAt: "2026-02-01T00:00:00.000Z",
+        },
+      ],
+    })),
+    getConversationMessages: vi.fn(async () => ({
+      messages: [
+        {
+          id: "msg-1",
+          role: "assistant",
+          text: "hello",
+          timestamp: Date.now(),
+        },
+      ],
+    })),
+    sendWsMessage: vi.fn(),
+    connectWs: vi.fn(),
+    disconnectWs: vi.fn(),
+    onWsEvent: vi.fn(() => () => {}),
+    getAgentEvents: vi.fn(async () => ({ events: [], latestEventId: null })),
+    getStatus: vi.fn(async () => ({
+      state: "running",
+      agentName: "Milaidy",
+      model: undefined,
+      startedAt: undefined,
+      uptime: undefined,
+    })),
+    getWalletAddresses: vi.fn(async () => null),
+    getConfig: vi.fn(async () => ({})),
+    getCloudStatus: vi.fn(async () => ({ enabled: false, connected: false })),
+    getWorkbenchOverview: vi.fn(async () => ({
+      tasks: [],
+      triggers: [],
+      todos: [],
+    })),
+    setUpdateChannel: vi.fn(async () => ({ channel: "beta" })),
+    getUpdateStatus: vi.fn(async () => ({
+      currentVersion: "0.0.0",
+      channel: "stable",
+      updateAvailable: false,
+      latestVersion: null,
+      lastCheckAt: null,
+      error: null,
+    })),
+  },
+}));
+
+vi.mock("../../src/api-client", () => ({
+  client: mockClient,
+  SkillScanReportSummary: {},
+}));
+
+import { AppProvider, useApp } from "../../src/AppContext";
+
+type ProbeApi = {
+  handleChannelChange: (channel: "stable" | "beta" | "nightly") => Promise<void>;
+};
+
+function Probe(props: { onReady: (api: ProbeApi) => void }) {
+  const { onReady } = props;
+  const app = useApp();
+
+  useEffect(() => {
+    onReady({ handleChannelChange: app.handleChannelChange });
+  }, [app, onReady]);
+
+  return null;
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe("update channel locking", () => {
+  beforeEach(() => {
+    Object.assign(window.location, { protocol: "file:", pathname: "/chat" });
+    Object.assign(window, {
+      setTimeout: globalThis.setTimeout,
+      clearTimeout: globalThis.clearTimeout,
+      setInterval: globalThis.setInterval,
+      clearInterval: globalThis.clearInterval,
+    });
+    Object.assign(document.documentElement, { setAttribute: vi.fn() });
+
+    for (const fn of Object.values(mockClient)) {
+      if (typeof fn === "function" && "mockReset" in fn) {
+        (fn as { mockReset: () => void }).mockReset();
+      }
+    }
+
+    mockClient.hasToken.mockReturnValue(false);
+    mockClient.getAuthStatus.mockResolvedValue({
+      required: false,
+      pairingEnabled: false,
+      expiresAt: null,
+    });
+    mockClient.getOnboardingStatus.mockResolvedValue({ complete: true });
+    mockClient.listConversations.mockResolvedValue({
+      conversations: [
+        {
+          id: "conv-1",
+          title: "Chat",
+          roomId: "room-1",
+          createdAt: "2026-02-01T00:00:00.000Z",
+          updatedAt: "2026-02-01T00:00:00.000Z",
+        },
+      ],
+    });
+    mockClient.getConversationMessages.mockResolvedValue({
+      messages: [
+        {
+          id: "msg-1",
+          role: "assistant",
+          text: "hello",
+          timestamp: Date.now(),
+        },
+      ],
+    });
+    mockClient.sendWsMessage.mockImplementation(() => {});
+    mockClient.connectWs.mockImplementation(() => {});
+    mockClient.disconnectWs.mockImplementation(() => {});
+    mockClient.onWsEvent.mockReturnValue(() => {});
+    mockClient.getAgentEvents.mockResolvedValue({ events: [], latestEventId: null });
+    mockClient.getStatus.mockResolvedValue({
+      state: "running",
+      agentName: "Milaidy",
+      model: undefined,
+      startedAt: undefined,
+      uptime: undefined,
+    });
+    mockClient.getWalletAddresses.mockResolvedValue(null);
+    mockClient.getConfig.mockResolvedValue({});
+    mockClient.getCloudStatus.mockResolvedValue({ enabled: false, connected: false });
+    mockClient.getWorkbenchOverview.mockResolvedValue({
+      tasks: [],
+      triggers: [],
+      todos: [],
+    });
+    mockClient.setUpdateChannel.mockResolvedValue({ channel: "beta" });
+    mockClient.getUpdateStatus.mockResolvedValue({
+      currentVersion: "0.0.0",
+      channel: "stable",
+      updateAvailable: false,
+      latestVersion: null,
+      lastCheckAt: null,
+      error: null,
+    });
+  });
+
+  it("allows only one same-tick update channel request", async () => {
+    const deferred = createDeferred<{ channel: string }>();
+    mockClient.setUpdateChannel.mockReturnValue(deferred.promise);
+
+    let api: ProbeApi | null = null;
+    let tree: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      tree = TestRenderer.create(
+        React.createElement(
+          AppProvider,
+          null,
+          React.createElement(Probe, {
+            onReady: (nextApi) => {
+              api = nextApi;
+            },
+          }),
+        ),
+      );
+    });
+
+    expect(api).not.toBeNull();
+
+    await act(async () => {
+      void api!.handleChannelChange("beta");
+      void api!.handleChannelChange("beta");
+    });
+
+    expect(mockClient.setUpdateChannel).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      deferred.resolve({ channel: "beta" });
+      await deferred.promise;
+    });
+
+    await act(async () => {
+      tree!.unmount();
+    });
+  });
+
+  it("releases lock after failed update channel change so retry can run", async () => {
+    mockClient.setUpdateChannel
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockRejectedValueOnce(new Error("boom-2"));
+
+    let api: ProbeApi | null = null;
+    let tree: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      tree = TestRenderer.create(
+        React.createElement(
+          AppProvider,
+          null,
+          React.createElement(Probe, {
+            onReady: (nextApi) => {
+              api = nextApi;
+            },
+          }),
+        ),
+      );
+    });
+
+    expect(api).not.toBeNull();
+
+    await act(async () => {
+      await api!.handleChannelChange("beta");
+    });
+    await act(async () => {
+      await api!.handleChannelChange("beta");
+    });
+
+    expect(mockClient.setUpdateChannel).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      tree!.unmount();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Prevent duplicate release-channel update requests caused by same-tick double submits in settings.

## What changed
- Added a synchronous lock (`updateChannelSavingRef`) in `handleChannelChange`.
- Guard now blocks duplicate requests before React state updates settle.
- Lock and UI saving state are released in `finally` on success and failure.
- Added regression tests for:
  - same-tick duplicate channel changes (single backend call)
  - lock release after failure (retry allowed)

## Files changed
- `apps/app/src/AppContext.tsx`
- `apps/app/test/app/update-channel-lock.test.ts`

## Tests
- `bun x vitest run --config apps/app/vitest.config.ts apps/app/test/app/update-channel-lock.test.ts apps/app/test/app/wallet-api-save-lock.test.ts apps/app/test/app/pairing-lock.test.ts`
