### PR TITLE
fix(release): make electron sync script cross-platform

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -21,7 +21,7 @@
     "cap:sync": "capacitor sync",
     "cap:sync:ios": "capacitor sync ios",
     "cap:sync:android": "capacitor sync android",
-    "cap:sync:electron": "../../scripts/rt.sh run sync:electron:web-assets",
+    "cap:sync:electron": "node scripts/sync-electron-web-assets.mjs",
     "cap:open:ios": "capacitor open ios",
     "cap:open:android": "capacitor open android",
     "cap:open:electron": "capacitor open @capacitor-community/electron"


### PR DESCRIPTION
Windows release job failed at Electron sync because the apps/app script cap:sync:electron used ../../scripts/rt.sh, which is not invokable in the Windows bash runner.\n\nThis switches the script to call node scripts/sync-electron-web-assets.mjs directly so release sync works cross-platform.