### PR TITLE
fix: reset CloudManager status on connection failure

### DIFF
--- a/src/cloud/cloud-manager.ts
+++ b/src/cloud/cloud-manager.ts
@@ -54,8 +54,15 @@ export class CloudManager {
     this.setStatus("connecting");
     this.activeAgentId = agentId;
 
-    await this.client.provision(agentId);
-    const agent = await this.client.getAgent(agentId);
+    let agent: Awaited<ReturnType<ElizaCloudClient["getAgent"]>>;
+    try {
+      await this.client.provision(agentId);
+      agent = await this.client.getAgent(agentId);
+    } catch (err) {
+      this.activeAgentId = null;
+      this.setStatus("error");
+      throw err;
+    }
 
     this.proxy = new CloudRuntimeProxy(this.client, agentId, agent.agentName);
 


### PR DESCRIPTION
## Summary
- Wraps `provision()` and `getAgent()` in `CloudManager.connect()` with try-catch
- On failure, resets `activeAgentId` to null and sets status to `"error"` before re-throwing
- Without this fix, a failed connection attempt leaves the manager permanently stuck in `"connecting"` state with a stale agent ID and no way to recover

Closes #200

## Test plan
- [x] All 1033 unit tests pass
- [x] All 327 e2e tests pass
- [x] Reconnect monitor tests (6/6) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)