### PR TITLE
fix: prevent corrupt config from crashing CLI via update-notifier

### DIFF
--- a/src/services/update-notifier.ts
+++ b/src/services/update-notifier.ts
@@ -13,7 +13,12 @@ export function scheduleUpdateNotification(): void {
   if (notified) return;
   notified = true;
 
-  const config = loadMilaidyConfig();
+  let config: ReturnType<typeof loadMilaidyConfig>;
+  try {
+    config = loadMilaidyConfig();
+  } catch {
+    return;
+  }
   if (config.update?.checkOnStart === false) return;
   if (process.env.CI || !process.stderr.isTTY) return;
 


### PR DESCRIPTION
## Summary
- Wraps `loadMilaidyConfig()` call in `scheduleUpdateNotification()` with try-catch
- If `~/.milaidy/milaidy.json` contains invalid JSON5, the fire-and-forget update notifier now silently bails out instead of propagating a `SyntaxError` through the preaction hook
- Without this fix, a corrupt config file crashes **every** CLI command (even unrelated ones like `milaidy start`) before it can execute

Closes #210

## Test plan
- [x] All 1033 unit tests pass (including 11 update-notifier tests)
- [x] All 327 e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)