### PR TITLE
fix(api): enforce plugin config key allowlist

### DIFF
--- a/src/api/plugin-validation.test.ts
+++ b/src/api/plugin-validation.test.ts
@@ -264,6 +264,26 @@ describe("validatePluginConfig", () => {
       );
       expect(result.valid).toBe(true);
     });
+
+    it("rejects undeclared keys even when all declared fields are valid", () => {
+      const result = validatePluginConfig(
+        "discord",
+        "connector",
+        "DISCORD_API_TOKEN",
+        ["DISCORD_API_TOKEN", "DISCORD_APPLICATION_ID", "CHANNEL_IDS"],
+        {
+          DISCORD_API_TOKEN: "MTE1MDY2NjQwOTA3MTQzODg5MA.token",
+          DISCORD_APPLICATION_ID: "1150666409071438890",
+          UNDECLARED_KEY: "x",
+        },
+        discordParams,
+      );
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual({
+        field: "UNDECLARED_KEY",
+        message: "UNDECLARED_KEY is not a declared config key for this plugin",
+      });
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/src/api/plugin-validation.ts
+++ b/src/api/plugin-validation.ts
@@ -83,12 +83,26 @@ export function validatePluginConfig(
   _pluginId: string,
   _category: string,
   envKey: string | null,
-  _configKeys: string[],
+  configKeys: string[],
   providedConfig?: Record<string, string>,
   paramDefs?: PluginParamInfo[],
 ): PluginValidationResult {
   const errors: Array<{ field: string; message: string }> = [];
   const warnings: Array<{ field: string; message: string }> = [];
+  const normalizedConfigKeys = new Set(
+    configKeys.map((key) => key.trim().toUpperCase()),
+  );
+
+  if (providedConfig) {
+    for (const key of Object.keys(providedConfig)) {
+      if (!normalizedConfigKeys.has(key.trim().toUpperCase())) {
+        errors.push({
+          field: key,
+          message: `${key} is not a declared config key for this plugin`,
+        });
+      }
+    }
+  }
 
   // ── Check all required parameters ─────────────────────────────────────
   if (paramDefs && paramDefs.length > 0) {

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -5911,7 +5911,7 @@ async function handleRequest(
         pluginId,
         plugin.category,
         plugin.envKey,
-        Object.keys(body.config),
+        plugin.configKeys,
         body.config,
         submittedParamInfos,
       );


### PR DESCRIPTION
## Summary
Prevent plugin config updates from accepting undeclared config keys during `PUT /api/plugins/:id`.

## What changed
- Enforced declared config key allowlist in `validatePluginConfig()` using `configKeys`.
- `server.ts` now passes plugin-declared `configKeys` to validation for config mutations.
- Added regression test for unknown key rejection.

## Files changed
- `src/api/plugin-validation.ts`
- `src/api/server.ts`
- `src/api/plugin-validation.test.ts`

## Tests
- `bun x vitest run src/api/plugin-validation.test.ts`
