### PR TITLE
fix: align deps with @elizaos/core 2.0.0-alpha.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "typecheck": "bunx tsc --noEmit"
   },
   "dependencies": {
-    "@clack/prompts": "^0.12.0",
+    "@clack/prompts": "^1.0.0",
     "@elizaos/core": "2.0.0-alpha.4",
     "@elizaos/plugin-google-genai": "2.0.0-alpha.4",
     "@elizaos/plugin-knowledge": "2.0.0-alpha.4",

--- a/src/runtime/milaidy-plugin.ts
+++ b/src/runtime/milaidy-plugin.ts
@@ -20,10 +20,7 @@ import type {
   State,
 } from "@elizaos/core";
 import {
-  attachmentsProvider,
   createUniqueUuid,
-  entitiesProvider,
-  factsProvider,
   getSessionProviders,
   resolveDefaultSessionStorePath,
 } from "@elizaos/core";
@@ -178,12 +175,8 @@ export function createMilaidyPlugin(config?: MilaidyPluginConfig): Plugin {
     ...getSessionProviders({ storePath: sessionStorePath }),
   ];
 
-  // Optionally add bootstrap providers (can be heavy for small context windows)
-  const bootstrapProviders = enableBootstrap
-    ? [attachmentsProvider, entitiesProvider, factsProvider].filter(
-        (provider): provider is Provider => Boolean(provider),
-      )
-    : [];
+  // Bootstrap providers were removed from @elizaos/core 2.0.0-alpha.4
+  const bootstrapProviders: Provider[] = [];
 
   // UI catalog provider — injects component knowledge so the agent can
   // generate UiSpec JSON and [CONFIG:pluginId] markers in responses.


### PR DESCRIPTION
## Summary
- Fix `@clack/prompts` version in package.json (`^0.12.0` → `^1.0.0`) — no such version exists on npm, lockfile already had `^1.0.0`
- Remove `attachmentsProvider`, `entitiesProvider`, `factsProvider` imports from `milaidy-plugin.ts` — dropped in `@elizaos/core@2.0.0-alpha.4`, causing a startup crash

## Test plan
- [ ] `bun install` succeeds without resolution errors
- [ ] `bun run src/entry.ts start` launches the API server without import errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)