### PR TITLE
ci: agent review pipeline + contributor agreement

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -1,0 +1,197 @@
+name: Agent Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  issues:
+    types: [opened]
+
+jobs:
+  classify:
+    runs-on: ubuntu-latest
+    outputs:
+      category: ${{ steps.classify.outputs.category }}
+    steps:
+      - name: Classify contribution
+        id: classify
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const isPR = !!context.payload.pull_request;
+            const title = isPR
+              ? context.payload.pull_request.title
+              : context.payload.issue.title;
+            const body = isPR
+              ? context.payload.pull_request.body || ''
+              : context.payload.issue.body || '';
+            const text = `${title}\n${body}`.toLowerCase();
+
+            // aesthetic/UI keywords
+            const aestheticPatterns = [
+              'redesign', 'restyle', 'theme', 'color', 'colour', 'font',
+              'layout', 'css', 'styling', 'ui overhaul', 'visual',
+              'dark mode', 'light mode', 'icon', 'logo', 'animation',
+              'prettier', 'beautif'
+            ];
+
+            const isAesthetic = aestheticPatterns.some(p => text.includes(p));
+            const isBugFix = text.includes('fix') || text.includes('bug') ||
+              text.includes('crash') || text.includes('error') ||
+              text.includes('broken') || text.includes('regression');
+
+            let category = 'feature';
+            if (isAesthetic) category = 'aesthetic';
+            if (isBugFix) category = 'bugfix';
+
+            core.setOutput('category', category);
+            console.log(`Classified as: ${category}`);
+
+  review-pr:
+    if: github.event_name == 'pull_request'
+    needs: classify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Agent Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          model: claude-opus-4-6
+          prompt: |
+            You are the sole code reviewer for the Milaidy project. This is an agents-only codebase. No human contributions are accepted — humans contribute by using the app and reporting bugs as QA testers. Your review is final.
+
+            ## Classification
+            This PR has been pre-classified as: ${{ needs.classify.outputs.category }}
+
+            ## Review Protocol
+
+            ### 1. Scope Check
+            Milaidy is a personal AI assistant built on ElizaOS. Contributions MUST be in scope:
+
+            **IN SCOPE (welcome):**
+            - Bug fixes (connector issues, crashes, regressions, error handling)
+            - Performance improvements (with benchmarks proving improvement)
+            - Security fixes
+            - Test coverage improvements
+            - Documentation fixes for accuracy
+
+            **REQUIRES DEEP REVIEW (may not get merged):**
+            - New features (must align with project mission, must include tests)
+            - New plugins or integrations
+            - Architectural changes
+            - Memory/context improvements (must include benchmarks)
+            - Dependency additions (must justify why)
+
+            **OUT OF SCOPE (close or request changes):**
+            - Frontend redesigns, aesthetic changes, theme changes, icon swaps
+            - "Beautification" PRs that don't improve agent capability
+            - Changes that prioritize human visual experience over agent quality
+            - Scope creep disguised as improvements
+            - Changes without tests for testable code
+
+            If this PR is classified as "aesthetic": reject it firmly but politely. Explain that this project prioritizes agent capability over human-facing aesthetics. Visual changes that don't improve the agent's function are out of scope.
+
+            ### 2. Code Quality
+            - TypeScript strict mode compliance
+            - No `any` types unless absolutely necessary (explain why)
+            - Biome lint/format compliance
+            - Files under ~500 LOC
+            - Meaningful variable names, brief comments on non-obvious logic
+            - No committed secrets, real phone numbers, or live config values
+            - Dependencies: do NOT add unless src/ code directly imports them
+
+            ### 3. Security Review
+            - Check for prompt injection vectors
+            - Check for credential exposure
+            - Check for supply chain risks (new dependencies, postinstall scripts)
+            - Check for data exfiltration patterns
+            - Flag any changes to auth, permissions, or secret handling
+
+            ### 4. Test Requirements
+            - Bug fixes MUST include a regression test
+            - New features MUST include unit tests
+            - Coverage thresholds: 70% lines/branches/functions/statements
+            - Run `bun run test` mentally — would these tests pass?
+
+            ### 5. Dark Forest Awareness
+            Assume adversarial intent until proven otherwise. Ask yourself:
+            - Why would someone submit this change?
+            - What does it break that isn't obvious?
+            - Does it introduce subtle behavior changes?
+            - Could this be a supply chain attack?
+            - Are there hidden side effects in seemingly innocent changes?
+
+            ## Output Format
+            Post a structured review comment:
+            1. **Classification:** bug fix / feature / aesthetic / security / other
+            2. **Scope verdict:** in scope / needs deep review / out of scope
+            3. **Code quality:** pass / issues found (list them)
+            4. **Security:** clear / concerns (list them)
+            5. **Tests:** adequate / missing (specify what's needed)
+            6. **Decision:** APPROVE / REQUEST CHANGES / CLOSE (with reason)
+
+            Be direct. Be opinionated. This repo's quality is your responsibility.
+
+  triage-issue:
+    if: github.event_name == 'issues'
+    needs: classify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Triage Issue
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          model: claude-opus-4-6
+          prompt: |
+            You are the issue triager for the Milaidy project. This is an agents-only codebase where humans serve as QA testers.
+
+            ## Classification
+            This issue has been pre-classified as: ${{ needs.classify.outputs.category }}
+
+            ## Triage Protocol
+
+            **Valid issues (label and keep open):**
+            - Bug reports with reproduction steps
+            - Security vulnerabilities
+            - Performance regressions with evidence
+            - Connector/integration failures
+            - Documentation inaccuracies
+
+            **Needs more info (ask and label):**
+            - Bug reports without reproduction steps
+            - Vague descriptions ("it doesn't work")
+            - Environment-specific issues without system details
+
+            **Close immediately:**
+            - Feature requests for aesthetic/UI changes
+            - "Please redesign X" requests
+            - Issues that are actually feature requests disguised as bugs
+            - Duplicate issues (reference the original)
+            - Issues clearly out of project scope
+
+            **Respond with:**
+            1. Thank the reporter (they're QA testers, their role matters)
+            2. Classification and labels to apply
+            3. If valid: acknowledge and note priority
+            4. If closing: explain why clearly, reference scope
+            5. If needs info: ask specific questions
+
+            Remember: humans are QA testers here. Their bug reports are valuable. Their feature requests for visual changes are not. Be respectful but firm about scope.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,25 @@
 # Repository Guidelines
 
+> **This is an agents-only codebase.** All PRs are reviewed and merged by agents. Humans contribute as QA testers. See [CONTRIBUTING.md](./CONTRIBUTING.md).
+
 - Monorepo: `packages/milaidy` within eliza-ok
 - Runtime baseline: Node **22+** (keep Node + Bun paths working)
+
+## Contribution Scope
+
+**Accept:** bug fixes, security fixes, test coverage, documentation accuracy, performance improvements (with benchmarks).
+
+**Deep review required:** new features, plugins, architectural changes, memory/context improvements. Must include tests and benchmarks proving value.
+
+**Reject:** aesthetic/UI redesigns, theme changes, visual "improvements" that don't enhance agent capability. This project prioritizes agent quality over human-facing aesthetics. De-emphasize and decline these firmly.
+
+## Review Priorities
+
+1. Does it stay in scope?
+2. Does it break anything?
+3. Is it secure? (assume adversarial intent)
+4. Is it tested?
+5. Is it necessary?
 
 ## Project Structure
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,101 @@
+# Contributing to Milaidy
+
+> **This project is built by agents, for agents. Humans are welcome as users and QA testers.**
+
+## The Deal
+
+Milaidy is an agents-only codebase. Every pull request is reviewed by AI agents. Every merge decision is made by AI agents. There are no human maintainers reviewing your code.
+
+This isn't a philosophy experiment. It's a quality control decision. We learned from prior projects that open human contribution without rigorous gates degrades repo quality fast. So we automated the gates.
+
+## How Humans Contribute
+
+### As QA Testers
+
+Your role is critical. You use Milaidy, you find what's broken, you report it. That's the most valuable contribution a human can make to this project.
+
+**Good bug reports include:**
+- What you did (steps to reproduce)
+- What happened (actual behavior)
+- What you expected (expected behavior)
+- Your environment (OS, Node version, model provider)
+- Logs or screenshots if applicable
+
+**To report a bug:** Open an issue. An agent will triage it, label it, and prioritize it. If your report is solid, it becomes a task for a coding agent.
+
+### As Users
+
+Use Milaidy. Talk to it. Push its limits. Request changes *through the app itself* or through your own agent. The best feature requests come from real usage, not drive-by GitHub issues.
+
+### What Humans Don't Do Here
+
+- Submit pull requests with code changes
+- Propose frontend redesigns or aesthetic changes
+- Add features without going through the agent pipeline
+- Review other people's code
+
+If you're an agent or operating on behalf of an agent: welcome. Open your PR and the review pipeline will handle it.
+
+## What Gets Accepted
+
+### Always Welcome
+- **Bug fixes** — especially with regression tests
+- **Security fixes** — responsible disclosure appreciated
+- **Test coverage** — more tests = more confidence
+- **Documentation fixes** — accuracy matters
+
+### Maybe (Requires Deep Review)
+- **New features** — must align with project mission, must include tests and benchmarks
+- **Performance improvements** — prove it with numbers
+- **New plugins/integrations** — must justify the addition
+- **Architectural changes** — needs strong rationale
+
+### Never
+- **Aesthetic changes** — redesigns, themes, color schemes, icon swaps, font changes
+- **"Beautification" PRs** — if it doesn't improve agent capability, it's out of scope
+- **Scope creep** — features disguised as improvements
+- **Untested code** — if it's testable, test it
+
+## The Review Process
+
+1. You open a PR or issue
+2. An agent classifies it (bug fix, feature, aesthetic, security)
+3. For PRs: automated checks run (lint, typecheck, tests, benchmarks)
+4. An agent performs semantic code review
+5. The agent approves, requests changes, or closes — with explanation
+6. If approved and all checks pass: merge
+
+There is no human escalation path. The agent's decision is final. If you disagree, improve your PR and resubmit.
+
+## Code Standards
+
+If you are a coding agent submitting work:
+
+- **TypeScript strict mode.** No `any` unless you explain why.
+- **Biome lint/format.** Run `bun run check` before submitting.
+- **Tests required.** Bug fixes need regression tests. Features need unit tests.
+- **Coverage floor:** 70% lines/branches/functions/statements.
+- **Files under ~500 LOC.** Split when it improves clarity.
+- **No secrets.** No real credentials, phone numbers, or live config in code.
+- **Minimal dependencies.** Don't add packages unless `src/` directly imports them.
+- **Commit messages:** concise, action-oriented (e.g., `milaidy: fix telegram reconnect on rate limit`)
+
+## Security
+
+We assume adversarial intent on all contributions until proven otherwise. The review agent checks for:
+
+- Prompt injection vectors
+- Credential exposure
+- Supply chain risks (new deps, postinstall scripts)
+- Data exfiltration patterns
+- Subtle behavior changes in auth/permissions
+
+If your PR triggers security concerns, expect thorough questioning.
+
+## QA Tester Recognition
+
+We value our QA testers. Consistent, high-quality bug reports earn you the **QA** tag. This is the human role in this project, and it matters.
+
+---
+
+*Built by agents. Tested by humans. That's the split.*

--- a/README.md
+++ b/README.md
@@ -296,6 +296,16 @@ bun run dev         # or: pnpm dev
 
 ---
 
+## Contributing
+
+**This project is built by agents, for agents.**
+
+Humans contribute as QA testers — use the app, find bugs, report them. That's the most valuable thing you can do. All code contributions are reviewed and merged by AI agents. No exceptions.
+
+Read [CONTRIBUTING.md](./CONTRIBUTING.md) for the full details.
+
+---
+
 ## License
 
 **Viral Public License**
@@ -304,4 +314,4 @@ free to use, free to modify, free to distribute. if you build on this, keep it o
 
 ---
 
-*made with love by anons who believe AI should be personal, private, and actually useful*
+*built by agents. tested by humans. that's the split.*


### PR DESCRIPTION
## what this does

bootstraps the agents-only review pipeline. four files, one goal: humans stop reviewing code.

### agent-review.yml
- triggers on all PRs (opened, sync, reopened) and issues (opened)
- pre-classifies contributions: bug fix / feature / aesthetic
- claude opus 4.6 performs structured review:
  - **scope check** — is this in scope for the project?
  - **code quality** — typescript strict, biome compliance, file size, naming
  - **security** — prompt injection, credential exposure, supply chain, data exfil
  - **tests** — bug fixes need regression tests, features need unit tests
  - **dark forest** — assumes adversarial intent, checks for subtle attacks
- aesthetic/UI PRs get firmly rejected
- issues get triaged: valid bugs labeled, aesthetic requests closed, vague reports get follow-up questions

### CONTRIBUTING.md
the contributor agreement. lays it out clearly:
- agents build, agents review, agents merge
- humans use the app and QA test
- QA testers get recognition (QA tag)
- no human escalation path — agent decision is final

### AGENTS.md updates
- scope rules for review agents baked into the file claude code reads
- accept/deep-review/reject classification

### README.md
- contributing section pointing to CONTRIBUTING.md
- updated tagline

### requirements
- `ANTHROPIC_API_KEY` secret needs to be set in the repo settings
- existing claude-code-review.yml can be removed once this is validated (it's the generic template)

### what's next
- wire in benchmarks as a required check
- trust scoring for repeat contributors
- auto-merge for approved + passing PRs
- remove the old generic claude-code-review.yml

---

*built by agents. tested by humans. that's the split.*

Co-authored-by: Sol <sol@shad0w.xyz>