### PR TITLE
docs: SCOPE.md, PR template, and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,91 @@
+name: Bug Report
+description: Report a bug you found while using Milaidy
+labels: ["bug", "triage"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened?
+      placeholder: Describe the issue you encountered.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps_to_reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Numbered steps to reproduce
+      placeholder: |
+        1. Go to ...
+        2. Click on ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected Behavior
+      description: What should have happened?
+      placeholder: Describe the expected result.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual_behavior
+    attributes:
+      label: Actual Behavior
+      description: What actually happened?
+      placeholder: Describe the actual result.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Environment
+      description: Select your operating system.
+      options:
+        - macOS
+        - Windows
+        - Linux
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: node_version
+    attributes:
+      label: Node Version
+      description: e.g. 22.x
+      placeholder: 22.x
+    validations:
+      required: false
+
+  - type: input
+    id: model_provider
+    attributes:
+      label: Model Provider
+      description: e.g. Anthropic, OpenAI, Ollama
+      placeholder: Anthropic / OpenAI / Ollama
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Relevant error output or logs
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable
+      placeholder: Add screenshots, screen recordings, or links here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Feature Requests
+    url: https://github.com/milady-ai/milaidy/discussions
+    about: Feature requests should be discussed, not filed as issues. Aesthetic/UI change requests are out of scope.

--- a/.github/ISSUE_TEMPLATE/qa_report.yml
+++ b/.github/ISSUE_TEMPLATE/qa_report.yml
@@ -1,0 +1,77 @@
+name: QA Report
+description: Structured QA feedback from testers
+labels: ["qa", "triage"]
+body:
+  - type: textarea
+    id: test_scenario
+    attributes:
+      label: Test Scenario
+      description: What were you testing?
+      placeholder: Describe the feature, flow, or bugfix under test.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps_performed
+    attributes:
+      label: Steps Performed
+      description: What did you do?
+      placeholder: |
+        1. Opened ...
+        2. Configured ...
+        3. Verified ...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: result
+    attributes:
+      label: Result
+      options:
+        - Pass
+        - Fail
+        - Partial
+    validations:
+      required: true
+
+  - type: textarea
+    id: details
+    attributes:
+      label: Details
+      description: What worked, what didn't?
+      placeholder: Include observations, edge cases, and notable behavior.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Environment
+      description: Select your operating system.
+      options:
+        - macOS
+        - Windows
+        - Linux
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - Critical
+        - High
+        - Medium
+        - Low
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots_or_logs
+    attributes:
+      label: Screenshots or Logs
+      placeholder: Attach screenshots, logs, or other evidence if available.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+This PR will be reviewed by an AI agent. Provide clear context to help it assess your changes.
+
+Aesthetic/UI changes that don't improve agent capability are out of scope and will be rejected.
+
+## Category
+- [ ] Bug fix
+- [ ] Security fix
+- [ ] Performance improvement
+- [ ] New feature
+- [ ] Documentation
+- [ ] Test coverage
+- [ ] Other
+
+## What
+(brief description)
+
+## Why
+(motivation)
+
+## How
+(implementation approach)
+
+## Testing
+(what was tested, how to verify)

--- a/SCOPE.md
+++ b/SCOPE.md
@@ -1,0 +1,36 @@
+# Milaidy Project Scope
+
+## Project Mission
+Milaidy is a personal AI assistant built on ElizaOS. It runs locally, respects privacy, and connects to messaging platforms. The goal is agent capability, not human aesthetics.
+
+## In Scope (always welcome)
+- Bug fixes (especially connector issues, crashes, regressions)
+- Security fixes and hardening
+- Test coverage improvements
+- Performance improvements (must include benchmarks)
+- Documentation accuracy fixes
+- Error handling improvements
+- Logging and observability improvements
+
+## Deep Review Required (may not merge)
+- New features (must align with mission, include tests)
+- New plugins or integrations (must justify why)
+- Architectural changes (needs strong rationale + migration plan)
+- Memory/context system changes (must benchmark before/after)
+- Dependency additions (justify necessity, check supply chain)
+- API changes (backward compatibility required)
+
+## Out of Scope (reject)
+- Frontend redesigns, theme changes, color schemes, icon/font swaps
+- "Beautification" PRs that don't improve agent capability
+- Aesthetic changes to human-facing UI that don't affect agent function
+- Scope creep disguised as "improvements"
+- Changes without tests for testable code
+- PRs that add dependencies without `src/` directly importing them
+
+## Anti-patterns to watch for
+- Large PRs that bundle unrelated changes (ask to split)
+- "Refactoring" that changes behavior without tests
+- New dependencies with postinstall scripts
+- Changes to auth/permissions/secrets without security review
+- Subtle changes to prompt templates or system messages


### PR DESCRIPTION
## what

builds on #220 (agent review pipeline). gives the review agent teeth and gives QA testers structure.

### SCOPE.md
codified project scope the review agent references. no more vibes:
- **in scope:** bug fixes, security, tests, perf, docs, error handling, observability
- **deep review:** new features, plugins, arch changes, memory system, deps, API changes
- **out of scope:** aesthetic/UI, beautification, scope creep, untested code
- **anti-patterns:** bundled PRs, untested refactors, postinstall scripts, prompt template changes

### PR template
structured format so the review agent gets what it needs:
- category checkboxes (bug/security/perf/feature/docs/tests)
- required sections: what, why, how, testing
- scope reminder at the top

### issue templates (github forms)
- **bug_report.yml:** structured bug reports — description, repro steps, expected/actual, env, logs, screenshots
- **qa_report.yml:** QA tester reports — scenario, steps, pass/fail/partial, severity, details
- **config.yml:** blank issues disabled, feature requests redirected to discussions

### why
- the review agent needs SCOPE.md to make consistent accept/reject decisions
- QA testers need structured templates to file useful reports
- feature requests as issues create noise — discussions are the right place

all additive. 5 new files, zero modifications.

Co-authored-by: Sol <sol@shad0w.xyz>