### PR TITLE
fix: gate auto-merge on actual review verdict

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -55,6 +55,10 @@ jobs:
     if: github.event_name == 'pull_request_target'
     needs: classify
     runs-on: ubuntu-latest
+    outputs:
+      verdict: ${{ steps.extract-verdict.outputs.verdict }}
+      decision: ${{ steps.extract-verdict.outputs.decision }}
+      decision_comment_url: ${{ steps.extract-verdict.outputs.decision_comment_url }}
     permissions:
       contents: read
       pull-requests: write
@@ -76,6 +80,8 @@ jobs:
           fi
 
       - name: Agent Review
+        id: claude-review
+        continue-on-error: false
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -161,20 +167,123 @@ jobs:
 
             Be direct. Be opinionated. This repo's quality is your responsibility.
 
+      - name: Extract Claude decision from PR comments
+        id: extract-verdict
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.payload.pull_request.number;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            // Prefer bot-authored comments first, then fall back to any matching comment.
+            const decisionPattern = /(?:^|\n)\s*(?:\d+\.\s*)?\*\*?Decision:\*\*?\s*(APPROVE|REQUEST CHANGES|CLOSE)\b/i;
+            const structuredPattern = /\*\*?Classification:|\*\*?Scope verdict:|\*\*?Code quality:/i;
+
+            const findLatest = (items) => {
+              const filtered = items.filter((c) => {
+                if (!c?.body) return false;
+                if (!decisionPattern.test(c.body)) return false;
+                return structuredPattern.test(c.body);
+              });
+              return filtered.sort((a, b) =>
+                new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+              )[0];
+            };
+
+            const botComments = comments.filter((c) => c.user?.type === 'Bot');
+            const latest = findLatest(botComments) || findLatest(comments);
+
+            let verdict = 'reject';
+            let decision = 'REQUEST CHANGES';
+            let decisionCommentUrl = '';
+
+            if (latest) {
+              const match = latest.body.match(decisionPattern);
+              const normalized = (match?.[1] || '').toUpperCase();
+              decision = normalized || decision;
+              decisionCommentUrl = latest.html_url || '';
+
+              if (normalized === 'APPROVE') {
+                verdict = 'approve';
+              } else if (normalized === 'CLOSE') {
+                verdict = 'close';
+              } else {
+                verdict = 'reject';
+              }
+            } else {
+              core.warning('No structured Claude decision comment found. Treating as reject.');
+            }
+
+            core.setOutput('verdict', verdict);
+            core.setOutput('decision', decision);
+            core.setOutput('decision_comment_url', decisionCommentUrl);
+
+            core.summary
+              .addHeading('Agent review decision gate')
+              .addRaw(`- Verdict: ${verdict}\n`)
+              .addRaw(`- Decision: ${decision}\n`)
+              .addRaw(`- Decision comment: ${decisionCommentUrl || 'not found'}\n`)
+              .write();
+
+            console.log(`Verdict parsed from PR comments: ${verdict} (${decision})`);
+
   auto-merge:
     name: Auto-merge approved PRs
     needs: [classify, review-pr]
-    if: needs.review-pr.result == 'success' && github.event_name == 'pull_request_target'
+    if: github.event_name == 'pull_request_target' && needs.review-pr.result == 'success' && needs.review-pr.outputs.verdict == 'approve'
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
     steps:
       - name: Enable auto-merge
-        run: gh pr merge ${{ github.event.pull_request.number }} --auto --squash
+        run: |
+          method="${MERGE_METHOD:-squash}"
+          case "$method" in
+            merge|squash|rebase) ;;
+            *)
+              echo "Invalid AGENT_REVIEW_MERGE_METHOD='$method', defaulting to 'squash'"
+              method="squash"
+              ;;
+          esac
+
+          echo "Enabling auto-merge using '$method' method"
+          gh pr merge ${{ github.event.pull_request.number }} --auto --"$method"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
+          MERGE_METHOD: ${{ vars.AGENT_REVIEW_MERGE_METHOD }}
+
+  close-pr:
+    name: Close PRs with CLOSE verdict
+    needs: [review-pr]
+    if: github.event_name == 'pull_request_target' && needs.review-pr.result == 'success' && needs.review-pr.outputs.verdict == 'close'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Close PR after agent verdict
+        run: |
+          comment="Closing this pull request because the automated agent review decision was **CLOSE**."
+          if [ -n "${DECISION_COMMENT_URL}" ]; then
+            comment="$comment\n\nDecision source: ${DECISION_COMMENT_URL}"
+          fi
+
+          gh pr close ${{ github.event.pull_request.number }} --comment "$comment"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          DECISION_COMMENT_URL: ${{ needs.review-pr.outputs.decision_comment_url }}
 
   triage-issue:
     if: github.event_name == 'issues'

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -177,16 +177,13 @@ jobs:
             const repo = context.repo.repo;
             const issue_number = context.payload.pull_request.number;
 
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
-              issue_number,
-              per_page: 100,
-            });
-
             // Prefer bot-authored comments first, then fall back to any matching comment.
             const decisionPattern = /(?:^|\n)\s*(?:\d+\.\s*)?\*\*?Decision:\*\*?\s*(APPROVE|REQUEST CHANGES|CLOSE)\b/i;
             const structuredPattern = /\*\*?Classification:|\*\*?Scope verdict:|\*\*?Code quality:/i;
+            const maxAttempts = 6; // ~60s total with a 10s interval
+            const pollIntervalMs = 10_000;
+
+            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
             const findLatest = (items) => {
               const filtered = items.filter((c) => {
@@ -199,8 +196,31 @@ jobs:
               )[0];
             };
 
-            const botComments = comments.filter((c) => c.user?.type === 'Bot');
-            const latest = findLatest(botComments) || findLatest(comments);
+            let latest = null;
+            let attemptUsed = 1;
+
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+              attemptUsed = attempt;
+
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number,
+                per_page: 100,
+              });
+
+              const botComments = comments.filter((c) => c.user?.type === 'Bot');
+              latest = findLatest(botComments) || findLatest(comments);
+
+              if (latest) {
+                break;
+              }
+
+              if (attempt < maxAttempts) {
+                console.log(`Structured decision comment not found yet (attempt ${attempt}/${maxAttempts}); waiting ${pollIntervalMs / 1000}s...`);
+                await sleep(pollIntervalMs);
+              }
+            }
 
             let verdict = 'reject';
             let decision = 'REQUEST CHANGES';
@@ -220,7 +240,7 @@ jobs:
                 verdict = 'reject';
               }
             } else {
-              core.warning('No structured Claude decision comment found. Treating as reject.');
+              core.warning(`No structured Claude decision comment found after ${attemptUsed} attempts. Treating as reject.`);
             }
 
             core.setOutput('verdict', verdict);
@@ -229,6 +249,7 @@ jobs:
 
             core.summary
               .addHeading('Agent review decision gate')
+              .addRaw(`- Poll attempts used: ${attemptUsed}\n`)
               .addRaw(`- Verdict: ${verdict}\n`)
               .addRaw(`- Decision: ${decision}\n`)
               .addRaw(`- Decision comment: ${decisionCommentUrl || 'not found'}\n`)


### PR DESCRIPTION
## Summary
Fixes a critical logic bug in `.github/workflows/agent-review.yml` where PRs were auto-merged whenever `review-pr` *completed successfully*, even if Claude's verdict was `REQUEST CHANGES` or `CLOSE`.

## Root cause
`anthropics/claude-code-action` exits with status 0 when the action runs successfully, regardless of the review decision. We were gating on job success instead of the review verdict.

## What changed
- Added explicit review step guardrails:
  - `continue-on-error: false` on the Claude review step.
- Added a post-review verdict extraction step (`actions/github-script`):
  - Reads PR comments.
  - Finds the latest structured Claude review comment.
  - Parses `Decision: APPROVE | REQUEST CHANGES | CLOSE`.
  - Exposes machine-readable outputs from `review-pr`:
    - `verdict` (`approve|reject|close`)
    - `decision`
    - `decision_comment_url`
- Updated `auto-merge` job gating:
  - Now requires `needs.review-pr.outputs.verdict == 'approve'`.
  - Still requires `review-pr` job success.
- Added configurable merge method for auto-merge:
  - Uses `vars.AGENT_REVIEW_MERGE_METHOD` (`merge|squash|rebase`).
  - Falls back to `squash` if unset/invalid.
- Added `close-pr` job:
  - Runs only when `verdict == 'close'`.
  - Closes the PR and leaves a short explanation with a link to the decision comment when available.

## Why this is safer
This creates a hard gate between "action executed" and "PR approved" so non-approved PRs cannot auto-merge just because Claude ran successfully.

## Notes
- This change is workflow-logic only (no runtime code changes).
- Branch protection (required reviews / merge rules) should still be configured in repo settings as a defense-in-depth follow-up.
