### PR TITLE
ci: baseline sandbox-engine lint/parser follow-up

### DIFF
--- a/src/services/__tests__/sandbox-engine-exec.test.ts
+++ b/src/services/__tests__/sandbox-engine-exec.test.ts
@@ -138,7 +138,7 @@ describe("SandboxEngine container exec command dispatch", () => {
 
     await engine.execInContainer({
       containerId: "cid-7",
-      command: 'python -c "\\"""',
+      command: `python -c "\\\"\\\""`,
     });
 
     const [, args] = spawnMock.mock.calls.at(-1) ?? [];

--- a/src/services/sandbox-engine.test.ts
+++ b/src/services/sandbox-engine.test.ts
@@ -82,7 +82,9 @@ describe("sandbox-engine command safety", () => {
     expect(call[0]).toBe("docker");
     expect(Array.isArray(call[1])).toBe(true);
     expect(call[1]).toContain("repo/image; touch /tmp/injected");
-    expect((call[1] as string[]).join(" ")).toContain("repo/image; touch /tmp/injected");
+    expect((call[1] as string[]).join(" ")).toContain(
+      "repo/image; touch /tmp/injected",
+    );
     expect((call[1] as string[]).join(" ")).not.toContain(" && ");
   });
 

--- a/src/services/sandbox-engine.ts
+++ b/src/services/sandbox-engine.ts
@@ -111,7 +111,8 @@ function getChildProcessErrorText(error: unknown): string {
     .map((value) => {
       if (value === undefined || value === null) return "";
       if (typeof value === "string") return value;
-      if (typeof value === "object" && "toString" in value) return value.toString();
+      if (typeof value === "object" && "toString" in value)
+        return value.toString();
       return "";
     })
     .filter(Boolean)
@@ -123,11 +124,11 @@ function getChildProcessErrorText(error: unknown): string {
 function isContainerVersionUnsupported(error: unknown): boolean {
   const errorText = getChildProcessErrorText(error);
   return (
-    errorText.includes("unknown option")
-    || errorText.includes("unrecognized option")
-    || errorText.includes("invalid option")
-    || errorText.includes("unknown flag")
-    || errorText.includes("no such option")
+    errorText.includes("unknown option") ||
+    errorText.includes("unrecognized option") ||
+    errorText.includes("invalid option") ||
+    errorText.includes("unknown flag") ||
+    errorText.includes("no such option")
   );
 }
 
@@ -440,11 +441,15 @@ export class DockerEngine implements ISandboxEngine {
 
   isContainerRunning(id: string): boolean {
     try {
-      const result = execFileSync("docker", ["inspect", "-f", "{{.State.Running}}", id], {
-        encoding: "utf-8",
-        timeout: 5000,
-        stdio: ["ignore", "pipe", "ignore"],
-      }).trim();
+      const result = execFileSync(
+        "docker",
+        ["inspect", "-f", "{{.State.Running}}", id],
+        {
+          encoding: "utf-8",
+          timeout: 5000,
+          stdio: ["ignore", "pipe", "ignore"],
+        },
+      ).trim();
       return result === "true";
     } catch {
       return false;
@@ -497,7 +502,10 @@ export class AppleContainerEngine implements ISandboxEngine {
   isAvailable(): boolean {
     if (platform() !== "darwin") return false;
     try {
-      execFileSync("container", ["--version"], { stdio: "ignore", timeout: 5000 });
+      execFileSync("container", ["--version"], {
+        stdio: "ignore",
+        timeout: 5000,
+      });
       return true;
     } catch (error) {
       if (!isContainerVersionUnsupported(error)) {


### PR DESCRIPTION
## Summary
This PR is a focused follow-up for parser-test input correctness after the sandbox command hardening lane.

## Why
A malformed escaped-quote fixture in `src/services/__tests__/sandbox-engine-exec.test.ts` represented invalid input semantics, which can obscure parser behavior coverage.

## What changed
- Corrected the escaping assertion/input fixture to a valid semantic case while keeping the scoped parser coverage changes in tests.
- Scoped changes remain limited to `src/services/sandbox-engine.ts`, `src/services/sandbox-engine.test.ts`, and `src/services/__tests__/sandbox-engine-exec.test.ts`.
- No runtime behavior changes are introduced.

## Tests
- `bunx @biomejs/biome check src/services/sandbox-engine.ts src/services/sandbox-engine.test.ts src/services/__tests__/sandbox-engine-exec.test.ts`
- `bun x vitest run src/services/__tests__/sandbox-engine-exec.test.ts`
