### PR TITLE
feat(ui): cyberpunk theme - neon purple and cyan vaporwave aesthetics

### DIFF
--- a/apps/app/src/styles/base.css
+++ b/apps/app/src/styles/base.css
@@ -782,3 +782,75 @@ html:not([data-theme]) #root {
   from { opacity: 0; }
   to { opacity: 1; }
 }
+
+/* ═══════════════════════════════════════════════════════════════════════
+   cyberpunk — neon purple and electric blue, vaporwave aesthetics
+   ═══════════════════════════════════════════════════════════════════════ */
+
+[data-theme="cyberpunk"] {
+  --bg: #0a0015;
+  --bg-accent: #1a0a2e;
+  --bg-elevated: #120820;
+  --bg-hover: #2a1050;
+  --bg-muted: #0f0520;
+
+  --card: #1a0a2e;
+  --card-foreground: #e0d0ff;
+  --surface: #0a0015;
+
+  --text: #e0d0ff;
+  --text-strong: #ff00ff;
+  --chat-text: #c0b0e0;
+  --muted: #8060b0;
+  --muted-strong: #a080d0;
+
+  --border: #ff00ff;
+  --border-strong: #00ffff;
+  --border-hover: #ff66ff;
+  --input: #ff00ff;
+  --ring: #00ffff;
+
+  --accent: #ff00ff;
+  --accent-hover: #cc00cc;
+  --accent-muted: #ff66ff;
+  --accent-subtle: rgba(255, 0, 255, 0.15);
+  --accent-foreground: #0a0015;
+  --primary: #00ffff;
+  --primary-foreground: #0a0015;
+
+  --ok: #00ff88;
+  --ok-muted: rgba(0, 255, 136, 0.7);
+  --ok-subtle: rgba(0, 255, 136, 0.1);
+  --destructive: #ff0055;
+  --destructive-foreground: #ffffff;
+  --destructive-subtle: rgba(255, 0, 85, 0.1);
+  --warn: #ffaa00;
+  --warn-muted: rgba(255, 170, 0, 0.7);
+  --warn-subtle: rgba(255, 170, 0, 0.1);
+  --danger: #ff0055;
+  --info: #00ffff;
+
+  --focus: rgba(0, 255, 255, 0.2);
+  --focus-ring: 0 0 0 2px #00ffff;
+
+  --header-bg: linear-gradient(135deg, #1a0a2e, #0a0015);
+  --header-text: #ff00ff;
+  --header-border: #ff00ff;
+
+  --sidebar-bg: #0f0520;
+  --sidebar-text: #c0b0e0;
+  --sidebar-hover: #2a1050;
+  --sidebar-active: #ff00ff;
+  --sidebar-border: #ff00ff;
+
+  --scrollbar-thumb: #ff00ff;
+  --scrollbar-track: #0a0015;
+
+  --shadow-sm: 0 0 8px rgba(255, 0, 255, 0.3);
+  --shadow-md: 0 0 16px rgba(255, 0, 255, 0.4);
+  --shadow-lg: 0 0 32px rgba(0, 255, 255, 0.3);
+
+  --radius: 2px;
+  --radius-md: 4px;
+  --radius-lg: 6px;
+}


### PR DESCRIPTION
## What
Adds a new cyberpunk-inspired color theme to the theme system.

## Why  
Users have been asking for more theme variety. The current milady and dark themes are great but some users want something more futuristic and eye-catching.

## How
- Added new `[data-theme="cyberpunk"]` CSS custom properties block
- Neon purple (#ff00ff) and electric cyan (#00ffff) as primary accent colors
- Dark base (#0a0015) for contrast
- Glow effects on shadows for that neon sign look

## Testing
- Manually tested by switching data-theme attribute
- All existing themes unaffected (additive change only)