### PR TITLE
fix(api): validate audio record duration input

### DIFF
--- a/src/api/__tests__/sandbox-routes.test.ts
+++ b/src/api/__tests__/sandbox-routes.test.ts
@@ -309,6 +309,43 @@ describe("handleSandboxRoute", () => {
       expect([200, 500]).toContain(res._status);
     });
 
+    it("POST /api/sandbox/audio/record should reject non-finite duration", async () => {
+      const req = createMockReq("POST", '{"durationMs":null}');
+      const res = createMockRes();
+      await handleSandboxRoute(req, res, "/api/sandbox/audio/record", "POST", {
+        sandboxManager: mgr,
+      });
+      expect(res._status).toBe(400);
+      expect(JSON.parse(res._body).error).toContain(
+        "durationMs must be a finite number",
+      );
+    });
+
+    it("POST /api/sandbox/audio/record should reject string duration", async () => {
+      const req = createMockReq("POST", '{"durationMs":"1000"}');
+      const res = createMockRes();
+      await handleSandboxRoute(req, res, "/api/sandbox/audio/record", "POST", {
+        sandboxManager: mgr,
+      });
+      expect(res._status).toBe(400);
+      expect(JSON.parse(res._body).error).toContain(
+        "durationMs must be a finite number",
+      );
+    });
+
+    it("POST /api/sandbox/audio/record should reject oversized duration", async () => {
+      const req = createMockReq(
+        "POST",
+        JSON.stringify({ durationMs: 60000 }),
+      );
+      const res = createMockRes();
+      await handleSandboxRoute(req, res, "/api/sandbox/audio/record", "POST", {
+        sandboxManager: mgr,
+      });
+      expect(res._status).toBe(400);
+      expect(JSON.parse(res._body).error).toContain("durationMs must be between");
+    });
+
     it("POST /api/sandbox/audio/play should require data field", async () => {
       const req = createMockReq("POST", JSON.stringify({}));
       const res = createMockRes();


### PR DESCRIPTION
## Summary\nHardens /api/sandbox/audio/record duration validation to reject malformed values.\n\n## What changed\n- Rejects durationMs when provided but not a finite number.\n- Enforces duration bounds (250-30000 ms).\n- Continues using Math.floor for validated values.\n\n## Files changed\n- src/api/sandbox-routes.ts\n- src/api/__tests__/sandbox-routes.test.ts\n\n## Verification\n- bun x vitest run src/api/__tests__/sandbox-routes.test.ts