### PR TITLE
fix(api): reject fractional audio duration input

### DIFF
--- a/src/api/__tests__/sandbox-routes.test.ts
+++ b/src/api/__tests__/sandbox-routes.test.ts
@@ -343,6 +343,18 @@ describe("handleSandboxRoute", () => {
       );
     });
 
+    it("POST /api/sandbox/audio/record should reject fractional duration", async () => {
+      const req = createMockReq("POST", JSON.stringify({ durationMs: 1000.7 }));
+      const res = createMockRes();
+      await handleSandboxRoute(req, res, "/api/sandbox/audio/record", "POST", {
+        sandboxManager: mgr,
+      });
+      expect(res._status).toBe(400);
+      expect(JSON.parse(res._body).error).toContain(
+        "durationMs must be an integer number of milliseconds",
+      );
+    });
+
     it("POST /api/sandbox/audio/record should reject oversized duration", async () => {
       const req = createMockReq("POST", JSON.stringify({ durationMs: 60000 }));
       const res = createMockRes();

--- a/src/api/sandbox-routes.ts
+++ b/src/api/sandbox-routes.ts
@@ -272,6 +272,12 @@ export async function handleSandboxRoute(
           });
           return true;
         }
+        if (!Number.isInteger(durationValue)) {
+          sendJson(res, 400, {
+            error: "durationMs must be an integer number of milliseconds",
+          });
+          return true;
+        }
         if (
           durationValue < MIN_AUDIO_RECORD_DURATION_MS ||
           durationValue > MAX_AUDIO_RECORD_DURATION_MS
@@ -281,7 +287,7 @@ export async function handleSandboxRoute(
           });
           return true;
         }
-        durationMs = Math.floor(durationValue);
+        durationMs = durationValue;
       }
     }
     try {


### PR DESCRIPTION
## Summary\nFurther hardening for /api/sandbox/audio/record request validation: duration values must be an integer number of milliseconds.\n\n## What changed\n- Reject fractional  values (e.g., 1000.7) with HTTP 400.\n- Keep finite/number/range checks intact and now assign duration directly from validated integer input.\n\n## Files changed\n- src/api/sandbox-routes.ts\n- src/api/__tests__/sandbox-routes.test.ts\n\n## Tests\n- bun x vitest run src/api/__tests__/sandbox-routes.test.ts