### PR TITLE
fix(api): remove duplicated plugin config key allowlist checks

### DIFF
--- a/src/api/plugin-validation.ts
+++ b/src/api/plugin-validation.ts
@@ -104,19 +104,6 @@ export function validatePluginConfig(
     }
   }
 
-  // Reject any submitted keys that are not declared for this plugin.
-  if (providedConfig) {
-    const allowedConfigKeys = new Set(configKeys);
-    for (const key of Object.keys(providedConfig)) {
-      if (!allowedConfigKeys.has(key)) {
-        errors.push({
-          field: key,
-          message: `${key} is not a declared config key for this plugin`,
-        });
-      }
-    }
-  }
-
   // ── Check all required parameters ─────────────────────────────────────
   if (paramDefs && paramDefs.length > 0) {
     for (const param of paramDefs) {


### PR DESCRIPTION
## Summary
Remove duplicated plugin config key allowlist validation in `validatePluginConfig`.

## What changed
- `src/api/plugin-validation.ts`

## Why
Prevents duplicate "undeclared key" errors when `providedConfig` contains unknown keys and keeps the allowlist behavior deterministic.
