### PR TITLE
fix(app): correct ConfigPageView RPC section prop types

### DIFF
--- a/apps/app/src/components/ConfigPageView.tsx
+++ b/apps/app/src/components/ConfigPageView.tsx
@@ -137,7 +137,7 @@ function buildRpcRendererConfig(
   return props;
 }
 
-type RpcSectionCloudProps = Omit<CloudRpcStatusProps, "onLogin">;
+type RpcSectionCloudProps = CloudRpcStatusProps;
 
 type RpcSectionProps<T extends string> = {
   title: string;
@@ -163,7 +163,7 @@ function RpcConfigSection<T extends string>({
   onRpcFieldChange,
   cloud,
   containerClassName,
-}: RpcConfigSectionProps<T>) {
+}: RpcSectionProps<T>) {
   const rpcConfig = buildRpcRendererConfig(selectedProvider, providerConfigs, rpcFieldValues);
 
   return (


### PR DESCRIPTION
## Summary
Fix the Config page compile break in `ConfigPageView` from PR #215.

## What changed
- `apps/app/src/components/ConfigPageView.tsx`
  - Use the existing `RpcSectionProps` type in `RpcConfigSection` props.
  - Keep `onLogin` on `cloud` status props so login button wiring remains typed and valid.

## Why
These fixes remove the TypeScript errors introduced in the config page refactor and restore runtime typing correctness for cloud login rendering.
