### PR TITLE
ci: fix codex review prompt invocation

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -244,7 +244,7 @@ jobs:
             --base "origin/${{ github.event.pull_request.base.ref }}" \
             --title "${{ github.event.pull_request.title }}" \
             -c 'model="gpt-5.3-codex"' \
-            "$(cat /tmp/review-prompt.md)" \
+            - < /tmp/review-prompt.md \
             > /tmp/review-output.md 2>&1 || true
 
           echo "Review output:"


### PR DESCRIPTION
## Summary
- Update `.github/workflows/agent-review.yml` `Run Codex Review` step to pass prompt content through stdin:
  - `- < /tmp/review-prompt.md`
- Keeps `--base` and `--title` flags intact.

## Why this is needed
`pull_request_target` executes workflow files from the base branch (`develop`), not the PR head. This compatibility fix must land on `develop` for PR reviewers to get a valid `codex review` invocation.

## Root-cause fix
This prevents the failure:

- `error: the argument '--base <BRANCH>' cannot be used with '[PROMPT]'`

## Validation
- Diff is one-line compatible CLI invocation change.
- No runtime or application behavior changes.
