### PR TITLE
fix(api): harden knowledge routes fragment handling

### DIFF
--- a/src/api/knowledge-routes.test.ts
+++ b/src/api/knowledge-routes.test.ts
@@ -1,0 +1,236 @@
+import type { AgentRuntime, Memory, UUID } from "@elizaos/core";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { createRouteInvoker } from "../test-support/route-test-helpers.js";
+import { handleKnowledgeRoutes } from "./knowledge-routes.js";
+
+const AGENT_ID = "00000000-0000-0000-0000-000000000001" as UUID;
+
+function uuid(n: number): UUID {
+  return `00000000-0000-0000-0000-${String(n).padStart(12, "0")}` as UUID;
+}
+
+function buildMemory(overrides: Partial<Memory> = {}): Memory {
+  return {
+    id: uuid(9000),
+    agentId: AGENT_ID,
+    roomId: AGENT_ID,
+    entityId: AGENT_ID,
+    content: { text: "" },
+    createdAt: 1,
+    ...overrides,
+  } as Memory;
+}
+
+describe("knowledge routes", () => {
+  let runtime: AgentRuntime | null;
+  let getMemoriesMock: ReturnType<typeof vi.fn>;
+  let deleteMemoryMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    getMemoriesMock = vi.fn(async () => []);
+    deleteMemoryMock = vi.fn(async () => undefined);
+
+    const knowledgeService = {
+      addKnowledge: vi.fn(async () => ({
+        clientDocumentId: uuid(1111),
+        storedDocumentMemoryId: uuid(1112),
+        fragmentCount: 0,
+      })),
+      getKnowledge: vi.fn(async () => []),
+      getMemories: getMemoriesMock,
+      countMemories: vi.fn(async () => 0),
+      deleteMemory: deleteMemoryMock,
+    };
+
+    runtime = {
+      agentId: AGENT_ID,
+      getService: (name: string) => (name === "knowledge" ? knowledgeService : null),
+      getServiceLoadPromise: async () => undefined,
+    } as unknown as AgentRuntime;
+  });
+
+  const invoke = createRouteInvoker<
+    Record<string, unknown> | null,
+    AgentRuntime | null,
+    Record<string, unknown>
+  >(
+    (ctx) =>
+      handleKnowledgeRoutes({
+        req: ctx.req,
+        res: ctx.res,
+        method: ctx.method,
+        pathname: ctx.pathname,
+        url: new URL(ctx.req.url ?? ctx.pathname, "http://localhost:2138"),
+        runtime: ctx.runtime,
+        readJsonBody: async () => ctx.readJsonBody(),
+        json: (res, data, status) => ctx.json(res, data, status),
+        error: (res, message, status) => ctx.error(res, message, status),
+      }),
+    { runtimeProvider: () => runtime },
+  );
+
+  test("passes offset=1 through documents endpoint without off-by-one", async () => {
+    getMemoriesMock.mockResolvedValueOnce([]);
+
+    const result = await invoke({
+      method: "GET",
+      pathname: "/api/knowledge/documents",
+      url: "/api/knowledge/documents?limit=10&offset=1",
+    });
+
+    expect(result.status).toBe(200);
+    expect(getMemoriesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tableName: "documents",
+        roomId: AGENT_ID,
+        count: 10,
+        offset: 1,
+      }),
+    );
+  });
+
+  test("treats offset=0 as no skip for documents endpoint", async () => {
+    getMemoriesMock.mockResolvedValueOnce([]);
+
+    const result = await invoke({
+      method: "GET",
+      pathname: "/api/knowledge/documents",
+      url: "/api/knowledge/documents?limit=10&offset=0",
+    });
+
+    expect(result.status).toBe(200);
+    expect(getMemoriesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tableName: "documents",
+        roomId: AGENT_ID,
+        count: 10,
+        offset: undefined,
+      }),
+    );
+  });
+
+  test("filters fragments without id/createdAt and paginates batches", async () => {
+    const documentId = uuid(1200);
+    const firstBatch = [
+      buildMemory({
+        id: undefined,
+        createdAt: 10,
+        metadata: { documentId, position: 2 },
+        content: { text: "missing-id" },
+      }),
+      buildMemory({
+        id: uuid(1201),
+        createdAt: undefined,
+        metadata: { documentId, position: 1 },
+        content: { text: "missing-created-at" },
+      }),
+      buildMemory({
+        id: uuid(1202),
+        createdAt: 20,
+        metadata: { documentId, position: 5 },
+        content: { text: "valid-first-batch" },
+      }),
+      ...Array.from({ length: 497 }, (_, i) =>
+        buildMemory({
+          id: uuid(2000 + i),
+          metadata: { documentId: uuid(9999), position: i + 10 },
+          createdAt: i + 100,
+          content: { text: "other-doc" },
+        }),
+      ),
+    ];
+
+    const secondBatch = [
+      buildMemory({
+        id: uuid(1300),
+        createdAt: 30,
+        metadata: { documentId, position: 0 },
+        content: { text: "valid-second-batch" },
+      }),
+      buildMemory({
+        id: uuid(1301),
+        createdAt: 40,
+        metadata: { documentId: uuid(8888), position: 9 },
+        content: { text: "other-doc-2" },
+      }),
+    ];
+
+    getMemoriesMock.mockImplementation(async ({ tableName, offset }) => {
+      if (tableName !== "knowledge") return [];
+      if (offset === 0) return firstBatch;
+      if (offset === 500) return secondBatch;
+      return [];
+    });
+
+    const result = await invoke({
+      method: "GET",
+      pathname: `/api/knowledge/fragments/${documentId}`,
+    });
+
+    expect(result.status).toBe(200);
+    expect(getMemoriesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tableName: "knowledge",
+        roomId: AGENT_ID,
+        count: 500,
+        offset: 0,
+      }),
+    );
+    expect(getMemoriesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tableName: "knowledge",
+        roomId: AGENT_ID,
+        count: 500,
+        offset: 500,
+      }),
+    );
+
+    const fragments = (
+      result.payload as {
+        fragments: Array<{ id: UUID; text: string; position: unknown; createdAt: number }>;
+      }
+    ).fragments;
+
+    expect(fragments).toEqual([
+      {
+        id: uuid(1300),
+        text: "valid-second-batch",
+        position: 0,
+        createdAt: 30,
+      },
+      {
+        id: uuid(1202),
+        text: "valid-first-batch",
+        position: 5,
+        createdAt: 20,
+      },
+    ]);
+  });
+
+  test("delete document only deletes fragment memories with defined ids", async () => {
+    const documentId = uuid(1400);
+    const validFragmentId = uuid(1401);
+
+    getMemoriesMock.mockResolvedValueOnce([
+      buildMemory({
+        id: undefined,
+        metadata: { documentId },
+      }),
+      buildMemory({
+        id: validFragmentId,
+        metadata: { documentId },
+      }),
+    ]);
+
+    const result = await invoke({
+      method: "DELETE",
+      pathname: `/api/knowledge/documents/${documentId}`,
+    });
+
+    expect(result.status).toBe(200);
+    expect(deleteMemoryMock).toHaveBeenCalledTimes(2);
+    expect(deleteMemoryMock).toHaveBeenNthCalledWith(1, validFragmentId);
+    expect(deleteMemoryMock).toHaveBeenNthCalledWith(2, documentId);
+    expect(result.payload).toMatchObject({ ok: true, deletedFragments: 1 });
+  });
+});

--- a/src/api/knowledge-routes.ts
+++ b/src/api/knowledge-routes.ts
@@ -54,6 +54,86 @@ interface KnowledgeServiceLike {
   deleteMemory(memoryId: UUID): Promise<void>;
 }
 
+const FRAGMENT_COUNT_BATCH_SIZE = 500;
+
+function hasUuidId(memory: Memory): memory is Memory & { id: UUID } {
+  return typeof memory.id === "string" && memory.id.length > 0;
+}
+
+function hasUuidIdAndCreatedAt(
+  memory: Memory,
+): memory is Memory & { id: UUID; createdAt: number } {
+  return hasUuidId(memory) && typeof memory.createdAt === "number";
+}
+
+async function countKnowledgeFragmentsForDocument(
+  knowledgeService: KnowledgeServiceLike,
+  roomId: UUID,
+  documentId: UUID,
+): Promise<number> {
+  let offset = 0;
+  let fragmentCount = 0;
+
+  while (true) {
+    const knowledgeBatch = await knowledgeService.getMemories({
+      tableName: "knowledge",
+      roomId,
+      count: FRAGMENT_COUNT_BATCH_SIZE,
+      offset,
+    });
+
+    if (knowledgeBatch.length === 0) {
+      break;
+    }
+
+    fragmentCount += knowledgeBatch.filter((memory) => {
+      const metadata = memory.metadata as Record<string, unknown> | undefined;
+      return metadata?.documentId === documentId;
+    }).length;
+
+    if (knowledgeBatch.length < FRAGMENT_COUNT_BATCH_SIZE) {
+      break;
+    }
+
+    offset += FRAGMENT_COUNT_BATCH_SIZE;
+  }
+
+  return fragmentCount;
+}
+
+async function listKnowledgeFragmentsForDocument(
+  knowledgeService: KnowledgeServiceLike,
+  roomId: UUID,
+  documentId: UUID,
+): Promise<UUID[]> {
+  let offset = 0;
+  const fragmentIds: UUID[] = [];
+
+  while (true) {
+    const knowledgeBatch = await knowledgeService.getMemories({
+      tableName: "knowledge",
+      roomId,
+      count: FRAGMENT_COUNT_BATCH_SIZE,
+      offset,
+    });
+
+    for (const memory of knowledgeBatch) {
+      const metadata = memory.metadata as Record<string, unknown> | undefined;
+      if (metadata?.documentId === documentId && hasUuidId(memory)) {
+        fragmentIds.push(memory.id);
+      }
+    }
+
+    if (knowledgeBatch.length < FRAGMENT_COUNT_BATCH_SIZE) {
+      break;
+    }
+
+    offset += FRAGMENT_COUNT_BATCH_SIZE;
+  }
+
+  return fragmentIds;
+}
+
 async function getKnowledgeService(
   runtime: AgentRuntime | null,
 ): Promise<KnowledgeServiceLike | null> {
@@ -306,7 +386,7 @@ export async function handleKnowledgeRoutes(
   // ── GET /api/knowledge/documents ────────────────────────────────────────
   if (method === "GET" && pathname === "/api/knowledge/documents") {
     const limit = parsePositiveInteger(url.searchParams.get("limit"), 100);
-    const offset = parsePositiveInteger(url.searchParams.get("offset"), 0) - 1;
+    const offset = parsePositiveInteger(url.searchParams.get("offset"), 0);
 
     const documents = await knowledgeService.getMemories({
       tableName: "documents",
@@ -357,16 +437,11 @@ export async function handleKnowledgeRoutes(
     }
 
     // Get fragment count for this document
-    const allFragments = await knowledgeService.getMemories({
-      tableName: "knowledge",
-      roomId: agentId,
-      count: 50000,
-    });
-
-    const fragmentCount = allFragments.filter((f) => {
-      const meta = f.metadata as Record<string, unknown> | undefined;
-      return meta?.documentId === documentId;
-    }).length;
+    const fragmentCount = await countKnowledgeFragmentsForDocument(
+      knowledgeService,
+      agentId,
+      documentId,
+    );
 
     const metadata = document.metadata as Record<string, unknown> | undefined;
 
@@ -390,20 +465,14 @@ export async function handleKnowledgeRoutes(
   if (method === "DELETE" && docIdMatch) {
     const documentId = decodeURIComponent(docIdMatch[1]) as UUID;
 
-    // First, delete all fragments associated with this document
-    const allFragments = await knowledgeService.getMemories({
-      tableName: "knowledge",
-      roomId: agentId,
-      count: 50000,
-    });
+    const fragmentIds = await listKnowledgeFragmentsForDocument(
+      knowledgeService,
+      agentId,
+      documentId,
+    );
 
-    const fragmentsToDelete = allFragments.filter((f) => {
-      const meta = f.metadata as Record<string, unknown> | undefined;
-      return meta?.documentId === documentId;
-    });
-
-    for (const fragment of fragmentsToDelete) {
-      await knowledgeService.deleteMemory(fragment.id as UUID);
+    for (const fragmentId of fragmentIds) {
+      await knowledgeService.deleteMemory(fragmentId);
     }
 
     // Then delete the document itself
@@ -411,7 +480,7 @@ export async function handleKnowledgeRoutes(
 
     json(res, {
       ok: true,
-      deletedFragments: fragmentsToDelete.length,
+      deletedFragments: fragmentIds.length,
     });
     return true;
   }
@@ -568,33 +637,63 @@ export async function handleKnowledgeRoutes(
   if (method === "GET" && fragmentsMatch) {
     const documentId = decodeURIComponent(fragmentsMatch[1]) as UUID;
 
-    const allFragments = await knowledgeService.getMemories({
-      tableName: "knowledge",
-      roomId: agentId,
-      count: 50000,
-    });
+    const allFragments: Array<{
+      id: UUID;
+      text: string;
+      position: unknown;
+      createdAt: number;
+    }> = [];
+    let fragmentOffset = 0;
+
+    while (true) {
+      const fragmentBatch = await knowledgeService.getMemories({
+        tableName: "knowledge",
+        roomId: agentId,
+        count: FRAGMENT_COUNT_BATCH_SIZE,
+        offset: fragmentOffset,
+      });
+
+      if (fragmentBatch.length === 0) {
+        break;
+      }
+
+      const matchingFragments = fragmentBatch.filter((fragment) => {
+        const metadata = fragment.metadata as
+          | Record<string, unknown>
+          | undefined;
+        return metadata?.documentId === documentId;
+      });
+
+      for (const fragment of matchingFragments) {
+        if (!hasUuidIdAndCreatedAt(fragment)) {
+          continue;
+        }
+        const meta = fragment.metadata as Record<string, unknown> | undefined;
+        allFragments.push({
+          id: fragment.id,
+          text: (fragment.content as { text?: string })?.text || "",
+          position: meta?.position,
+          createdAt: fragment.createdAt,
+        });
+      }
+
+      if (fragmentBatch.length < FRAGMENT_COUNT_BATCH_SIZE) {
+        break;
+      }
+      fragmentOffset += FRAGMENT_COUNT_BATCH_SIZE;
+    }
 
     const documentFragments = allFragments
-      .filter((f) => {
-        const meta = f.metadata as Record<string, unknown> | undefined;
-        return meta?.documentId === documentId;
-      })
       .sort((a, b) => {
-        const posA = (a.metadata as Record<string, unknown> | undefined)
-          ?.position;
-        const posB = (b.metadata as Record<string, unknown> | undefined)
-          ?.position;
-        return (
-          (typeof posA === "number" ? posA : 0) -
-          (typeof posB === "number" ? posB : 0)
-        );
+        const posA = typeof a.position === "number" ? a.position : 0;
+        const posB = typeof b.position === "number" ? b.position : 0;
+        return posA - posB;
       })
       .map((f) => {
-        const meta = f.metadata as Record<string, unknown> | undefined;
         return {
           id: f.id,
-          text: (f.content as { text?: string })?.text || "",
-          position: meta?.position,
+          text: f.text,
+          position: f.position,
           createdAt: f.createdAt,
         };
       });


### PR DESCRIPTION
## Summary
- fix off-by-one behavior in `/api/knowledge/documents` offset parsing (no `-1` shift)
- batch knowledge fragment scans in document detail/delete/fragment endpoints using `FRAGMENT_COUNT_BATCH_SIZE`
- guard optional `Memory.id` / `Memory.createdAt` before using them in strict-typed fragment flows
- add regression tests for offset handling, batched fragment loading/filtering, and delete-path ID guards

## Validation
- `bunx vitest run src/api/knowledge-routes.test.ts` ✅ (4/4)
- `bun run check` ❌ (pre-existing repo-wide TUI typing/module errors and `src/plugins/telegram-enhanced/chunking.ts`)
- `bun run typecheck` ❌ (same pre-existing failures as above)

## Notes
- This PR is scoped to knowledge-routes correctness and regression coverage.
- Existing unrelated typecheck failures are left unchanged.
