### PR TITLE
milaidy: stabilize cloud and registry flaky tests

### DIFF
--- a/src/api/cloud-routes.test.ts
+++ b/src/api/cloud-routes.test.ts
@@ -11,6 +11,13 @@ const fetchMock =
   vi.fn<
     (input: string | URL | Request, init?: RequestInit) => Promise<Response>
   >();
+const { validateCloudBaseUrlMock } = vi.hoisted(() => ({
+  validateCloudBaseUrlMock: vi.fn<(rawUrl: string) => Promise<string | null>>(),
+}));
+
+vi.mock("../cloud/validate-url.js", () => ({
+  validateCloudBaseUrl: validateCloudBaseUrlMock,
+}));
 
 function createState(createAgent: (args: unknown) => Promise<unknown>) {
   return {
@@ -123,6 +130,7 @@ function cloudState(): CloudRouteState {
 describe("handleCloudRoute timeout behavior", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", fetchMock);
+    validateCloudBaseUrlMock.mockResolvedValue(null);
   });
 
   afterEach(() => {

--- a/src/api/knowledge-routes.test.ts
+++ b/src/api/knowledge-routes.test.ts
@@ -44,7 +44,8 @@ describe("knowledge routes", () => {
 
     runtime = {
       agentId: AGENT_ID,
-      getService: (name: string) => (name === "knowledge" ? knowledgeService : null),
+      getService: (name: string) =>
+        name === "knowledge" ? knowledgeService : null,
       getServiceLoadPromise: async () => undefined,
     } as unknown as AgentRuntime;
   });
@@ -187,7 +188,12 @@ describe("knowledge routes", () => {
 
     const fragments = (
       result.payload as {
-        fragments: Array<{ id: UUID; text: string; position: unknown; createdAt: number }>;
+        fragments: Array<{
+          id: UUID;
+          text: string;
+          position: unknown;
+          createdAt: number;
+        }>;
       }
     ).fragments;
 


### PR DESCRIPTION
## Summary\n- mock cloud URL validation in timeout-path tests to isolate route behavior from DNS/network variability\n- use `vi.hoisted` mock initialization to avoid Vitest module-hoist runtime errors\n- add retry wrapper for temp-dir cleanup to prevent transient `ENOTEMPTY` failures\n- apply Biome-required formatting in knowledge routes test\n\n## Dependency\n- This PR is intended to land after #263.\n\n## Verification\n- bunx biome check src/api/cloud-routes.test.ts src/services/registry-client.test.ts src/api/knowledge-routes.test.ts\n- CI=true bunx vitest run src/api/cloud-routes.test.ts src/services/registry-client.test.ts src/api/knowledge-routes.test.ts\n