### PR TITLE
milaidy: redact auto-generated API token logs

### DIFF
--- a/src/api/server.api-token-bind.test.ts
+++ b/src/api/server.api-token-bind.test.ts
@@ -1,0 +1,42 @@
+import { logger } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ensureApiTokenForBindHost } from "./server.js";
+
+describe("ensureApiTokenForBindHost", () => {
+  const previousToken = process.env.MILAIDY_API_TOKEN;
+
+  afterEach(() => {
+    if (previousToken === undefined) delete process.env.MILAIDY_API_TOKEN;
+    else process.env.MILAIDY_API_TOKEN = previousToken;
+    vi.restoreAllMocks();
+  });
+
+  it("does not generate a token on loopback bind hosts", () => {
+    delete process.env.MILAIDY_API_TOKEN;
+    ensureApiTokenForBindHost("127.0.0.1");
+    expect(process.env.MILAIDY_API_TOKEN).toBeUndefined();
+  });
+
+  it("preserves an explicitly configured token", () => {
+    process.env.MILAIDY_API_TOKEN = "existing-token";
+    ensureApiTokenForBindHost("0.0.0.0");
+    expect(process.env.MILAIDY_API_TOKEN).toBe("existing-token");
+  });
+
+  it("generates a token for non-loopback binds without logging raw token", () => {
+    delete process.env.MILAIDY_API_TOKEN;
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+    ensureApiTokenForBindHost("0.0.0.0");
+
+    const generated = process.env.MILAIDY_API_TOKEN ?? "";
+    expect(generated).toMatch(/^[a-f0-9]{64}$/);
+
+    const loggedMessages = warnSpy.mock.calls
+      .map((call) => call[0])
+      .map((value) => String(value));
+    expect(loggedMessages.some((message) => message.includes(generated))).toBe(
+      false,
+    );
+  });
+});

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -3082,7 +3082,7 @@ function isLoopbackBindHost(host: string): boolean {
   return false;
 }
 
-function ensureApiTokenForBindHost(host: string): void {
+export function ensureApiTokenForBindHost(host: string): void {
   const token = process.env.MILAIDY_API_TOKEN?.trim();
   if (token) return;
   if (isLoopbackBindHost(host)) return;
@@ -3093,8 +3093,9 @@ function ensureApiTokenForBindHost(host: string): void {
   logger.warn(
     `[milaidy-api] MILAIDY_API_BIND=${host} is non-loopback and MILAIDY_API_TOKEN is unset.`,
   );
+  const tokenFingerprint = `${generated.slice(0, 4)}...${generated.slice(-4)}`;
   logger.warn(
-    `[milaidy-api] Generated temporary MILAIDY_API_TOKEN=${generated}. Set MILAIDY_API_TOKEN explicitly to override.`,
+    `[milaidy-api] Generated temporary MILAIDY_API_TOKEN (${tokenFingerprint}) for this process. Set MILAIDY_API_TOKEN explicitly to override.`,
   );
 }
 


### PR DESCRIPTION
## Summary
- stop logging full auto-generated `MILAIDY_API_TOKEN` when API binds to non-loopback hosts
- log only a short token fingerprint (`xxxx...yyyy`) for operator correlation
- export `ensureApiTokenForBindHost` for direct regression testing
- add API test coverage for loopback, preconfigured token, and non-loopback generation behavior

## Security impact
- removes plaintext token disclosure in logs for auto-generated API auth tokens

## Validation
- bun run check
- bun run test
- bunx vitest run src/api/server.api-token-bind.test.ts
