### PR TITLE
database: block SELECT INTO in read-only query guard

### DIFF
--- a/src/api/database.ts
+++ b/src/api/database.ts
@@ -1093,6 +1093,7 @@ async function handleQuery(
       "INSERT",
       "UPDATE",
       "DELETE",
+      "INTO",
       "DROP",
       "ALTER",
       "TRUNCATE",


### PR DESCRIPTION
## Summary
- add `INTO` to the read-only mutation keyword guard in the database query endpoint
- block `SELECT ... INTO ...` from executing when `readOnly` is enabled
- add regression coverage for the bypass case

## Testing
- bunx vitest run src/api/database.readonly-query-guard.test.ts
- bunx vitest run src/api/database.security.test.ts
- bun run check