### PR TITLE
database: block mutating sequence functions in read-only queries

### DIFF
--- a/src/api/database.ts
+++ b/src/api/database.ts
@@ -1081,13 +1081,16 @@ async function handleQuery(
       .replace(/--.*$/gm, "")
       .trim();
 
-    // Strip string literals so that keywords inside quoted strings are ignored.
-    // Handles single-quoted ('...'), dollar-quoted ($$...$$), and tagged
-    // dollar-quoted ($tag$...$tag$) strings, plus double-quoted identifiers.
-    const noStrings = stripped
+    // Strip string literals so that mutation keywords/functions inside quoted
+    // strings are ignored. Handles single-quoted ('...'), dollar-quoted
+    // ($$...$$), and tagged dollar-quoted ($tag$...$tag$) strings.
+    const noLiterals = stripped
       .replace(/\$([A-Za-z0-9_]*)\$[\s\S]*?\$\1\$/g, " ")
-      .replace(/'(?:[^']|'')*'/g, " ")
-      .replace(/"(?:[^"]|"")*"/g, " ");
+      .replace(/'(?:[^']|'')*'/g, " ");
+
+    // For keyword checks, also strip double-quoted identifiers to avoid
+    // matching words inside quoted table/column names.
+    const noStrings = noLiterals.replace(/"(?:[^"]|"")*"/g, " ");
 
     const mutationKeywords = [
       "INSERT",
@@ -1121,6 +1124,20 @@ async function handleQuery(
       );
       return;
     }
+
+    // Some SELECT functions still mutate server state (for example sequence
+    // advancement via nextval/setval). Reject those in read-only mode.
+    const mutatingFunctionPattern =
+      /(?:^|[^\w$])"?((?:nextval|setval))"?\s*\(/i;
+    const mutatingFunctionMatch = mutatingFunctionPattern.exec(noLiterals);
+    if (mutatingFunctionMatch) {
+      sendJsonError(
+        res,
+        `Query rejected: "${mutatingFunctionMatch[1].toUpperCase()}" is a mutating function. Set readOnly: false to execute mutations.`,
+      );
+      return;
+    }
+
     // Reject multi-statement queries (naive: any semicolon not at the very end)
     const trimmedForSemicolon = stripped.replace(/;\s*$/, "");
     if (trimmedForSemicolon.includes(";")) {


### PR DESCRIPTION
## Summary
- extend read-only SQL guard to reject mutating sequence functions (`nextval`, `setval`)
- keep existing keyword-based mutation detection and semicolon guard behavior
- add regressions for both bypass forms in read-only mode

## Testing
- bunx vitest run src/api/database.readonly-query-guard.test.ts
- bunx vitest run src/api/database.security.test.ts
- bun run check