### PR TITLE
api: add terminal run concurrency and timeout limits

### DIFF
--- a/src/api/server.terminal-limits.test.ts
+++ b/src/api/server.terminal-limits.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveTerminalRunLimits } from "./server.js";
+
+describe("resolveTerminalRunLimits", () => {
+  const prevMaxConcurrent = process.env.MILAIDY_TERMINAL_MAX_CONCURRENT;
+  const prevMaxDuration = process.env.MILAIDY_TERMINAL_MAX_DURATION_MS;
+
+  afterEach(() => {
+    if (prevMaxConcurrent === undefined)
+      delete process.env.MILAIDY_TERMINAL_MAX_CONCURRENT;
+    else process.env.MILAIDY_TERMINAL_MAX_CONCURRENT = prevMaxConcurrent;
+
+    if (prevMaxDuration === undefined)
+      delete process.env.MILAIDY_TERMINAL_MAX_DURATION_MS;
+    else process.env.MILAIDY_TERMINAL_MAX_DURATION_MS = prevMaxDuration;
+  });
+
+  it("uses secure defaults when env vars are unset", () => {
+    delete process.env.MILAIDY_TERMINAL_MAX_CONCURRENT;
+    delete process.env.MILAIDY_TERMINAL_MAX_DURATION_MS;
+
+    expect(resolveTerminalRunLimits()).toEqual({
+      maxConcurrent: 2,
+      maxDurationMs: 5 * 60 * 1000,
+    });
+  });
+
+  it("clamps env values into safe bounds", () => {
+    process.env.MILAIDY_TERMINAL_MAX_CONCURRENT = "999";
+    process.env.MILAIDY_TERMINAL_MAX_DURATION_MS = "100";
+
+    expect(resolveTerminalRunLimits()).toEqual({
+      maxConcurrent: 16,
+      maxDurationMs: 1000,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds defensive limits to terminal command execution to reduce DoS/stall risk.

## Changes
- Add max concurrent terminal runs (default 2, capped 16)
- Add max runtime per run (default 5m, capped 60m)
- Reject excess runs with HTTP 429
- Terminate overlong runs via SIGTERM then SIGKILL fallback
- Add tests for secure defaults and env clamping

## Reliability/Security impact
Prevents unbounded terminal workload accumulation and long-running command abuse.