### PR TITLE
fix: correct @clack/prompts version (^0.12.0 does not exist)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "typecheck": "bunx tsc --noEmit"
   },
   "dependencies": {
-    "@clack/prompts": "^0.12.0",
+    "@clack/prompts": "^1.0.0",
     "@elizaos/core": "2.0.0-alpha.4",
     "@elizaos/plugin-google-genai": "2.0.0-alpha.4",
     "@elizaos/plugin-knowledge": "2.0.0-alpha.4",


### PR DESCRIPTION
## Summary
- Changes `@clack/prompts` from `^0.12.0` to `^1.0.0` in package.json
- Version 0.12.0 was never published to npm — the highest 0.x is 0.11.0
- The `main` branch already uses `^1.0.0`, so this aligns develop

This blocks `pnpm install` on the develop branch:
```
ERR_PNPM_NO_MATCHING_VERSION  No matching version found for @clack/prompts@^0.12.0
```

**Note:** There's also a broader issue on develop where the `devDependencies` section was removed (vitest, typescript, @types/node, etc.), which prevents tests from running. The test scripts use `bunx vitest` but the vitest config files import from `vitest` which needs it in node_modules. This might be an in-progress migration — just flagging it.

Closes #238

## Test plan
- [x] `pnpm install` succeeds after this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)