### PR TITLE
chore: add Homebrew formula and cask for distribution

### DIFF
--- a/homebrew/README.md
+++ b/homebrew/README.md
@@ -1,0 +1,103 @@
+# Homebrew Distribution
+
+This directory contains Homebrew formula and cask definitions for Milaidy.
+
+## Files
+
+- `milaidy.rb` — Formula for the CLI tool (installed via npm)
+- `milaidy.cask.rb` — Cask for the desktop app (DMG installer)
+
+## Setup
+
+### 1. Create Homebrew Tap Repository
+
+Create a new repo: `milady-ai/homebrew-milaidy`
+
+Structure:
+```
+homebrew-milaidy/
+├── Formula/
+│   └── milaidy.rb
+├── Casks/
+│   └── milaidy.rb      # renamed from milaidy.cask.rb
+└── README.md
+```
+
+### 2. Update SHA256 Hashes
+
+Before publishing, replace placeholder hashes:
+
+**For the cask (DMG files):**
+```bash
+# Download and hash ARM64 DMG
+curl -sL https://github.com/milady-ai/milaidy/releases/download/v2.0.0-alpha.21/Milaidy-2.0.0-alpha.21-arm64.dmg | shasum -a 256
+
+# Download and hash Intel DMG
+curl -sL https://github.com/milady-ai/milaidy/releases/download/v2.0.0-alpha.21/Milaidy-2.0.0-alpha.21.dmg | shasum -a 256
+```
+
+**For the formula (npm tarball):**
+```bash
+curl -sL https://registry.npmjs.org/milaidy/-/milaidy-2.0.0-alpha.21.tgz | shasum -a 256
+```
+
+### 3. Users Can Install
+
+```bash
+# Add tap
+brew tap milady-ai/milaidy
+
+# Install desktop app
+brew install --cask milaidy
+
+# Or install CLI only
+brew install milaidy
+```
+
+## Auto-Update Workflow
+
+Add this GitHub Action to the main repo to auto-update the tap on release:
+
+```yaml
+# .github/workflows/update-homebrew.yml
+name: Update Homebrew
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-tap:
+    runs-on: macos-latest
+    steps:
+      - name: Update Homebrew formula
+        uses: mislav/bump-homebrew-formula-action@v3
+        with:
+          formula-name: milaidy
+          homebrew-tap: milady-ai/homebrew-milaidy
+          tag-name: ${{ github.ref_name }}
+          download-url: https://registry.npmjs.org/milaidy/-/milaidy-${{ github.ref_name }}.tgz
+        env:
+          COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+```
+
+## Testing Locally
+
+```bash
+# Test formula syntax
+brew audit --strict milaidy.rb
+
+# Test cask syntax
+brew audit --cask --strict milaidy.cask.rb
+
+# Test installation (from local file)
+brew install --formula ./milaidy.rb
+brew install --cask ./milaidy.cask.rb
+```
+
+## Notes
+
+- The cask requires macOS Monterey (12.0) or later
+- The formula requires Node.js 22+ (installed as dependency)
+- Both support auto-updates via Homebrew's built-in mechanisms
+- Desktop app also has built-in auto-update via electron-updater

--- a/homebrew/milaidy.cask.rb
+++ b/homebrew/milaidy.cask.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# Homebrew Cask for Milaidy Desktop App
+# This cask installs the Electron desktop application.
+#
+# Usage:
+#   brew tap milady-ai/milaidy
+#   brew install --cask milaidy
+#
+# For the CLI only, use the formula instead:
+#   brew install milaidy
+
+cask "milaidy" do
+  arch arm: "arm64", intel: "x64"
+
+  version "2.0.0-alpha.21"
+
+  on_arm do
+    sha256 "PLACEHOLDER_ARM64_SHA256"
+    url "https://github.com/milady-ai/milaidy/releases/download/v#{version}/Milaidy-#{version}-arm64.dmg"
+  end
+
+  on_intel do
+    sha256 "PLACEHOLDER_X64_SHA256"
+    url "https://github.com/milady-ai/milaidy/releases/download/v#{version}/Milaidy-#{version}.dmg"
+  end
+
+  name "Milaidy"
+  desc "Personal AI assistant built on ElizaOS"
+  homepage "https://github.com/milady-ai/milaidy"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: ">= :monterey"
+
+  app "Milaidy.app"
+
+  zap trash: [
+    "~/Library/Application Support/Milaidy",
+    "~/Library/Caches/ai.milady.milaidy",
+    "~/Library/Caches/ai.milady.milaidy.ShipIt",
+    "~/Library/Preferences/ai.milady.milaidy.plist",
+    "~/Library/Saved Application State/ai.milady.milaidy.savedState",
+    "~/.milaidy",
+  ]
+
+  caveats <<~EOS
+    Milaidy desktop app has been installed.
+
+    On first launch, you'll be guided through setup to:
+    - Choose your agent's name and personality
+    - Connect an AI provider (Anthropic, OpenAI, Ollama, etc.)
+
+    The CLI is also available via: brew install milaidy (without --cask)
+  EOS
+end

--- a/homebrew/milaidy.rb
+++ b/homebrew/milaidy.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Homebrew formula for Milaidy CLI
+# This formula installs the Node.js-based CLI tool via npm.
+#
+# Usage:
+#   brew tap milady-ai/milaidy
+#   brew install milaidy
+#
+# For the desktop app, use the cask instead:
+#   brew install --cask milaidy
+
+class Milaidy < Formula
+  desc "Personal AI assistant built on ElizaOS"
+  homepage "https://github.com/milady-ai/milaidy"
+  url "https://registry.npmjs.org/milaidy/-/milaidy-2.0.0-alpha.21.tgz"
+  sha256 "PLACEHOLDER_SHA256"
+  license "MIT"
+
+  depends_on "node@22"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  def caveats
+    <<~EOS
+      Milaidy requires Node.js 22+.
+
+      To start the agent:
+        milaidy start
+
+      To configure:
+        milaidy setup
+
+      Dashboard will be available at http://localhost:2138
+    EOS
+  end
+
+  test do
+    assert_match "milaidy", shell_output("#{bin}/milaidy --version")
+  end
+end


### PR DESCRIPTION
**PR Template:**

```markdown
Adds Homebrew formula and cask for macOS/Linux distribution.

Addresses #65

This PR will be reviewed by an AI agent. Provide clear context to help it assess your changes. Aesthetic/UI changes that don't improve agent capability are out of scope and will be rejected.

## Category
- [ ] Bug fix
- [ ] Security fix
- [ ] Performance improvement
- [x] New feature
- [ ] Documentation
- [ ] Test coverage
- [ ] Other

## What (brief description)

Homebrew distribution files for Milaidy:
- `homebrew/milaidy.rb` — Formula for CLI installation via npm
- `homebrew/milaidy.cask.rb` — Cask for desktop app (DMG)
- `homebrew/README.md` — Setup instructions for tap maintainers

## Why (motivation)

Issue #65 requests Homebrew support. Currently users install via `npx milaidy` or download DMGs manually. Homebrew makes installation and updates seamless for macOS/Linux users with `brew install milaidy`.

## How (implementation approach)

**Formula (CLI):**
- Uses `npm install` with Homebrew's std_npm_args
- Depends on `node@22`
- Installs `milaidy` binary to PATH

**Cask (Desktop):**
- Downloads DMG from GitHub releases
- Supports both Apple Silicon (arm64) and Intel (x64)
- Includes livecheck for auto-updates
- Cleans up app data on `brew uninstall --zap`

## Testing (what was tested, how to verify)

⚠️ **Requires macOS tester** — I'm on Windows/WSL and cannot test Homebrew installation.

**To test:**
```bash
# Test formula syntax
brew audit --strict homebrew/milaidy.rb

# Test cask syntax  
brew audit --cask --strict homebrew/milaidy.cask.rb

# Test installation (after updating SHA256 hashes)
brew install --formula ./homebrew/milaidy.rb
brew install --cask ./homebrew/milaidy.cask.rb
```

**Before merging:**
1. Create `milady-ai/homebrew-milaidy` tap repository
2. Calculate and update SHA256 hashes (see homebrew/README.md)
3. Test installation on macOS (ARM + Intel ideally)

cc: Looking for a macOS user to help verify installation works.