### PR TITLE
Cloud: block redirect-following in auth and bridge client

### DIFF
--- a/src/cloud/auth.test.ts
+++ b/src/cloud/auth.test.ts
@@ -186,9 +186,11 @@ describe("cloudLogin", () => {
 
   it("sets per-request timeout signal on cloud fetches", async () => {
     const signals: Array<AbortSignal | null | undefined> = [];
+    const redirects: Array<RequestRedirect | undefined> = [];
     let callCount = 0;
     fetchMock.mockImplementation(async (_input, init) => {
       signals.push(init?.signal);
+      redirects.push(init?.redirect);
       callCount++;
       if (callCount === 1)
         return jsonResponse({ sessionId: "test-session" }, 201);
@@ -210,6 +212,30 @@ describe("cloudLogin", () => {
     for (const signal of signals) {
       expect(signal).toBeInstanceOf(AbortSignal);
     }
+    for (const redirect of redirects) {
+      expect(redirect).toBe("manual");
+    }
+  });
+
+  it("rejects redirect responses during session creation", async () => {
+    fetchMock.mockResolvedValue(
+      new Response("", {
+        status: 302,
+        headers: { location: "https://evil.example" },
+      }),
+    );
+
+    await expect(
+      cloudLogin({
+        baseUrl: "https://test.elizacloud.ai",
+        requestTimeoutMs: 50,
+      }),
+    ).rejects.toThrow("redirected");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://test.elizacloud.ai/api/auth/cli-session",
+      expect.objectContaining({ redirect: "manual" }),
+    );
   });
 
   it("throws when session becomes 404 mid-poll", async () => {

--- a/src/cloud/auth.ts
+++ b/src/cloud/auth.ts
@@ -24,6 +24,10 @@ export interface CloudLoginOptions {
 
 const DEFAULT_CLOUD_REQUEST_TIMEOUT_MS = 10_000;
 
+function isRedirectResponse(response: Response): boolean {
+  return response.status >= 300 && response.status < 400;
+}
+
 function isTimeoutError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
   if (err.name === "TimeoutError" || err.name === "AbortError") return true;
@@ -38,6 +42,7 @@ async function fetchWithTimeout(
 ): Promise<Response> {
   return fetch(input, {
     ...init,
+    redirect: "manual",
     signal: AbortSignal.timeout(timeoutMs),
   });
 }
@@ -84,6 +89,11 @@ export async function cloudLogin(
   }
 
   if (!createResponse.ok) {
+    if (isRedirectResponse(createResponse)) {
+      throw new Error(
+        "Cloud login request was redirected; redirects are not allowed.",
+      );
+    }
     const errorText = await createResponse.text();
     throw new Error(
       `Failed to create auth session (HTTP ${createResponse.status}): ${errorText}`,
@@ -125,6 +135,11 @@ export async function cloudLogin(
     }
 
     if (!pollResponse.ok) {
+      if (isRedirectResponse(pollResponse)) {
+        throw new Error(
+          "Cloud login polling request was redirected; redirects are not allowed.",
+        );
+      }
       if (pollResponse.status === 404) {
         throw new Error("Auth session expired or not found. Please try again.");
       }


### PR DESCRIPTION
## Summary
- enforce `redirect: "manual"` for cloud auth and bridge-client fetches
- reject 3xx redirect responses across auth session creation/polling and bridge request paths
- add regression tests for redirect rejection and manual redirect mode assertions

## Validation
- bunx vitest run src/cloud/auth.test.ts
- bunx vitest run src/cloud/bridge-client.test.ts
- bun run check *(fails only on pre-existing baseline files: .github/trust-scoring.cjs and .github/contributor-trust.json)*
