### PR TITLE
ci(agent-review): require checks before auto-merge

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
 
       - name: Check PR author permissions
@@ -143,6 +143,8 @@ jobs:
             - **Base**: ${{ github.event.pull_request.base.ref }}
             - **Pre-classification**: ${{ needs.classify.outputs.category }}
             - **Contributor trust**: ${{ steps.trust-context.outputs.trust_info }}
+            This environment is checked out at the PR base ref.
+            The PR patch is available via 'gh pr diff'.
 
             ## Review Protocol
 


### PR DESCRIPTION
## Summary
- run review job on base SHA and instruct reviewer to use `gh pr diff`
- gate auto-merge on required check completion (`gh pr checks --required --watch --fail-fast`)
- cap check-watch duration to 15 minutes with 10s poll interval
- keep PAT fallback + manual-merge label path for workflow-file permission constraints

## Validation
- bun run check *(fails only on pre-existing baseline files: .github/trust-scoring.cjs and .github/contributor-trust.json)*
