### PR TITLE
fix(api): remove duplicated plugin config key allowlist checks

### DIFF
--- a/src/api/plugin-validation.test.ts
+++ b/src/api/plugin-validation.test.ts
@@ -349,6 +349,43 @@ describe("validatePluginConfig", () => {
     expect(undeclaredErrors).toHaveLength(1);
   });
 
+  it("rejects differently-cased config keys to avoid silent no-op updates", () => {
+    const result = validatePluginConfig(
+      "anthropic",
+      "ai-provider",
+      "ANTHROPIC_API_KEY",
+      ["ANTHROPIC_API_KEY", "ANTHROPIC_SMALL_MODEL"],
+      {
+        ANTHROPIC_API_KEY: "sk-ant-test-1234567890abcdef",
+        anthropic_small_model: "claude-3-5-sonnet-20241022",
+      },
+      [
+        {
+          key: "ANTHROPIC_API_KEY",
+          required: true,
+          sensitive: true,
+          type: "string",
+          description: "API key",
+        },
+        {
+          key: "ANTHROPIC_SMALL_MODEL",
+          required: false,
+          sensitive: false,
+          type: "string",
+          description: "Small model",
+          default: "claude-3-5-haiku-20241022",
+        },
+      ],
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContainEqual({
+      field: "anthropic_small_model",
+      message:
+        "anthropic_small_model does not match declared config key casing; use ANTHROPIC_SMALL_MODEL",
+    });
+  });
+
   // ---------------------------------------------------------------------------
   // API key format validation
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- remove duplicate undeclared-key validation block in `validatePluginConfig`
- preserve single undeclared-key error behavior
- explicitly reject case-mismatched config keys with canonical-casing guidance to prevent silent no-op updates in `/api/plugins/:id`
- add regression tests for:
  - single error per undeclared key
  - case-mismatched key rejection

## Validation
- bunx vitest run src/api/plugin-validation.test.ts
- bun run check *(fails only on pre-existing baseline files: .github/trust-scoring.cjs and .github/contributor-trust.json)*
