### PR TITLE
cloud: block full IPv6 link-local range in URL validator

### DIFF
--- a/src/cloud/validate-url.test.ts
+++ b/src/cloud/validate-url.test.ts
@@ -79,6 +79,16 @@ describe("validateCloudBaseUrl", () => {
     expect(dnsMockState.lookupMock).not.toHaveBeenCalled();
   });
 
+  it("blocks direct IPv6 link-local targets across fe80::/10", async () => {
+    const fe80Result = await validateCloudBaseUrl("https://[fe80::1]");
+    const fea0Result = await validateCloudBaseUrl("https://[fea0::1]");
+    const febfResult = await validateCloudBaseUrl("https://[febf::1]");
+    expect(fe80Result).toContain("blocked");
+    expect(fea0Result).toContain("blocked");
+    expect(febfResult).toContain("blocked");
+    expect(dnsMockState.lookupMock).not.toHaveBeenCalled();
+  });
+
   it("blocks direct IPv6 ULA targets across fc00::/7", async () => {
     const fcResult = await validateCloudBaseUrl("https://[fc12::1]");
     const fdResult = await validateCloudBaseUrl("https://[fd12::1]");

--- a/src/cloud/validate-url.ts
+++ b/src/cloud/validate-url.ts
@@ -13,7 +13,7 @@ const dnsLookupAll = promisify(dns.lookup);
 const ALWAYS_BLOCKED_IP_PATTERNS: RegExp[] = [
   /^169\.254\./, // Link-local / cloud metadata endpoints
   /^0\./, // "This" network
-  /^fe80:/i, // IPv6 link-local
+  /^fe[89ab][0-9a-f]:/i, // IPv6 link-local fe80::/10
 ];
 
 const PRIVATE_IP_PATTERNS: RegExp[] = [


### PR DESCRIPTION
## Summary
Block IPv6 link-local addresses across the full fe80::/10 range in cloud base URL validation.

## Behavioral contract
Cloud base URLs must never resolve to link-local/metadata/internal targets.
fe80::/10 (including fea0::/16 and febf::/16) must be rejected.

## Changes
- Update IPv6 link-local pattern in `src/cloud/validate-url.ts` from `^fe80:` to `^fe[89ab][0-9a-f]:`.
- Add regressions in `src/cloud/validate-url.test.ts` for `fe80::1`, `fea0::1`, and `febf::1`.

## Validation
- `bunx vitest run src/cloud/validate-url.test.ts`

Supersedes #284 (force-push to the existing branch is blocked by repo policy in this environment).
