### PR TITLE
runtime: block full IPv6 link-local range in custom action SSRF guard

### DIFF
--- a/src/runtime/custom-actions.test.ts
+++ b/src/runtime/custom-actions.test.ts
@@ -67,6 +67,17 @@ describe("custom action SSRF guard", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  it("rejects direct IPv6 link-local targets across fe80::/10", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const handler = buildTestHandler(makeHttpAction("http://[fea0::1]/test"));
+
+    const result = await handler({});
+    expect(result.ok).toBe(false);
+    expect(result.output).toContain("Blocked");
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(vi.mocked(dnsLookup)).not.toHaveBeenCalled();
+  });
+
   it("allows explicit localhost API target on the configured API port", async () => {
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")

--- a/src/runtime/custom-actions.ts
+++ b/src/runtime/custom-actions.ts
@@ -55,7 +55,7 @@ function shellEscape(value: string): string {
 const ALWAYS_BLOCKED_IP_PATTERNS: RegExp[] = [
   /^0\./, // "this" network
   /^169\.254\./, // link-local / metadata
-  /^fe80:/i, // IPv6 link-local
+  /^fe[89ab][0-9a-f]:/i, // IPv6 link-local fe80::/10
   /^::$/i, // unspecified
   /^::1$/i, // IPv6 loopback
 ];


### PR DESCRIPTION
## Summary
Block IPv6 link-local addresses across the full fe80::/10 range in custom action SSRF policy.

## Behavioral contract
Custom HTTP actions must not reach internal/link-local/metadata targets.
All of fe80::/10 (including fea0::/16 and febf::/16) must be blocked before fetch.

## Changes
- Update IPv6 link-local matcher in `src/runtime/custom-actions.ts` from `^fe80:` to `^fe[89ab][0-9a-f]:`.
- Keep fail-closed DNS/IP resolution behavior unchanged.
- Add regression in `src/runtime/custom-actions.test.ts` to verify direct `http://[fea0::1]/...` is rejected and fetch is not called.

## Validation
- `bunx vitest run src/runtime/custom-actions.test.ts`

Supersedes #287 (force-push to existing branch is blocked by repo policy in this environment).
