### PR TITLE
fix: responsive grid layout for mobile onboarding

### DIFF
--- a/apps/app/src/components/OnboardingWizard.tsx
+++ b/apps/app/src/components/OnboardingWizard.tsx
@@ -347,7 +347,7 @@ export function OnboardingWizard() {
             <div className="onboarding-speech bg-card border border-border rounded-xl px-5 py-4 mx-auto mb-6 max-w-[600px] relative text-[15px] text-txt leading-relaxed">
               <h2 className="text-[28px] font-normal mb-1 text-txt-strong">whats my vibe?</h2>
             </div>
-            <div className="grid grid-cols-3 gap-2 mx-auto max-w-[480px]">
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mx-auto max-w-[480px]">
               {onboardingOptions?.styles.map((preset: StylePreset) => (
                 <button
                   key={preset.catchphrase}
@@ -379,7 +379,7 @@ export function OnboardingWizard() {
             <div className="onboarding-speech bg-card border border-border rounded-xl px-5 py-4 mx-auto mb-6 max-w-[600px] relative text-[15px] text-txt leading-relaxed">
               <h2 className="text-[28px] font-normal mb-1 text-txt-strong">what colors do u like?</h2>
             </div>
-            <div className="grid grid-cols-3 gap-2 max-w-[600px] mx-auto">
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 max-w-[600px] mx-auto">
               {THEMES.map((theme) => (
                 <button
                   key={theme.id}
@@ -741,7 +741,7 @@ export function OnboardingWizard() {
                 )}
 
                 <div className="mb-4 text-left">
-                  <div className="grid grid-cols-4 gap-2">
+                  <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-2">
                     {cloudProviders.map((p: ProviderOption) => renderProviderCard(p))}
                     {subscriptionProviders.map((p: ProviderOption) => renderProviderCard(p))}
                     {apiProviders.map((p: ProviderOption) => renderProviderCard(p))}


### PR DESCRIPTION
## Problem
Provider selection grid on the 'what is my brain?' onboarding page uses `grid-cols-4` with no responsive breakpoint. On mobile, cards are tiny with all text truncated/clipped.

## Fix
- Provider grid: `grid-cols-2 sm:grid-cols-3 lg:grid-cols-4` (2 columns mobile, 3 tablet, 4 desktop)
- Style preset grids: `grid-cols-2 sm:grid-cols-3` (2 columns mobile, 3 tablet+)

Only grid column classes changed — no other modifications.

## Testing
Verified all grid instances in OnboardingWizard.tsx are now responsive.