### PR TITLE
Improve custom actions generation flow

### DIFF
--- a/apps/app/src/components/ChatView.tsx
+++ b/apps/app/src/components/ChatView.tsx
@@ -324,16 +324,18 @@ export function ChatView() {
             Power
           </button>
         </div>
-        <div className="flex gap-1.5">
+          <div className="flex gap-1.5">
           {/* Custom Actions panel toggle */}
           <button
-            className="w-7 h-7 flex items-center justify-center border rounded cursor-pointer transition-all bg-card border-border text-muted hover:border-accent hover:text-accent"
+            className="h-7 px-2 flex items-center gap-1 border rounded cursor-pointer transition-all bg-card border-border text-muted hover:border-accent hover:text-accent"
             onClick={() => window.dispatchEvent(new Event("toggle-custom-actions-panel"))}
             title="Custom Actions"
+            aria-label="Open custom actions panel"
           >
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
             </svg>
+            <span className="text-[10px] font-medium">Actions</span>
           </button>
 
           {/* Show / hide avatar */}

--- a/apps/app/src/components/CustomActionEditor.tsx
+++ b/apps/app/src/components/CustomActionEditor.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { client, type CustomActionDef, type CustomActionHandler } from "../api-client";
 
 interface CustomActionEditorProps {
@@ -9,6 +9,7 @@ interface CustomActionEditorProps {
 }
 
 type HandlerType = "http" | "shell" | "code";
+type HttpMethod = "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
 
 interface ParamDef {
   name: string;
@@ -21,13 +22,284 @@ interface HeaderRow {
   value: string;
 }
 
-export function CustomActionEditor({ open, action, onSave, onClose }: CustomActionEditorProps) {
+interface ParsedGeneration {
+  name: string;
+  description: string;
+  handlerType: HandlerType;
+  handler: CustomActionHandler;
+  parameters: ParamDef[];
+  similes: string[];
+  enabled: boolean;
+}
+
+const HTTP_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH"] as const;
+const METHODS_SET = new Set<string>(HTTP_METHODS);
+
+const HTTP_METHODS_LIST = HTTP_METHODS;
+
+function toNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function normalizeActionName(value: string): string {
+  return value
+    .trim()
+    .toUpperCase()
+    .replace(/[^A-Z0-9_]+/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function normalizeAlias(value: string): string {
+  return normalizeActionName(value);
+}
+
+function normalizeParamName(value: string): string {
+  return value
+    .trim()
+    .replace(/[^A-Za-z0-9_]+/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function normalizeMethod(value: unknown): HttpMethod {
+  const method = toNonEmptyString(value)?.toUpperCase();
+  return method && METHODS_SET.has(method) ? (method as HttpMethod) : "GET";
+}
+
+function parseHeaders(value: unknown): HeaderRow[] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return [];
+  }
+  return Object.entries(value).flatMap(([key, rawValue]) => {
+    const trimmedKey = normalizeParamName(key);
+    if (!trimmedKey) return [];
+    if (typeof rawValue !== "string") return [];
+    return [{ key: key.trim(), value: rawValue }];
+  });
+}
+
+function parseParameters(value: unknown): ParamDef[] {
+  if (!Array.isArray(value)) return [];
+
+  const seen = new Set<string>();
+
+  return value
+    .map((raw) => {
+      if (!raw || typeof raw !== "object") return null;
+
+      const candidate = raw as {
+        name?: unknown;
+        description?: unknown;
+        required?: unknown;
+      };
+
+      const rawName = toNonEmptyString(candidate.name);
+      if (!rawName) return null;
+
+      const name = normalizeParamName(rawName);
+      if (!name || seen.has(name.toLowerCase())) return null;
+      seen.add(name.toLowerCase());
+
+      return {
+        name,
+        description: toNonEmptyString(candidate.description) || name,
+        required: candidate.required === true,
+      } satisfies ParamDef;
+    })
+    .filter((param): param is ParamDef => param !== null);
+}
+
+function parseSimiles(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+
+  const seen = new Set<string>();
+
+  return value
+    .map((raw) => toNonEmptyString(raw) || "")
+    .map((simile) => normalizeAlias(simile))
+    .filter((simile) => simile.length > 0)
+    .filter((simile) => {
+      const key = simile.toLowerCase();
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+}
+
+function parseGeneratedAction(
+  payload: unknown,
+): { ok: boolean; action?: ParsedGeneration; errors: string[] } {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return { ok: false, errors: ["Generation returned an invalid payload."] };
+  }
+
+  const raw = payload as Record<string, unknown>;
+
+  const name = normalizeActionName(raw.name?.toString() ?? "");
+  const description = toNonEmptyString(raw.description) ?? "";
+
+  if (!name) {
+    return {
+      ok: false,
+      errors: ["Generated action must include a name."],
+    };
+  }
+
+  const handlerSource = raw.handler;
+  if (!handlerSource || typeof handlerSource !== "object" || Array.isArray(handlerSource)) {
+    return {
+      ok: false,
+      errors: ["Generated action must include a handler block."],
+    };
+  }
+
+  const hTypeRaw =
+    toNonEmptyString((raw as { handlerType?: unknown }).handlerType) ??
+    toNonEmptyString((handlerSource as { type?: unknown }).type);
+  const handlerType = (hTypeRaw?.toLowerCase() as HandlerType | undefined);
+
+  if (handlerType !== "http" && handlerType !== "shell" && handlerType !== "code") {
+    return {
+      ok: false,
+      errors: ["Generated handler type must be http, shell, or code."],
+    };
+  }
+
+  const params = parseParameters(raw.parameters);
+
+  if (handlerType === "http") {
+    const rawHttp = handlerSource as {
+      method?: unknown;
+      url?: unknown;
+      headers?: unknown;
+      bodyTemplate?: unknown;
+      methodType?: unknown;
+      type?: unknown;
+    };
+
+    const url = toNonEmptyString(rawHttp.url);
+    if (!url) {
+      return {
+        ok: false,
+        errors: ["HTTP action requires a URL."],
+      };
+    }
+
+    const handler: CustomActionHandler = {
+      type: "http",
+      method: normalizeMethod(rawHttp.method ?? rawHttp.methodType),
+      url,
+      headers: parseHeaders(rawHttp.headers).length
+        ? parseHeaders(rawHttp.headers).reduce<Record<string, string>>((acc, item) => {
+          if (item.key) {
+            acc[item.key] = item.value;
+          }
+          return acc;
+        }, {})
+        : undefined,
+      bodyTemplate: toNonEmptyString(rawHttp.bodyTemplate),
+    };
+
+    return {
+      ok: true,
+      action: {
+        name,
+        description,
+        handlerType,
+        handler,
+        parameters: params,
+        similes: parseSimiles(raw.similes),
+        enabled: raw.enabled === true,
+      },
+      errors: [],
+    };
+  }
+
+  if (handlerType === "shell") {
+    const rawShell = handlerSource as {
+      command?: unknown;
+    };
+
+    const command = toNonEmptyString(rawShell.command);
+    if (!command) {
+      return {
+        ok: false,
+        errors: ["Shell action requires a command template."],
+      };
+    }
+
+    return {
+      ok: true,
+      action: {
+        name,
+        description,
+        handlerType,
+        handler: {
+          type: "shell",
+          command,
+        },
+        parameters: params,
+        similes: parseSimiles(raw.similes),
+        enabled: raw.enabled === true,
+      },
+      errors: [],
+    };
+  }
+
+  const rawCode = handlerSource as {
+    code?: unknown;
+    source?: unknown;
+  };
+  const code = toNonEmptyString(rawCode.code) ?? toNonEmptyString(rawCode.source);
+
+  if (!code) {
+    return {
+      ok: false,
+      errors: ["Code action requires a JavaScript code block."],
+    };
+  }
+
+    return {
+      ok: true,
+      action: {
+        name,
+        description,
+      handlerType,
+      handler: {
+        type: "code",
+        code,
+      },
+        parameters: params,
+        similes: parseSimiles(raw.similes),
+        enabled: raw.enabled === true,
+      },
+      errors: [],
+    };
+  }
+
+function parseSimilesInput(value: string): string[] {
+  return value
+    .split(",")
+    .map((raw) => normalizeAlias(raw))
+    .filter(Boolean);
+}
+
+export function CustomActionEditor({
+  open,
+  action,
+  onSave,
+  onClose,
+}: CustomActionEditorProps) {
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
+  const [similesInput, setSimilesInput] = useState("");
   const [handlerType, setHandlerType] = useState<HandlerType>("http");
 
   // HTTP handler fields
-  const [httpMethod, setHttpMethod] = useState<"GET" | "POST" | "PUT" | "DELETE" | "PATCH">("GET");
+  const [httpMethod, setHttpMethod] = useState<HttpMethod>("GET");
   const [httpUrl, setHttpUrl] = useState("");
   const [httpHeaders, setHttpHeaders] = useState<HeaderRow[]>([{ key: "", value: "" }]);
   const [httpBody, setHttpBody] = useState("");
@@ -51,28 +323,40 @@ export function CustomActionEditor({ open, action, onSave, onClose }: CustomActi
   const [testResult, setTestResult] = useState<{ output?: string; error?: string; duration?: number } | null>(null);
   const [testing, setTesting] = useState(false);
 
+  const [saving, setSaving] = useState(false);
+  const [formError, setFormError] = useState("");
+
   // Populate form when action changes
   useEffect(() => {
     if (!open) return;
 
+    setFormError("");
+
     if (action) {
       setName(action.name);
       setDescription(action.description || "");
-      setParameters(action.parameters?.map(p => ({
-        name: p.name,
-        description: p.description || "",
-        required: p.required || false
-      })) || []);
+      setSimilesInput((action.similes ?? []).join(", "));
+      setParameters(
+        action.parameters?.map((p) => ({
+          name: p.name,
+          description: p.description || "",
+          required: p.required || false,
+        })) || [],
+      );
 
       const handler = action.handler;
       if (handler.type === "http") {
         setHandlerType("http");
-        setHttpMethod((handler.method as "GET" | "POST" | "PUT" | "DELETE" | "PATCH") || "GET");
+        setHttpMethod((handler.method as HttpMethod) || "GET");
         setHttpUrl(handler.url || "");
         const headers = handler.headers || {};
-        setHttpHeaders(Object.keys(headers).length > 0
-          ? Object.entries(headers).map(([k, v]) => ({ key: k, value: v }))
-          : [{ key: "", value: "" }]
+        setHttpHeaders(
+          Object.keys(headers).length > 0
+            ? Object.entries(headers).map(([key, value]) => ({
+                key,
+                value,
+              }))
+            : [{ key: "", value: "" }],
         );
         setHttpBody(handler.bodyTemplate || "");
       } else if (handler.type === "shell") {
@@ -86,6 +370,7 @@ export function CustomActionEditor({ open, action, onSave, onClose }: CustomActi
       // Reset for create mode
       setName("");
       setDescription("");
+      setSimilesInput("");
       setHandlerType("http");
       setHttpMethod("GET");
       setHttpUrl("");
@@ -101,54 +386,78 @@ export function CustomActionEditor({ open, action, onSave, onClose }: CustomActi
     }
   }, [open, action]);
 
-  const handleNameChange = (value: string) => {
-    const normalized = value.toUpperCase().replace(/\s+/g, "_");
-    setName(normalized);
+  const setNormalizedName = (value: string) => {
+    setName(normalizeActionName(value));
+    setFormError("");
+  };
+
+  const setDescriptionValue = (value: string) => {
+    setDescription(value);
+    setFormError("");
+  };
+
+  const applyGenerated = (parsed: ParsedGeneration) => {
+    setName(parsed.name);
+    setDescription(parsed.description);
+    setSimilesInput(parsed.similes.join(", "));
+
+    if (parsed.handlerType === "http") {
+      const handler = parsed.handler as CustomActionHandler & {
+        type: "http";
+        method: HttpMethod;
+      };
+      setHandlerType("http");
+      setHttpMethod(handler.method || "GET");
+      setHttpUrl(handler.url);
+      setHttpBody(handler.bodyTemplate || "");
+      setHttpHeaders(
+        handler.headers
+          ? Object.entries(handler.headers).map(([key, value]) => ({
+              key,
+              value,
+            }))
+          : [{ key: "", value: "" }],
+      );
+    } else if (parsed.handlerType === "shell") {
+      const handler = parsed.handler as CustomActionHandler & { type: "shell" };
+      setHandlerType("shell");
+      setShellCommand(handler.command);
+    } else {
+      const handler = parsed.handler as CustomActionHandler & { type: "code" };
+      setHandlerType("code");
+      setCode(handler.code);
+    }
+
+    setParameters(parsed.parameters);
+    setFormError("");
+    setAiPrompt("");
   };
 
   const handleGenerate = async () => {
     if (!aiPrompt.trim()) return;
     setGenerating(true);
+    setFormError("");
+
     try {
       const result = await client.generateCustomAction(aiPrompt.trim());
-      if (!result.ok || !result.generated) return;
-      const g = result.generated;
-
-      if (typeof g.name === "string") setName(g.name.toUpperCase().replace(/\s+/g, "_"));
-      if (typeof g.description === "string") setDescription(g.description);
-
-      const handler = (g.handler ?? g) as Record<string, unknown>;
-      const hType = (handler.type ?? g.handlerType) as string | undefined;
-
-      if (hType === "http") {
-        setHandlerType("http");
-        if (typeof handler.method === "string") setHttpMethod(handler.method as "GET" | "POST" | "PUT" | "DELETE" | "PATCH");
-        if (typeof handler.url === "string") setHttpUrl(handler.url);
-        if (handler.headers && typeof handler.headers === "object") {
-          setHttpHeaders(Object.entries(handler.headers as Record<string, string>).map(([k, v]) => ({ key: k, value: v })));
-        }
-        if (typeof handler.bodyTemplate === "string") setHttpBody(handler.bodyTemplate);
-      } else if (hType === "shell") {
-        setHandlerType("shell");
-        if (typeof handler.command === "string") setShellCommand(handler.command);
-      } else if (hType === "code") {
-        setHandlerType("code");
-        if (typeof handler.code === "string") setCode(handler.code);
+      if (!result.ok || !result.generated) {
+        setFormError("AI generation returned no action definition.");
+        return;
       }
 
-      if (Array.isArray(g.parameters)) {
-        setParameters(
-          (g.parameters as Array<{ name?: string; description?: string; required?: boolean }>)
-            .filter((p) => p.name)
-            .map((p) => ({
-              name: p.name ?? "",
-              description: p.description ?? "",
-              required: p.required ?? false,
-            }))
+      const parsed = parseGeneratedAction(result.generated);
+      if (!parsed.ok || !parsed.action) {
+        setFormError(
+          parsed.errors.length > 0
+            ? parsed.errors.join(" ")
+            : "AI generation was incomplete.",
         );
+        return;
       }
-    } catch (err: any) {
-      alert(`Generation failed: ${err.message || String(err)}`);
+
+      applyGenerated(parsed.action);
+    } catch (err: unknown) {
+      setFormError(`Generation failed: ${err instanceof Error ? err.message : String(err)}`);
     } finally {
       setGenerating(false);
     }
@@ -163,9 +472,26 @@ export function CustomActionEditor({ open, action, onSave, onClose }: CustomActi
   };
 
   const updateParameter = (index: number, field: keyof ParamDef, value: string | boolean) => {
-    setParameters(parameters.map((p, i) =>
-      i === index ? { ...p, [field]: value } : p
-    ));
+    setParameters((prevParameters) =>
+      prevParameters.map((parameter, i) => {
+        if (i !== index) {
+          return parameter;
+        }
+
+        if (field === "name") {
+          return {
+            ...parameter,
+            [field]: normalizeParamName(value as string),
+          };
+        }
+
+        return {
+          ...parameter,
+          [field]: value,
+        };
+      }),
+    );
+    setFormError("");
   };
 
   const addHeader = () => {
@@ -177,14 +503,140 @@ export function CustomActionEditor({ open, action, onSave, onClose }: CustomActi
   };
 
   const updateHeader = (index: number, field: "key" | "value", value: string) => {
-    setHttpHeaders(httpHeaders.map((h, i) =>
-      i === index ? { ...h, [field]: value } : h
-    ));
+    setHttpHeaders((prevHeaders) =>
+      prevHeaders.map((header, i) =>
+        i === index ? { ...header, [field]: value } : header,
+      ),
+    );
+    setFormError("");
+  };
+
+  const buildHeaders = (): Record<string, string> | undefined => {
+    const headers: Record<string, string> = {};
+
+    for (const header of httpHeaders) {
+      const key = header.key.trim();
+      if (key) {
+        headers[key] = header.value;
+      }
+    }
+
+    return Object.keys(headers).length > 0 ? headers : undefined;
+  };
+
+  const validateParameters = (items: ParamDef[]): string | null => {
+    const seen = new Set<string>();
+
+    for (const parameter of items) {
+      const normalized = normalizeParamName(parameter.name);
+      if (!normalized) {
+        return "Each parameter needs a non-empty name.";
+      }
+
+      if (seen.has(normalized.toLowerCase())) {
+        return `Duplicate parameter name: ${normalized}`;
+      }
+
+      seen.add(normalized.toLowerCase());
+      parameter.name = normalized;
+    }
+
+    return null;
+  };
+
+  const handleSave = async () => {
+    if (saving) return;
+    setSaving(true);
+    setFormError("");
+
+    try {
+      const actionName = normalizeActionName(name);
+      const actionDescription = description.trim();
+
+      if (!actionName) {
+        setFormError("Name is required.");
+        return;
+      }
+
+      if (!actionDescription) {
+        setFormError("Description is required.");
+        return;
+      }
+
+      const normalizedParameters = [...parameters];
+      const validationError = validateParameters(normalizedParameters);
+      if (validationError) {
+        setFormError(validationError);
+        return;
+      }
+
+      let handler: CustomActionHandler;
+
+      if (handlerType === "http") {
+        if (!httpUrl.trim()) {
+          setFormError("HTTP URL is required.");
+          return;
+        }
+
+        const headers = buildHeaders();
+
+        handler = {
+          type: "http",
+          method: normalizeMethod(httpMethod),
+          url: httpUrl,
+          headers,
+          bodyTemplate: httpBody || undefined,
+        };
+      } else if (handlerType === "shell") {
+        if (!shellCommand.trim()) {
+          setFormError("Shell command is required.");
+          return;
+        }
+
+        handler = {
+          type: "shell",
+          command: shellCommand,
+        };
+      } else {
+        if (!code.trim()) {
+          setFormError("Code is required.");
+          return;
+        }
+
+        handler = {
+          type: "code",
+          code,
+        };
+      }
+
+      const similes = parseSimilesInput(similesInput);
+
+      const actionDef = {
+        name: actionName,
+        description: actionDescription,
+        similes,
+        parameters: normalizedParameters,
+        handler,
+        enabled: action?.enabled ?? true,
+      };
+
+      const saved = action?.id
+        ? await client.updateCustomAction(action.id, actionDef)
+        : await client.createCustomAction(actionDef);
+
+      onSave(saved);
+      setAiPrompt("");
+      setFormError("");
+    } catch (err: unknown) {
+      setFormError(`Failed to save: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setSaving(false);
+    }
   };
 
   const handleTest = async () => {
     if (!action?.id) {
-      setTestResult({ error: "Save the action first to test it" });
+      setTestResult({ error: "Save the action first to test it." });
       return;
     }
 
@@ -195,71 +647,18 @@ export function CustomActionEditor({ open, action, onSave, onClose }: CustomActi
     try {
       const result = await client.testCustomAction(action.id, testParams);
       const duration = Date.now() - startTime;
-      setTestResult({ output: JSON.stringify(result, null, 2), duration });
-    } catch (err: any) {
+      setTestResult({
+        output: JSON.stringify(result, null, 2),
+        duration,
+      });
+    } catch (err: unknown) {
       const duration = Date.now() - startTime;
-      setTestResult({ error: err.message || String(err), duration });
+      setTestResult({
+        error: err instanceof Error ? err.message : String(err),
+        duration,
+      });
     } finally {
       setTesting(false);
-    }
-  };
-
-  const handleSave = async () => {
-    if (!name.trim()) {
-      alert("Name is required");
-      return;
-    }
-
-    let handler: CustomActionHandler;
-
-    if (handlerType === "http") {
-      const headers: Record<string, string> = {};
-      httpHeaders.forEach(h => {
-        if (h.key.trim()) {
-          headers[h.key.trim()] = h.value;
-        }
-      });
-
-      handler = {
-        type: "http",
-        method: httpMethod,
-        url: httpUrl,
-        headers: Object.keys(headers).length > 0 ? headers : undefined,
-        bodyTemplate: httpBody || undefined
-      };
-    } else if (handlerType === "shell") {
-      handler = {
-        type: "shell",
-        command: shellCommand
-      };
-    } else {
-      handler = {
-        type: "code",
-        code
-      };
-    }
-
-    const actionDef = {
-      name: name.trim(),
-      description: description.trim(),
-      similes: [] as string[],
-      parameters: parameters.filter(p => p.name.trim()).map(p => ({
-        name: p.name.trim(),
-        description: p.description.trim(),
-        required: p.required
-      })),
-      handler,
-      enabled: action?.enabled ?? true,
-    };
-
-    try {
-      const saved = action?.id
-        ? await client.updateCustomAction(action.id, actionDef)
-        : await client.createCustomAction(actionDef);
-
-      onSave(saved);
-    } catch (err: any) {
-      alert(`Failed to save: ${err.message || String(err)}`);
     }
   };
 
@@ -283,6 +682,12 @@ export function CustomActionEditor({ open, action, onSave, onClose }: CustomActi
 
         {/* Body */}
         <div className="px-5 py-4 flex flex-col gap-4 max-h-[70vh] overflow-y-auto">
+          {formError && (
+            <div className="border border-danger/30 bg-danger/10 text-danger px-3 py-2 text-xs rounded">
+              {formError}
+            </div>
+          )}
+
           {/* AI Generate */}
           {!action && (
             <div className="flex flex-col gap-1 border border-accent/30 bg-accent/5 p-3">
@@ -291,9 +696,16 @@ export function CustomActionEditor({ open, action, onSave, onClose }: CustomActi
                 <input
                   type="text"
                   value={aiPrompt}
-                  onChange={(e) => setAiPrompt(e.target.value)}
-                  onKeyDown={(e) => e.key === "Enter" && !generating && handleGenerate()}
-                  placeholder="e.g. Check if a website is up and return the status code"
+                  onChange={(e) => {
+                    setAiPrompt(e.target.value);
+                    setFormError("");
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" && !generating) {
+                      void handleGenerate();
+                    }
+                  }}
+                  placeholder="e.g. Check if a website is up and return status"
                   className="flex-1 bg-surface border border-border px-2 py-1.5 text-sm text-txt placeholder:text-muted/50 outline-none focus:border-accent"
                 />
                 <button
@@ -304,7 +716,7 @@ export function CustomActionEditor({ open, action, onSave, onClose }: CustomActi
                   {generating ? "Generating..." : "Generate"}
                 </button>
               </div>
-              <span className="text-xs text-muted/70">The agent will generate the action config for you to review and edit</span>
+              <span className="text-xs text-muted/70">The agent will generate the action config for you to review and edit.</span>
             </div>
           )}
 
@@ -314,7 +726,7 @@ export function CustomActionEditor({ open, action, onSave, onClose }: CustomActi
             <input
               type="text"
               value={name}
-              onChange={(e) => handleNameChange(e.target.value)}
+              onChange={(e) => setNormalizedName(e.target.value)}
               placeholder="MY_ACTION"
               className="flex-1 bg-surface border border-border px-2 py-1.5 text-sm text-txt placeholder:text-muted/50 outline-none focus:border-accent"
             />
@@ -325,11 +737,27 @@ export function CustomActionEditor({ open, action, onSave, onClose }: CustomActi
             <label className="text-xs text-muted">Description</label>
             <textarea
               value={description}
-              onChange={(e) => setDescription(e.target.value)}
+              onChange={(e) => setDescriptionValue(e.target.value)}
               placeholder="What does this action do?"
               rows={2}
               className="flex-1 bg-surface border border-border px-2 py-1.5 text-sm text-txt placeholder:text-muted/50 outline-none focus:border-accent resize-none"
             />
+          </div>
+
+          {/* Similes */}
+          <div className="flex flex-col gap-1">
+            <label className="text-xs text-muted">Aliases (optional)</label>
+            <input
+              type="text"
+              value={similesInput}
+              onChange={(e) => {
+                setSimilesInput(e.target.value);
+                setFormError("");
+              }}
+              placeholder="SYNONYM_ONE, SYNONYM_TWO"
+              className="flex-1 bg-surface border border-border px-2 py-1.5 text-sm text-txt placeholder:text-muted/50 outline-none focus:border-accent"
+            />
+            <span className="text-xs text-muted/70">Comma-separated alternatives the agent can match against.</span>
           </div>
 
           {/* Handler Type Tabs */}
@@ -339,7 +767,10 @@ export function CustomActionEditor({ open, action, onSave, onClose }: CustomActi
               {(["http", "shell", "code"] as const).map((type) => (
                 <button
                   key={type}
-                  onClick={() => setHandlerType(type)}
+                  onClick={() => {
+                    setHandlerType(type);
+                    setFormError("");
+                  }}
                   className={`px-3 py-1.5 text-xs border cursor-pointer ${
                     handlerType === type
                       ? "border-accent bg-accent text-white"
@@ -358,19 +789,24 @@ export function CustomActionEditor({ open, action, onSave, onClose }: CustomActi
               <div className="flex gap-2">
                 <select
                   value={httpMethod}
-                  onChange={(e) => setHttpMethod(e.target.value as "GET" | "POST" | "PUT" | "DELETE" | "PATCH")}
+                  onChange={(e) =>
+                    setHttpMethod(e.target.value as HttpMethod)
+                  }
                   className="bg-surface border border-border px-2 py-1.5 text-sm text-txt outline-none focus:border-accent"
                 >
-                  <option value="GET">GET</option>
-                  <option value="POST">POST</option>
-                  <option value="PUT">PUT</option>
-                  <option value="DELETE">DELETE</option>
-                  <option value="PATCH">PATCH</option>
+                  {HTTP_METHODS_LIST.map((method) => (
+                    <option key={method} value={method}>
+                      {method}
+                    </option>
+                  ))}
                 </select>
                 <input
                   type="text"
                   value={httpUrl}
-                  onChange={(e) => setHttpUrl(e.target.value)}
+                  onChange={(e) => {
+                    setHttpUrl(e.target.value);
+                    setFormError("");
+                  }}
                   placeholder="https://api.example.com/{{param}}"
                   className="flex-1 bg-surface border border-border px-2 py-1.5 text-sm text-txt placeholder:text-muted/50 outline-none focus:border-accent"
                 />
@@ -416,7 +852,10 @@ export function CustomActionEditor({ open, action, onSave, onClose }: CustomActi
                 <label className="text-xs text-muted">Body Template (optional)</label>
                 <textarea
                   value={httpBody}
-                  onChange={(e) => setHttpBody(e.target.value)}
+                  onChange={(e) => {
+                    setHttpBody(e.target.value);
+                    setFormError("");
+                  }}
                   placeholder={'{"key": "{{param}}"}'}
                   rows={3}
                   className="bg-surface border border-border px-2 py-1.5 text-sm text-txt placeholder:text-muted/50 outline-none focus:border-accent resize-none font-mono"
@@ -430,7 +869,10 @@ export function CustomActionEditor({ open, action, onSave, onClose }: CustomActi
               <label className="text-xs text-muted">Command Template</label>
               <textarea
                 value={shellCommand}
-                onChange={(e) => setShellCommand(e.target.value)}
+                onChange={(e) => {
+                  setShellCommand(e.target.value);
+                  setFormError("");
+                }}
                 placeholder="echo {{message}} > /tmp/output.txt"
                 rows={4}
                 className="bg-surface border border-border px-2 py-1.5 text-sm text-txt placeholder:text-muted/50 outline-none focus:border-accent resize-none font-mono"
@@ -444,7 +886,10 @@ export function CustomActionEditor({ open, action, onSave, onClose }: CustomActi
               <label className="text-xs text-muted">JavaScript Code</label>
               <textarea
                 value={code}
-                onChange={(e) => setCode(e.target.value)}
+                onChange={(e) => {
+                  setCode(e.target.value);
+                  setFormError("");
+                }}
                 placeholder="// Available: params.paramName, fetch()\nreturn { result: params.input };"
                 rows={6}
                 className="bg-surface border border-border px-2 py-1.5 text-sm text-txt placeholder:text-muted/50 outline-none focus:border-accent resize-none font-mono"
@@ -464,18 +909,22 @@ export function CustomActionEditor({ open, action, onSave, onClose }: CustomActi
               </button>
             </div>
             {parameters.map((param, i) => (
-              <div key={i} className="flex gap-2 items-start">
+              <div key={`${param.name}-${i}`} className="flex gap-2 items-start">
                 <input
                   type="text"
                   value={param.name}
-                  onChange={(e) => updateParameter(i, "name", e.target.value)}
+                  onChange={(e) =>
+                    updateParameter(i, "name", e.target.value)
+                  }
                   placeholder="paramName"
                   className="w-32 bg-surface border border-border px-2 py-1.5 text-sm text-txt placeholder:text-muted/50 outline-none focus:border-accent"
                 />
                 <input
                   type="text"
                   value={param.description}
-                  onChange={(e) => updateParameter(i, "description", e.target.value)}
+                  onChange={(e) =>
+                    updateParameter(i, "description", e.target.value)
+                  }
                   placeholder="Description"
                   className="flex-1 bg-surface border border-border px-2 py-1.5 text-sm text-txt placeholder:text-muted/50 outline-none focus:border-accent"
                 />
@@ -483,7 +932,9 @@ export function CustomActionEditor({ open, action, onSave, onClose }: CustomActi
                   <input
                     type="checkbox"
                     checked={param.required}
-                    onChange={(e) => updateParameter(i, "required", e.target.checked)}
+                    onChange={(e) =>
+                      updateParameter(i, "required", e.target.checked)
+                    }
                     className="cursor-pointer"
                   />
                   Required
@@ -501,7 +952,7 @@ export function CustomActionEditor({ open, action, onSave, onClose }: CustomActi
           {/* Test Section */}
           <div className="flex flex-col gap-2 border-t border-border pt-3">
             <button
-              onClick={() => setTestExpanded(!testExpanded)}
+              onClick={() => setTestExpanded((expanded) => !expanded)}
               className="flex items-center justify-between text-xs text-muted hover:text-txt cursor-pointer"
             >
               <span>Test Action</span>
@@ -509,18 +960,25 @@ export function CustomActionEditor({ open, action, onSave, onClose }: CustomActi
             </button>
             {testExpanded && (
               <div className="flex flex-col gap-2 pl-2 border-l-2 border-border">
-                {parameters.filter(p => p.name.trim()).map((param) => (
-                  <div key={param.name} className="flex flex-col gap-1">
-                    <label className="text-xs text-muted">{param.name}</label>
-                    <input
-                      type="text"
-                      value={testParams[param.name] || ""}
-                      onChange={(e) => setTestParams({ ...testParams, [param.name]: e.target.value })}
-                      placeholder={param.description || "value"}
-                      className="bg-surface border border-border px-2 py-1.5 text-sm text-txt placeholder:text-muted/50 outline-none focus:border-accent"
-                    />
-                  </div>
-                ))}
+                {parameters
+                  .filter((p) => p.name.trim())
+                  .map((param) => (
+                    <div key={param.name} className="flex flex-col gap-1">
+                      <label className="text-xs text-muted">{param.name}</label>
+                      <input
+                        type="text"
+                        value={testParams[param.name] || ""}
+                        onChange={(e) =>
+                          setTestParams({
+                            ...testParams,
+                            [param.name]: e.target.value,
+                          })
+                        }
+                        placeholder={param.description || "value"}
+                        className="bg-surface border border-border px-2 py-1.5 text-sm text-txt placeholder:text-muted/50 outline-none focus:border-accent"
+                      />
+                    </div>
+                  ))}
                 {testResult && (
                   <div className="bg-surface border border-border p-2 text-xs font-mono">
                     {testResult.error && (
@@ -544,7 +1002,7 @@ export function CustomActionEditor({ open, action, onSave, onClose }: CustomActi
           {testExpanded && (
             <button
               onClick={handleTest}
-              disabled={testing}
+              disabled={testing || !action?.id}
               className="px-3 py-1.5 text-xs border border-border text-muted hover:text-txt cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {testing ? "Testing..." : "Test"}
@@ -557,10 +1015,11 @@ export function CustomActionEditor({ open, action, onSave, onClose }: CustomActi
             Cancel
           </button>
           <button
-            onClick={handleSave}
-            className="px-3 py-1.5 text-xs border border-accent bg-accent text-white hover:opacity-90 cursor-pointer"
+            onClick={() => void handleSave()}
+            disabled={saving}
+            className="px-3 py-1.5 text-xs border border-accent bg-accent text-white hover:opacity-90 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            Save
+            {saving ? "Saving..." : "Save"}
           </button>
         </div>
       </div>

--- a/apps/app/src/components/CustomActionsPanel.tsx
+++ b/apps/app/src/components/CustomActionsPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { client, type CustomActionDef } from "../api-client";
 
 interface CustomActionsPanelProps {
@@ -13,6 +13,12 @@ const HANDLER_TYPE_COLORS: Record<string, string> = {
   code: "bg-purple-500/20 text-purple-400",
 };
 
+const HANDLER_TYPE_NAMES: Record<string, string> = {
+  http: "HTTP",
+  shell: "Shell",
+  code: "Code",
+};
+
 export function CustomActionsPanel({
   open,
   onClose,
@@ -20,14 +26,18 @@ export function CustomActionsPanel({
 }: CustomActionsPanelProps) {
   const [actions, setActions] = useState<CustomActionDef[]>([]);
   const [loading, setLoading] = useState(false);
+  const [search, setSearch] = useState("");
+  const [error, setError] = useState("");
 
   const loadActions = async () => {
     try {
       setLoading(true);
+      setError("");
       const result = await client.listCustomActions();
       setActions(result || []);
-    } catch (error) {
-      console.error("Failed to load custom actions:", error);
+    } catch (err) {
+      console.error("Failed to load custom actions:", err);
+      setError("Failed to load custom actions. Please retry.");
     } finally {
       setLoading(false);
     }
@@ -35,32 +45,68 @@ export function CustomActionsPanel({
 
   useEffect(() => {
     if (open) {
-      loadActions();
+      void loadActions();
     }
   }, [open]);
 
+  const filteredActions = useMemo(() => {
+    const searchTerm = search.trim().toLowerCase();
+    if (!searchTerm) return actions;
+
+    return actions.filter((action) => {
+      const hasName = action.name.toLowerCase().includes(searchTerm);
+      const hasDescription =
+        typeof action.description === "string" &&
+        action.description.toLowerCase().includes(searchTerm);
+      const hasAlias =
+        (action.similes ?? []).some((alias) =>
+          alias.toLowerCase().includes(searchTerm),
+        );
+      return hasName || hasDescription || hasAlias;
+    });
+  }, [actions, search]);
+
+  const enabledCount = useMemo(
+    () => actions.filter((action) => action.enabled).length,
+    [actions],
+  );
+
   const handleToggleEnabled = async (action: CustomActionDef) => {
     try {
+      const next = !action.enabled;
       await client.updateCustomAction(action.id, {
-        enabled: !action.enabled,
+        enabled: next,
       });
-      await loadActions();
-    } catch (error) {
-      console.error("Failed to toggle action:", error);
+      setActions((prev) =>
+        prev.map((item) =>
+          item.id === action.id
+            ? {
+                ...item,
+                enabled: next,
+              }
+            : item,
+        ),
+      );
+    } catch (err) {
+      console.error("Failed to toggle action:", err);
+      setError("Failed to update this action. Try again.");
     }
   };
 
   const handleDelete = async (action: CustomActionDef) => {
     const confirmed = window.confirm(
-      `Are you sure you want to delete "${action.name}"?`
+      `Are you sure you want to delete "${action.name}"?`,
     );
-    if (!confirmed) return;
+    if (!confirmed) {
+      return;
+    }
 
     try {
       await client.deleteCustomAction(action.id);
-      await loadActions();
-    } catch (error) {
-      console.error("Failed to delete action:", error);
+      setActions((prev) => prev.filter((item) => item.id !== action.id));
+    } catch (err) {
+      console.error("Failed to delete action:", err);
+      setError("Failed to delete action. Try again.");
     }
   };
 
@@ -75,14 +121,19 @@ export function CustomActionsPanel({
   return (
     <div
       className={`border-l border-border bg-card flex flex-col transition-all duration-200 ${
-        open ? "w-72" : "w-0 overflow-hidden"
+        open ? "w-80" : "w-0 overflow-hidden"
       }`}
     >
       {open && (
         <>
           {/* Header */}
-          <div className="flex items-center justify-between p-4 border-b border-border">
-            <h2 className="text-sm font-semibold text-txt">Custom Actions</h2>
+          <div className="flex items-start justify-between p-4 border-b border-border">
+            <div>
+              <h2 className="text-sm font-semibold text-txt">Custom Actions</h2>
+              <p className="text-xs text-muted mt-0.5">
+                {actions.length} action{actions.length === 1 ? "" : "s"} · {enabledCount} enabled
+              </p>
+            </div>
             <button
               onClick={onClose}
               className="text-muted hover:text-txt transition-colors"
@@ -102,112 +153,111 @@ export function CustomActionsPanel({
             </button>
           </div>
 
+          <div className="space-y-3 p-3 border-b border-border">
+            <button
+              onClick={handleCreate}
+              className="w-full bg-accent text-txt hover:bg-accent/90 transition-colors rounded px-3 py-2 text-sm font-medium"
+            >
+              + New Custom Action
+            </button>
+
+            <div className="relative">
+              <input
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+                placeholder="Search by name, description, alias..."
+                className="w-full bg-surface border border-border px-2 py-1.5 text-xs text-txt placeholder:text-muted/50 outline-none focus:border-accent"
+              />
+            </div>
+
+            {error && (
+              <div className="text-xs text-danger bg-danger/10 border border-danger/30 px-2 py-1 rounded">
+                {error}
+              </div>
+            )}
+          </div>
+
           {/* Action List */}
           <div className="flex-1 overflow-y-auto p-3 space-y-2">
             {loading ? (
               <div className="text-center text-muted text-xs py-8">
-                Loading...
+                Loading your actions...
               </div>
-            ) : actions.length === 0 ? (
+            ) : filteredActions.length === 0 ? (
               <div className="text-center text-muted text-xs py-8">
-                No custom actions yet
+                {search
+                  ? "No actions match this search."
+                  : "No custom actions yet. Create one to get started."}
               </div>
             ) : (
-              actions.map((action) => (
+              filteredActions.map((action) => (
                 <div
                   key={action.id}
                   className="border border-border bg-surface rounded p-2 space-y-2"
                 >
-                  {/* Action Name */}
-                  <div className="font-semibold text-xs text-txt truncate">
-                    {action.name}
-                  </div>
-
-                  {/* Description */}
-                  {action.description && (
-                    <div className="text-xs text-muted line-clamp-2">
-                      {action.description}
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <div className="font-semibold text-xs text-txt truncate">
+                        {action.name}
+                      </div>
+                      <p className="text-[10px] text-muted mt-0.5">
+                        {action.parameters?.length || 0} parameter
+                        {(action.parameters?.length || 0) === 1 ? "" : "s"}
+                        {action.similes?.length ?
+                          ` • ${action.similes.length} alias`
+                            .concat(action.similes.length === 1 ? "" : "es") :
+                          ""
+                        }
+                      </p>
                     </div>
-                  )}
 
-                  {/* Bottom Row: Badge, Toggle, Buttons */}
-                  <div className="flex items-center gap-2">
-                    {/* Handler Type Badge */}
                     <span
-                      className={`text-xs px-1.5 py-0.5 rounded ${
+                      className={`text-[10px] px-1.5 py-0.5 rounded whitespace-nowrap ${
                         HANDLER_TYPE_COLORS[action.handler.type] ||
                         "bg-surface text-muted"
                       }`}
                     >
-                      {action.handler.type}
+                      {HANDLER_TYPE_NAMES[action.handler.type] ?? action.handler.type}
                     </span>
+                  </div>
 
-                    <div className="flex-1" />
+                  {action.description && (
+                    <p className="text-xs text-muted line-clamp-2 break-words">
+                      {action.description}
+                    </p>
+                  )}
 
-                    {/* Enabled Toggle */}
-                    <label className="flex items-center gap-1 cursor-pointer">
+                  <div className="flex items-center gap-2 pt-1 border-t border-border">
+                    <label className="flex items-center gap-1 cursor-pointer text-xs text-muted">
                       <input
                         type="checkbox"
                         checked={action.enabled}
                         onChange={() => handleToggleEnabled(action)}
                         className="w-3 h-3 cursor-pointer accent-accent"
                       />
-                      <span className="text-xs text-muted">on</span>
+                      <span>Enabled</span>
                     </label>
 
-                    {/* Edit Button */}
-                    <button
-                      onClick={() => handleEdit(action)}
-                      className="text-xs text-accent hover:text-accent/80 transition-colors"
-                      title="Edit action"
-                    >
-                      <svg
-                        width="14"
-                        height="14"
-                        viewBox="0 0 16 16"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="1.5"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
+                    <div className="ml-auto flex items-center gap-2">
+                      <button
+                        onClick={() => handleEdit(action)}
+                        className="text-xs text-accent hover:text-accent/80 transition-colors"
+                        title="Edit action"
                       >
-                        <path d="M11.5 2.5l2 2L6 12H4v-2l7.5-7.5z" />
-                      </svg>
-                    </button>
-
-                    {/* Delete Button */}
-                    <button
-                      onClick={() => handleDelete(action)}
-                      className="text-xs text-danger hover:text-danger/80 transition-colors"
-                      title="Delete action"
-                    >
-                      <svg
-                        width="14"
-                        height="14"
-                        viewBox="0 0 16 16"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="1.5"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
+                        Edit
+                      </button>
+                      <button
+                        onClick={() => handleDelete(action)}
+                        className="text-xs text-danger hover:text-danger/80 transition-colors"
+                        title="Delete action"
                       >
-                        <path d="M3 4h10M5 4V3h6v1M6 7v5M10 7v5M4 4l1 9h6l1-9" />
-                      </svg>
-                    </button>
+                        Delete
+                      </button>
+                    </div>
                   </div>
                 </div>
               ))
             )}
-          </div>
-
-          {/* Footer */}
-          <div className="p-3 border-t border-border">
-            <button
-              onClick={handleCreate}
-              className="w-full bg-accent text-txt hover:bg-accent/90 transition-colors rounded px-3 py-2 text-sm font-medium"
-            >
-              Create Action
-            </button>
           </div>
         </>
       )}

--- a/apps/app/test/app/custom-actions-smoke.test.ts
+++ b/apps/app/test/app/custom-actions-smoke.test.ts
@@ -1,0 +1,343 @@
+import React, { useEffect, useState } from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import type { CustomActionDef } from "../../src/api-client";
+
+const { mockClient, mockUseApp, mockUseVoiceChat } = vi.hoisted(() => ({
+  mockClient: {
+    listCustomActions: vi.fn(),
+    generateCustomAction: vi.fn(),
+    createCustomAction: vi.fn(),
+    updateCustomAction: vi.fn(),
+    deleteCustomAction: vi.fn(),
+    testCustomAction: vi.fn(),
+  },
+  mockUseApp: vi.fn(),
+  mockUseVoiceChat: vi.fn(),
+}));
+
+vi.mock("../../src/AppContext", () => ({
+  useApp: () => mockUseApp(),
+  getVrmPreviewUrl: () => null,
+}));
+
+vi.mock("../../src/hooks/useVoiceChat", () => ({
+  useVoiceChat: () => mockUseVoiceChat(),
+}));
+
+vi.mock("../../src/components/ChatAvatar", () => ({
+  ChatAvatar: () => null,
+}));
+
+vi.mock("../../src/components/MessageContent", () => ({
+  MessageContent: ({ message }: { message: { text: string } }) =>
+    React.createElement("span", null, message.text),
+}));
+
+vi.mock("../../src/api-client", () => ({
+  client: mockClient,
+}));
+
+interface ChatViewContextStub {
+  agentStatus: { agentName: string } | null;
+  chatInput: string;
+  chatSending: boolean;
+  chatFirstTokenReceived: boolean;
+  conversationMessages: Array<{
+    id: string;
+    role: "user" | "assistant";
+    text: string;
+    timestamp: number;
+    source?: string;
+  }>;
+  handleChatSend: (mode: "simple" | "power") => Promise<void>;
+  handleChatStop: () => void;
+  setState: (key: string, value: unknown) => void;
+  droppedFiles: string[];
+  shareIngestNotice: string;
+  selectedVrmIndex: number;
+}
+
+function createContext(
+  overrides?: Partial<ChatViewContextStub>,
+): ChatViewContextStub {
+  return {
+    agentStatus: { agentName: "Milaidy" },
+    chatInput: "",
+    chatSending: false,
+    chatFirstTokenReceived: false,
+    conversationMessages: [],
+    handleChatSend: vi.fn(async () => {}),
+    handleChatStop: vi.fn(),
+    setState: vi.fn(),
+    droppedFiles: [],
+    shareIngestNotice: "",
+    selectedVrmIndex: 0,
+    ...overrides,
+  };
+}
+
+function text(node: TestRenderer.ReactTestInstance): string {
+  return node.children
+    .map((child) => (typeof child === "string" ? child : text(child as TestRenderer.ReactTestInstance)))
+    .join("")
+    .trim();
+}
+
+function findButtonByText(
+  root: TestRenderer.ReactTestRenderer,
+  label: string,
+): TestRenderer.ReactTestInstance {
+  const found = root.root.findAll(
+    (n) => n.type === "button" && text(n) === label,
+  );
+  expect(found.length).toBeGreaterThan(0);
+  return found[0];
+}
+
+function findInputByPlaceholder(
+  root: TestRenderer.ReactTestRenderer,
+  placeholder: string,
+): TestRenderer.ReactTestInstance {
+  const found = root.root.findAll(
+    (n) => n.type === "input" && n.props.placeholder === placeholder,
+  );
+  expect(found.length).toBeGreaterThan(0);
+  return found[0];
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+import { ChatView } from "../../src/components/ChatView";
+import { CustomActionsPanel } from "../../src/components/CustomActionsPanel";
+import { CustomActionEditor } from "../../src/components/CustomActionEditor";
+
+function FlowHarness({
+  onSaved,
+}: {
+  onSaved: (action: CustomActionDef) => void;
+}) {
+  const [panelOpen, setPanelOpen] = useState(false);
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [editingAction, setEditingAction] = useState<CustomActionDef | null>(null);
+
+  useEffect(() => {
+    const handler = () => setPanelOpen((open) => !open);
+    window.addEventListener("toggle-custom-actions-panel", handler);
+    return () => window.removeEventListener("toggle-custom-actions-panel", handler);
+  }, []);
+
+  return React.createElement(
+    "div",
+    null,
+    React.createElement(ChatView),
+    React.createElement(CustomActionsPanel, {
+      open: panelOpen,
+      onClose: () => setPanelOpen(false),
+      onOpenEditor: (action: CustomActionDef | null) => {
+        setEditingAction(action);
+        setEditorOpen(true);
+      },
+    }),
+    React.createElement(CustomActionEditor, {
+      open: editorOpen,
+      action: editingAction,
+      onSave: (action: CustomActionDef) => {
+        onSaved(action);
+        setEditorOpen(false);
+        setEditingAction(null);
+      },
+      onClose: () => {
+        setEditorOpen(false);
+        setEditingAction(null);
+      },
+    }),
+  );
+}
+
+describe("custom actions smoke flow", () => {
+  beforeEach(() => {
+    mockUseApp.mockReset();
+    mockUseVoiceChat.mockReset();
+    mockUseApp.mockReturnValue(createContext());
+    mockUseVoiceChat.mockReturnValue({
+      supported: false,
+      isListening: false,
+      interimTranscript: "",
+      toggleListening: vi.fn(),
+      mouthOpen: 0,
+      isSpeaking: false,
+      usingAudioAnalysis: false,
+      speak: vi.fn(),
+      stopSpeaking: vi.fn(),
+    });
+
+    for (const fn of Object.values(mockClient)) {
+      if (typeof fn === "function" && "mockReset" in fn) {
+        fn.mockReset();
+      }
+    }
+
+    const listeners = new Map<string, Set<(event: Event) => void>>();
+    Object.assign(window, {
+      addEventListener: (type: string, handler: (event: Event) => void) => {
+        const set = listeners.get(type) ?? new Set();
+        set.add(handler);
+        listeners.set(type, set);
+      },
+      removeEventListener: (type: string, handler: (event: Event) => void) => {
+        const set = listeners.get(type);
+        if (set) {
+          set.delete(handler);
+        }
+      },
+      dispatchEvent: (event: Event) => {
+        const set = listeners.get(event.type) ?? new Set();
+        for (const handler of set) {
+          handler(event);
+        }
+        return true;
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("opens action panel, generates and saves an action", async () => {
+    mockClient.listCustomActions.mockResolvedValue([]);
+    mockClient.generateCustomAction.mockResolvedValue({
+      ok: true,
+      generated: {
+        name: "check_site",
+        description: "Checks if a URL responds.",
+        handlerType: "http",
+        handler: {
+          type: "http",
+          method: "GET",
+          url: "https://example.com/{{url}}",
+          headers: {
+            accept: "application/json",
+          },
+          bodyTemplate: '{"ping": true}',
+        },
+        parameters: [
+          {
+            name: "url",
+            description: "Target URL",
+            required: true,
+          },
+        ],
+        similes: ["site", "health check"],
+      },
+    });
+    mockClient.createCustomAction.mockImplementation(async (payload: CustomActionDef) => ({
+      ...payload,
+      id: "act-1",
+    }));
+
+    const onSaved = vi.fn();
+
+    let tree: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      tree = TestRenderer.create(
+        React.createElement(FlowHarness, { onSaved }),
+      );
+    });
+
+    const actionsButton = findButtonByText(tree!, "Actions");
+    await act(async () => {
+      actionsButton.props.onClick();
+    });
+    await flush();
+
+    expect(mockClient.listCustomActions).toHaveBeenCalledTimes(1);
+
+    const title = tree!.root.findAll(
+      (node) => node.type === "h2" && text(node) === "Custom Actions",
+    );
+    expect(title.length).toBe(1);
+
+    const createButton = findButtonByText(tree!, "+ New Custom Action");
+    await act(async () => {
+      createButton.props.onClick();
+    });
+    await flush();
+
+    const editorHeader = tree!.root.findAll(
+      (node) => node.type === "h2" && text(node) === "New Custom Action",
+    );
+    expect(editorHeader.length).toBe(1);
+
+    const promptInput = findInputByPlaceholder(
+      tree!,
+      "e.g. Check if a website is up and return status",
+    );
+    await act(async () => {
+      promptInput.props.onChange({ target: { value: "Build a URL health check action" } });
+    });
+    await flush();
+
+    const generateButton = findButtonByText(tree!, "Generate");
+    await act(async () => {
+      generateButton.props.onClick();
+    });
+    await flush();
+
+    expect(mockClient.generateCustomAction).toHaveBeenCalledWith(
+      "Build a URL health check action",
+    );
+
+    const nameInput = findInputByPlaceholder(tree!, "MY_ACTION");
+    expect(nameInput.props.value).toBe("CHECK_SITE");
+
+    const descriptionArea = tree!.root.findAll(
+      (node) => node.type === "textarea" && node.props.placeholder === "What does this action do?",
+    )[0];
+    expect(descriptionArea.props.value).toBe("Checks if a URL responds.");
+
+    const saveButton = findButtonByText(tree!, "Save");
+    await act(async () => {
+      saveButton.props.onClick();
+    });
+    await flush();
+
+    expect(mockClient.createCustomAction).toHaveBeenCalledWith({
+      name: "CHECK_SITE",
+      description: "Checks if a URL responds.",
+      similes: ["SITE", "HEALTH_CHECK"],
+      parameters: [
+        {
+          name: "url",
+          description: "Target URL",
+          required: true,
+        },
+      ],
+      handler: {
+        type: "http",
+        method: "GET",
+        url: "https://example.com/{{url}}",
+        headers: {
+          accept: "application/json",
+        },
+        bodyTemplate: '{"ping": true}',
+      },
+      enabled: true,
+    });
+
+    expect(onSaved).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -11627,6 +11627,7 @@ async function handleRequest(
         "",
         "- name: string (UPPER_SNAKE_CASE action name)",
         "- description: string (clear description of what the action does)",
+        "- similes: optional string[] of alternative action names and phrases",
         '- handlerType: "http" | "shell" | "code"',
         "- handler: object with type-specific fields:",
         '  For http: { type: "http", method: "GET"|"POST"|etc, url: string, headers?: object, bodyTemplate?: string }',


### PR DESCRIPTION
## Category
- [x] New feature
- [x] Test coverage

## What
- Improves custom actions UX and discoverability in the app and streamlines generation/save workflows.
- Adds a focused smoke test for the end-to-end button/panel/generate/save flow.
- Keeps backend generation run through the connected runtime path for `/api/custom-actions/generate`.

## Why
To make creating and generating custom actions easier to use and less error-prone for end users, while preserving runtime-based generation.

## How
- Updated `apps/app/src/components/ChatView.tsx` and `apps/app/src/components/CustomActionsPanel.tsx` for clearer action controls and safer panel behavior.
- Refined `apps/app/src/components/CustomActionEditor.tsx` for better generation prompt UX, validation, and robust JSON payload parsing.
- Updated `src/api/server.ts` generation route wiring remains runtime-backed.
- Added `apps/app/test/app/custom-actions-smoke.test.ts`.

## Testing
- Passed: `npm run test test/app/custom-actions-smoke.test.ts` (from `apps/app`)
- Passed: `npm run test` (from `apps/app`)
- Passed: `npm run test:electron:e2e` (from `apps/app`)
- Failed (pre-existing/unrelated): `npm run test -- test/apps-e2e.e2e.test.ts` in root currently reports 8 failures in app catalog/engine launch assertions; failures are unrelated to custom actions.
