### PR TITLE
test: add plugin coverage edge cases

### DIFF
--- a/src/actions/__tests__/emote.test.ts
+++ b/src/actions/__tests__/emote.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { emoteAction } from "../../actions/emote";
+
+function mockResponse(response: { ok: boolean }): Response {
+  return {
+    ok: response.ok,
+  } as unknown as Response;
+}
+
+describe("emoteAction", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("requires an emote id", async () => {
+    const result = await emoteAction.handler(
+      undefined,
+      { roomId: "room", content: { text: "" } },
+      undefined,
+      undefined,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.text).toBe("");
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown emote IDs", async () => {
+    const result = await emoteAction.handler(
+      undefined,
+      { roomId: "room", content: { text: "" } },
+      undefined,
+      { parameters: { emote: "does-not-exist" } },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.text).toBe("");
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+  });
+
+  it("returns false when endpoint responds with non-ok", async () => {
+    vi.mocked(fetch).mockResolvedValue(mockResponse({ ok: false }));
+
+    const result = await emoteAction.handler(
+      undefined,
+      { roomId: "room", content: { text: "" } },
+      undefined,
+      { parameters: { emote: "wave" } },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.text).toBe("");
+    expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+      "http://localhost:2138/api/emote",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("plays a valid emote", async () => {
+    vi.mocked(fetch).mockResolvedValue(mockResponse({ ok: true }));
+
+    const result = await emoteAction.handler(
+      undefined,
+      { roomId: "room", content: { text: "" } },
+      undefined,
+      { parameters: { emote: "wave" } },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.text).toBe("*waves*");
+    expect(result.data).toMatchObject({ emoteId: "wave" });
+  });
+
+  it("handles fetch exceptions", async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error("server down"));
+
+    const result = await emoteAction.handler(
+      undefined,
+      { roomId: "room", content: { text: "" } },
+      undefined,
+      { parameters: { emote: "wave" } },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.text).toBe("");
+  });
+});

--- a/src/actions/__tests__/install-plugin.test.ts
+++ b/src/actions/__tests__/install-plugin.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { installPluginAction } from "../../actions/install-plugin";
+
+function mockJsonResponse(response: {
+  ok: boolean;
+  status: number;
+  body: unknown;
+  jsonThrows?: boolean;
+}): Response {
+  return {
+    ok: response.ok,
+    status: response.status,
+    json: response.jsonThrows
+      ? vi.fn(async () => {
+          throw new Error("invalid json");
+        })
+      : vi.fn(async () => response.body),
+  } as unknown as Response;
+}
+
+describe("installPluginAction", () => {
+  const originalApiPort = process.env.API_PORT;
+  const originalServerPort = process.env.SERVER_PORT;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.stubGlobal("fetch", vi.fn());
+    process.env.API_PORT = "2138";
+    process.env.SERVER_PORT = undefined;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    process.env.API_PORT = originalApiPort;
+    process.env.SERVER_PORT = originalServerPort;
+  });
+
+  it("requires a plugin ID", async () => {
+    const result = await installPluginAction.handler(
+      undefined,
+      { roomId: "room", content: { text: "" } },
+      undefined,
+      undefined,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.text).toContain("I need a plugin ID to install");
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+  });
+
+  it("prefixes short plugin IDs with @elizaos/plugin-", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockJsonResponse({
+        ok: true,
+        status: 200,
+        body: { ok: true },
+      }),
+    );
+
+    const result = await installPluginAction.handler(
+      undefined,
+      { roomId: "room", content: { text: "" } },
+      undefined,
+      { parameters: { pluginId: "telegram" } },
+    );
+
+    expect(result.success).toBe(true);
+    expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+      "http://localhost:2138/api/plugins/install",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          name: "@elizaos/plugin-telegram",
+          autoRestart: true,
+        }),
+      }),
+    );
+  });
+
+  it("returns API error message when response is not ok", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockJsonResponse({
+        ok: false,
+        status: 500,
+        body: { error: "failed to install" },
+      }),
+    );
+
+    const result = await installPluginAction.handler(
+      undefined,
+      { roomId: "room", content: { text: "" } },
+      undefined,
+      { parameters: { pluginId: "discord" } },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.text).toContain(
+      "Failed to install discord: failed to install",
+    );
+  });
+
+  it("falls back to HTTP status when error body is not parseable", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockJsonResponse({
+        ok: false,
+        status: 502,
+        body: null,
+        jsonThrows: true,
+      }),
+    );
+
+    const result = await installPluginAction.handler(
+      undefined,
+      { roomId: "room", content: { text: "" } },
+      undefined,
+      { parameters: { pluginId: "discord" } },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.text).toBe("Failed to install discord: HTTP 502");
+  });
+
+  it("returns a failure message when install service reports ok:false", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockJsonResponse({
+        ok: true,
+        status: 200,
+        body: { ok: false, error: "service rejected plugin" },
+      }),
+    );
+
+    const result = await installPluginAction.handler(
+      undefined,
+      { roomId: "room", content: { text: "" } },
+      undefined,
+      { parameters: { pluginId: "@elizaos/plugin-telegram" } },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.text).toContain(
+      "Failed to install @elizaos/plugin-telegram: service rejected plugin",
+    );
+  });
+
+  it("uses plugin service response message when provided", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockJsonResponse({
+        ok: true,
+        status: 200,
+        body: {
+          ok: true,
+          message: "plugin-telegram installed and restart scheduled",
+        },
+      }),
+    );
+
+    const result = await installPluginAction.handler(
+      undefined,
+      { roomId: "room", content: { text: "" } },
+      undefined,
+      { parameters: { pluginId: "@elizaos/plugin-telegram" } },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.text).toBe("plugin-telegram installed and restart scheduled");
+  });
+});

--- a/src/actions/__tests__/media.test.ts
+++ b/src/actions/__tests__/media.test.ts
@@ -1,0 +1,223 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockImageGenerate = vi.fn();
+const mockVideoGenerate = vi.fn();
+const mockAudioGenerate = vi.fn();
+const mockVisionAnalyze = vi.fn();
+
+vi.mock("../../providers/media-provider", () => ({
+  createImageProvider: vi.fn(() => ({
+    generate: mockImageGenerate,
+  })),
+  createVideoProvider: vi.fn(() => ({
+    generate: mockVideoGenerate,
+  })),
+  createAudioProvider: vi.fn(() => ({
+    generate: mockAudioGenerate,
+  })),
+  createVisionProvider: vi.fn(() => ({
+    analyze: mockVisionAnalyze,
+  })),
+}));
+
+vi.mock("../../config/config", () => ({
+  loadMiladyConfig: vi.fn(() => ({ media: {}, cloud: {} })),
+}));
+
+async function loadMediaActions() {
+  vi.resetModules();
+  return await import("../../actions/media");
+}
+
+describe("media actions", () => {
+  beforeEach(() => {
+    mockImageGenerate.mockReset();
+    mockVideoGenerate.mockReset();
+    mockAudioGenerate.mockReset();
+    mockVisionAnalyze.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("requires a prompt for image generation", async () => {
+    const { generateImageAction } = await loadMediaActions();
+    const result = await generateImageAction.handler(
+      undefined,
+      { roomId: "room", content: { text: "" } },
+      undefined,
+      { parameters: { prompt: "   " } },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.text).toContain("I need a prompt");
+  });
+
+  it("returns generated image result", async () => {
+    mockImageGenerate.mockResolvedValue({
+      success: true,
+      data: {
+        imageUrl: "https://example.com/image.png",
+        revisedPrompt: "sunset by the sea",
+      },
+    });
+
+    const { generateImageAction } = await loadMediaActions();
+    const result = await generateImageAction.handler(
+      undefined,
+      { roomId: "room", content: { text: "" } },
+      undefined,
+      { parameters: { prompt: "sunset at beach" } },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.text).toContain(
+      'Here\'s the generated image based on: "sunset by the sea"',
+    );
+    expect(result.data?.imageUrl).toBe("https://example.com/image.png");
+    expect(result.attachments).toEqual([
+      {
+        type: "image",
+        url: "https://example.com/image.png",
+        base64: undefined,
+        mimeType: "image/png",
+      },
+    ]);
+  });
+
+  it("returns image failure when provider fails", async () => {
+    mockImageGenerate.mockResolvedValue({
+      success: false,
+      error: "provider unavailable",
+    });
+
+    const { generateImageAction } = await loadMediaActions();
+    const result = await generateImageAction.handler(
+      undefined,
+      { roomId: "room", content: { text: "" } },
+      undefined,
+      { parameters: { prompt: "sunset" } },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.text).toContain("provider unavailable");
+  });
+
+  it("requires a prompt for video generation", async () => {
+    const { generateVideoAction } = await loadMediaActions();
+    const result = await generateVideoAction.handler(
+      undefined,
+      { roomId: "room", content: { text: "" } },
+      undefined,
+      { parameters: { prompt: "" } },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.text).toContain("I need a prompt to generate a video");
+  });
+
+  it("generates video output", async () => {
+    mockVideoGenerate.mockResolvedValue({
+      success: true,
+      data: {
+        videoUrl: "https://example.com/video.mp4",
+        thumbnailUrl: "https://example.com/video-thumb.png",
+        duration: 12,
+      },
+    });
+
+    const { generateVideoAction } = await loadMediaActions();
+    const result = await generateVideoAction.handler(
+      undefined,
+      { roomId: "room", content: { text: "" } },
+      undefined,
+      { parameters: { prompt: "cat dancing" } },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({
+      videoUrl: "https://example.com/video.mp4",
+      duration: 12,
+    });
+    expect(result.attachments).toEqual([
+      {
+        type: "video",
+        url: "https://example.com/video.mp4",
+        mimeType: "video/mp4",
+      },
+    ]);
+  });
+
+  it("generates audio output", async () => {
+    mockAudioGenerate.mockResolvedValue({
+      success: true,
+      data: {
+        audioUrl: "https://example.com/song.mp3",
+        title: "ambient track",
+        duration: 40,
+      },
+    });
+
+    const { generateAudioAction } = await loadMediaActions();
+    const result = await generateAudioAction.handler(
+      undefined,
+      { roomId: "room", content: { text: "" } },
+      undefined,
+      { parameters: { prompt: "ambient music for focus" } },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({
+      audioUrl: "https://example.com/song.mp3",
+      title: "ambient track",
+    });
+    expect(result.attachments).toEqual([
+      {
+        type: "audio",
+        url: "https://example.com/song.mp3",
+        mimeType: "audio/mpeg",
+        title: "ambient track",
+      },
+    ]);
+  });
+
+  it("requires an image input for analysis", async () => {
+    const { analyzeImageAction } = await loadMediaActions();
+    const result = await analyzeImageAction.handler(
+      undefined,
+      { roomId: "room", content: { text: "" } },
+      undefined,
+      { parameters: {} },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.text).toContain("I need an image to analyze");
+  });
+
+  it("analyzes image and returns description", async () => {
+    mockVisionAnalyze.mockResolvedValue({
+      success: true,
+      data: {
+        description: "A sunset over city lights",
+        labels: ["sunset", "city"],
+        confidence: 0.98,
+      },
+    });
+
+    const { analyzeImageAction } = await loadMediaActions();
+    const result = await analyzeImageAction.handler(
+      undefined,
+      { roomId: "room", content: { text: "" } },
+      undefined,
+      { parameters: { imageUrl: "https://example.com/source.png" } },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({
+      description: "A sunset over city lights",
+      labels: ["sunset", "city"],
+      confidence: 0.98,
+    });
+  });
+});

--- a/src/actions/__tests__/plugin-management.test.ts
+++ b/src/actions/__tests__/plugin-management.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ejectPluginAction } from "../../actions/eject-plugin";
+import { listEjectedAction } from "../../actions/list-ejected";
+import { reinjectPluginAction } from "../../actions/reinject-plugin";
+import { requestRestart } from "../../runtime/restart";
+import {
+  ejectPlugin,
+  listEjectedPlugins,
+  reinjectPlugin,
+} from "../../services/plugin-eject";
+
+vi.mock("../../services/plugin-eject", () => ({
+  ejectPlugin: vi.fn(),
+  reinjectPlugin: vi.fn(),
+  listEjectedPlugins: vi.fn(),
+}));
+
+vi.mock("../../runtime/restart", () => ({
+  requestRestart: vi.fn(),
+}));
+
+describe("plugin eject/reinject/list actions", () => {
+  const mockEjectPlugin = vi.mocked(ejectPlugin);
+  const mockReinjectPlugin = vi.mocked(reinjectPlugin);
+  const mockListEjectedPlugins = vi.mocked(listEjectedPlugins);
+  const mockRequestRestart = vi.mocked(requestRestart);
+
+  beforeEach(() => {
+    vi.useRealTimers();
+    mockEjectPlugin.mockReset();
+    mockReinjectPlugin.mockReset();
+    mockListEjectedPlugins.mockReset();
+    mockRequestRestart.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("ejectPluginAction", () => {
+    it("requires a plugin id", async () => {
+      const result = await ejectPluginAction.handler(
+        undefined,
+        { roomId: "room", content: { text: "" } },
+        undefined,
+        undefined,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.text).toContain("I need a plugin ID to eject.");
+      expect(mockEjectPlugin).not.toHaveBeenCalled();
+      expect(mockRequestRestart).not.toHaveBeenCalled();
+    });
+
+    it("trims plugin id and schedules restart on successful eject", async () => {
+      vi.useFakeTimers();
+      mockEjectPlugin.mockResolvedValue({
+        success: true,
+        pluginName: "discord",
+        ejectedPath: "/tmp/discord-fork",
+        removedFiles: 0,
+        upstreamVersion: "2.0.0",
+        pluginDir: "/tmp/discord-fork",
+        commitHash: "abc123",
+        upstreamCommits: 0,
+        localChanges: false,
+      });
+
+      const result = await ejectPluginAction.handler(
+        undefined,
+        { roomId: "room", content: { text: "" } },
+        undefined,
+        { parameters: { pluginId: "  discord  " } },
+      );
+
+      expect(mockEjectPlugin).toHaveBeenCalledWith("discord");
+      expect(result.success).toBe(true);
+      expect(result.text).toContain("Ejected discord to /tmp/discord-fork");
+      expect(mockRequestRestart).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1100);
+      expect(mockRequestRestart).toHaveBeenCalledOnce();
+      expect(mockRequestRestart).toHaveBeenCalledWith("Plugin discord ejected");
+    });
+
+    it("returns failure text when eject fails", async () => {
+      mockEjectPlugin.mockResolvedValue({
+        success: false,
+        error: "already ejected",
+      });
+
+      const result = await ejectPluginAction.handler(
+        undefined,
+        { roomId: "room", content: { text: "" } },
+        undefined,
+        { parameters: { pluginId: "discord" } },
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.text).toContain("Failed to eject discord: already ejected");
+      expect(mockRequestRestart).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("reinjectPluginAction", () => {
+    it("requires a plugin id", async () => {
+      const result = await reinjectPluginAction.handler(
+        undefined,
+        { roomId: "room", content: { text: "" } },
+        undefined,
+        undefined,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.text).toContain("I need a plugin ID to reinject.");
+      expect(mockReinjectPlugin).not.toHaveBeenCalled();
+      expect(mockRequestRestart).not.toHaveBeenCalled();
+    });
+
+    it("trims plugin id and schedules restart on successful reinject", async () => {
+      vi.useFakeTimers();
+      mockReinjectPlugin.mockResolvedValue({
+        success: true,
+        pluginName: "discord",
+        removedPath: "/tmp/discord-fork",
+      });
+
+      const result = await reinjectPluginAction.handler(
+        undefined,
+        { roomId: "room", content: { text: "" } },
+        undefined,
+        { parameters: { pluginId: "  discord  " } },
+      );
+
+      expect(mockReinjectPlugin).toHaveBeenCalledWith("discord");
+      expect(result.success).toBe(true);
+      expect(result.text).toContain("Removed ejected plugin discord.");
+      expect(mockRequestRestart).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1100);
+      expect(mockRequestRestart).toHaveBeenCalledOnce();
+      expect(mockRequestRestart).toHaveBeenCalledWith(
+        "Plugin discord reinjected",
+      );
+    });
+
+    it("returns failure text when reinject fails", async () => {
+      mockReinjectPlugin.mockResolvedValue({
+        success: false,
+        error: "not ejected",
+      });
+
+      const result = await reinjectPluginAction.handler(
+        undefined,
+        { roomId: "room", content: { text: "" } },
+        undefined,
+        { parameters: { pluginId: "discord" } },
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.text).toContain("Failed to reinject discord: not ejected");
+      expect(mockRequestRestart).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("listEjectedAction", () => {
+    it("returns a friendly message when no plugins exist", async () => {
+      mockListEjectedPlugins.mockResolvedValue([]);
+
+      const result = await listEjectedAction.handler(
+        undefined,
+        { roomId: "room", content: { text: "" } },
+        undefined,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.text).toBe("No ejected plugins found.");
+      expect(result.data).toMatchObject({ count: 0, plugins: [] });
+    });
+
+    it("formats plugin entries including branch when present", async () => {
+      mockListEjectedPlugins.mockResolvedValue([
+        {
+          name: "@elizaos/plugin-discord",
+          path: "/tmp/plugins/ejected/_elizaos_plugin-discord",
+          version: "2.0.0",
+          upstream: {
+            $schema: "milaidy-upstream-v1",
+            branch: "develop",
+            gitUrl: "https://github.com/elizaos-plugins/plugin-discord",
+            commitHash: "abc",
+            source: "github:elizaos-plugins/plugin-discord",
+            npmPackage: "@elizaos/plugin-discord",
+            npmVersion: "2.0.0",
+            lastSyncAt: null,
+            localCommits: 0,
+          },
+        },
+        {
+          name: "@elizaos/plugin-telegram",
+          path: "/tmp/plugins/ejected/_elizaos_plugin-telegram",
+          version: "1.0.0",
+          upstream: {
+            $schema: "milaidy-upstream-v1",
+            gitUrl: "https://github.com/elizaos-plugins/plugin-telegram",
+            commitHash: "def",
+            source: "github:elizaos-plugins/plugin-telegram",
+            npmPackage: "@elizaos/plugin-telegram",
+            npmVersion: "1.0.0",
+            localCommits: 0,
+            lastSyncAt: null,
+          },
+        },
+      ]);
+
+      const result = await listEjectedAction.handler(
+        undefined,
+        { roomId: "room", content: { text: "" } },
+        undefined,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.text).toContain("Ejected plugins (2):");
+      expect(result.text).toContain(
+        "- @elizaos/plugin-discord@develop (/tmp/plugins/ejected/_elizaos_plugin-discord)",
+      );
+      expect(result.text).toContain(
+        "- @elizaos/plugin-telegram (/tmp/plugins/ejected/_elizaos_plugin-telegram)",
+      );
+      expect(result.data).toMatchObject({ count: 2 });
+      expect(result.data.plugins).toHaveLength(2);
+    });
+  });
+});

--- a/src/actions/__tests__/sync-plugin.test.ts
+++ b/src/actions/__tests__/sync-plugin.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { syncPluginAction } from "../../actions/sync-plugin";
+import { syncPlugin } from "../../services/plugin-eject";
+
+vi.mock("../../services/plugin-eject", () => {
+  return {
+    syncPlugin: vi.fn(),
+  };
+});
+
+describe("syncPluginAction", () => {
+  const mockSyncPlugin = vi.mocked(syncPlugin);
+
+  beforeEach(() => {
+    mockSyncPlugin.mockReset();
+  });
+
+  it("should require a plugin ID", async () => {
+    const result = await syncPluginAction.handler(
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.text).toContain("plugin ID");
+    expect(mockSyncPlugin).not.toHaveBeenCalled();
+  });
+
+  it("should trim the plugin ID before syncing", async () => {
+    mockSyncPlugin.mockResolvedValue({
+      success: true,
+      pluginName: "discord",
+      upstreamCommits: 2,
+      conflicts: [],
+    });
+
+    const result = await syncPluginAction.handler(
+      undefined,
+      undefined,
+      undefined,
+      { parameters: { pluginId: "  discord  " } },
+    );
+
+    expect(mockSyncPlugin).toHaveBeenCalledWith("discord");
+    expect(result.success).toBe(true);
+    expect(result.text).toContain("Synced discord");
+  });
+
+  it("should surface conflicts when sync fails", async () => {
+    mockSyncPlugin.mockResolvedValue({
+      success: false,
+      pluginName: "discord",
+      upstreamCommits: 0,
+      conflicts: ["src/index.ts"],
+      error: "merge conflict",
+    });
+
+    const result = await syncPluginAction.handler(
+      undefined,
+      undefined,
+      undefined,
+      { parameters: { pluginId: "discord" } },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.text).toContain("merge conflict");
+    expect(result.text).toContain("Conflicts: src/index.ts");
+    expect(result.data).toMatchObject({ success: false });
+  });
+
+  it("should report upstream commit count on success", async () => {
+    mockSyncPlugin.mockResolvedValue({
+      success: true,
+      pluginName: "telegram-enhanced",
+      upstreamCommits: 5,
+      conflicts: [],
+    });
+
+    const result = await syncPluginAction.handler(
+      undefined,
+      undefined,
+      undefined,
+      { parameters: { pluginId: "telegram-enhanced" } },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.text).toContain("telegram-enhanced");
+    expect(result.text).toContain("5 upstream commits");
+    expect(result.data).toMatchObject({ success: true });
+  });
+});

--- a/src/actions/__tests__/terminal.test.ts
+++ b/src/actions/__tests__/terminal.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { terminalAction } from "../../actions/terminal";
+
+function mockResponse(response: { ok: boolean }): Response {
+  return {
+    ok: response.ok,
+  } as unknown as Response;
+}
+
+describe("terminalAction", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.stubGlobal("fetch", vi.fn());
+    process.env.API_PORT = "2138";
+    process.env.SERVER_PORT = undefined;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("requires a command", async () => {
+    const result = await terminalAction.handler(
+      undefined,
+      { roomId: "room", content: { text: "" } },
+      undefined,
+      { parameters: { command: "" } },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.text).toBe("");
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+  });
+
+  it("fails when API returns error", async () => {
+    vi.mocked(fetch).mockResolvedValue(mockResponse({ ok: false }));
+
+    const result = await terminalAction.handler(
+      undefined,
+      { roomId: "room", content: { text: "" } },
+      undefined,
+      { parameters: { command: "ls -la" } },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.text).toBe("");
+    expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+      "http://localhost:2138/api/terminal/run",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("succeeds when API returns ok", async () => {
+    vi.mocked(fetch).mockResolvedValue(mockResponse({ ok: true }));
+
+    const result = await terminalAction.handler(
+      undefined,
+      { roomId: "room", content: { text: "" } },
+      undefined,
+      { parameters: { command: "pnpm --version" } },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.text).toBe("Running in terminal: `pnpm --version`");
+    expect(result.data).toEqual({ command: "pnpm --version" });
+  });
+
+  it("handles fetch exceptions", async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error("network down"));
+
+    const result = await terminalAction.handler(
+      undefined,
+      { roomId: "room", content: { text: "" } },
+      undefined,
+      { parameters: { command: "echo hi" } },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.text).toBe("");
+  });
+});

--- a/src/services/__tests__/plugin-installer.helpers.test.ts
+++ b/src/services/__tests__/plugin-installer.helpers.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RegistryPluginInfo } from "../registry-client";
+
+const execFileMock = vi.fn();
+
+vi.mock("node:child_process", () => ({
+  execFile: execFileMock,
+}));
+
+function setupExecFileHandler(
+  responses: Array<{ stdout: string; branch?: string; list?: boolean }> = [],
+) {
+  let callIndex = 0;
+  execFileMock.mockImplementation(
+    (
+      _file: string,
+      args: string[] | readonly string[],
+      _options: unknown,
+      callback?: (err: Error | null, result?: { stdout?: string }) => void,
+    ) => {
+      const response = responses[callIndex++];
+
+      const expected = response?.list ? "ls-remote --heads" : response?.branch;
+      if (expected && Array.isArray(args)) {
+        const joinArgs = args.join(" ");
+        expect(joinArgs).toContain(expected);
+      }
+
+      if (response) {
+        callback?.(null, { stdout: response.stdout });
+        return;
+      }
+
+      callback?.(null, { stdout: "" });
+    },
+  );
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  execFileMock.mockReset();
+});
+
+describe("plugin-installer input validators", () => {
+  it("validates package names", async () => {
+    const { assertValidPackageName, VALID_PACKAGE_NAME } = await import(
+      "../plugin-installer"
+    );
+
+    expect(VALID_PACKAGE_NAME.test("@elizaos/plugin-test")).toBe(true);
+    expect(assertValidPackageName("@elizaos/plugin-test")).toBeUndefined();
+    expect(VALID_PACKAGE_NAME.test("plugin-test")).toBe(true);
+    expect(assertValidPackageName("plugin-test")).toBeUndefined();
+  });
+
+  it("rejects invalid package names", async () => {
+    const { assertValidPackageName } = await import("../plugin-installer");
+    expect(() => assertValidPackageName("../../etc")).toThrow(
+      /Invalid package name/,
+    );
+    expect(() => assertValidPackageName("bad name")).toThrow(
+      /Invalid package name/,
+    );
+    expect(() => assertValidPackageName("")).toThrow(/Invalid package name/);
+  });
+
+  it("validates git URLs", async () => {
+    const { assertValidGitUrl } = await import("../plugin-installer");
+    expect(() =>
+      assertValidGitUrl("https://github.com/elizaos-plugins/plugin-test.git"),
+    ).not.toThrow();
+    expect(() =>
+      assertValidGitUrl("https://gitlab.com/elizaos-plugins/plugin-test.git"),
+    ).not.toThrow();
+  });
+
+  it("rejects invalid git URLs", async () => {
+    const { assertValidGitUrl } = await import("../plugin-installer");
+    expect(() =>
+      assertValidGitUrl("git@github.com:elizaos-plugins/plugin-test.git"),
+    ).toThrow(/Invalid git URL/);
+    expect(() => assertValidGitUrl("https://invalid-url")).toThrow(
+      /Invalid git URL/,
+    );
+  });
+});
+
+describe("resolveGitBranch", () => {
+  it("returns the first valid branch reported by git remote checks", async () => {
+    setupExecFileHandler([
+      { stdout: "abcd\trefs/heads/main\n" },
+      { stdout: "1234\trefs/heads/main\n" }, // fallback call, should not execute
+    ]);
+
+    const { resolveGitBranch } = await import("../plugin-installer");
+
+    const pluginInfo = {
+      name: "@elizaos/plugin-test",
+      gitRepo: "elizaos-plugins/plugin-test",
+      gitUrl: "https://github.com/elizaos-plugins/plugin-test.git",
+      git: {
+        v0Branch: null,
+        v1Branch: null,
+        v2Branch: "main",
+      },
+      npm: { package: "@elizaos/plugin-test" },
+      supports: { v0: false, v1: false, v2: true },
+      description: "Test plugin",
+      homepage: null,
+      topics: [],
+      stars: 0,
+      language: "TypeScript",
+    } as RegistryPluginInfo;
+
+    const branch = await resolveGitBranch(pluginInfo);
+    expect(branch).toBe("main");
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to remote branch discovery when configured branches are unavailable", async () => {
+    setupExecFileHandler([
+      { stdout: "" }, // main
+      { stdout: "" }, // next
+      { stdout: "" }, // v1Branch check
+      { stdout: "", list: true }, // git ls-remote --heads
+    ]);
+
+    const { resolveGitBranch } = await import("../plugin-installer");
+
+    const pluginInfo = {
+      name: "@elizaos/plugin-test",
+      gitRepo: "elizaos-plugins/plugin-test",
+      gitUrl: "https://github.com/elizaos-plugins/plugin-test.git",
+      git: {
+        v0Branch: null,
+        v1Branch: null,
+        v2Branch: "dev",
+      },
+      npm: { package: "@elizaos/plugin-test" },
+      supports: { v0: false, v1: false, v2: true },
+      description: "Test plugin",
+      homepage: null,
+      topics: [],
+      stars: 0,
+      language: "TypeScript",
+    } as RegistryPluginInfo;
+
+    const branch = await resolveGitBranch(pluginInfo);
+    expect(branch).toBe("main");
+    expect(execFileMock).toHaveBeenCalledTimes(5);
+  });
+
+  it("chooses a preferred branch from git ls-remote --heads output", async () => {
+    setupExecFileHandler([
+      { stdout: "" }, // main
+      { stdout: "" }, // next
+      { stdout: "" }, // v1Branch check
+      { stdout: "" }, // master check
+      {
+        stdout: "1234\trefs/heads/release\n5678\trefs/heads/dev\n",
+        list: true,
+      },
+    ]);
+
+    const { resolveGitBranch } = await import("../plugin-installer");
+
+    const pluginInfo = {
+      name: "@elizaos/plugin-test",
+      gitRepo: "elizaos-plugins/plugin-test",
+      gitUrl: "https://github.com/elizaos-plugins/plugin-test.git",
+      git: {
+        v0Branch: null,
+        v1Branch: null,
+        v2Branch: "dev",
+      },
+      npm: { package: "@elizaos/plugin-test" },
+      supports: { v0: false, v1: false, v2: true },
+      description: "Test plugin",
+      homepage: null,
+      topics: [],
+      stars: 0,
+      language: "TypeScript",
+    } as RegistryPluginInfo;
+
+    const branch = await resolveGitBranch(pluginInfo);
+    expect(branch).toBe("dev");
+    expect(execFileMock).toHaveBeenCalledTimes(5);
+  });
+});


### PR DESCRIPTION
Summary
	•	Add comprehensive deterministic tests for plugin eject/sync/reinject/list flows, including invalid inputs and non-Error failures.
	•	Add action test coverage for plugin management, install, media, terminal, emote, and sync use cases.
	•	Extend plugin installer helper tests to cover git-branch parsing edge cases.

Validation
	•	bunx vitest run src/services/plugin-eject.test.ts
	•	bunx vitest run src/actions/__tests__ src/actions/restart.test.ts src/services/__tests__/plugin-installer.helpers.test.ts src/services/plugin-installer.test.ts src/services/plugin-eject.test.ts