### PR TITLE
cloud: block full IPv6 link-local range in URL validation

### DIFF
--- a/src/cloud/validate-url.test.ts
+++ b/src/cloud/validate-url.test.ts
@@ -79,6 +79,16 @@ describe("validateCloudBaseUrl", () => {
     expect(dnsMockState.lookupMock).not.toHaveBeenCalled();
   });
 
+  it("blocks IPv6 link-local targets across fe80::/10", async () => {
+    const fe80 = await validateCloudBaseUrl("https://[fe80::1]");
+    const fea0 = await validateCloudBaseUrl("https://[fea0::1]");
+    const febf = await validateCloudBaseUrl("https://[febf::1]");
+
+    expect(fe80).toContain("blocked");
+    expect(fea0).toContain("blocked");
+    expect(febf).toContain("blocked");
+  });
+
   it("blocks additional special-use IPv4 ranges", async () => {
     const cgnat = await validateCloudBaseUrl("https://100.64.1.10");
     const benchmark = await validateCloudBaseUrl("https://198.18.0.5");

--- a/src/cloud/validate-url.ts
+++ b/src/cloud/validate-url.ts
@@ -98,7 +98,7 @@ function isBlockedIpv6(ip: string): boolean {
   return (
     normalized === "::" || // unspecified address
     normalized === "::1" || // loopback
-    normalized.startsWith("fe80:") || // link-local
+    /^fe[89ab][0-9a-f]:/.test(normalized) || // link-local fe80::/10
     /^f[cd][0-9a-f]{2}:/i.test(normalized) || // ULA (fc00::/7)
     normalized.startsWith("ff") // multicast (ff00::/8)
   );


### PR DESCRIPTION
## Summary
- harden `validateCloudBaseUrl` IPv6 link-local detection from `fe80::/16` to full `fe80::/10`
- add regression coverage for `fe80::1`, `fea0::1`, and `febf::1`

## Validation
- `bun run vitest src/cloud/validate-url.test.ts` (pass, 12/12)
- `bun run check` (fails on existing baseline TS7016 in untouched `src/benchmark/server.ts` for `@elizaos/plugin-sql` typings)
