### PR TITLE
fix(ui): responsive polish for 13-inch screens + fix avatar T-pose

### DIFF
--- a/apps/app/public/animations/idle.glb
+++ b/apps/app/public/animations/idle.glb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c56b4f79ae304b31ee0f81ebd66b8f5a906ff508d739bf9deeafe7b68484efbe
-size 88600
+oid sha256:5dafa3b7dfa0efa80db1b0cefc4c83ef30f5c628bb454ae2e84f3208f383f3f6
+size 134360

--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -224,7 +224,7 @@ export function App() {
             ) : (
               <>
                 <ConversationsSidebar />
-                <main className="flex flex-col flex-1 min-w-0 overflow-visible pt-3 px-5">
+                <main className="flex flex-col flex-1 min-w-0 overflow-visible pt-3 px-3 xl:px-5">
                   <ChatView />
                 </main>
                 <AutonomousPanel />
@@ -245,7 +245,7 @@ export function App() {
         <div className="flex flex-col flex-1 min-h-0 w-full font-body text-txt bg-bg">
           <Header />
           <Nav />
-          <main className={`flex-1 min-h-0 py-6 px-5 ${isAdvancedTab ? "overflow-hidden" : "overflow-y-auto"}`}>
+          <main className={`flex-1 min-h-0 py-4 px-3 xl:py-6 xl:px-5 ${isAdvancedTab ? "overflow-hidden" : "overflow-y-auto"}`}>
             <ViewRouter />
           </main>
           <TerminalPanel />

--- a/apps/app/src/components/AutonomousPanel.tsx
+++ b/apps/app/src/components/AutonomousPanel.tsx
@@ -94,7 +94,7 @@ export function AutonomousPanel({ mobile = false, onClose }: AutonomousPanelProp
 
   return (
     <aside
-      className={`${mobile ? "w-full min-w-0" : "w-[420px] min-w-[420px] border-l"} border-border bg-bg flex flex-col h-full font-body text-[13px]`}
+      className={`${mobile ? "w-full min-w-0" : "w-[280px] min-w-[280px] xl:w-[340px] xl:min-w-[340px] 2xl:w-[420px] 2xl:min-w-[420px] border-l"} border-border bg-bg flex flex-col h-full font-body text-[13px]`}
       data-testid="autonomous-panel"
     >
       <div className="px-3 py-2 border-b border-border flex items-start justify-between gap-2">
@@ -298,7 +298,7 @@ export function AutonomousPanel({ mobile = false, onClose }: AutonomousPanelProp
       <div className="border-t border-border px-3 py-2">
         <div className="text-xs uppercase tracking-wide text-muted mb-2">Chat Controls</div>
 
-        <div className={`${mobile ? "h-[300px]" : "h-[420px]"} border border-border bg-bg-hover/20 rounded overflow-hidden relative`}>
+        <div className={`${mobile ? "h-[300px]" : "h-[260px] xl:h-[320px] 2xl:h-[420px]"} border border-border bg-bg-hover/20 rounded overflow-hidden relative`}>
           {chatAvatarVisible ? (
             <ChatAvatar
               isSpeaking={chatAvatarSpeaking}

--- a/apps/app/src/components/ChatView.tsx
+++ b/apps/app/src/components/ChatView.tsx
@@ -42,7 +42,8 @@ export function ChatView() {
     droppedFiles,
     shareIngestNotice,
     chatMode,
-    chatAgentVoiceMuted,
+    chatAvatarVisible: avatarVisible,
+    chatAgentVoiceMuted: agentVoiceMuted,
     selectedVrmIndex,
   } = useApp();
 
@@ -157,7 +158,7 @@ export function ChatView() {
   const agentInitial = agentName.trim().charAt(0).toUpperCase() || "A";
 
   useEffect(() => {
-    if (chatAgentVoiceMuted) return;
+    if (agentVoiceMuted) return;
 
     const latestAssistant = [...msgs]
       .reverse()
@@ -165,12 +166,12 @@ export function ChatView() {
     if (!latestAssistant || !latestAssistant.text.trim()) return;
 
     queueAssistantSpeech(latestAssistant.id, latestAssistant.text, !chatSending);
-  }, [msgs, chatSending, chatAgentVoiceMuted, queueAssistantSpeech]);
+  }, [msgs, chatSending, agentVoiceMuted, queueAssistantSpeech]);
 
   useEffect(() => {
-    if (!chatAgentVoiceMuted) return;
+    if (!agentVoiceMuted) return;
     stopSpeaking();
-  }, [chatAgentVoiceMuted, stopSpeaking]);
+  }, [agentVoiceMuted, stopSpeaking]);
 
   useEffect(() => {
     setState("chatAvatarSpeaking", voice.isSpeaking && !voice.usingAudioAnalysis);
@@ -296,7 +297,7 @@ export function ChatView() {
                           typeof msg.source === "string" &&
                           msg.source &&
                           msg.source !== "client_chat" && (
-                            <span className="ml-1.5 text-[10px] font-normal text-muted">
+                            <span className="ml-1.5 text-[10px] font-normal text-muted opacity-40">
                               via {msg.source}
                             </span>
                           )}
@@ -385,7 +386,7 @@ export function ChatView() {
                 ? "border-accent text-accent"
                 : "border-border text-muted hover:border-accent hover:text-accent"
             }`}
-            onClick={() => setAvatarVisible((v) => !v)}
+            onClick={() => setState("chatAvatarVisible", !avatarVisible)}
             title={avatarVisible ? "Hide avatar" : "Show avatar"}
           >
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -404,7 +405,7 @@ export function ChatView() {
             }`}
             onClick={() => {
               const muting = !agentVoiceMuted;
-              setAgentVoiceMuted(muting);
+              setState("chatAgentVoiceMuted", muting);
               if (muting) voice.stopSpeaking();
             }}
             title={agentVoiceMuted ? "Unmute agent voice" : "Mute agent voice"}

--- a/apps/app/src/components/ConversationsSidebar.tsx
+++ b/apps/app/src/components/ConversationsSidebar.tsx
@@ -86,7 +86,7 @@ export function ConversationsSidebar({ mobile = false, onClose }: ConversationsS
 
   return (
     <aside
-      className={`${mobile ? "w-full min-w-0 h-full" : "w-60 min-w-60 border-r"} border-border bg-bg flex flex-col overflow-y-auto text-[13px]`}
+      className={`${mobile ? "w-full min-w-0 h-full" : "w-48 min-w-48 xl:w-60 xl:min-w-60 border-r"} border-border bg-bg flex flex-col overflow-y-auto text-[13px]`}
       data-testid="conversations-sidebar"
     >
       {mobile && (
@@ -105,7 +105,7 @@ export function ConversationsSidebar({ mobile = false, onClose }: ConversationsS
       <div className="p-3 border-b border-border">
         <button
           type="button"
-          className="w-full px-3 py-2 border border-border rounded-md bg-accent text-accent-fg text-[13px] font-medium cursor-pointer transition-opacity hover:opacity-90"
+          className="w-full px-3 py-1.5 border border-accent rounded-md bg-transparent text-accent text-[12px] font-medium cursor-pointer transition-colors hover:bg-accent hover:text-accent-fg"
           onClick={() => {
             handleNewConversation();
             onClose?.();

--- a/apps/app/src/components/Header.tsx
+++ b/apps/app/src/components/Header.tsx
@@ -34,10 +34,10 @@ export function Header() {
 
   return (
     <>
-      <header className="border-b border-border py-3 px-3 sm:py-4 sm:px-5">
+      <header className="border-b border-border py-2 px-3 sm:py-3 sm:px-4">
         <div className="flex items-center gap-2 min-w-0">
           <div className="shrink-0 min-w-0">
-            <span className="text-lg font-bold text-txt-strong truncate block" data-testid="agent-name">{name}</span>
+            <span className="text-base font-bold text-txt-strong truncate block" data-testid="agent-name">{name}</span>
           </div>
           <div className="flex-1 min-w-0 overflow-x-auto">
             <div className="flex items-center gap-1.5 w-max ml-auto pr-0.5">

--- a/apps/app/src/components/Nav.tsx
+++ b/apps/app/src/components/Nav.tsx
@@ -42,7 +42,7 @@ export function Nav({ mobileLeft }: NavProps) {
         </button>
       </nav>
 
-      <nav className="hidden lg:flex border-b border-border py-2 px-5 gap-1 overflow-x-auto whitespace-nowrap">
+      <nav className="hidden lg:flex border-b border-border py-1.5 px-3 xl:px-5 gap-0.5 overflow-x-auto whitespace-nowrap">
         {TAB_GROUPS.map((group: (typeof TAB_GROUPS)[number]) => {
           const primaryTab = group.tabs[0];
           const isActive = group.tabs.includes(tab);
@@ -50,7 +50,7 @@ export function Nav({ mobileLeft }: NavProps) {
             <button
               type="button"
               key={group.label}
-              className={`inline-block shrink-0 px-3 py-1.5 text-[13px] bg-transparent border-0 border-b-2 cursor-pointer transition-colors ${
+              className={`inline-block shrink-0 px-2 xl:px-3 py-1 text-[12px] bg-transparent border-0 border-b-2 cursor-pointer transition-colors ${
                 isActive
                   ? "text-accent font-medium border-b-accent"
                   : "text-muted border-b-transparent hover:text-txt"


### PR DESCRIPTION
## Summary

Responsive layout polish for smaller (13") screens and a fix for the avatar T-pose bug.

### UI Polish
- **App.tsx**: Responsive padding (`px-5` → `px-3 xl:px-5`, `py-6` → `py-4 xl:py-6`)
- **AutonomousPanel.tsx**: Responsive widths (`w-[420px]` → `w-[280px] xl:w-[340px] 2xl:w-[420px]`), chat controls height scaled
- **ConversationsSidebar.tsx**: Sidebar width `w-60` → `w-48 xl:w-60`, "New Chat" button restyled as subtle outline
- **Header.tsx**: Tighter padding, agent name `text-lg` → `text-base`
- **Nav.tsx**: Tighter padding/gaps, tab text `text-[13px]` → `text-[12px]`
- **ChatView.tsx**: Source label ("via agent_greeting") dimmed to 40% opacity; **fixed undefined `avatarVisible`/`setAvatarVisible`/`agentVoiceMuted`/`setAgentVoiceMuted` references** — wired to AppContext `setState` with correct keys (`chatAvatarVisible`, `chatAgentVoiceMuted`)

### Avatar T-Pose Fix
- `idle.glb` was a 130-byte Git LFS pointer stub — avatar had no idle animation, stuck in T-pose
- Replaced with real 134KB GLB converted from source FBX using FBX2glTF

### Bug Fix (ChatView.tsx)
The develop branch had undefined variable references for avatar visibility and voice mute toggles:
- `avatarVisible`, `setAvatarVisible` — never destructured from `useApp()`
- `agentVoiceMuted`, `setAgentVoiceMuted` — never destructured from `useApp()`

Clicking these buttons would crash at runtime. Fixed by properly destructuring `chatAvatarVisible` and `chatAgentVoiceMuted` from `useApp()` and using `setState()` for updates.

### Testing
- 1718 tests passing (1 pre-existing failure in `plugin-eject.test.ts`, unrelated)
- Breakpoints: `xl:` (1280px), `2xl:` (1536px) — standard Tailwind defaults