### PR TITLE
fix(discord): make application ID optional and auto-resolve from bot token

### DIFF
--- a/apps/app/src/components/OnboardingWizard.tsx
+++ b/apps/app/src/components/OnboardingWizard.tsx
@@ -1271,16 +1271,15 @@ export function OnboardingWizard() {
                   )}
                 </div>
                 <p className="text-xs text-muted mb-3 mt-1">
-                  Create a bot at the{" "}
+                  Only a bot token is needed.{" "}
                   <a
                     href="https://discord.com/developers/applications"
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="text-accent underline"
+                    className="text-accent hover:underline"
                   >
-                    Discord Developer Portal
-                  </a>{" "}
-                  and copy the bot token
+                    Create a bot →
+                  </a>
                 </p>
                 <input
                   type="password"

--- a/plugins.json
+++ b/plugins.json
@@ -1896,8 +1896,8 @@
         },
         "DISCORD_APPLICATION_ID": {
           "type": "string",
-          "description": "Discord application ID for the bot",
-          "required": true,
+          "description": "Discord application ID for the bot (auto-resolved from bot token if omitted)",
+          "required": false,
           "sensitive": false
         },
         "CHANNEL_IDS": {


### PR DESCRIPTION
## Summary

Makes the Discord plugin work out of the box with just a bot token by:

1. **`plugins.json`** — Changed `DISCORD_APPLICATION_ID.required` from `true` to `false`
2. **`src/runtime/eliza.ts`** — Added `applicationId` mapping in `CHANNEL_ENV_MAP` so config-based application IDs bridge to the env var
3. **`src/runtime/eliza.ts`** — Added `autoResolveDiscordAppId()` async function that fetches the application ID from Discord's `/oauth2/applications/@me` endpoint when not explicitly set. Called during startup and hot-reload.
4. **`apps/app/src/components/OnboardingWizard.tsx`** — Updated helper text to clarify only a bot token is needed

## Testing

All 1718 tests pass. The single pre-existing failure in `plugin-eject.test.ts` is unrelated.