### PR TITLE
chore: bump version to 2.0.0-alpha.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "milady",
-  "version": "2.0.0-alpha.7",
+  "version": "2.0.0-alpha.22",
   "description": "Cute agents for the acceleration",
   "homepage": "https://github.com/milady-ai/milady",
   "author": {


### PR DESCRIPTION
## Summary
Bump version to 2.0.0-alpha.22 for release.

## Test plan
- [x] Version number updated in package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)