### PR TITLE
fix: add retry logic for bun install in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,12 @@ jobs:
           bun-version: latest
 
       - name: Install root dependencies
-        run: bun install --frozen-lockfile
+        run: |
+          for i in 1 2 3; do
+            bun install --frozen-lockfile && break
+            echo "Retry $i: bun install failed, retrying..."
+            sleep 5
+          done
 
       - name: Align package versions with release tag
         run: |
@@ -124,7 +129,12 @@ jobs:
           echo '{"type":"module"}' > dist/package.json
 
       - name: Install Capacitor app dependencies
-        run: bun install
+        run: |
+          for i in 1 2 3; do
+            bun install && break
+            echo "Retry $i: bun install failed, retrying..."
+            sleep 5
+          done
         working-directory: apps/app
 
       - name: Build Capacitor plugins
@@ -137,7 +147,12 @@ jobs:
         shell: bash
 
       - name: Refresh Capacitor app dependencies
-        run: bun install
+        run: |
+          for i in 1 2 3; do
+            bun install && break
+            echo "Retry $i: bun install failed, retrying..."
+            sleep 5
+          done
         working-directory: apps/app
 
       - name: Build Capacitor app
@@ -155,7 +170,12 @@ jobs:
         working-directory: apps/app
 
       - name: Install Electron dependencies
-        run: bun install --no-save
+        run: |
+          for i in 1 2 3; do
+            bun install --no-save && break
+            echo "Retry $i: bun install failed, retrying..."
+            sleep 5
+          done
         working-directory: apps/app/electron
 
       - name: Build Electron app


### PR DESCRIPTION
## Summary
Add retry logic to bun install commands in the release workflow to handle transient "Failed to install 1 package" errors.

## Changes
- Added 3-retry loop to all `bun install` commands in the release workflow
- 5 second delay between retries

## Test plan
- [x] Workflow syntax is valid
- Release workflow will retry failed installs

🤖 Generated with [Claude Code](https://claude.com/claude-code)