### PR TITLE
fix: use npx vite build directly in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,7 +157,10 @@ jobs:
 
       - name: Build Capacitor app
         if: matrix.platform.os != 'windows'
-        run: bun run build
+        run: |
+          # Run vite build directly instead of the build script
+          # (the build script's rt.sh install is handled by previous steps)
+          npx vite build
         working-directory: apps/app
 
       - name: Build Capacitor app (Windows)


### PR DESCRIPTION
## Summary
Use npx vite build directly instead of bun run build to avoid the redundant and flaky internal bun install call.

## Changes
- Changed "Build Capacitor app" step to run `npx vite build` directly
- The previous install steps already handle dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)