### PR TITLE
fix: update notarize config for electron-builder v26+

### DIFF
--- a/apps/app/electron/electron-builder.config.json
+++ b/apps/app/electron/electron-builder.config.json
@@ -40,9 +40,7 @@
     "gatekeeperAssess": false,
     "entitlements": "entitlements.mac.plist",
     "entitlementsInherit": "entitlements.mac.plist",
-    "notarize": {
-      "teamId": "25877RY2EH"
-    }
+    "notarize": true
   },
   "dmg": {
     "format": "UDZO",


### PR DESCRIPTION
## Summary
Update mac.notarize config to boolean for electron-builder v26+ compatibility.

## Changes
- Changed `mac.notarize` from object to `true`
- APPLE_TEAM_ID is passed via environment variable in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)