### PR TITLE
feat: deferred restart banner, OAuth fixes, plugin manager composite

### DIFF
--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -24,6 +24,7 @@ import { OnboardingWizard } from "./components/OnboardingWizard";
 import { PairingView } from "./components/PairingView";
 import { SaveCommandModal } from "./components/SaveCommandModal";
 import { SettingsView } from "./components/SettingsView";
+import { RestartBanner } from "./components/RestartBanner";
 import { TerminalPanel } from "./components/TerminalPanel";
 import { useContextMenu } from "./hooks/useContextMenu";
 
@@ -314,6 +315,7 @@ export function App() {
           setEditingAction(null);
         }}
       />
+      <RestartBanner />
       {actionNotice && (
         <div
           className={`fixed bottom-6 left-1/2 -translate-x-1/2 px-5 py-2 rounded-lg text-[13px] font-medium z-[10000] text-white ${

--- a/apps/app/src/api-client.ts
+++ b/apps/app/src/api-client.ts
@@ -166,6 +166,8 @@ export interface AgentStatus {
   model: string | undefined;
   uptime: number | undefined;
   startedAt: number | undefined;
+  pendingRestart?: boolean;
+  pendingRestartReasons?: string[];
 }
 
 export interface RuntimeOrderItem {

--- a/apps/app/src/components/CharacterView.tsx
+++ b/apps/app/src/components/CharacterView.tsx
@@ -16,6 +16,7 @@ import type { ConfigUiHint } from "../types";
 import { AvatarSelector } from "./AvatarSelector";
 import type { JsonSchemaObject } from "./config-catalog";
 import { ConfigRenderer, defaultRegistry } from "./config-renderer";
+import { SecretsView } from "./SecretsView";
 
 const DEFAULT_ELEVEN_FAST_MODEL = "eleven_flash_v2_5";
 const REDACTED_SECRET = "[REDACTED]";
@@ -447,6 +448,9 @@ export function CharacterView() {
     null,
   );
   const [selectedPresetId, setSelectedPresetId] = useState<string | null>(null);
+
+  /* ── Secrets vault modal state ───────────────────────────────── */
+  const [secretsOpen, setSecretsOpen] = useState(false);
 
   /* ── ElevenLabs voice presets ──────────────────────────────────── */
   type VoicePreset = {
@@ -1051,6 +1055,28 @@ export function CharacterView() {
             >
               export
             </button>
+            <button
+              type="button"
+              className="flex items-center gap-1 px-2 py-0.5 text-[10px] text-[var(--muted)] hover:text-[var(--txt)] bg-transparent border border-[var(--border)] cursor-pointer transition-colors hover:border-[var(--accent)]"
+              onClick={() => setSecretsOpen(true)}
+              title="Secrets Vault"
+            >
+              <svg
+                width="11"
+                height="11"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <title>Secrets vault</title>
+                <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+                <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+              </svg>
+              secrets
+            </button>
           </div>
         </div>
 
@@ -1624,6 +1650,57 @@ export function CharacterView() {
           )}
         </div>
       </div>
+
+      {/* ── Secrets vault modal ── */}
+      {secretsOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) setSecretsOpen(false);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Escape" || e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              setSecretsOpen(false);
+            }
+          }}
+          role="dialog"
+          aria-modal="true"
+        >
+          <div className="w-full max-w-2xl max-h-[80vh] border border-[var(--border)] bg-[var(--card)] p-5 shadow-lg flex flex-col">
+            <div className="flex items-center justify-between mb-4 flex-shrink-0">
+              <div className="flex items-center gap-2">
+                <svg
+                  width="15"
+                  height="15"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="text-[var(--accent)]"
+                >
+                  <title>Secrets vault</title>
+                  <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+                  <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+                </svg>
+                <span className="font-bold text-sm">Secrets Vault</span>
+              </div>
+              <button
+                type="button"
+                className="text-[var(--muted)] hover:text-[var(--txt)] text-lg leading-none px-1 bg-transparent border-0 cursor-pointer"
+                onClick={() => setSecretsOpen(false)}
+              >
+                &times;
+              </button>
+            </div>
+            <div className="flex-1 min-h-0 overflow-y-auto">
+              <SecretsView />
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/app/src/components/OnboardingWizard.tsx
+++ b/apps/app/src/components/OnboardingWizard.tsx
@@ -872,7 +872,7 @@ export function OnboardingWizard() {
           },
           "openai-subscription": {
             name: "ChatGPT Subscription",
-            description: "$20-200/mo ChatGPT Plus/Pro subscription",
+            description: "Coming soon \u2014 use OpenAI API Key instead",
           },
           anthropic: { name: "Anthropic API Key" },
           openai: { name: "OpenAI API Key" },
@@ -1060,213 +1060,44 @@ export function OnboardingWizard() {
               </div>
             )}
 
-            {/* Claude Subscription — setup token / OAuth */}
+            {/* Claude Subscription — setup token */}
             {onboardingProvider === "anthropic-subscription" && (
               <div className="text-left">
-                <div className="flex items-center gap-4 border-b border-border mb-3">
-                  <button
-                    type="button"
-                    className={`text-sm pb-2 border-b-2 ${
-                      onboardingSubscriptionTab === "token"
-                        ? "border-accent text-accent"
-                        : "border-transparent text-muted hover:text-txt"
-                    }`}
-                    onClick={() =>
-                      setState("onboardingSubscriptionTab", "token")
-                    }
-                  >
-                    Setup Token
-                  </button>
-                  <button
-                    type="button"
-                    className={`text-sm pb-2 border-b-2 ${
-                      onboardingSubscriptionTab === "oauth"
-                        ? "border-accent text-accent"
-                        : "border-transparent text-muted hover:text-txt"
-                    }`}
-                    onClick={() =>
-                      setState("onboardingSubscriptionTab", "oauth")
-                    }
-                  >
-                    OAuth Login
-                  </button>
-                </div>
-
-                {onboardingSubscriptionTab === "token" ? (
-                  <>
-                    <span className="text-[13px] font-bold text-txt-strong block mb-2">
-                      Setup Token:
-                    </span>
-                    <input
-                      type="password"
-                      value={onboardingApiKey}
-                      onChange={handleApiKeyChange}
-                      placeholder="sk-ant-oat01-..."
-                      className="w-full px-3 py-2 border border-border bg-card text-sm focus:border-accent focus:outline-none"
-                    />
-                    <p className="text-xs text-muted mt-2 whitespace-pre-line">
-                      {
-                        'How to get your setup token:\n\n• Option A: Run  claude setup-token  in your terminal (if you have Claude Code CLI installed)\n\n• Option B: Go to claude.ai/settings/api → "Claude Code" → "Use setup token"'
-                      }
-                    </p>
-                  </>
-                ) : anthropicConnected ? (
-                  <div className="flex flex-col items-center gap-3">
-                    <div className="flex items-center gap-2 px-6 py-3 border border-green-500/30 bg-green-500/10 text-green-400 text-sm font-medium w-full max-w-xs justify-center">
-                      <svg
-                        width="18"
-                        height="18"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2.5"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                      >
-                        <title>Connected</title>
-                        <polyline points="20 6 9 17 4 12" />
-                      </svg>
-                      Connected to Claude
-                    </div>
-                    <p className="text-xs text-muted text-center">
-                      Your Claude subscription is linked. Click Next to
-                      continue.
-                    </p>
-                  </div>
-                ) : !anthropicOAuthStarted ? (
-                  <div className="flex flex-col items-center gap-3">
-                    <button
-                      type="button"
-                      className="w-full max-w-xs px-6 py-3 border border-accent bg-accent text-accent-fg text-sm font-medium cursor-pointer hover:bg-accent-hover transition-colors"
-                      onClick={() => void handleAnthropicStart()}
-                    >
-                      Login with Anthropic
-                    </button>
-                    <p className="text-xs text-muted text-center">
-                      Requires Claude Pro ($20/mo) or Max ($100/mo).
-                    </p>
-                    {anthropicError && (
-                      <p className="text-xs text-red-400">{anthropicError}</p>
-                    )}
-                  </div>
-                ) : (
-                  <div className="flex flex-col items-center gap-3">
-                    <p className="text-sm text-txt text-center">
-                      After logging in, you'll see a code on Anthropic's page.
-                      <br />
-                      Copy and paste it below:
-                    </p>
-                    <input
-                      type="text"
-                      placeholder="Paste the authorization code here..."
-                      value={anthropicCode}
-                      onChange={(e) => setAnthropicCode(e.target.value)}
-                      className="w-full max-w-xs px-3 py-2 border border-border bg-card text-sm text-center focus:border-accent focus:outline-none"
-                    />
-                    {anthropicError && (
-                      <p className="text-xs text-red-400">{anthropicError}</p>
-                    )}
-                    <button
-                      type="button"
-                      disabled={!anthropicCode}
-                      className="w-full max-w-xs px-6 py-2 border border-accent bg-accent text-accent-fg text-sm cursor-pointer hover:bg-accent-hover disabled:opacity-40 disabled:cursor-not-allowed"
-                      onClick={() => void handleAnthropicExchange()}
-                    >
-                      Connect
-                    </button>
-                  </div>
-                )}
+                <span className="text-[13px] font-bold text-txt-strong block mb-2">
+                  Setup Token:
+                </span>
+                <input
+                  type="password"
+                  value={onboardingApiKey}
+                  onChange={handleApiKeyChange}
+                  placeholder="sk-ant-oat01-..."
+                  className="w-full px-3 py-2 border border-border bg-card text-sm focus:border-accent focus:outline-none"
+                />
+                <p className="text-xs text-muted mt-2 whitespace-pre-line">
+                  {
+                    'How to get your setup token:\n\n\u2022 Option A: Run  claude setup-token  in your terminal (if you have Claude Code CLI installed)\n\n\u2022 Option B: Go to claude.ai/settings/api \u2192 "Claude Code" \u2192 "Use setup token"'
+                  }
+                </p>
+                <p className="text-xs text-muted mt-2">
+                  Requires Claude Pro ($20/mo) or Max ($100/mo).
+                </p>
               </div>
             )}
 
-            {/* ChatGPT Subscription — OAuth */}
+            {/* ChatGPT Subscription — OAuth (not yet available) */}
             {onboardingProvider === "openai-subscription" && (
               <div className="space-y-4">
-                {openaiConnected ? (
-                  <div className="flex flex-col items-center gap-3">
-                    <div className="flex items-center gap-2 px-6 py-3 border border-green-500/30 bg-green-500/10 text-green-400 text-sm font-medium w-full max-w-xs justify-center">
-                      <svg
-                        width="18"
-                        height="18"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2.5"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                      >
-                        <title>Connected</title>
-                        <polyline points="20 6 9 17 4 12" />
-                      </svg>
-                      Connected to ChatGPT
-                    </div>
-                    <p className="text-xs text-muted text-center">
-                      Your ChatGPT subscription is linked. Click Next to
-                      continue.
-                    </p>
-                  </div>
-                ) : !openaiOAuthStarted ? (
-                  <div className="flex flex-col items-center gap-3">
-                    <button
-                      type="button"
-                      className="w-full max-w-xs px-6 py-3 border border-accent bg-accent text-accent-fg text-sm font-medium cursor-pointer hover:bg-accent-hover transition-colors"
-                      onClick={() => void handleOpenAIStart()}
-                    >
-                      Login with OpenAI
-                    </button>
-                    <p className="text-xs text-muted text-center">
-                      Requires ChatGPT Plus ($20/mo) or Pro ($200/mo).
-                    </p>
-                  </div>
-                ) : (
-                  <div className="flex flex-col gap-3">
-                    <div className="p-3 border border-border bg-card text-sm text-fg rounded">
-                      <p className="font-medium mb-1">Almost there!</p>
-                      <p className="text-muted text-xs leading-relaxed">
-                        After logging in, you'll be redirected to a page that
-                        won't load (starts with{" "}
-                        <code className="text-fg bg-input px-1 py-0.5 text-xs">
-                          localhost:1455
-                        </code>
-                        ). Copy the <strong>entire URL</strong> from your
-                        browser's address bar and paste it below.
-                      </p>
-                    </div>
-                    <input
-                      type="text"
-                      className="w-full px-3 py-2.5 border border-border bg-input text-fg text-sm placeholder:text-muted"
-                      placeholder="http://localhost:1455/auth/callback?code=..."
-                      value={openaiCallbackUrl}
-                      onChange={(e) => {
-                        setOpenaiCallbackUrl(e.target.value);
-                        setOpenaiError("");
-                      }}
-                    />
-                    {openaiError && (
-                      <p className="text-xs text-red-400">{openaiError}</p>
-                    )}
-                    <div className="flex gap-2 justify-center">
-                      <button
-                        type="button"
-                        className="px-6 py-2.5 border border-accent bg-accent text-accent-fg text-sm font-medium cursor-pointer hover:bg-accent-hover transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-                        disabled={!openaiCallbackUrl}
-                        onClick={() => void handleOpenAIExchange()}
-                      >
-                        Complete Login
-                      </button>
-                      <button
-                        type="button"
-                        className="px-4 py-2.5 border border-border text-muted text-sm cursor-pointer hover:text-fg transition-colors"
-                        onClick={() => {
-                          setOpenaiOAuthStarted(false);
-                          setOpenaiCallbackUrl("");
-                        }}
-                      >
-                        Start Over
-                      </button>
-                    </div>
-                  </div>
-                )}
+                <div className="p-4 border border-border bg-card text-center">
+                  <p className="text-sm text-txt font-medium mb-1">
+                    ChatGPT subscription login is coming soon.
+                  </p>
+                  <p className="text-xs text-muted">
+                    In the meantime, select{" "}
+                    <strong>OpenAI (API Key)</strong> from the provider list
+                    above and use an API key from{" "}
+                    <span className="text-fg">platform.openai.com/api-keys</span>.
+                  </p>
+                </div>
               </div>
             )}
 
@@ -1721,12 +1552,11 @@ export function OnboardingWizard() {
         return cloudConnected;
       case "llmProvider":
         if (onboardingProvider === "anthropic-subscription") {
-          return onboardingSubscriptionTab === "token"
-            ? onboardingApiKey.length > 0
-            : anthropicConnected;
+          return onboardingApiKey.length > 0;
         }
         if (onboardingProvider === "openai-subscription") {
-          return openaiConnected;
+          // OAuth flow not yet available — Next is always disabled
+          return false;
         }
         if (
           onboardingProvider === "elizacloud" ||

--- a/apps/app/src/components/RestartBanner.tsx
+++ b/apps/app/src/components/RestartBanner.tsx
@@ -1,0 +1,56 @@
+import { useCallback, useState } from "react";
+import { useApp } from "../AppContext";
+
+export function RestartBanner() {
+  const {
+    pendingRestart,
+    pendingRestartReasons,
+    restartBannerDismissed,
+    dismissRestartBanner,
+    triggerRestart,
+  } = useApp();
+
+  const [restarting, setRestarting] = useState(false);
+
+  const handleRestart = useCallback(async () => {
+    setRestarting(true);
+    try {
+      await triggerRestart();
+    } finally {
+      setRestarting(false);
+    }
+  }, [triggerRestart]);
+
+  if (!pendingRestart || restartBannerDismissed) return null;
+
+  const reasons = pendingRestartReasons;
+  const text =
+    reasons.length === 1
+      ? `${reasons[0]} — restart to apply.`
+      : reasons.length > 1
+        ? `${reasons.length} changes pending — restart to apply.`
+        : "Restart required to apply changes.";
+
+  return (
+    <div className="fixed top-0 left-0 right-0 z-[9998] flex items-center justify-between gap-3 bg-amber-600 px-4 py-2 text-[13px] font-medium text-white shadow-lg">
+      <span className="truncate">{text}</span>
+      <div className="flex items-center gap-2 shrink-0">
+        <button
+          type="button"
+          onClick={dismissRestartBanner}
+          className="rounded px-3 py-1 text-[12px] text-amber-100 hover:bg-amber-700 transition-colors"
+        >
+          Later
+        </button>
+        <button
+          type="button"
+          onClick={handleRestart}
+          disabled={restarting}
+          className="rounded bg-white px-3 py-1 text-[12px] font-semibold text-amber-700 hover:bg-amber-50 transition-colors disabled:opacity-60"
+        >
+          {restarting ? "Restarting..." : "Restart Now"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/components/SettingsView.tsx
+++ b/apps/app/src/components/SettingsView.tsx
@@ -255,7 +255,6 @@ export function SettingsView() {
         },
       });
       setState("cloudEnabled", true);
-      await client.restartAgent();
     } catch {
       /* non-fatal */
     }
@@ -630,7 +629,6 @@ export function SettingsView() {
                                       () => setModelSaveSuccess(false),
                                       2000,
                                     );
-                                    await client.restartAgent();
                                   } catch {
                                     /* ignore */
                                   }

--- a/apps/app/test/app/restart-banner.test.tsx
+++ b/apps/app/test/app/restart-banner.test.tsx
@@ -1,0 +1,155 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+interface RestartBannerContextStub {
+  pendingRestart: boolean;
+  pendingRestartReasons: string[];
+  restartBannerDismissed: boolean;
+  dismissRestartBanner: () => void;
+  triggerRestart: () => Promise<void>;
+}
+
+const mockUseApp = vi.fn<() => RestartBannerContextStub>();
+
+vi.mock("../../src/AppContext", async () => {
+  const actual = await vi.importActual<typeof import("../../src/AppContext")>(
+    "../../src/AppContext",
+  );
+  return {
+    ...actual,
+    useApp: () => mockUseApp(),
+  };
+});
+
+import { RestartBanner } from "../../src/components/RestartBanner";
+
+function makeContext(
+  overrides: Partial<RestartBannerContextStub> = {},
+): RestartBannerContextStub {
+  return {
+    pendingRestart: false,
+    pendingRestartReasons: [],
+    restartBannerDismissed: false,
+    dismissRestartBanner: vi.fn(),
+    triggerRestart: vi.fn(async () => undefined),
+    ...overrides,
+  };
+}
+
+/** Extract visible text from HTML markup (strip tags). */
+function readAllText(markup: string): string {
+  return markup.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+}
+
+describe("RestartBanner", () => {
+  beforeEach(() => {
+    mockUseApp.mockReset();
+  });
+
+  it("renders nothing when no restart is pending", () => {
+    mockUseApp.mockReturnValue(makeContext({ pendingRestart: false }));
+
+    const markup = renderToStaticMarkup(React.createElement(RestartBanner));
+    expect(markup).toBe("");
+  });
+
+  it("renders nothing when banner is dismissed", () => {
+    mockUseApp.mockReturnValue(
+      makeContext({
+        pendingRestart: true,
+        pendingRestartReasons: ["Configuration updated"],
+        restartBannerDismissed: true,
+      }),
+    );
+
+    const markup = renderToStaticMarkup(React.createElement(RestartBanner));
+    expect(markup).toBe("");
+  });
+
+  it("renders banner with single reason text", () => {
+    mockUseApp.mockReturnValue(
+      makeContext({
+        pendingRestart: true,
+        pendingRestartReasons: ["Plugin toggled"],
+      }),
+    );
+
+    const markup = renderToStaticMarkup(React.createElement(RestartBanner));
+    const text = readAllText(markup);
+
+    expect(text).toContain("Plugin toggled");
+    expect(text).toContain("restart to apply");
+  });
+
+  it("renders banner with count for multiple reasons", () => {
+    mockUseApp.mockReturnValue(
+      makeContext({
+        pendingRestart: true,
+        pendingRestartReasons: [
+          "Plugin toggled",
+          "Configuration updated",
+          "Wallet configuration updated",
+        ],
+      }),
+    );
+
+    const markup = renderToStaticMarkup(React.createElement(RestartBanner));
+    const text = readAllText(markup);
+
+    expect(text).toContain("3 changes pending");
+    expect(text).toContain("restart to apply");
+  });
+
+  it("renders Later button", () => {
+    mockUseApp.mockReturnValue(
+      makeContext({
+        pendingRestart: true,
+        pendingRestartReasons: ["Plugin toggled"],
+      }),
+    );
+
+    const markup = renderToStaticMarkup(React.createElement(RestartBanner));
+    expect(markup).toContain("Later");
+  });
+
+  it("renders Restart Now button", () => {
+    mockUseApp.mockReturnValue(
+      makeContext({
+        pendingRestart: true,
+        pendingRestartReasons: ["Plugin toggled"],
+      }),
+    );
+
+    const markup = renderToStaticMarkup(React.createElement(RestartBanner));
+    expect(markup).toContain("Restart Now");
+  });
+
+  it("renders with amber background styling", () => {
+    mockUseApp.mockReturnValue(
+      makeContext({
+        pendingRestart: true,
+        pendingRestartReasons: ["Configuration updated"],
+      }),
+    );
+
+    const markup = renderToStaticMarkup(React.createElement(RestartBanner));
+    expect(markup).toContain("bg-amber-600");
+    expect(markup).toContain("z-[9998]");
+  });
+
+  it("renders with zero reasons gracefully (edge case: pendingRestart true but empty reasons)", () => {
+    mockUseApp.mockReturnValue(
+      makeContext({
+        pendingRestart: true,
+        pendingRestartReasons: [],
+      }),
+    );
+
+    const markup = renderToStaticMarkup(React.createElement(RestartBanner));
+    const text = readAllText(markup);
+
+    // Should still render with fallback text
+    expect(text).toContain("Restart required to apply changes");
+  });
+});

--- a/src/api/agent-admin-routes.ts
+++ b/src/api/agent-admin-routes.ts
@@ -22,6 +22,7 @@ export interface AgentAdminRouteState {
   chatUserId: UUID | null;
   chatConnectionReady: { userId: UUID; roomId: UUID; worldId: UUID } | null;
   chatConnectionPromise: Promise<void> | null;
+  pendingRestartReasons: string[];
 }
 
 export interface AgentAdminRouteContext
@@ -86,8 +87,10 @@ export async function handleAgentAdminRoutes(
         state.agentState = "running";
         state.agentName = newRuntime.character.name ?? "Milady";
         state.startedAt = Date.now();
+        state.pendingRestartReasons = [];
         json(res, {
           ok: true,
+          pendingRestart: false,
           status: {
             state: state.agentState,
             agentName: state.agentName,
@@ -166,6 +169,7 @@ export async function handleAgentAdminRoutes(
       state.chatUserId = null;
       state.chatConnectionReady = null;
       state.chatConnectionPromise = null;
+      state.pendingRestartReasons = [];
 
       json(res, { ok: true });
     } catch (err) {

--- a/src/api/wallet-routes.ts
+++ b/src/api/wallet-routes.ts
@@ -59,6 +59,7 @@ export interface WalletRouteContext
     req: http.IncomingMessage,
     body: WalletExportRequestBody,
   ) => WalletExportRejectionLike | null;
+  scheduleRuntimeRestart?: (reason: string) => void;
   deps?: WalletRouteDependencies;
 }
 
@@ -317,6 +318,7 @@ export async function handleWalletRoutes(
       );
     }
 
+    ctx.scheduleRuntimeRestart?.("Wallet configuration updated");
     json(res, { ok: true });
     return true;
   }

--- a/src/services/app-manager.test.ts
+++ b/src/services/app-manager.test.ts
@@ -1,433 +1,164 @@
-// biome-ignore-all lint/suspicious/noExplicitAny: extensive fake runtime stubs require broad casts.
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
-import {
-  type Action,
-  type Character,
-  type Evaluator,
-  elizaLogger,
-  type IAgentRuntime,
-  type IMessageService,
-  type Memory,
-  type Plugin,
-  type Provider,
-  type Route,
-  type RuntimeEventStorage,
-  type Service,
-  type ServiceClass,
-  type ServiceTypeName,
-  type State,
-} from "@elizaos/core";
-import { PluginManagerService } from "@elizaos/plugin-plugin-manager";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  PluginManagerLike,
+  RegistryPluginInfo,
+} from "./plugin-manager-types";
 import { AppManager } from "./app-manager";
 
-// Fake Runtime implementation
-class FakeAgentRuntime implements IAgentRuntime {
-  agentId =
-    "fake-agent-id" as `${string}-${string}-${string}-${string}-${string}`;
-  serverUrl = "http://localhost:3000";
-  token = "fake-token";
-  character = {} as Character;
-  databaseAdapter = {} as any;
-  memoryRoots = {} as any;
-  cacheManager = {} as any;
-  providers: Provider[] = [];
-  actions: Action[] = [];
-  evaluators: Evaluator[] = [];
-  plugins: Plugin[] = [];
-  services: Map<ServiceTypeName, Service[]> = new Map();
-  initPromise = Promise.resolve();
-  enableAutonomy = false;
-  messageService = {} as IMessageService;
-  routes: Route[] = [];
-  stateCache = new Map<string, State>();
-  logLevelOverrides = new Map<string, string>();
-  logger = elizaLogger;
-  events: RuntimeEventStorage = {};
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
 
-  // IDatabaseAdapter methods (stubbed)
-  db = {};
-  async registerMemory(_memory: Memory): Promise<void> {}
-  async getMemory(_messageId: string): Promise<Memory | null> {
-    return null;
-  }
-  async getMemories() {
-    return [];
-  }
-  async getMemoriesByRoomIds() {
-    return [];
-  }
-  async getMemoryByContent() {
-    return null;
-  }
-  async getMemoriesCount() {
-    return 0;
-  }
-  async createLog() {}
-  async getLogs() {
-    return [];
-  }
-  async searchMemories() {
-    return [];
-  }
-  async searchMemoriesByEmbedding() {
-    return [];
-  }
-  async removeMemory() {}
-  async removeAllMemories() {}
-  async countMemories() {
-    return 0;
-  }
-  async getGoals() {
-    return [];
-  } // If getGoals exists in IDatabaseAdapter? Wait, I didn't see it in database.ts!
-  // It was removed or I missed it. IDatabaseAdapter does NOT have getGoals in the file I read.
-  // So I will remove getGoals stub.
+const APP_NAME = "@elizaos/app-example";
+const APP_PLUGIN_NAME = "@elizaos/plugin-example";
 
-  async getRoom() {
-    return null;
-  }
-  async createRoom() {
-    return "fake-room-id" as any;
-  }
-  async removeRoom() {}
-  async getRoomsForParticipant() {
-    return [];
-  }
-  async getRoomsForParticipants() {
-    return [];
-  }
-  async addParticipant() {
-    return true;
-  }
-  async removeParticipant() {
-    return true;
-  }
-  async getParticipantsForRoom() {
-    return [];
-  }
-  async getParticipantsForAccount() {
-    return [];
-  }
-  async getParticipantUserState() {
-    return null;
-  }
-  async setParticipantUserState() {}
-  async createRelationship() {
-    return true;
-  }
-  async getRelationship() {
-    return null;
-  }
-  async getRelationships() {
-    return [];
-  }
-  async getAccountById() {
-    return null;
-  }
-  async createAccount() {
-    return true;
-  }
-  async getActorDetails() {
-    return [];
-  }
-  // Cache methods matching declarations
-  async getCache<T>(_key: string): Promise<T | undefined> {
-    return undefined;
-  }
-  async setCache<T>(_key: string, _value: T): Promise<boolean> {
-    return true;
-  }
-  async deleteCache(_key: string): Promise<boolean> {
-    return true;
-  }
+const APP_REGISTRY_ENTRY: RegistryPluginInfo = {
+  name: APP_NAME,
+  gitRepo: "elizaos/app-example",
+  gitUrl: "https://github.com/elizaos/app-example",
+  description: "An example app",
+  topics: ["app"],
+  stars: 10,
+  language: "TypeScript",
+  npm: { package: APP_PLUGIN_NAME, v0Version: null, v1Version: null, v2Version: "1.0.0" },
+  supports: { v0: true, v1: false, v2: false },
+};
 
-  // Runtime methods
-  initialize = async () => {};
-  stop = async () => {};
-  processActions = async () => {};
-  evaluate = async () => null;
-  evaluatePre = async () => ({ blocked: false, redacted: false });
-  ensureConnection = async () => {};
-  ensureConnections = async () => {};
-  ensureParticipantInRoom = async () => {};
-  ensureWorldExists = async () => {};
-  ensureRoomExists = async () => {};
-  composeState = async () => ({}) as State;
-  useModel = async () => "fake-response";
-  generateText = async () => ({}) as any;
-  registerModel = () => {};
-  getModel = () => undefined;
-  getModelConfiguration = () => undefined;
-  registerEvent = () => {};
-  getEvent = () => undefined;
-  emitEvent = async () => {};
-  registerTaskWorker = () => {};
-  getTaskWorker = () => undefined;
-  dynamicPromptExecFromState = async () => null;
-  addEmbeddingToMemory = async (m: Memory) => m;
-  queueEmbeddingGeneration = async () => {};
-  getAllMemories = async () => [];
-  clearAllAgentMemories = async () => {};
-  updateMemory = async () => true;
-  createRunId = () => "fake-run-id" as any;
-  startRun = () => "fake-run-id" as any;
-  endRun = () => {};
-  getCurrentRunId = () => "fake-run-id" as any;
-  getEntityById = async () => null;
-  createEntity = async () => true;
-  getRooms = async () => [];
-  registerSendHandler = () => {};
-  sendMessageToTarget = async () => {};
-  updateWorld = async () => {};
-  redactSecrets = (t: string) => t;
-  getConnection = async () => ({});
-  getServiceLoadPromise = async () => ({}) as Service;
-  getRegisteredServiceTypes = () => [];
-  hasService = () => false;
-  registerDatabaseAdapter = () => {};
-  setSetting = () => {};
-  getSetting = () => null;
-  getConversationLength = () => 0;
-  isActionPlanningEnabled = () => true;
-  getLLMMode = () => "DEFAULT" as any;
-  isCheckShouldRespondEnabled = () => true;
-  getActionResults = () => [];
-  getAllActions = () => [];
-  getFilteredActions = () => [];
-  isActionAllowed = () => ({ allowed: true, reason: "" });
-  registerPlugin = async () => {};
+// ---------------------------------------------------------------------------
+// Mock factory (matches pattern from apps-routes.test.ts)
+// ---------------------------------------------------------------------------
 
-  // Synchronous registration methods to match interface
-  registerProvider(provider: Provider): void {
-    this.providers.push(provider);
-  }
-  registerAction(action: Action): void {
-    this.actions.push(action);
-  }
-  registerEvaluator(evaluator: Evaluator): void {
-    this.evaluators.push(evaluator);
-  }
-
-  // Service methods matched
-  getService<T extends Service>(service: ServiceTypeName | string): T | null {
-    const type = service as ServiceTypeName;
-    const services = this.services.get(type);
-    if (services && services.length > 0) {
-      return services[0] as T;
-    }
-    return null;
-  }
-
-  getServicesByType<T extends Service>(service: ServiceTypeName | string): T[] {
-    return (this.services.get(service as ServiceTypeName) || []) as T[];
-  }
-
-  getAllServices() {
-    return this.services;
-  }
-
-  async registerService(serviceClass: ServiceClass): Promise<void> {
-    // Instantiate the service
-    const service = new serviceClass(this);
-    // Initialize if needed (though runtime usually calls initialize later)
-    await service.initialize(this);
-
-    // Add to map
-    const type = service.serviceType;
-    if (!this.services.has(type)) {
-      this.services.set(type, []);
-    }
-    this.services.get(type)?.push(service);
-  }
-
-  // Missing DB methods from IDatabaseAdapter coverage (since 'any' cast on databaseAdapter property isn't enough?)
-  // NO, IAgentRuntime extends IDatabaseAdapter, so FakeAgentRuntime MUST implement them.
-  // I need to be careful. I added most of them.
-  // getGoals was removed.
-  // createGoal, removeGoal, removeAllGoals, updateGoal - are those in IDatabaseAdapter?
-  // Checking database.ts again... I did NOT see 'Goal' related methods in IDatabaseAdapter interface.
-  // So I should remove them.
-  // Same for getActorDetails, getAccountById, createAccount ?
-  // In database.ts: getAgent, getAgents, createAgent, updateAgent, deleteAgent.
-  // NO getAccountById, createAccount.
-  // NO getActorDetails.
-
-  getAgent = async () => null;
-  getAgents = async () => [];
-  createAgent = async () => true;
-  updateAgent = async () => true;
-  deleteAgent = async () => true;
-  ensureEmbeddingDimension = async () => {};
-  getEntitiesByIds = async () => null;
-  getEntitiesForRoom = async () => [];
-  createEntities = async () => true;
-  updateEntity = async () => {};
-  getComponent = async () => null;
-  getComponents = async () => [];
-  createComponent = async () => true;
-  updateComponent = async () => {};
-  deleteComponent = async () => {};
-  deleteManyMemories = async () => {};
-  deleteAllMemories = async () => {};
-  createWorld = async () => "fake-world-id" as any;
-  getWorld = async () => null;
-  removeWorld = async () => {};
-  getAllWorlds = async () => [];
-  getRoomsByIds = async () => null;
-  createRooms = async () => [];
-  deleteRoom = async () => {};
-  deleteRoomsByWorldId = async () => {};
-  updateRoom = async () => {};
-  addParticipantsRoom = async () => true;
-  updateRelationship = async () => {};
-  getTasks = async () => [];
-  getTask = async () => null;
-  getTasksByName = async () => [];
-  createTask = async () => "fake-task-id" as any;
-  updateTask = async () => {};
-  deleteTask = async () => {};
-  getMemoriesByWorldId = async () => [];
-  getPairingRequests = async () => [];
-  createPairingRequest = async () => "fake-req-id" as any;
-  updatePairingRequest = async () => {};
-  deletePairingRequest = async () => {};
-  getPairingAllowlist = async () => [];
-  createPairingAllowlistEntry = async () => "fake-entry-id" as any;
-  deletePairingAllowlistEntry = async () => {};
-  isReady = async () => true;
-  close = async () => {};
-  getCachedEmbeddings = async () => [];
-  log = async () => {};
-  deleteLog = async () => {};
-  isRoomParticipant = async () => false;
-  getParticipantsForEntity = async () => [];
+function createPluginManagerMock(
+  overrides: Partial<PluginManagerLike> = {},
+): PluginManagerLike {
+  return {
+    refreshRegistry: vi.fn(async () => new Map([[APP_NAME, APP_REGISTRY_ENTRY]])),
+    listInstalledPlugins: vi.fn(async () => []),
+    getRegistryPlugin: vi.fn(async (name: string) =>
+      name === APP_NAME ? APP_REGISTRY_ENTRY : null,
+    ),
+    searchRegistry: vi.fn(async () => []),
+    installPlugin: vi.fn(async () => ({
+      success: true,
+      pluginName: APP_PLUGIN_NAME,
+      version: "1.0.0",
+      installPath: "/tmp/plugins/installed/_elizaos_plugin-example",
+      requiresRestart: true,
+    })),
+    uninstallPlugin: vi.fn(async () => ({
+      success: true,
+      pluginName: APP_PLUGIN_NAME,
+      requiresRestart: false,
+    })),
+    listEjectedPlugins: vi.fn(async () => []),
+    ejectPlugin: vi.fn(),
+    syncPlugin: vi.fn(),
+    reinjectPlugin: vi.fn(),
+    ...overrides,
+  };
 }
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 describe("AppManager Integration", () => {
   let appManager: AppManager;
-  let pluginManager: PluginManagerService;
-  let runtime: FakeAgentRuntime;
-  let tempDir: string;
 
-  const APP_NAME = "@elizaos/app-example";
-  const APP_PLUGIN_NAME = "@elizaos/plugin-example";
-
-  beforeEach(async () => {
-    // Setup temp directory for plugins
-    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "milady-test-"));
-    const pluginsDir = path.join(tempDir, "plugins");
-    fs.mkdirSync(pluginsDir);
-
-    // Mock registry response
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        registry: {
-          [APP_NAME]: {
-            git: { repo: "elizaos/app-example", v0: {}, v1: {}, v2: {} },
-            npm: { repo: APP_PLUGIN_NAME, v0: null, v1: null, v2: "1.0.0" },
-            supports: { v0: true, v1: false, v2: false },
-            description: "An example app",
-            topics: ["app"],
-            stargazers_count: 10,
-            language: "TypeScript",
-          },
-          // Add the plugin entry so uninstallPlugin can find it
-          [APP_PLUGIN_NAME]: {
-            git: { repo: "elizaos/plugin-example", v0: {}, v1: {}, v2: {} },
-            npm: { repo: APP_PLUGIN_NAME, v0: null, v1: null, v2: "1.0.0" },
-            supports: { v0: true, v1: false, v2: false },
-            description: "An example plugin",
-            topics: ["plugin"],
-          },
-        },
-      }),
-    });
-
-    runtime = new FakeAgentRuntime();
-    // Initialize PluginManager with real file system path
-    pluginManager = new PluginManagerService(runtime, {
-      pluginDirectory: pluginsDir,
-    });
-
-    process.env.MILADY_STATE_DIR = tempDir;
-
+  beforeEach(() => {
     appManager = new AppManager();
   });
 
   afterEach(() => {
-    // Cleanup
-    fs.rmSync(tempDir, { recursive: true, force: true });
     vi.restoreAllMocks();
   });
 
   it("launches an app directly if plugin is already installed", async () => {
-    // Setup: Simulate installed plugin
-    // Use hyphen in sanitized name as verified
-    const installedDir = path.join(
-      tempDir,
-      "plugins",
-      "installed",
-      "_elizaos_plugin-example",
-    );
-    fs.mkdirSync(installedDir, { recursive: true });
-    fs.writeFileSync(
-      path.join(installedDir, "package.json"),
-      JSON.stringify({ name: APP_PLUGIN_NAME, version: "1.0.0" }),
-    );
-
-    // Act
-    const result = await appManager.launch(pluginManager, APP_NAME);
-
-    // Assert
-    expect(result.pluginInstalled).toBe(true);
-    expect(result.needsRestart).toBe(false);
-  });
-
-  it("installs plugin if not installed (integration - skipping actual install via mock if possible, or failing)", async () => {
-    // We spy on installPlugin to verify it is called
-    const installSpy = vi.spyOn(pluginManager, "installPlugin");
-    installSpy.mockResolvedValue({
-      success: true,
-      pluginName: APP_PLUGIN_NAME,
-      version: "1.0.0",
-      requiresRestart: true,
-      installPath: "/tmp",
+    const pluginManager = createPluginManagerMock({
+      listInstalledPlugins: vi.fn(async () => [
+        { name: APP_PLUGIN_NAME, version: "1.0.0" },
+      ]),
     });
 
     const result = await appManager.launch(pluginManager, APP_NAME);
 
-    expect(installSpy).toHaveBeenCalled();
+    expect(result.pluginInstalled).toBe(true);
+    expect(result.needsRestart).toBe(false);
+    // installPlugin should NOT have been called since it was already installed
+    expect(pluginManager.installPlugin).not.toHaveBeenCalled();
+  });
+
+  it("installs plugin if not installed", async () => {
+    const pluginManager = createPluginManagerMock();
+
+    const result = await appManager.launch(pluginManager, APP_NAME);
+
+    expect(pluginManager.installPlugin).toHaveBeenCalledWith(
+      APP_PLUGIN_NAME,
+      undefined,
+    );
     expect(result.pluginInstalled).toBe(true);
     expect(result.needsRestart).toBe(true);
   });
 
-  it("stops an app by uninstalling its plugin", async () => {
-    // Setup: Simulate installed plugin
-    // Use hyphen in sanitized name as verified
-    const installedDir = path.join(
-      tempDir,
-      "plugins",
-      "installed",
-      "_elizaos_plugin-example",
-    );
-    fs.mkdirSync(installedDir, { recursive: true });
-    fs.writeFileSync(
-      path.join(installedDir, "package.json"),
-      JSON.stringify({ name: APP_PLUGIN_NAME, version: "1.0.0" }),
-    );
+  it("throws if plugin installation fails", async () => {
+    const pluginManager = createPluginManagerMock({
+      installPlugin: vi.fn(async () => ({
+        success: false,
+        pluginName: APP_PLUGIN_NAME,
+        version: "",
+        installPath: "",
+        requiresRestart: false,
+        error: "npm install failed",
+      })),
+    });
 
-    // Act
+    await expect(
+      appManager.launch(pluginManager, APP_NAME),
+    ).rejects.toThrow(/Failed to install plugin/);
+  });
+
+  it("throws if app is not found in registry", async () => {
+    const pluginManager = createPluginManagerMock({
+      getRegistryPlugin: vi.fn(async () => null),
+    });
+
+    await expect(
+      appManager.launch(pluginManager, "@elizaos/app-nonexistent"),
+    ).rejects.toThrow(/not found in the registry/);
+  });
+
+  it("stops an app by uninstalling its plugin", async () => {
+    const pluginManager = createPluginManagerMock({
+      listInstalledPlugins: vi.fn(async () => [
+        { name: APP_PLUGIN_NAME, version: "1.0.0" },
+      ]),
+    });
+
     const result = await appManager.stop(pluginManager, APP_NAME);
 
-    // Assert
     expect(result.success).toBe(true);
     expect(result.pluginUninstalled).toBe(true);
+    expect(pluginManager.uninstallPlugin).toHaveBeenCalledWith(APP_PLUGIN_NAME);
+  });
 
-    // Verify file system
-    expect(fs.existsSync(installedDir)).toBe(false);
+  it("returns no-op when stopping app that is not installed", async () => {
+    const pluginManager = createPluginManagerMock();
+
+    const result = await appManager.stop(pluginManager, APP_NAME);
+
+    expect(result.success).toBe(false);
+    expect(result.pluginUninstalled).toBe(false);
+    expect(pluginManager.uninstallPlugin).not.toHaveBeenCalled();
+  });
+
+  it("throws when stopping an app not in registry", async () => {
+    const pluginManager = createPluginManagerMock({
+      getRegistryPlugin: vi.fn(async () => null),
+    });
+
+    await expect(
+      appManager.stop(pluginManager, "@elizaos/app-nonexistent"),
+    ).rejects.toThrow(/not found in the registry/);
   });
 });

--- a/src/services/plugin-manager-composite.test.ts
+++ b/src/services/plugin-manager-composite.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock the three utility modules — use vi.hoisted so refs work in factories
+// ---------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+  refreshRegistry: vi.fn(),
+  getPluginInfo: vi.fn(),
+  searchPlugins: vi.fn(),
+  installPlugin: vi.fn(),
+  uninstallPlugin: vi.fn(),
+  listInstalledPlugins: vi.fn(),
+  ejectPlugin: vi.fn(),
+  syncPlugin: vi.fn(),
+  reinjectPlugin: vi.fn(),
+  listEjectedPlugins: vi.fn(),
+}));
+
+vi.mock("./registry-client", () => ({
+  refreshRegistry: mocks.refreshRegistry,
+  getPluginInfo: mocks.getPluginInfo,
+  searchPlugins: mocks.searchPlugins,
+}));
+
+vi.mock("./plugin-installer", () => ({
+  installPlugin: mocks.installPlugin,
+  uninstallPlugin: mocks.uninstallPlugin,
+  listInstalledPlugins: mocks.listInstalledPlugins,
+}));
+
+vi.mock("./plugin-eject", () => ({
+  ejectPlugin: mocks.ejectPlugin,
+  syncPlugin: mocks.syncPlugin,
+  reinjectPlugin: mocks.reinjectPlugin,
+  listEjectedPlugins: mocks.listEjectedPlugins,
+}));
+
+import { createPluginManager } from "./plugin-manager-composite";
+import { isPluginManagerLike } from "./plugin-manager-types";
+
+// ---------------------------------------------------------------------------
+// Fixtures — registry-client's richer type (has `git`, `appMeta`, etc.)
+// ---------------------------------------------------------------------------
+
+const REGISTRY_ENTRY = {
+  name: "@elizaos/plugin-foo",
+  gitRepo: "elizaos/plugin-foo",
+  gitUrl: "https://github.com/elizaos/plugin-foo",
+  description: "A test plugin",
+  homepage: null,
+  topics: ["test"],
+  stars: 42,
+  language: "TypeScript",
+  npm: { package: "@elizaos/plugin-foo", v0Version: null, v1Version: null, v2Version: "1.0.0" },
+  git: { v0Branch: null, v1Branch: null, v2Branch: "main" },
+  supports: { v0: false, v1: false, v2: true },
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("createPluginManager", () => {
+  it("passes isPluginManagerLike type guard", () => {
+    const pm = createPluginManager();
+    expect(isPluginManagerLike(pm)).toBe(true);
+  });
+
+  it("refreshRegistry delegates and maps types", async () => {
+    mocks.refreshRegistry.mockResolvedValue(
+      new Map([["@elizaos/plugin-foo", REGISTRY_ENTRY]]),
+    );
+
+    const pm = createPluginManager();
+    const result = await pm.refreshRegistry();
+
+    expect(mocks.refreshRegistry).toHaveBeenCalled();
+    expect(result.size).toBe(1);
+
+    const entry = result.get("@elizaos/plugin-foo");
+    expect(entry).toBeDefined();
+    expect(entry!.name).toBe("@elizaos/plugin-foo");
+    // The `git` field should NOT be on the mapped type
+    expect("git" in entry!).toBe(false);
+  });
+
+  it("getRegistryPlugin delegates to getPluginInfo", async () => {
+    mocks.getPluginInfo.mockResolvedValue(REGISTRY_ENTRY);
+
+    const pm = createPluginManager();
+    const result = await pm.getRegistryPlugin("@elizaos/plugin-foo");
+
+    expect(mocks.getPluginInfo).toHaveBeenCalledWith("@elizaos/plugin-foo");
+    expect(result).toBeDefined();
+    expect(result!.name).toBe("@elizaos/plugin-foo");
+  });
+
+  it("getRegistryPlugin returns null when not found", async () => {
+    mocks.getPluginInfo.mockResolvedValue(null);
+
+    const pm = createPluginManager();
+    const result = await pm.getRegistryPlugin("@elizaos/nonexistent");
+
+    expect(result).toBeNull();
+  });
+
+  it("searchRegistry delegates and maps results", async () => {
+    mocks.searchPlugins.mockResolvedValue([
+      {
+        name: "@elizaos/plugin-foo",
+        description: "A test plugin",
+        score: 0.9,
+        tags: ["test"],
+        latestVersion: "1.0.0",
+        stars: 42,
+        supports: { v0: false, v1: false, v2: true },
+        repository: "https://github.com/elizaos/plugin-foo",
+      },
+    ]);
+
+    const pm = createPluginManager();
+    const results = await pm.searchRegistry("foo", 10);
+
+    expect(mocks.searchPlugins).toHaveBeenCalledWith("foo", 10);
+    expect(results).toHaveLength(1);
+    expect(results[0].name).toBe("@elizaos/plugin-foo");
+    expect(results[0].version).toBe("1.0.0");
+    expect(results[0].npmPackage).toBe("@elizaos/plugin-foo");
+  });
+
+  it("listInstalledPlugins delegates", async () => {
+    mocks.listInstalledPlugins.mockReturnValue([
+      { name: "@elizaos/plugin-foo", version: "1.0.0", installPath: "/tmp/foo", installedAt: "2026-01-01" },
+    ]);
+
+    const pm = createPluginManager();
+    const results = await pm.listInstalledPlugins();
+
+    expect(results).toHaveLength(1);
+    expect(results[0].name).toBe("@elizaos/plugin-foo");
+    expect(results[0].version).toBe("1.0.0");
+  });
+
+  it("installPlugin delegates with progress adapter", async () => {
+    mocks.installPlugin.mockResolvedValue({
+      success: true,
+      pluginName: "@elizaos/plugin-foo",
+      version: "1.0.0",
+      installPath: "/tmp/foo",
+      requiresRestart: true,
+    });
+
+    const pm = createPluginManager();
+    const onProgress = vi.fn();
+    const result = await pm.installPlugin("@elizaos/plugin-foo", onProgress);
+
+    expect(mocks.installPlugin).toHaveBeenCalledWith(
+      "@elizaos/plugin-foo",
+      expect.any(Function),
+    );
+    expect(result.success).toBe(true);
+    expect(result.requiresRestart).toBe(true);
+  });
+
+  it("uninstallPlugin delegates", async () => {
+    mocks.uninstallPlugin.mockResolvedValue({
+      success: true,
+      pluginName: "@elizaos/plugin-foo",
+      requiresRestart: true,
+    });
+
+    const pm = createPluginManager();
+    const result = await pm.uninstallPlugin("@elizaos/plugin-foo");
+
+    expect(mocks.uninstallPlugin).toHaveBeenCalledWith("@elizaos/plugin-foo");
+    expect(result.success).toBe(true);
+  });
+
+  it("ejectPlugin delegates and maps result", async () => {
+    mocks.ejectPlugin.mockResolvedValue({
+      success: true,
+      pluginName: "@elizaos/plugin-foo",
+      ejectedPath: "/tmp/ejected/foo",
+      upstreamCommit: "abc123",
+    });
+
+    const pm = createPluginManager();
+    const result = await pm.ejectPlugin("@elizaos/plugin-foo");
+
+    expect(result.success).toBe(true);
+    expect(result.ejectedPath).toBe("/tmp/ejected/foo");
+    expect(result.requiresRestart).toBe(true);
+  });
+
+  it("syncPlugin delegates and maps result", async () => {
+    mocks.syncPlugin.mockResolvedValue({
+      success: true,
+      pluginName: "@elizaos/plugin-foo",
+      ejectedPath: "/tmp/ejected/foo",
+      upstreamCommits: 3,
+      localChanges: false,
+      conflicts: [],
+      commitHash: "def456",
+    });
+
+    const pm = createPluginManager();
+    const result = await pm.syncPlugin("@elizaos/plugin-foo");
+
+    expect(result.success).toBe(true);
+    expect(result.requiresRestart).toBe(true); // upstreamCommits > 0
+  });
+
+  it("syncPlugin sets requiresRestart false when no upstream changes", async () => {
+    mocks.syncPlugin.mockResolvedValue({
+      success: true,
+      pluginName: "@elizaos/plugin-foo",
+      ejectedPath: "/tmp/ejected/foo",
+      upstreamCommits: 0,
+      localChanges: false,
+      conflicts: [],
+      commitHash: "same",
+    });
+
+    const pm = createPluginManager();
+    const result = await pm.syncPlugin("@elizaos/plugin-foo");
+
+    expect(result.requiresRestart).toBe(false);
+  });
+
+  it("reinjectPlugin delegates and maps result", async () => {
+    mocks.reinjectPlugin.mockResolvedValue({
+      success: true,
+      pluginName: "@elizaos/plugin-foo",
+      removedPath: "/tmp/ejected/foo",
+    });
+
+    const pm = createPluginManager();
+    const result = await pm.reinjectPlugin("@elizaos/plugin-foo");
+
+    expect(result.success).toBe(true);
+    expect(result.requiresRestart).toBe(true);
+  });
+
+  it("listEjectedPlugins delegates and maps results", async () => {
+    mocks.listEjectedPlugins.mockResolvedValue([
+      { name: "@elizaos/plugin-foo", path: "/tmp/ejected/foo", version: "1.0.0", upstream: null },
+    ]);
+
+    const pm = createPluginManager();
+    const results = await pm.listEjectedPlugins();
+
+    expect(results).toHaveLength(1);
+    expect(results[0].name).toBe("@elizaos/plugin-foo");
+    expect(results[0].version).toBe("1.0.0");
+  });
+});

--- a/src/services/plugin-manager-composite.ts
+++ b/src/services/plugin-manager-composite.ts
@@ -1,0 +1,212 @@
+/**
+ * Composes the three utility modules (registry-client, plugin-installer,
+ * plugin-eject) into a single object that satisfies PluginManagerLike.
+ *
+ * This is the "glue" layer Shaw's design intended but never wired up.
+ *
+ * @module services/plugin-manager-composite
+ */
+
+import type {
+  EjectResult,
+  InstalledPluginInfo,
+  InstallProgressLike,
+  PluginInstallResult,
+  PluginManagerLike,
+  PluginUninstallResult,
+  ReinjectResult,
+  RegistryPluginInfo,
+  RegistrySearchResult,
+  SyncResult,
+} from "./plugin-manager-types";
+
+import {
+  getPluginInfo,
+  refreshRegistry as refreshRegistryFn,
+  searchPlugins,
+  type RegistryPluginInfo as RegistryClientPluginInfo,
+  type RegistrySearchResult as RegistryClientSearchResult,
+} from "./registry-client";
+
+import {
+  installPlugin as installPluginFn,
+  listInstalledPlugins as listInstalledPluginsFn,
+  uninstallPlugin as uninstallPluginFn,
+  type InstallProgress,
+} from "./plugin-installer";
+
+import {
+  ejectPlugin as ejectPluginFn,
+  listEjectedPlugins as listEjectedPluginsFn,
+  reinjectPlugin as reinjectPluginFn,
+  syncPlugin as syncPluginFn,
+  type EjectResult as EjectModuleResult,
+  type ReinjectResult as ReinjectModuleResult,
+  type SyncResult as SyncModuleResult,
+} from "./plugin-eject";
+
+// ---------------------------------------------------------------------------
+// Type adapters — bridge differences between utility module types and
+// the PluginManagerLike interface types.
+// ---------------------------------------------------------------------------
+
+/** registry-client's RegistryPluginInfo → plugin-manager-types RegistryPluginInfo */
+function toInterfacePluginInfo(p: RegistryClientPluginInfo): RegistryPluginInfo {
+  return {
+    name: p.name,
+    gitRepo: p.gitRepo,
+    gitUrl: p.gitUrl,
+    description: p.description,
+    homepage: p.homepage,
+    topics: p.topics,
+    stars: p.stars,
+    language: p.language,
+    npm: p.npm,
+    supports: p.supports,
+    // Carry through optional app metadata when present
+    ...(p.appMeta?.displayName && { displayName: p.appMeta.displayName }),
+    ...(p.appMeta?.category && { category: p.appMeta.category }),
+    ...(p.appMeta?.launchType && { launchType: p.appMeta.launchType }),
+    ...(p.appMeta?.launchUrl !== undefined && { launchUrl: p.appMeta.launchUrl }),
+    ...(p.appMeta?.icon !== undefined && { icon: p.appMeta.icon }),
+    ...(p.appMeta?.capabilities && { capabilities: p.appMeta.capabilities }),
+    ...(p.appMeta?.viewer && { viewer: p.appMeta.viewer }),
+  };
+}
+
+/** registry-client's RegistrySearchResult → plugin-manager-types RegistrySearchResult */
+function toInterfaceSearchResult(r: RegistryClientSearchResult): RegistrySearchResult {
+  return {
+    name: r.name,
+    description: r.description,
+    score: r.score,
+    tags: r.tags,
+    version: r.latestVersion,
+    latestVersion: r.latestVersion,
+    npmPackage: r.name, // npm package name is typically the same as registry name
+    repository: r.repository,
+    stars: r.stars,
+    supports: r.supports,
+  };
+}
+
+/** plugin-eject's EjectResult → plugin-manager-types EjectResult */
+function toInterfaceEjectResult(r: EjectModuleResult): EjectResult {
+  return {
+    success: r.success,
+    pluginName: r.pluginName,
+    ejectedPath: r.ejectedPath,
+    requiresRestart: r.success, // ejecting always requires restart when successful
+    error: r.error,
+  };
+}
+
+/** plugin-eject's SyncResult → plugin-manager-types SyncResult */
+function toInterfaceSyncResult(r: SyncModuleResult): SyncResult {
+  return {
+    success: r.success,
+    pluginName: r.pluginName,
+    ejectedPath: r.ejectedPath,
+    requiresRestart: r.success && r.upstreamCommits > 0,
+    error: r.error,
+  };
+}
+
+/** plugin-eject's ReinjectResult → plugin-manager-types ReinjectResult */
+function toInterfaceReinjectResult(r: ReinjectModuleResult): ReinjectResult {
+  return {
+    success: r.success,
+    pluginName: r.pluginName,
+    removedPath: r.removedPath,
+    requiresRestart: r.success,
+    error: r.error,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Composite implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a PluginManagerLike by composing the three utility modules.
+ * Stateless — safe to call multiple times (modules maintain their own state).
+ */
+export function createPluginManager(): PluginManagerLike {
+  return {
+    async refreshRegistry(): Promise<Map<string, RegistryPluginInfo>> {
+      const raw = await refreshRegistryFn();
+      const mapped = new Map<string, RegistryPluginInfo>();
+      Array.from(raw.entries()).forEach(([key, value]) => {
+        mapped.set(key, toInterfacePluginInfo(value));
+      });
+      return mapped;
+    },
+
+    async getRegistryPlugin(name: string): Promise<RegistryPluginInfo | null> {
+      const info = await getPluginInfo(name);
+      return info ? toInterfacePluginInfo(info) : null;
+    },
+
+    async searchRegistry(
+      query: string,
+      limit?: number,
+    ): Promise<RegistrySearchResult[]> {
+      const results = await searchPlugins(query, limit);
+      return results.map(toInterfaceSearchResult);
+    },
+
+    async listInstalledPlugins(): Promise<InstalledPluginInfo[]> {
+      const raw = listInstalledPluginsFn();
+      return raw.map((p) => ({
+        name: p.name,
+        version: p.version,
+        installedAt: p.installedAt,
+      }));
+    },
+
+    async installPlugin(
+      pluginName: string,
+      onProgress?: (progress: InstallProgressLike) => void,
+    ): Promise<PluginInstallResult> {
+      // Adapt the progress callback shape
+      const progressAdapter: ((p: InstallProgress) => void) | undefined =
+        onProgress
+          ? (p: InstallProgress) =>
+              onProgress({
+                phase: p.phase,
+                message: p.message,
+                pluginName: p.pluginName,
+              })
+          : undefined;
+
+      return installPluginFn(pluginName, progressAdapter);
+    },
+
+    async uninstallPlugin(pluginName: string): Promise<PluginUninstallResult> {
+      return uninstallPluginFn(pluginName);
+    },
+
+    async listEjectedPlugins(): Promise<InstalledPluginInfo[]> {
+      const raw = await listEjectedPluginsFn();
+      return raw.map((p) => ({
+        name: p.name,
+        version: p.version,
+      }));
+    },
+
+    async ejectPlugin(pluginName: string): Promise<EjectResult> {
+      const result = await ejectPluginFn(pluginName);
+      return toInterfaceEjectResult(result);
+    },
+
+    async syncPlugin(pluginName: string): Promise<SyncResult> {
+      const result = await syncPluginFn(pluginName);
+      return toInterfaceSyncResult(result);
+    },
+
+    async reinjectPlugin(pluginName: string): Promise<ReinjectResult> {
+      const result = await reinjectPluginFn(pluginName);
+      return toInterfaceReinjectResult(result);
+    },
+  };
+}

--- a/src/tui/eliza-tui-bridge.ts
+++ b/src/tui/eliza-tui-bridge.ts
@@ -266,7 +266,16 @@ export class ElizaTUIBridge {
         },
         {
           abortSignal: this.abortController.signal,
-        },
+          // Signal "rich consumer" to suppress inline retry separators
+          // ("-- that's not right, let me start again:") from
+          // ValidationStreamExtractor. The type is not yet in the
+          // @elizaos/core typedefs, so we spread into the options.
+          ...{
+            onStreamEvent: (event: StreamEvent) => {
+              this.onStreamEvent(event);
+            },
+          },
+        } as Record<string, unknown>,
       );
     } catch (error) {
       // User-initiated cancellation should keep the partial response without

--- a/test/deferred-restart.e2e.test.ts
+++ b/test/deferred-restart.e2e.test.ts
@@ -1,0 +1,334 @@
+/**
+ * E2E tests for the deferred restart feature.
+ *
+ * Verifies that config changes accumulate pending restart reasons instead of
+ * immediately restarting, that GET /api/status exposes them, that WebSocket
+ * broadcasts include them, and that POST /api/agent/restart clears them.
+ */
+
+import http from "node:http";
+import type { AgentRuntime } from "@elizaos/core";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { WebSocket } from "ws";
+import { startApiServer } from "../src/api/server";
+
+// ---------------------------------------------------------------------------
+// HTTP helper (same pattern as api-server.e2e.test.ts)
+// ---------------------------------------------------------------------------
+
+function req(
+  port: number,
+  method: string,
+  p: string,
+  body?: Record<string, unknown>,
+): Promise<{
+  status: number;
+  headers: http.IncomingHttpHeaders;
+  data: Record<string, unknown>;
+}> {
+  return new Promise((resolve, reject) => {
+    const b = body ? JSON.stringify(body) : undefined;
+    const r = http.request(
+      {
+        hostname: "127.0.0.1",
+        port,
+        path: p,
+        method,
+        headers: {
+          "Content-Type": "application/json",
+          ...(b ? { "Content-Length": Buffer.byteLength(b) } : {}),
+        },
+      },
+      (res) => {
+        const ch: Buffer[] = [];
+        res.on("data", (c: Buffer) => ch.push(c));
+        res.on("end", () => {
+          const raw = Buffer.concat(ch).toString("utf-8");
+          let data: Record<string, unknown> = {};
+          try {
+            data = JSON.parse(raw) as Record<string, unknown>;
+          } catch {
+            data = { _raw: raw };
+          }
+          resolve({ status: res.statusCode ?? 0, headers: res.headers, data });
+        });
+      },
+    );
+    r.on("error", reject);
+    if (b) r.write(b);
+    r.end();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// WebSocket helpers
+// ---------------------------------------------------------------------------
+
+function connectWs(port: number): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`);
+    ws.on("open", () => resolve(ws));
+    ws.on("error", reject);
+  });
+}
+
+function waitForWsMessage(
+  ws: WebSocket,
+  predicate: (message: Record<string, unknown>) => boolean,
+  timeoutMs = 5000,
+): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error("Timed out waiting for websocket message"));
+    }, timeoutMs);
+
+    const onMessage = (raw: WebSocket.RawData) => {
+      try {
+        const text = Buffer.isBuffer(raw)
+          ? raw.toString("utf-8")
+          : String(raw);
+        const message = JSON.parse(text) as Record<string, unknown>;
+        if (predicate(message)) {
+          cleanup();
+          resolve(message);
+        }
+      } catch {
+        // Ignore malformed WS frames in tests.
+      }
+    };
+
+    const onError = (err: Error) => {
+      cleanup();
+      reject(err);
+    };
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      ws.off("message", onMessage);
+      ws.off("error", onError);
+    };
+
+    ws.on("message", onMessage);
+    ws.on("error", onError);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Deferred restart E2E", () => {
+  let port: number;
+  let close: () => Promise<void>;
+
+  beforeAll(async () => {
+    const server = await startApiServer({ port: 0 });
+    port = server.port;
+    close = server.close;
+  }, 30_000);
+
+  afterAll(async () => {
+    await close();
+  });
+
+  // -- Initial state --
+
+  describe("initial state (no pending restart)", () => {
+    it("GET /api/status returns pendingRestart: false with empty reasons", async () => {
+      const { status, data } = await req(port, "GET", "/api/status");
+      expect(status).toBe(200);
+      expect(data.pendingRestart).toBe(false);
+      expect(data.pendingRestartReasons).toEqual([]);
+    });
+  });
+
+  // -- Config change triggers pending restart --
+
+  describe("PUT /api/config marks restart as pending", () => {
+    it("adds pendingRestart after config update", async () => {
+      // Make a config change (env var update)
+      await req(port, "PUT", "/api/config", {
+        env: { vars: { TEST_DEFERRED_KEY: "value1" } },
+      });
+
+      const { data } = await req(port, "GET", "/api/status");
+      expect(data.pendingRestart).toBe(true);
+      expect(data.pendingRestartReasons).toContain("Configuration updated");
+    });
+
+    it("does not duplicate the same reason on repeated config saves", async () => {
+      await req(port, "PUT", "/api/config", {
+        env: { vars: { TEST_DEFERRED_KEY: "value2" } },
+      });
+
+      const { data } = await req(port, "GET", "/api/status");
+      expect(data.pendingRestart).toBe(true);
+      const reasons = data.pendingRestartReasons as string[];
+      const configReasonCount = reasons.filter(
+        (r) => r === "Configuration updated",
+      ).length;
+      expect(configReasonCount).toBe(1);
+    });
+  });
+
+  // -- WebSocket broadcasts restart-required --
+
+  describe("WebSocket restart-required event", () => {
+    it("broadcasts restart-required when config is saved", async () => {
+      const ws = await connectWs(port);
+
+      try {
+        // Set up listener before making the config change
+        const messagePromise = waitForWsMessage(
+          ws,
+          (msg) => msg.type === "restart-required",
+        );
+
+        // Make another config update
+        await req(port, "PUT", "/api/config", {
+          env: { vars: { ANOTHER_KEY: "test" } },
+        });
+
+        const msg = await messagePromise;
+        expect(msg.type).toBe("restart-required");
+        expect(Array.isArray(msg.reasons)).toBe(true);
+        expect((msg.reasons as string[]).length).toBeGreaterThan(0);
+      } finally {
+        ws.close();
+      }
+    });
+
+    it("periodic status broadcast includes pending restart fields", async () => {
+      const ws = await connectWs(port);
+
+      try {
+        // Wait for a periodic status broadcast (server sends these every ~5s)
+        const msg = await waitForWsMessage(
+          ws,
+          (msg) => msg.type === "status",
+          10_000,
+        );
+
+        expect(typeof msg.pendingRestart).toBe("boolean");
+        expect(Array.isArray(msg.pendingRestartReasons)).toBe(true);
+      } finally {
+        ws.close();
+      }
+    });
+  });
+
+  // -- scheduleRuntimeRestart does NOT restart the agent --
+
+  describe("scheduleRuntimeRestart defers (does not restart)", () => {
+    it("agent state remains not_started after config change (no actual restart)", async () => {
+      // The server was started without a runtime, so agentState stays "not_started"
+      // or whatever it transitioned to. The key point: config changes should NOT
+      // trigger a real restart, so we should not see "restarting" state.
+      const { data } = await req(port, "GET", "/api/status");
+      expect(data.state).not.toBe("restarting");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test with onRestart handler — proves restart clears pending reasons
+// ---------------------------------------------------------------------------
+
+describe("Deferred restart E2E (with restart handler)", () => {
+  let port: number;
+  let close: () => Promise<void>;
+  let restartCallCount: number;
+
+  beforeAll(async () => {
+    restartCallCount = 0;
+
+    const mockRuntime = {
+      character: { name: "TestAgent" },
+      plugins: [],
+      getService: () => null,
+    } as unknown as AgentRuntime;
+
+    const server = await startApiServer({
+      port: 0,
+      runtime: mockRuntime,
+      onRestart: async () => {
+        restartCallCount++;
+        return mockRuntime;
+      },
+    });
+    port = server.port;
+    close = server.close;
+  }, 30_000);
+
+  afterAll(async () => {
+    await close();
+  });
+
+  it("accumulates reasons, then restart clears them", async () => {
+    // 1. Trigger a pending restart via config change
+    await req(port, "PUT", "/api/config", {
+      env: { vars: { KEY_A: "a" } },
+    });
+
+    // 2. Verify pending reasons are present
+    let { data } = await req(port, "GET", "/api/status");
+    expect(data.pendingRestart).toBe(true);
+    expect((data.pendingRestartReasons as string[]).length).toBeGreaterThan(0);
+
+    // 3. Perform explicit restart
+    const restartResult = await req(port, "POST", "/api/agent/restart");
+    expect(restartResult.data.ok).toBe(true);
+    expect(restartResult.data.pendingRestart).toBe(false);
+
+    // 4. Verify pending reasons are cleared
+    ({ data } = await req(port, "GET", "/api/status"));
+    expect(data.pendingRestart).toBe(false);
+    expect(data.pendingRestartReasons).toEqual([]);
+  });
+
+  it("config changes do not trigger onRestart", async () => {
+    const before = restartCallCount;
+
+    // Multiple config changes
+    await req(port, "PUT", "/api/config", {
+      env: { vars: { KEY_B: "b" } },
+    });
+    await req(port, "PUT", "/api/config", {
+      env: { vars: { KEY_C: "c" } },
+    });
+
+    // onRestart should NOT have been called
+    expect(restartCallCount).toBe(before);
+
+    // Only explicit restart triggers onRestart
+    await req(port, "POST", "/api/agent/restart");
+    expect(restartCallCount).toBe(before + 1);
+  });
+
+  it("WebSocket restart-required event includes all accumulated reasons", async () => {
+    // Clear state by restarting first
+    await req(port, "POST", "/api/agent/restart");
+
+    const ws = await connectWs(port);
+
+    try {
+      // Listen for restart-required
+      const messagePromise = waitForWsMessage(
+        ws,
+        (msg) => msg.type === "restart-required",
+      );
+
+      // Trigger config change
+      await req(port, "PUT", "/api/config", {
+        env: { vars: { KEY_D: "d" } },
+      });
+
+      const msg = await messagePromise;
+      const reasons = msg.reasons as string[];
+      expect(reasons).toContain("Configuration updated");
+    } finally {
+      ws.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- **Deferred restart system**: Replace 9 immediate auto-restart callsites with a pending restart accumulator. Backend broadcasts `restart-required` WS events; frontend shows a persistent amber banner with "Restart Now" / "Later" controls. Users can batch multiple config changes before restarting.

- **OAuth onboarding fixes**: Wire up Anthropic setup token submission during onboarding (was silently discarded because `envKey` is null for subscription providers). Remove broken OAuth login tabs — Anthropic shows setup token entry only, OpenAI subscription shows "coming soon" with guidance to use API key instead.

- **PluginManagerComposite**: New composition layer combining `registry-client`, `plugin-installer`, and `plugin-eject` into a unified `PluginManagerLike` interface. Used as fallback in `plugins-cli` and `server.ts` when the runtime service doesn't satisfy the type guard.

- **Dynamic secretKeys**: `collectPluginParameterKeys()` reads parameter definitions from installed plugins for runtime secret resolution.

- **Tests**: 1800 tests passing across 119 suites. New tests for RestartBanner, PluginManagerComposite (13 tests), deferred restart E2E, wallet-routes restart, and agent-admin-routes restart clearing.

## Test plan

- [ ] Toggle a plugin on → banner appears, agent does NOT restart. Click "Restart Now" → agent restarts, banner disappears
- [ ] Save secrets/API keys → banner appears. Save another → reason count increases. Single restart applies all
- [ ] Change model in Settings → banner appears (no auto-restart). "Later" hides it; new change re-shows it
- [ ] Page refresh while restart pending → banner re-appears (hydrated from GET /api/status)
- [ ] Complete onboarding with Anthropic setup token → token submitted via dedicated endpoint
- [ ] Verify OpenAI subscription shows "coming soon" message with API key guidance
- [ ] Manual restart from header menu → clears pending state

🤖 Generated with [Claude Code](https://claude.com/claude-code)