### PR TITLE
chore: bump version to 2.0.0-alpha.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "milady",
-  "version": "2.0.0-alpha.22",
+  "version": "2.0.0-alpha.23",
   "description": "Cute agents for the acceleration",
   "homepage": "https://github.com/milady-ai/milady",
   "author": {


### PR DESCRIPTION
## Summary
Bump version to 2.0.0-alpha.23 for release with embedded backend fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)