### PR TITLE
feat: deferred restart banner

### DIFF
--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -24,6 +24,7 @@ import { OnboardingWizard } from "./components/OnboardingWizard";
 import { PairingView } from "./components/PairingView";
 import { SaveCommandModal } from "./components/SaveCommandModal";
 import { SettingsView } from "./components/SettingsView";
+import { RestartBanner } from "./components/RestartBanner";
 import { TerminalPanel } from "./components/TerminalPanel";
 import { useContextMenu } from "./hooks/useContextMenu";
 
@@ -314,6 +315,7 @@ export function App() {
           setEditingAction(null);
         }}
       />
+      <RestartBanner />
       {actionNotice && (
         <div
           className={`fixed bottom-6 left-1/2 -translate-x-1/2 px-5 py-2 rounded-lg text-[13px] font-medium z-[10000] text-white ${

--- a/apps/app/src/api-client.ts
+++ b/apps/app/src/api-client.ts
@@ -166,6 +166,8 @@ export interface AgentStatus {
   model: string | undefined;
   uptime: number | undefined;
   startedAt: number | undefined;
+  pendingRestart?: boolean;
+  pendingRestartReasons?: string[];
 }
 
 export interface RuntimeOrderItem {

--- a/apps/app/src/components/RestartBanner.tsx
+++ b/apps/app/src/components/RestartBanner.tsx
@@ -1,0 +1,56 @@
+import { useCallback, useState } from "react";
+import { useApp } from "../AppContext";
+
+export function RestartBanner() {
+  const {
+    pendingRestart,
+    pendingRestartReasons,
+    restartBannerDismissed,
+    dismissRestartBanner,
+    triggerRestart,
+  } = useApp();
+
+  const [restarting, setRestarting] = useState(false);
+
+  const handleRestart = useCallback(async () => {
+    setRestarting(true);
+    try {
+      await triggerRestart();
+    } finally {
+      setRestarting(false);
+    }
+  }, [triggerRestart]);
+
+  if (!pendingRestart || restartBannerDismissed) return null;
+
+  const reasons = pendingRestartReasons;
+  const text =
+    reasons.length === 1
+      ? `${reasons[0]} — restart to apply.`
+      : reasons.length > 1
+        ? `${reasons.length} changes pending — restart to apply.`
+        : "Restart required to apply changes.";
+
+  return (
+    <div className="fixed top-0 left-0 right-0 z-[9998] flex items-center justify-between gap-3 bg-amber-600 px-4 py-2 text-[13px] font-medium text-white shadow-lg">
+      <span className="truncate">{text}</span>
+      <div className="flex items-center gap-2 shrink-0">
+        <button
+          type="button"
+          onClick={dismissRestartBanner}
+          className="rounded px-3 py-1 text-[12px] text-amber-100 hover:bg-amber-700 transition-colors"
+        >
+          Later
+        </button>
+        <button
+          type="button"
+          onClick={handleRestart}
+          disabled={restarting}
+          className="rounded bg-white px-3 py-1 text-[12px] font-semibold text-amber-700 hover:bg-amber-50 transition-colors disabled:opacity-60"
+        >
+          {restarting ? "Restarting..." : "Restart Now"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/components/SettingsView.tsx
+++ b/apps/app/src/components/SettingsView.tsx
@@ -255,7 +255,6 @@ export function SettingsView() {
         },
       });
       setState("cloudEnabled", true);
-      await client.restartAgent();
     } catch {
       /* non-fatal */
     }
@@ -630,7 +629,6 @@ export function SettingsView() {
                                       () => setModelSaveSuccess(false),
                                       2000,
                                     );
-                                    await client.restartAgent();
                                   } catch {
                                     /* ignore */
                                   }

--- a/apps/app/test/app/restart-banner.test.tsx
+++ b/apps/app/test/app/restart-banner.test.tsx
@@ -1,0 +1,155 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+interface RestartBannerContextStub {
+  pendingRestart: boolean;
+  pendingRestartReasons: string[];
+  restartBannerDismissed: boolean;
+  dismissRestartBanner: () => void;
+  triggerRestart: () => Promise<void>;
+}
+
+const mockUseApp = vi.fn<() => RestartBannerContextStub>();
+
+vi.mock("../../src/AppContext", async () => {
+  const actual = await vi.importActual<typeof import("../../src/AppContext")>(
+    "../../src/AppContext",
+  );
+  return {
+    ...actual,
+    useApp: () => mockUseApp(),
+  };
+});
+
+import { RestartBanner } from "../../src/components/RestartBanner";
+
+function makeContext(
+  overrides: Partial<RestartBannerContextStub> = {},
+): RestartBannerContextStub {
+  return {
+    pendingRestart: false,
+    pendingRestartReasons: [],
+    restartBannerDismissed: false,
+    dismissRestartBanner: vi.fn(),
+    triggerRestart: vi.fn(async () => undefined),
+    ...overrides,
+  };
+}
+
+/** Extract visible text from HTML markup (strip tags). */
+function readAllText(markup: string): string {
+  return markup.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+}
+
+describe("RestartBanner", () => {
+  beforeEach(() => {
+    mockUseApp.mockReset();
+  });
+
+  it("renders nothing when no restart is pending", () => {
+    mockUseApp.mockReturnValue(makeContext({ pendingRestart: false }));
+
+    const markup = renderToStaticMarkup(React.createElement(RestartBanner));
+    expect(markup).toBe("");
+  });
+
+  it("renders nothing when banner is dismissed", () => {
+    mockUseApp.mockReturnValue(
+      makeContext({
+        pendingRestart: true,
+        pendingRestartReasons: ["Configuration updated"],
+        restartBannerDismissed: true,
+      }),
+    );
+
+    const markup = renderToStaticMarkup(React.createElement(RestartBanner));
+    expect(markup).toBe("");
+  });
+
+  it("renders banner with single reason text", () => {
+    mockUseApp.mockReturnValue(
+      makeContext({
+        pendingRestart: true,
+        pendingRestartReasons: ["Plugin toggled"],
+      }),
+    );
+
+    const markup = renderToStaticMarkup(React.createElement(RestartBanner));
+    const text = readAllText(markup);
+
+    expect(text).toContain("Plugin toggled");
+    expect(text).toContain("restart to apply");
+  });
+
+  it("renders banner with count for multiple reasons", () => {
+    mockUseApp.mockReturnValue(
+      makeContext({
+        pendingRestart: true,
+        pendingRestartReasons: [
+          "Plugin toggled",
+          "Configuration updated",
+          "Wallet configuration updated",
+        ],
+      }),
+    );
+
+    const markup = renderToStaticMarkup(React.createElement(RestartBanner));
+    const text = readAllText(markup);
+
+    expect(text).toContain("3 changes pending");
+    expect(text).toContain("restart to apply");
+  });
+
+  it("renders Later button", () => {
+    mockUseApp.mockReturnValue(
+      makeContext({
+        pendingRestart: true,
+        pendingRestartReasons: ["Plugin toggled"],
+      }),
+    );
+
+    const markup = renderToStaticMarkup(React.createElement(RestartBanner));
+    expect(markup).toContain("Later");
+  });
+
+  it("renders Restart Now button", () => {
+    mockUseApp.mockReturnValue(
+      makeContext({
+        pendingRestart: true,
+        pendingRestartReasons: ["Plugin toggled"],
+      }),
+    );
+
+    const markup = renderToStaticMarkup(React.createElement(RestartBanner));
+    expect(markup).toContain("Restart Now");
+  });
+
+  it("renders with amber background styling", () => {
+    mockUseApp.mockReturnValue(
+      makeContext({
+        pendingRestart: true,
+        pendingRestartReasons: ["Configuration updated"],
+      }),
+    );
+
+    const markup = renderToStaticMarkup(React.createElement(RestartBanner));
+    expect(markup).toContain("bg-amber-600");
+    expect(markup).toContain("z-[9998]");
+  });
+
+  it("renders with zero reasons gracefully (edge case: pendingRestart true but empty reasons)", () => {
+    mockUseApp.mockReturnValue(
+      makeContext({
+        pendingRestart: true,
+        pendingRestartReasons: [],
+      }),
+    );
+
+    const markup = renderToStaticMarkup(React.createElement(RestartBanner));
+    const text = readAllText(markup);
+
+    // Should still render with fallback text
+    expect(text).toContain("Restart required to apply changes");
+  });
+});

--- a/src/api/agent-admin-routes.ts
+++ b/src/api/agent-admin-routes.ts
@@ -22,6 +22,7 @@ export interface AgentAdminRouteState {
   chatUserId: UUID | null;
   chatConnectionReady: { userId: UUID; roomId: UUID; worldId: UUID } | null;
   chatConnectionPromise: Promise<void> | null;
+  pendingRestartReasons: string[];
 }
 
 export interface AgentAdminRouteContext
@@ -86,8 +87,10 @@ export async function handleAgentAdminRoutes(
         state.agentState = "running";
         state.agentName = newRuntime.character.name ?? "Milady";
         state.startedAt = Date.now();
+        state.pendingRestartReasons = [];
         json(res, {
           ok: true,
+          pendingRestart: false,
           status: {
             state: state.agentState,
             agentName: state.agentName,
@@ -166,6 +169,7 @@ export async function handleAgentAdminRoutes(
       state.chatUserId = null;
       state.chatConnectionReady = null;
       state.chatConnectionPromise = null;
+      state.pendingRestartReasons = [];
 
       json(res, { ok: true });
     } catch (err) {

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -246,6 +246,8 @@ interface ServerState {
   >;
   /** Whether shell access is enabled (can be toggled in UI). */
   shellEnabled?: boolean;
+  /** Reasons a restart is pending. Empty array = no restart needed. */
+  pendingRestartReasons: string[];
 }
 
 interface ShareIngestItem {
@@ -4320,55 +4322,17 @@ async function handleRequest(
   const registryService = state.registryService;
   const dropService = state.dropService;
 
-  const scheduleRuntimeRestart = (reason: string, delayMs = 300): void => {
-    const restart = () => {
-      if (ctx?.onRestart) {
-        logger.info(`[milady-api] Triggering runtime restart (${reason})...`);
-        Promise.resolve(ctx.onRestart())
-          .then((newRuntime) => {
-            if (!newRuntime) {
-              logger.warn("[milady-api] Runtime restart returned null");
-              return;
-            }
-            state.runtime = newRuntime;
-            state.chatConnectionReady = null;
-            state.chatConnectionPromise = null;
-            state.agentState = "running";
-            state.agentName = newRuntime.character.name ?? "Milady";
-            state.startedAt = Date.now();
-            logger.info("[milady-api] Runtime restarted successfully");
-            // Notify WebSocket clients so the UI can refresh
-            state.broadcastWs?.({
-              type: "status",
-              state: state.agentState,
-              agentName: state.agentName,
-              startedAt: state.startedAt,
-              restarted: true,
-            });
-          })
-          .catch((err) => {
-            logger.error(
-              `[milady-api] Runtime restart failed: ${err instanceof Error ? err.message : err}`,
-            );
-          });
-        return;
-      }
-
-      logger.info(
-        `[milady-api] No in-process restart handler; exiting for external restart (${reason})`,
-      );
-      if (process.env.VITEST || process.env.NODE_ENV === "test") {
-        logger.info("[milady-api] Skipping process.exit during test execution");
-        return;
-      }
-      process.exit(API_RESTART_EXIT_CODE);
-    };
-
-    if (delayMs <= 0) {
-      restart();
-      return;
+  const scheduleRuntimeRestart = (reason: string, _delayMs?: number): void => {
+    if (!state.pendingRestartReasons.includes(reason)) {
+      state.pendingRestartReasons.push(reason);
     }
-    setTimeout(restart, delayMs);
+    logger.info(
+      `[milady-api] Restart required: ${reason} (${state.pendingRestartReasons.length} pending)`,
+    );
+    state.broadcastWs?.({
+      type: "restart-required",
+      reasons: [...state.pendingRestartReasons],
+    });
   };
 
   const resolveHyperscapeApiBaseUrl = async (): Promise<string> => {
@@ -4545,6 +4509,8 @@ async function handleRequest(
       model: state.model,
       uptime,
       cloud: cloudStatus,
+      pendingRestart: state.pendingRestartReasons.length > 0,
+      pendingRestartReasons: state.pendingRestartReasons,
     });
     return;
   }
@@ -7803,6 +7769,7 @@ async function handleRequest(
 
     try {
       saveMiladyConfig(state.config);
+      scheduleRuntimeRestart("Configuration updated");
     } catch (err) {
       logger.warn(
         `[api] Config save failed: ${err instanceof Error ? err.message : err}`,
@@ -10745,6 +10712,7 @@ export async function startApiServer(opts?: {
     activeConversationId: null,
     permissionStates: {},
     shellEnabled: config.features?.shellEnabled !== false,
+    pendingRestartReasons: [],
   };
 
   const trainingServiceCtor = await resolveTrainingServiceCtor();
@@ -11234,6 +11202,8 @@ export async function startApiServer(opts?: {
       agentName: state.agentName,
       model: state.model,
       startedAt: state.startedAt,
+      pendingRestart: state.pendingRestartReasons.length > 0,
+      pendingRestartReasons: state.pendingRestartReasons,
     });
   };
 

--- a/src/api/wallet-routes.ts
+++ b/src/api/wallet-routes.ts
@@ -59,6 +59,7 @@ export interface WalletRouteContext
     req: http.IncomingMessage,
     body: WalletExportRequestBody,
   ) => WalletExportRejectionLike | null;
+  scheduleRuntimeRestart?: (reason: string) => void;
   deps?: WalletRouteDependencies;
 }
 
@@ -317,6 +318,7 @@ export async function handleWalletRoutes(
       );
     }
 
+    ctx.scheduleRuntimeRestart?.("Wallet configuration updated");
     json(res, { ok: true });
     return true;
   }

--- a/test/deferred-restart.e2e.test.ts
+++ b/test/deferred-restart.e2e.test.ts
@@ -1,0 +1,334 @@
+/**
+ * E2E tests for the deferred restart feature.
+ *
+ * Verifies that config changes accumulate pending restart reasons instead of
+ * immediately restarting, that GET /api/status exposes them, that WebSocket
+ * broadcasts include them, and that POST /api/agent/restart clears them.
+ */
+
+import http from "node:http";
+import type { AgentRuntime } from "@elizaos/core";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { WebSocket } from "ws";
+import { startApiServer } from "../src/api/server";
+
+// ---------------------------------------------------------------------------
+// HTTP helper (same pattern as api-server.e2e.test.ts)
+// ---------------------------------------------------------------------------
+
+function req(
+  port: number,
+  method: string,
+  p: string,
+  body?: Record<string, unknown>,
+): Promise<{
+  status: number;
+  headers: http.IncomingHttpHeaders;
+  data: Record<string, unknown>;
+}> {
+  return new Promise((resolve, reject) => {
+    const b = body ? JSON.stringify(body) : undefined;
+    const r = http.request(
+      {
+        hostname: "127.0.0.1",
+        port,
+        path: p,
+        method,
+        headers: {
+          "Content-Type": "application/json",
+          ...(b ? { "Content-Length": Buffer.byteLength(b) } : {}),
+        },
+      },
+      (res) => {
+        const ch: Buffer[] = [];
+        res.on("data", (c: Buffer) => ch.push(c));
+        res.on("end", () => {
+          const raw = Buffer.concat(ch).toString("utf-8");
+          let data: Record<string, unknown> = {};
+          try {
+            data = JSON.parse(raw) as Record<string, unknown>;
+          } catch {
+            data = { _raw: raw };
+          }
+          resolve({ status: res.statusCode ?? 0, headers: res.headers, data });
+        });
+      },
+    );
+    r.on("error", reject);
+    if (b) r.write(b);
+    r.end();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// WebSocket helpers
+// ---------------------------------------------------------------------------
+
+function connectWs(port: number): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`);
+    ws.on("open", () => resolve(ws));
+    ws.on("error", reject);
+  });
+}
+
+function waitForWsMessage(
+  ws: WebSocket,
+  predicate: (message: Record<string, unknown>) => boolean,
+  timeoutMs = 5000,
+): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error("Timed out waiting for websocket message"));
+    }, timeoutMs);
+
+    const onMessage = (raw: WebSocket.RawData) => {
+      try {
+        const text = Buffer.isBuffer(raw)
+          ? raw.toString("utf-8")
+          : String(raw);
+        const message = JSON.parse(text) as Record<string, unknown>;
+        if (predicate(message)) {
+          cleanup();
+          resolve(message);
+        }
+      } catch {
+        // Ignore malformed WS frames in tests.
+      }
+    };
+
+    const onError = (err: Error) => {
+      cleanup();
+      reject(err);
+    };
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      ws.off("message", onMessage);
+      ws.off("error", onError);
+    };
+
+    ws.on("message", onMessage);
+    ws.on("error", onError);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Deferred restart E2E", () => {
+  let port: number;
+  let close: () => Promise<void>;
+
+  beforeAll(async () => {
+    const server = await startApiServer({ port: 0 });
+    port = server.port;
+    close = server.close;
+  }, 30_000);
+
+  afterAll(async () => {
+    await close();
+  });
+
+  // -- Initial state --
+
+  describe("initial state (no pending restart)", () => {
+    it("GET /api/status returns pendingRestart: false with empty reasons", async () => {
+      const { status, data } = await req(port, "GET", "/api/status");
+      expect(status).toBe(200);
+      expect(data.pendingRestart).toBe(false);
+      expect(data.pendingRestartReasons).toEqual([]);
+    });
+  });
+
+  // -- Config change triggers pending restart --
+
+  describe("PUT /api/config marks restart as pending", () => {
+    it("adds pendingRestart after config update", async () => {
+      // Make a config change (env var update)
+      await req(port, "PUT", "/api/config", {
+        env: { vars: { TEST_DEFERRED_KEY: "value1" } },
+      });
+
+      const { data } = await req(port, "GET", "/api/status");
+      expect(data.pendingRestart).toBe(true);
+      expect(data.pendingRestartReasons).toContain("Configuration updated");
+    });
+
+    it("does not duplicate the same reason on repeated config saves", async () => {
+      await req(port, "PUT", "/api/config", {
+        env: { vars: { TEST_DEFERRED_KEY: "value2" } },
+      });
+
+      const { data } = await req(port, "GET", "/api/status");
+      expect(data.pendingRestart).toBe(true);
+      const reasons = data.pendingRestartReasons as string[];
+      const configReasonCount = reasons.filter(
+        (r) => r === "Configuration updated",
+      ).length;
+      expect(configReasonCount).toBe(1);
+    });
+  });
+
+  // -- WebSocket broadcasts restart-required --
+
+  describe("WebSocket restart-required event", () => {
+    it("broadcasts restart-required when config is saved", async () => {
+      const ws = await connectWs(port);
+
+      try {
+        // Set up listener before making the config change
+        const messagePromise = waitForWsMessage(
+          ws,
+          (msg) => msg.type === "restart-required",
+        );
+
+        // Make another config update
+        await req(port, "PUT", "/api/config", {
+          env: { vars: { ANOTHER_KEY: "test" } },
+        });
+
+        const msg = await messagePromise;
+        expect(msg.type).toBe("restart-required");
+        expect(Array.isArray(msg.reasons)).toBe(true);
+        expect((msg.reasons as string[]).length).toBeGreaterThan(0);
+      } finally {
+        ws.close();
+      }
+    });
+
+    it("periodic status broadcast includes pending restart fields", async () => {
+      const ws = await connectWs(port);
+
+      try {
+        // Wait for a periodic status broadcast (server sends these every ~5s)
+        const msg = await waitForWsMessage(
+          ws,
+          (msg) => msg.type === "status",
+          10_000,
+        );
+
+        expect(typeof msg.pendingRestart).toBe("boolean");
+        expect(Array.isArray(msg.pendingRestartReasons)).toBe(true);
+      } finally {
+        ws.close();
+      }
+    });
+  });
+
+  // -- scheduleRuntimeRestart does NOT restart the agent --
+
+  describe("scheduleRuntimeRestart defers (does not restart)", () => {
+    it("agent state remains not_started after config change (no actual restart)", async () => {
+      // The server was started without a runtime, so agentState stays "not_started"
+      // or whatever it transitioned to. The key point: config changes should NOT
+      // trigger a real restart, so we should not see "restarting" state.
+      const { data } = await req(port, "GET", "/api/status");
+      expect(data.state).not.toBe("restarting");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test with onRestart handler — proves restart clears pending reasons
+// ---------------------------------------------------------------------------
+
+describe("Deferred restart E2E (with restart handler)", () => {
+  let port: number;
+  let close: () => Promise<void>;
+  let restartCallCount: number;
+
+  beforeAll(async () => {
+    restartCallCount = 0;
+
+    const mockRuntime = {
+      character: { name: "TestAgent" },
+      plugins: [],
+      getService: () => null,
+    } as unknown as AgentRuntime;
+
+    const server = await startApiServer({
+      port: 0,
+      runtime: mockRuntime,
+      onRestart: async () => {
+        restartCallCount++;
+        return mockRuntime;
+      },
+    });
+    port = server.port;
+    close = server.close;
+  }, 30_000);
+
+  afterAll(async () => {
+    await close();
+  });
+
+  it("accumulates reasons, then restart clears them", async () => {
+    // 1. Trigger a pending restart via config change
+    await req(port, "PUT", "/api/config", {
+      env: { vars: { KEY_A: "a" } },
+    });
+
+    // 2. Verify pending reasons are present
+    let { data } = await req(port, "GET", "/api/status");
+    expect(data.pendingRestart).toBe(true);
+    expect((data.pendingRestartReasons as string[]).length).toBeGreaterThan(0);
+
+    // 3. Perform explicit restart
+    const restartResult = await req(port, "POST", "/api/agent/restart");
+    expect(restartResult.data.ok).toBe(true);
+    expect(restartResult.data.pendingRestart).toBe(false);
+
+    // 4. Verify pending reasons are cleared
+    ({ data } = await req(port, "GET", "/api/status"));
+    expect(data.pendingRestart).toBe(false);
+    expect(data.pendingRestartReasons).toEqual([]);
+  });
+
+  it("config changes do not trigger onRestart", async () => {
+    const before = restartCallCount;
+
+    // Multiple config changes
+    await req(port, "PUT", "/api/config", {
+      env: { vars: { KEY_B: "b" } },
+    });
+    await req(port, "PUT", "/api/config", {
+      env: { vars: { KEY_C: "c" } },
+    });
+
+    // onRestart should NOT have been called
+    expect(restartCallCount).toBe(before);
+
+    // Only explicit restart triggers onRestart
+    await req(port, "POST", "/api/agent/restart");
+    expect(restartCallCount).toBe(before + 1);
+  });
+
+  it("WebSocket restart-required event includes all accumulated reasons", async () => {
+    // Clear state by restarting first
+    await req(port, "POST", "/api/agent/restart");
+
+    const ws = await connectWs(port);
+
+    try {
+      // Listen for restart-required
+      const messagePromise = waitForWsMessage(
+        ws,
+        (msg) => msg.type === "restart-required",
+      );
+
+      // Trigger config change
+      await req(port, "PUT", "/api/config", {
+        env: { vars: { KEY_D: "d" } },
+      });
+
+      const msg = await messagePromise;
+      const reasons = msg.reasons as string[];
+      expect(reasons).toContain("Configuration updated");
+    } finally {
+      ws.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Replace immediate auto-restarts with a deferred restart system
- `scheduleRuntimeRestart` accumulates reasons in `state.pendingRestartReasons` and broadcasts `restart-required` WS events instead of restarting
- Frontend `RestartBanner` component shows pending reasons with "Restart Now" / "Later" controls
- Removed 5 auto-restart calls (plugin toggle, plugin config save, wallet config, 2x settings save)
- `GET /api/status` and periodic WS broadcast include `pendingRestart` / `pendingRestartReasons`
- Reasons cleared on successful restart or factory reset

## Test plan

- [ ] Toggle a plugin → banner appears, agent does NOT restart. "Restart Now" → restarts, banner clears
- [ ] Save multiple config changes → reason count accumulates. Single restart applies all
- [ ] "Later" hides banner; new change re-shows it
- [ ] Page refresh with pending restart → banner re-appears (hydrated from status)
- [ ] Manual restart from header → clears pending state

🤖 Generated with [Claude Code](https://claude.com/claude-code)