### PR TITLE
chore: bump version to 2.0.0-alpha.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "milady",
-  "version": "2.0.0-alpha.23",
+  "version": "2.0.0-alpha.24",
   "description": "Cute agents for the acceleration",
   "homepage": "https://github.com/milady-ai/milady",
   "author": {


### PR DESCRIPTION
## Summary
- Bump version to 2.0.0-alpha.24 for release

## Changes in this release
- fix(electron): use hash routing in packaged builds - fixes "Not allowed to load local resource: file:///apps" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)