### PR TITLE
chore: bump version to 2.0.0-alpha.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "milady",
-  "version": "2.0.0-alpha.24",
+  "version": "2.0.0-alpha.25",
   "description": "Cute agents for the acceleration",
   "homepage": "https://github.com/milady-ai/milady",
   "author": {


### PR DESCRIPTION
## Summary
- Bump version to 2.0.0-alpha.25 for release

## Changes in this release
- fix(electron): relax CSP for embedded apps (WASM, fonts, eval)
  - Allows WebAssembly to run (yoga-layout, meshopt)
  - Allows Google Fonts to load
  - Allows data: URLs for WASM loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)