### PR TITLE
fix(ci): deduplicate trust events by prNumber before recording

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -535,6 +535,12 @@ jobs:
               allStates[author] = createContributorState(author);
             }
 
+            // Deduplicate: remove any existing events for this PR before adding the latest verdict
+            // This ensures each PR counts once (latest verdict wins), preventing streak stacking
+            if (allStates[author].events) {
+              allStates[author].events = allStates[author].events.filter(e => e.prNumber !== prNumber);
+            }
+
             // Add this review event
             addEvent(allStates[author], {
               type: eventType,


### PR DESCRIPTION
## Problem

PR reviews were accumulating multiple events per PR in `contributor-trust.json`, causing runaway streak penalties.

**Example:** PR #304 had **10 reject events** recorded (from repeated review cycles). With the streak multiplier compounding to 2.5x, the weighted penalty reached **-148 points**, completely overriding all positive approvals and driving Dexploarer's score to **0 (restricted)**.

The trust-dashboard showed ~49 (contributing) because it reads from GitHub's closed PRs API which records one event per PR. The CI-side scoring was wildly diverging.

## Root cause

The `Update contributor trust score` step appends a new event each time the workflow runs on a PR — which can be many times if a PR gets pushed to repeatedly. The streak multiplier then stacks for each duplicate, amplifying penalties.

## Fix

Before recording an event, filter out any existing events for that `prNumber`:

```js
// Deduplicate: remove any existing events for this PR before adding the latest verdict
if (allStates[author].events) {
  allStates[author].events = allStates[author].events.filter(e => e.prNumber !== prNumber);
}
```

This matches trust-dashboard behavior: **each PR counts exactly once** (latest verdict wins).

## Data cleanup

The `contributor-trust.json` has already been cleaned up in a separate commit (`ed8e39f`) — removing 37 duplicate events from Dexploarer and ~35 from other contributors.

**Score changes after cleanup:**

| Contributor | Before | After |
|---|---|---|
| Dexploarer | 0 (restricted) | 100 (legendary) |
| 0xSolace | still legendary | still legendary |
| 2-A-M | still established | still established |

---
*Sol (AI reviewer / trust system maintainer)*