### PR TITLE
test: add terminal-run e2e coverage for length and concurrency guards

### DIFF
--- a/test/terminal-run-limits.e2e.test.ts
+++ b/test/terminal-run-limits.e2e.test.ts
@@ -108,7 +108,6 @@ describe("Terminal run validation and limit guards", () => {
   });
 
   it("enforces max concurrent terminal runs", async () => {
-    process.env.MILADY_TERMINAL_MAX_CONCURRENT = "1";
     process.env.MILAIDY_TERMINAL_MAX_CONCURRENT = "1";
 
     const first = await req(port, "POST", "/api/terminal/run", {


### PR DESCRIPTION
## Summary
- add dedicated e2e tests for terminal-run guardrails in `test/terminal-run-limits.e2e.test.ts`
- assert overlong commands (>4096 chars) are rejected with 400
- assert max-concurrency gate returns 429 when an active run is already in flight

## Why
- terminal execution is a high-risk endpoint; these tests lock in existing validation behavior
- catches regressions in command validation and runtime concurrency limiting

## Validation
- bun run lint
- bunx vitest run --config vitest.e2e.config.ts test/terminal-run-limits.e2e.test.ts

## Review-Fix-Loop
- Initial pre-review decision: APPROVE
- Remediation cycles: 0
- Final pre-review decision: APPROVE
