### PR TITLE
fix(ci): add build-essential to debian build dependencies

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -248,7 +248,7 @@ jobs:
         run: |
           # Install Node.js 22 via NodeSource so dpkg-checkbuilddeps can find it
           curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
-          sudo apt-get install -y nodejs
+          sudo apt-get install -y nodejs build-essential
           node --version
           npm --version
 


### PR DESCRIPTION
Fixes Debian package build by installing build-essential alongside nodejs.