### PR TITLE
fix(ci): fix npm and debian publish workflows

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -87,10 +87,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          # Retry bun install up to 3 times to handle flaky network issues
+          # Use --ignore-scripts to skip postinstall (submodule init) since we don't need plugins for npm publish
+          # Retry up to 3 times to handle flaky network issues
           for attempt in 1 2 3; do
             echo "Attempt $attempt of 3..."
-            if bun install --frozen-lockfile; then
+            if bun install --frozen-lockfile --ignore-scripts; then
               echo "Dependencies installed successfully"
               exit 0
             fi

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -252,6 +252,13 @@ jobs:
           node --version
           npm --version
 
+      - name: Setup Bun
+        run: |
+          curl -fsSL https://bun.sh/install | bash
+          echo "$HOME/.bun/bin" >> $GITHUB_PATH
+          export PATH="$HOME/.bun/bin:$PATH"
+          bun --version
+
       - name: Prepare debian packaging
         run: |
           # Copy debian directory into project root

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -4,8 +4,14 @@
 	dh $@
 
 override_dh_auto_build:
-	npm ci --ignore-scripts
-	npm run build
+	# Use bun if available (installed by CI), fallback to npm
+	if command -v bun >/dev/null 2>&1; then \
+		bun install --frozen-lockfile --ignore-scripts; \
+		bun run build; \
+	else \
+		npm install --ignore-scripts; \
+		npm run build; \
+	fi
 
 override_dh_auto_install:
 	# Install the built distribution


### PR DESCRIPTION
## Summary
- npm: Add `--ignore-scripts` to bun install to skip submodule initialization
- debian: Update rules to use bun with npm fallback
- debian: Add bun installation step in workflow

Fixes the failing publish workflows for v2.0.0-alpha.26.


🤖 Generated with [Claude Code](https://claude.com/claude-code)