### PR TITLE
fix(ci): fix debian artifact upload path

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -282,10 +282,13 @@ jobs:
           dpkg-buildpackage -us -uc -b
           echo "Built packages:"
           ls -lh ../*.deb
+          # Copy to workspace for artifact upload (upload-artifact doesn't allow ../)
+          mkdir -p deb-output
+          cp ../*.deb ../*.changes deb-output/ 2>/dev/null || cp ../*.deb deb-output/
 
       - name: Test .deb package
         run: |
-          sudo dpkg -i ../*.deb || sudo apt-get -f install -y
+          sudo dpkg -i deb-output/*.deb || sudo apt-get -f install -y
           which milady
           milady --version || echo "Version check completed"
 
@@ -293,9 +296,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: debian-package
-          path: |
-            ../*.deb
-            ../*.changes
+          path: deb-output/
           retention-days: 90
 
       - name: Attach .deb to GitHub Release
@@ -303,7 +304,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          for deb in ../*.deb; do
+          for deb in deb-output/*.deb; do
             echo "Uploading $deb to release..."
             gh release upload "${{ github.event.release.tag_name }}" "$deb" --clobber
           done


### PR DESCRIPTION
Copy .deb files to workspace subdirectory since upload-artifact doesn't allow relative paths.