### PR TITLE
ci: relax agent-review decision parsing

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -312,9 +312,11 @@ jobs:
             const issue_number = context.payload.pull_request.number;
             const runMarker = (process.env.AGENT_REVIEW_MARKER || '').trim();
 
-            const inlineDecisionPattern = /(?:^|\n)\s*(?:#{1,4}\s+)?(?:\d+\.\s*)?(?:\*{0,2})Decision(?:\*{0,2})?\s*:\s*(?:\*{0,2})(APPROVE|REQUEST CHANGES|CLOSE)\b/i;
+            // Inline decision can appear mid-paragraph (e.g. "Decision: **APPROVE**.") so don't anchor to line start.
+            const inlineDecisionPattern = /\bDecision(?:\*{0,2})?\s*:\s*(?:\*{0,2})\s*(APPROVE|REQUEST CHANGES|CLOSE)\b/i;
             const multilineDecisionPattern = /(?:^|\n)\s*(?:#{1,4}\s+)?(?:\d+\.\s*)?(?:\*{0,2})Decision(?:\*{0,2})?\s*:?\s*\n+\s*(?:\*{0,2})(APPROVE|REQUEST CHANGES|CLOSE)\b/i;
-            const standaloneVerdictPattern = /(?:^|\n)\s*(?:\*{0,2})\s*(APPROVE|REQUEST CHANGES|CLOSE)\s*(?:\*{0,2})\b/i;
+            const boldVerdictPattern = /\*{1,3}(APPROVE|REQUEST CHANGES|CLOSE)\b\*{1,3}/i;
+            const bareLineVerdictPattern = /(?:^|\n)\s*(APPROVE|REQUEST CHANGES|CLOSE)\b/i;
             const maxAttempts = 5; // Increased for fallback comment posting
             const pollIntervalMs = 3_000;
 
@@ -327,8 +329,10 @@ jobs:
               const multiline = body.match(multilineDecisionPattern);
               if (multiline?.[1]) return multiline[1].toUpperCase();
               const prefix = body.slice(0, 1500);
-              const standalone = prefix.match(standaloneVerdictPattern);
-              if (standalone?.[1]) return standalone[1].toUpperCase();
+              const boldVerdict = prefix.match(boldVerdictPattern);
+              if (boldVerdict?.[1]) return boldVerdict[1].toUpperCase();
+              const bareLineVerdict = prefix.match(bareLineVerdictPattern);
+              if (bareLineVerdict?.[1]) return bareLineVerdict[1].toUpperCase();
               return '';
             };
 


### PR DESCRIPTION
Fixes false negatives in the Agent Review Verdict gate when the Claude review writes  mid-paragraph or uses  after a dash (without a dedicated Decision line).\n\n- Expands inline decision regex to match mid-paragraph occurrences\n- Parses bolded verdict tokens anywhere in the comment prefix\n\nNo runtime code changes.