### PR TITLE
fix(discord): auto-resolve application id from bot token

### DIFF
--- a/apps/app/src/components/OnboardingWizard.tsx
+++ b/apps/app/src/components/OnboardingWizard.tsx
@@ -1551,16 +1551,15 @@ export function OnboardingWizard() {
                   )}
                 </div>
                 <p className="text-xs text-muted mb-3 mt-1">
-                  Create a bot at the{" "}
+                  Only a bot token is needed.{" "}
                   <a
                     href="https://discord.com/developers/applications"
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="text-accent underline"
+                    className="text-accent hover:underline"
                   >
-                    Discord Developer Portal
-                  </a>{" "}
-                  and copy the bot token
+                    Create a bot →
+                  </a>
                 </p>
                 <input
                   type="password"

--- a/plugins.json
+++ b/plugins.json
@@ -1896,8 +1896,8 @@
         },
         "DISCORD_APPLICATION_ID": {
           "type": "string",
-          "description": "Discord application ID for the bot",
-          "required": true,
+          "description": "Discord application ID for the bot (auto-resolved from bot token if omitted)",
+          "required": false,
           "sensitive": false
         },
         "CHANNEL_IDS": {

--- a/src/runtime/eliza.test.ts
+++ b/src/runtime/eliza.test.ts
@@ -9,6 +9,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { logger } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { findPluginExport } from "../cli/plugins-cli";
 import type { MiladyConfig } from "../config/config";
@@ -16,6 +17,7 @@ import {
   applyCloudConfigToEnv,
   applyConnectorSecretsToEnv,
   applyDatabaseConfigToEnv,
+  autoResolveDiscordAppId,
   buildCharacterFromConfig,
   CORE_PLUGINS,
   CUSTOM_PLUGINS_DIRNAME,
@@ -562,6 +564,121 @@ describe("applyConnectorSecretsToEnv", () => {
     } as MiladyConfig;
     applyConnectorSecretsToEnv(config);
     expect(process.env.TELEGRAM_BOT_TOKEN).toBe("legacy-tg-tok");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// autoResolveDiscordAppId
+// ---------------------------------------------------------------------------
+
+describe("autoResolveDiscordAppId", () => {
+  const envKeys = [
+    "DISCORD_APPLICATION_ID",
+    "DISCORD_API_TOKEN",
+    "DISCORD_BOT_TOKEN",
+  ];
+  const snap = envSnapshot(envKeys);
+
+  beforeEach(() => {
+    snap.save();
+    for (const k of envKeys) delete process.env[k];
+  });
+
+  afterEach(() => {
+    snap.restore();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("no-ops when DISCORD_APPLICATION_ID is already set", async () => {
+    process.env.DISCORD_APPLICATION_ID = "app-existing";
+    process.env.DISCORD_API_TOKEN = "tok";
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    await autoResolveDiscordAppId();
+
+    expect(process.env.DISCORD_APPLICATION_ID).toBe("app-existing");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when no Discord token exists", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    await autoResolveDiscordAppId();
+
+    expect(process.env.DISCORD_APPLICATION_ID).toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("resolves app id from Discord API when token is present", async () => {
+    process.env.DISCORD_API_TOKEN = "tok";
+    const infoSpy = vi.spyOn(logger, "info").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ id: "app-123" }),
+    }));
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    await autoResolveDiscordAppId();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://discord.com/api/v10/oauth2/applications/@me",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bot tok",
+        }),
+      }),
+    );
+    expect(process.env.DISCORD_APPLICATION_ID).toBe("app-123");
+    expect(infoSpy).toHaveBeenCalledWith(
+      "[milady] Auto-resolved Discord Application ID: app-123",
+    );
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("logs a warning when Discord API responds with an error", async () => {
+    process.env.DISCORD_API_TOKEN = "tok";
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: false,
+        status: 401,
+      })) as unknown as typeof fetch,
+    );
+
+    await autoResolveDiscordAppId();
+
+    expect(process.env.DISCORD_APPLICATION_ID).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[milady] Failed to auto-resolve Discord Application ID: 401",
+    );
+  });
+
+  it("logs a warning when the Discord API request throws", async () => {
+    process.env.DISCORD_API_TOKEN = "tok";
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("network down");
+      }) as unknown as typeof fetch,
+    );
+
+    await autoResolveDiscordAppId();
+
+    expect(process.env.DISCORD_APPLICATION_ID).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Could not auto-resolve Discord Application ID"),
+    );
   });
 });
 

--- a/src/runtime/eliza.ts
+++ b/src/runtime/eliza.ts
@@ -351,6 +351,7 @@ const CHANNEL_ENV_MAP: Readonly<
   discord: {
     token: "DISCORD_API_TOKEN",
     botToken: "DISCORD_API_TOKEN",
+    applicationId: "DISCORD_APPLICATION_ID",
   },
   telegram: {
     botToken: "TELEGRAM_BOT_TOKEN",
@@ -1370,6 +1371,43 @@ export function applyConnectorSecretsToEnv(config: MiladyConfig): void {
         process.env[envKey] = value;
       }
     }
+  }
+}
+
+/**
+ * Auto-resolve Discord Application ID from the bot token via Discord API.
+ * Called during async runtime init so that users only need a bot token.
+ */
+/** @internal Exported for testing. */
+export async function autoResolveDiscordAppId(): Promise<void> {
+  if (process.env.DISCORD_APPLICATION_ID) return;
+
+  const discordToken =
+    process.env.DISCORD_API_TOKEN || process.env.DISCORD_BOT_TOKEN;
+  if (!discordToken) return;
+
+  try {
+    const res = await fetch(
+      "https://discord.com/api/v10/oauth2/applications/@me",
+      { headers: { Authorization: `Bot ${discordToken}` } },
+    );
+
+    if (!res.ok) {
+      logger.warn(
+        `[milady] Failed to auto-resolve Discord Application ID: ${res.status}`,
+      );
+      return;
+    }
+
+    const app = (await res.json()) as { id?: string };
+    if (!app.id) return;
+
+    process.env.DISCORD_APPLICATION_ID = app.id;
+    logger.info(`[milady] Auto-resolved Discord Application ID: ${app.id}`);
+  } catch (err) {
+    logger.warn(
+      `[milady] Could not auto-resolve Discord Application ID: ${err}`,
+    );
   }
 }
 
@@ -2420,6 +2458,7 @@ export async function startEliza(
 
   // 2. Push channel secrets into process.env for plugin discovery
   applyConnectorSecretsToEnv(config);
+  await autoResolveDiscordAppId();
 
   // 2b. Propagate cloud config into process.env for ElizaCloud plugin
   applyCloudConfigToEnv(config);
@@ -3001,6 +3040,7 @@ export async function startEliza(
           // because the config may have changed (e.g. cloud enabled during
           // onboarding).
           applyConnectorSecretsToEnv(freshConfig);
+          await autoResolveDiscordAppId();
           applyCloudConfigToEnv(freshConfig);
           applyX402ConfigToEnv(freshConfig);
           applyDatabaseConfigToEnv(freshConfig);


### PR DESCRIPTION
Ports fork PR #320 into a repo-owned branch.

What changed:
- Discord connector no longer requires DISCORD_APPLICATION_ID up-front; it is auto-resolved from the bot token via Discord's read-only /oauth2/applications/@me endpoint.
- plugins.json marks DISCORD_APPLICATION_ID as optional and documents auto-resolution.
- Added deterministic unit coverage for autoResolveDiscordAppId.

Validation:
- bun run lint
- bunx vitest run src/runtime/eliza.test.ts
- bunx vitest run --config vitest.e2e.config.ts test/e2e-validation.e2e.test.ts