### PR TITLE
config: auto-enable WhatsApp Baileys auth + docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,8 @@ knowledge/
 scripts/knowledge-loop.mjs
 test/contracts/
 apps/app/test-results/
+# WhatsApp session files (Baileys auth state)
+/auth/
 :memory:/
 benchmarks/
 plugins/

--- a/docs/WHATSAPP_INTEGRATION.md
+++ b/docs/WHATSAPP_INTEGRATION.md
@@ -1,0 +1,166 @@
+# WhatsApp Connector Integration Guide
+
+This guide explains how to use the WhatsApp connector in Milady with Baileys (QR code) authentication.
+
+## Overview
+
+As of `@elizaos/plugin-whatsapp@2.0.0-alpha.6`, the plugin supports two authentication methods:
+- **Cloud API**: For business accounts using the WhatsApp Business API
+- **Baileys**: For personal accounts using QR code authentication (like WhatsApp Web)
+
+## Quick Start with Baileys (QR Code)
+
+### 1. Configuration
+
+Add the WhatsApp connector to your character configuration file. Each account is defined under the `accounts` key:
+
+```json
+{
+  "name": "Your Bot Name",
+  "connectors": {
+    "whatsapp": {
+      "accounts": {
+        "default": {
+          "enabled": true,
+          "authDir": "./auth/whatsapp"
+        }
+      },
+      "dmPolicy": "pairing",
+      "sendReadReceipts": true,
+      "selfChatMode": false
+    }
+  }
+}
+```
+
+### 2. Start Milady
+
+```bash
+npm start -- --character=./whatsapp-test.character.json
+```
+
+### 3. Scan QR Code
+
+When Milady starts, a QR code will appear in your terminal:
+
+1. Open WhatsApp on your phone
+2. Go to **Settings** > **Linked Devices**
+3. Tap **Link a Device**
+4. Scan the QR code
+
+### 4. Connection Established
+
+Once scanned you'll see:
+
+```
+[WhatsApp] ✅ Connected to WhatsApp!
+```
+
+Your session is saved in `authDir` and reused on restart — no re-scanning needed.
+
+## Configuration Reference
+
+### Top-Level WhatsApp Config
+
+These fields apply to all accounts:
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `accounts` | object | — | Named account configs (see below) |
+| `dmPolicy` | string | `"pairing"` | DM acceptance policy |
+| `sendReadReceipts` | boolean | — | Send read receipts |
+| `selfChatMode` | boolean | — | Respond to own messages (avoid `true` in production) |
+| `messagePrefix` | string | — | Prefix added to all outgoing messages |
+| `groupPolicy` | string | `"allowlist"` | Group message policy |
+| `historyLimit` | number | — | Max messages to load from history |
+| `debounceMs` | number | `0` | Debounce delay before responding |
+| `mediaMaxMb` | number | `50` | Max media size in MB |
+
+### Per-Account Config (`accounts.<name>`)
+
+| Field | Type | Description |
+|---|---|---|
+| `enabled` | boolean | Enable/disable this account |
+| `authDir` | string | Directory to store Baileys session files |
+| `dmPolicy` | string | Override DM policy for this account |
+| `sendReadReceipts` | boolean | Override read receipts for this account |
+| `allowFrom` | string[] | Allowlist of phone numbers (required when `dmPolicy: "open"`) |
+
+### Cloud API Config
+
+For the WhatsApp Business API, configure via environment variables:
+
+```bash
+WHATSAPP_ACCESS_TOKEN=your_token
+WHATSAPP_PHONE_NUMBER_ID=your_phone_id
+WHATSAPP_WEBHOOK_VERIFY_TOKEN=your_verify_token
+WHATSAPP_BUSINESS_ACCOUNT_ID=your_account_id
+```
+
+## Session Persistence
+
+Baileys saves session state to `authDir`. This includes credentials, encryption keys, and device info. Keep this directory secure:
+
+- Never commit it to version control (`auth/` is in `.gitignore`)
+- Back it up if you want to avoid re-scanning on a new machine
+
+## Reconnection
+
+Milady automatically reconnects using saved session files on restart. A new QR code is only needed if:
+- The session files are deleted
+- Your phone revokes the linked device
+- The session expires
+
+## Troubleshooting
+
+### Plugin Not Loading
+
+If the WhatsApp plugin does not start, ensure your config has at least one account defined under `accounts` with `enabled: true` and a valid `authDir`. The auto-enable logic activates the plugin when it detects a configured account.
+
+### QR Code Expires
+
+QR codes have a short TTL. Milady automatically generates a new one if the previous expires. Ensure your phone has internet access when scanning.
+
+### Session Expired
+
+Delete the contents of `authDir` and restart to re-link your device.
+
+### `dmPolicy: "open"` Error
+
+When using `dmPolicy: "open"`, you must also set `allowFrom: ["*"]` in your config, otherwise validation will fail.
+
+## Testing Checklist
+
+From issue [#147](https://github.com/milady-ai/milaidy/issues/147):
+
+### Setup & Authentication
+- [ ] QR code authentication flow
+- [ ] Session persistence (`authDir`)
+- [ ] Reconnection after restart
+- [ ] Error messaging on auth failures
+
+### Message Handling
+- [ ] Text message receive/send
+- [ ] Long message handling
+- [ ] Message formatting
+
+### Platform Features
+- [ ] Group messaging
+- [ ] Reply quoting
+- [ ] Read receipts
+- [ ] Typing indicators
+
+### Media
+- [ ] Image/voice/document reception
+- [ ] Image/document sending
+
+### Error Handling
+- [ ] Session expiration
+- [ ] Network resilience
+- [ ] Rate limit compliance
+
+## Related
+
+- [WhatsApp Plugin Repository](https://github.com/elizaos-plugins/plugin-whatsapp)
+- [Baileys Library](https://github.com/WhiskeySockets/Baileys)
+- [Issue #147](https://github.com/milady-ai/milaidy/issues/147)

--- a/docs/examples/whatsapp-test.character.json
+++ b/docs/examples/whatsapp-test.character.json
@@ -1,0 +1,26 @@
+{
+  "name": "Milaidy WhatsApp Test",
+  "description": "Test configuration for WhatsApp connector with Baileys (QR code) authentication",
+  "bio": [
+    "A test bot for validating WhatsApp connector functionality",
+    "Supports both Cloud API and Baileys (QR code) authentication methods"
+  ],
+  "connectors": {
+    "whatsapp": {
+      "accounts": {
+        "default": {
+          "enabled": true,
+          "authDir": "./auth/whatsapp-test"
+        }
+      },
+      "dmPolicy": "pairing",
+      "sendReadReceipts": true,
+      "selfChatMode": false,
+      "messagePrefix": "[Milaidy] "
+    }
+  },
+  "modelProvider": "anthropic",
+  "secrets": {
+    "enableServerless": false
+  }
+}

--- a/plugins.json
+++ b/plugins.json
@@ -8733,10 +8733,11 @@
       "dirName": "plugin-whatsapp",
       "name": "Whatsapp",
       "npmName": "@elizaos/plugin-whatsapp",
-      "description": "WhatsApp Cloud API plugin for ElizaOS",
+      "description": "WhatsApp plugin for ElizaOS — supports Baileys (QR code) and Cloud API",
       "category": "connector",
       "envKey": "WHATSAPP_ACCESS_TOKEN",
       "configKeys": [
+        "WHATSAPP_AUTH_DIR",
         "WHATSAPP_ACCESS_TOKEN",
         "WHATSAPP_PHONE_NUMBER_ID",
         "WHATSAPP_WEBHOOK_VERIFY_TOKEN",
@@ -8745,12 +8746,18 @@
         "WHATSAPP_DM_POLICY",
         "WHATSAPP_GROUP_POLICY"
       ],
-      "version": "2.0.0-alpha.4",
+      "version": "2.0.0-alpha.6",
       "pluginParameters": {
+        "WHATSAPP_AUTH_DIR": {
+          "type": "string",
+          "description": "Path to Baileys auth directory (QR code mode). Set this OR WHATSAPP_ACCESS_TOKEN.",
+          "required": false,
+          "sensitive": false
+        },
         "WHATSAPP_ACCESS_TOKEN": {
           "type": "string",
-          "description": "Access token for Whatsapp",
-          "required": true,
+          "description": "Access token for WhatsApp Cloud API. Set this OR WHATSAPP_AUTH_DIR.",
+          "required": false,
           "sensitive": true
         },
         "WHATSAPP_PHONE_NUMBER_ID": {
@@ -8825,6 +8832,11 @@
           "label": "Group Policy",
           "group": "Policies",
           "width": "half"
+        },
+        "WHATSAPP_AUTH_DIR": {
+          "label": "Auth Directory (Baileys)",
+          "group": "Baileys (QR code)",
+          "width": "full"
         }
       }
     },

--- a/src/config/plugin-auto-enable.test.ts
+++ b/src/config/plugin-auto-enable.test.ts
@@ -401,3 +401,99 @@ describe("AUTH_PROVIDER_PLUGINS", () => {
     );
   });
 });
+
+// ============================================================================
+//  WhatsApp connector auto-enable — Baileys auth fields
+// ============================================================================
+
+describe("WhatsApp connector auto-enable", () => {
+  it("auto-enables via legacy authState field", () => {
+    const { config } = applyPluginAutoEnable(
+      makeParams({
+        config: { connectors: { whatsapp: { authState: "./auth" } } },
+      }),
+    );
+    expect(config.plugins?.allow).toContain("whatsapp");
+  });
+
+  it("auto-enables via legacy sessionPath field", () => {
+    const { config } = applyPluginAutoEnable(
+      makeParams({
+        config: { connectors: { whatsapp: { sessionPath: "./auth" } } },
+      }),
+    );
+    expect(config.plugins?.allow).toContain("whatsapp");
+  });
+
+  it("auto-enables via authDir (Baileys WhatsAppAccountSchema field)", () => {
+    const { config } = applyPluginAutoEnable(
+      makeParams({
+        config: { connectors: { whatsapp: { authDir: "./auth/whatsapp" } } },
+      }),
+    );
+    expect(config.plugins?.allow).toContain("whatsapp");
+  });
+
+  it("auto-enables when accounts object is configured", () => {
+    const { config } = applyPluginAutoEnable(
+      makeParams({
+        config: {
+          connectors: {
+            whatsapp: {
+              accounts: { default: { enabled: true, authDir: "./auth" } },
+            },
+          },
+        },
+      }),
+    );
+    expect(config.plugins?.allow).toContain("whatsapp");
+  });
+
+  it("does not auto-enable when whatsapp config is empty", () => {
+    const { config } = applyPluginAutoEnable(
+      makeParams({ config: { connectors: { whatsapp: {} } } }),
+    );
+    expect(config.plugins?.allow ?? []).not.toContain("whatsapp");
+  });
+
+  it("does not auto-enable when accounts object has no valid authDir", () => {
+    const { config } = applyPluginAutoEnable(
+      makeParams({
+        config: {
+          connectors: {
+            whatsapp: { accounts: { default: {} } },
+          },
+        },
+      }),
+    );
+    expect(config.plugins?.allow ?? []).not.toContain("whatsapp");
+  });
+
+  it("does not auto-enable when all accounts are explicitly disabled", () => {
+    const { config } = applyPluginAutoEnable(
+      makeParams({
+        config: {
+          connectors: {
+            whatsapp: {
+              accounts: { main: { enabled: false, authDir: "./auth" } },
+            },
+          },
+        },
+      }),
+    );
+    expect(config.plugins?.allow ?? []).not.toContain("whatsapp");
+  });
+
+  it("does not auto-enable when enabled is explicitly false", () => {
+    const { config } = applyPluginAutoEnable(
+      makeParams({
+        config: {
+          connectors: {
+            whatsapp: { enabled: false, authDir: "./auth/whatsapp" },
+          },
+        },
+      }),
+    );
+    expect(config.plugins?.allow ?? []).not.toContain("whatsapp");
+  });
+});

--- a/src/config/plugin-auto-enable.ts
+++ b/src/config/plugin-auto-enable.ts
@@ -149,7 +149,24 @@ function isConnectorConfigured(
           config.cliPath,
       );
     case "whatsapp":
-      return Boolean(config.authState || config.sessionPath);
+      // authState/sessionPath: legacy field names
+      // authDir: Baileys multi-file auth state directory (WhatsAppAccountSchema)
+      // accounts: at least one account with authDir set and not explicitly disabled
+      return Boolean(
+        config.authState ||
+          config.sessionPath ||
+          config.authDir ||
+          (config.accounts &&
+            typeof config.accounts === "object" &&
+            Object.values(config.accounts as Record<string, unknown>).some(
+              (account) => {
+                if (!account || typeof account !== "object") return false;
+                const acc = account as Record<string, unknown>;
+                if (acc.enabled === false) return false;
+                return Boolean(acc.authDir);
+              },
+            )),
+      );
     default:
       return false;
   }


### PR DESCRIPTION
Port of #248 (fork PR) onto a repo-owned branch.

Changes:
- Auto-enable WhatsApp connector when Baileys-style `authDir` is configured (including `accounts.*.authDir`), with tests.
- Add `/auth/` to `.gitignore` to prevent session credential leaks.
- Update `plugins.json` WhatsApp metadata for Baileys vs Cloud API and bump to `2.0.0-alpha.6`.
- Add WhatsApp integration docs + example character config.

Tested:
- `bun run lint`
- `bunx vitest run src/config/plugin-auto-enable.test.ts`
- `bun run typecheck`
