### PR TITLE
feat(chat): support image attachments

### DIFF
--- a/apps/app/src/api-client.ts
+++ b/apps/app/src/api-client.ts
@@ -545,6 +545,14 @@ export interface UiSpecBlock {
 /** Union of all content block types. */
 export type ContentBlock = TextBlock | ConfigFormBlock | UiSpecBlock;
 
+/** An image attachment to send with a chat message. */
+export interface ImageAttachment {
+  /** Base64-encoded image data (no data URL prefix). */
+  data: string;
+  mimeType: string;
+  name: string;
+}
+
 export interface ConfigSchemaResponse {
   schema: unknown;
   uiHints: Record<string, unknown>;
@@ -3265,6 +3273,7 @@ export class MiladyClient {
     onToken: (token: string) => void,
     channelType: ConversationChannelType = "DM",
     signal?: AbortSignal,
+    images?: ImageAttachment[],
   ): Promise<{ text: string; agentName: string }> {
     if (!this.apiAvailable) {
       throw new Error("API not available (no HTTP origin)");
@@ -3278,7 +3287,7 @@ export class MiladyClient {
         Accept: "text/event-stream",
         ...(token ? { Authorization: `Bearer ${token}` } : {}),
       },
-      body: JSON.stringify({ text, channelType }),
+      body: JSON.stringify({ text, channelType, ...(images?.length ? { images } : {}) }),
       signal,
     });
 
@@ -3458,6 +3467,7 @@ export class MiladyClient {
     id: string,
     text: string,
     channelType: ConversationChannelType = "DM",
+    images?: ImageAttachment[],
   ): Promise<{ text: string; agentName: string; blocks?: ContentBlock[] }> {
     const response = await this.fetch<{
       text: string;
@@ -3465,7 +3475,7 @@ export class MiladyClient {
       blocks?: ContentBlock[];
     }>(`/api/conversations/${encodeURIComponent(id)}/messages`, {
       method: "POST",
-      body: JSON.stringify({ text, channelType }),
+      body: JSON.stringify({ text, channelType, ...(images?.length ? { images } : {}) }),
     });
     return {
       ...response,
@@ -3479,6 +3489,7 @@ export class MiladyClient {
     onToken: (token: string) => void,
     channelType: ConversationChannelType = "DM",
     signal?: AbortSignal,
+    images?: ImageAttachment[],
   ): Promise<{ text: string; agentName: string }> {
     return this.streamChatEndpoint(
       `/api/conversations/${encodeURIComponent(id)}/messages/stream`,
@@ -3486,6 +3497,7 @@ export class MiladyClient {
       onToken,
       channelType,
       signal,
+      images,
     );
   }
 

--- a/apps/app/src/components/ChatView.tsx
+++ b/apps/app/src/components/ChatView.tsx
@@ -7,6 +7,8 @@
  */
 
 import {
+  type ChangeEvent,
+  type DragEvent,
   type KeyboardEvent,
   useCallback,
   useEffect,
@@ -14,7 +16,7 @@ import {
   useState,
 } from "react";
 import { getVrmPreviewUrl, useApp } from "../AppContext";
-import { client, type VoiceConfig } from "../api-client";
+import { client, type ImageAttachment, type VoiceConfig } from "../api-client";
 import {
   useVoiceChat,
   type VoicePlaybackStartEvent,
@@ -46,10 +48,14 @@ export function ChatView() {
     shareIngestNotice,
     chatAgentVoiceMuted: agentVoiceMuted,
     selectedVrmIndex,
+    chatPendingImages,
+    setChatPendingImages,
   } = useApp();
 
   const messagesRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [imageDragOver, setImageDragOver] = useState(false);
 
   // ── Voice config (ElevenLabs / browser TTS) ────────────────────────
   const [voiceConfig, setVoiceConfig] = useState<VoiceConfig | null>(null);
@@ -267,8 +273,75 @@ export function ChatView() {
     }
   };
 
+  const addImageFiles = useCallback(
+    (files: FileList | File[]) => {
+      const imageFiles = Array.from(files).filter((f) =>
+        f.type.startsWith("image/"),
+      );
+      if (!imageFiles.length) return;
+
+      const readers = imageFiles.map(
+        (file) =>
+          new Promise<ImageAttachment>((resolve) => {
+            const reader = new FileReader();
+            reader.onload = () => {
+              const result = reader.result as string;
+              // result is "data:<mime>;base64,<data>" — strip the prefix
+              const commaIdx = result.indexOf(",");
+              const data = commaIdx >= 0 ? result.slice(commaIdx + 1) : result;
+              resolve({ data, mimeType: file.type, name: file.name });
+            };
+            reader.readAsDataURL(file);
+          }),
+      );
+
+      void Promise.all(readers).then((attachments) => {
+        setChatPendingImages((prev) => {
+          const combined = [...prev, ...attachments];
+          // Mirror the server-side MAX_CHAT_IMAGES=4 limit so the user gets
+          // immediate feedback rather than a 400 after upload.
+          return combined.slice(0, 4);
+        });
+      });
+    },
+    [setChatPendingImages],
+  );
+
+  const handleImageDrop = useCallback(
+    (e: DragEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      setImageDragOver(false);
+      if (e.dataTransfer.files.length) {
+        addImageFiles(e.dataTransfer.files);
+      }
+    },
+    [addImageFiles],
+  );
+
+  const handleFileInputChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      if (e.target.files) {
+        addImageFiles(e.target.files);
+      }
+      e.target.value = "";
+    },
+    [addImageFiles],
+  );
+
+  const removeImage = useCallback(
+    (index: number) => {
+      setChatPendingImages((prev) => prev.filter((_, i) => i !== index));
+    },
+    [setChatPendingImages],
+  );
+
   return (
-    <div className="flex flex-col flex-1 min-h-0 px-2 sm:px-3 relative">
+    <div
+      className={`flex flex-col flex-1 min-h-0 px-2 sm:px-3 relative${imageDragOver ? " ring-2 ring-accent ring-inset" : ""}`}
+      onDragOver={(e) => { e.preventDefault(); setImageDragOver(true); }}
+      onDragLeave={() => setImageDragOver(false)}
+      onDrop={handleImageDrop}
+    >
       {/* ── Messages ───────────────────────────────────────────────── */}
       <div
         ref={messagesRef}
@@ -383,6 +456,32 @@ export function ChatView() {
         </div>
       )}
 
+      {/* Pending image thumbnails */}
+      {chatPendingImages.length > 0 && (
+        <div
+          className="flex gap-2 flex-wrap py-1 relative"
+          style={{ zIndex: 1 }}
+        >
+          {chatPendingImages.map((img, i) => (
+            <div key={`${img.name}-${i}`} className="relative group w-16 h-16 shrink-0">
+              <img
+                src={`data:${img.mimeType};base64,${img.data}`}
+                alt={img.name}
+                className="w-16 h-16 object-cover border border-border rounded"
+              />
+              <button
+                type="button"
+                title="Remove image"
+                onClick={() => removeImage(i)}
+                className="absolute -top-1.5 -right-1.5 w-4 h-4 rounded-full bg-danger text-white text-[10px] flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
+              >
+                ×
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
       {voiceLatency && (
         <div
           className="pb-1 text-[10px] text-muted relative"
@@ -399,11 +498,37 @@ export function ChatView() {
         </div>
       )}
 
-      {/* ── Input row: mic + textarea + send ───────────────────────── */}
+      {/* ── Input row: mic + paperclip + textarea + send ───────────── */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        multiple
+        className="hidden"
+        onChange={handleFileInputChange}
+      />
       <div
         className="flex gap-1.5 sm:gap-2 items-end border-t border-border pt-3 pb-3 sm:pb-4 relative"
         style={{ zIndex: 1 }}
       >
+        {/* Paperclip / image attach button */}
+        <button
+          type="button"
+          className={`h-[38px] w-[38px] shrink-0 flex items-center justify-center border rounded cursor-pointer transition-all self-end ${
+            chatPendingImages.length > 0
+              ? "border-accent bg-accent/10 text-accent"
+              : "border-border bg-card text-muted hover:border-accent hover:text-accent"
+          }`}
+          onClick={() => fileInputRef.current?.click()}
+          title="Attach image"
+          disabled={chatSending}
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <title>Attach image</title>
+            <path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48" />
+          </svg>
+        </button>
+
         {/* Mic button — user voice input */}
         {voice.supported && (
           <button

--- a/apps/app/test/app/chat-view.test.tsx
+++ b/apps/app/test/app/chat-view.test.tsx
@@ -20,6 +20,14 @@ interface ChatViewContextStub {
   droppedFiles: string[];
   shareIngestNotice: string;
   selectedVrmIndex: number;
+  chatPendingImages: Array<{ data: string; mimeType: string; name: string }>;
+  setChatPendingImages: (
+    updater:
+      | Array<{ data: string; mimeType: string; name: string }>
+      | ((
+          prev: Array<{ data: string; mimeType: string; name: string }>,
+        ) => Array<{ data: string; mimeType: string; name: string }>),
+  ) => void;
 }
 
 const { mockClient, mockUseApp, mockUseVoiceChat } = vi.hoisted(() => ({
@@ -69,6 +77,8 @@ function createContext(
     droppedFiles: [],
     shareIngestNotice: "",
     selectedVrmIndex: 0,
+    chatPendingImages: [],
+    setChatPendingImages: vi.fn(),
     ...overrides,
   };
 }
@@ -232,5 +242,87 @@ describe("ChatView", () => {
       "Hello world.",
       true,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addImageFiles — functional updater (stale closure fix)
+// ---------------------------------------------------------------------------
+
+describe("addImageFiles functional updater", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("calls setChatPendingImages with a functional updater, not a static array", async () => {
+    // Synchronous FileReader mock — calls onload immediately so we don't need
+    // to wait for real async I/O inside the test.
+    let readerInstance: { onload?: (() => void) | null; result: string };
+    const MockFileReader = vi.fn().mockImplementation(function () {
+      readerInstance = { onload: null, result: "" };
+      return {
+        get onload() {
+          return readerInstance.onload;
+        },
+        set onload(fn) {
+          readerInstance.onload = fn;
+        },
+        get result() {
+          return readerInstance.result;
+        },
+        readAsDataURL() {
+          readerInstance.result = "data:image/png;base64,abc123";
+          readerInstance.onload?.();
+        },
+      };
+    });
+    vi.stubGlobal("FileReader", MockFileReader);
+
+    const setChatPendingImages = vi.fn();
+    mockUseApp.mockReturnValue(
+      createContext({ chatPendingImages: [], setChatPendingImages }),
+    );
+
+    let tree: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      tree = TestRenderer.create(React.createElement(ChatView));
+    });
+    await flush();
+
+    // Find the hidden <input type="file"> and fire onChange with a fake File
+    const fileInput = tree!.root.find(
+      (node) => node.type === "input" && node.props.accept === "image/*",
+    );
+
+    const fakeFile = new Proxy(
+      { type: "image/png", name: "test.png" },
+      {
+        get(target, prop) {
+          return (target as Record<string | symbol, unknown>)[prop as string];
+        },
+      },
+    ) as unknown as File;
+
+    await act(async () => {
+      fileInput.props.onChange({
+        target: { files: [fakeFile], value: "" },
+      });
+    });
+    await flush();
+
+    // The fix: setChatPendingImages must be called with a function (functional
+    // updater), not a static array. This ensures rapid consecutive drops
+    // accumulate all images instead of overwriting with stale state.
+    expect(setChatPendingImages).toHaveBeenCalled();
+    const callArg = setChatPendingImages.mock.calls[0]?.[0];
+    expect(typeof callArg).toBe("function");
+
+    // Verify the updater correctly appends to the existing array
+    const prev = [{ data: "existing", mimeType: "image/jpeg", name: "prev.jpg" }];
+    const next = callArg(prev);
+    expect(next).toHaveLength(2);
+    expect(next[0]).toEqual(prev[0]);
+    expect(next[1]).toMatchObject({ mimeType: "image/png", name: "test.png" });
   });
 });

--- a/scripts/patch-deps.mjs
+++ b/scripts/patch-deps.mjs
@@ -411,3 +411,115 @@ if (!existsSync(openrouterTarget)) {
     );
   }
 }
+
+/**
+ * Patch @elizaos/plugin-twitter POST_TWEET action to upload image attachments.
+ *
+ * The action handler only passes text to sendTweet(), ignoring any
+ * message.content.attachments (e.g. images sent from the chat UI).
+ * This patch reads image data from the non-standard `_data`/`_mimeType` fields
+ * that Milady sets on attachments (keeping the `url` field compact to avoid
+ * bloating the LLM context window with base64 strings).
+ *
+ * Remove once plugin-twitter ships native attachment support.
+ */
+const twitterTarget = resolve(
+  root,
+  "node_modules/@elizaos/plugin-twitter/dist/index.js",
+);
+
+if (!existsSync(twitterTarget)) {
+  console.log("[patch-deps] plugin-twitter dist not found, skipping patch.");
+} else {
+  let twitterSrc = readFileSync(twitterTarget, "utf8");
+
+  // Original unpatched code.
+  const twitterBuggy = `      const result = await client.twitterClient.sendTweet(finalTweetText);`;
+
+  // v1 patch (url-based — reads base64 from att.url, may already be applied).
+  const twitterV1Fixed = `      // Upload any image attachments from the user's chat message
+      const imageAttachments = message.content?.attachments?.filter(
+        (att) => att.contentType === "image" || (att.url && att.url.startsWith("data:image/"))
+      ) ?? [];
+      const tweetMediaIds = [];
+      for (const att of imageAttachments) {
+        try {
+          const dataUrl = att.url ?? "";
+          const commaIdx = dataUrl.indexOf(",");
+          if (commaIdx === -1) continue;
+          const base64Data = dataUrl.slice(commaIdx + 1);
+          const mimeMatch = dataUrl.match(/^data:([^;]+);/);
+          const mimeType = mimeMatch ? mimeMatch[1] : "image/jpeg";
+          const buffer = Buffer.from(base64Data, "base64");
+          const mediaId = await client.twitterClient.uploadMedia(buffer, { mimeType });
+          tweetMediaIds.push(mediaId);
+        } catch (mediaErr) {
+          logger14.warn("Failed to upload tweet media attachment:", mediaErr);
+        }
+      }
+      const result = await client.twitterClient.sendTweet(
+        finalTweetText,
+        void 0,
+        void 0,
+        void 0,
+        tweetMediaIds.length > 0 ? tweetMediaIds : void 0
+      );`;
+
+  // v2 patch — reads base64 from att._data/_mimeType so the url field stays
+  // compact (attachment:img-0) and doesn't consume LLM context tokens.
+  const twitterFixed = `      // Upload any image attachments from the user's chat message
+      const imageAttachments = message.content?.attachments?.filter(
+        (att) => att.contentType === "image" && (att._data || (att.url && att.url.startsWith("data:image/")))
+      ) ?? [];
+      const tweetMediaIds = [];
+      for (const att of imageAttachments) {
+        try {
+          let base64Data, mimeType;
+          if (att._data) {
+            base64Data = att._data;
+            mimeType = att._mimeType || "image/jpeg";
+          } else {
+            const dataUrl = att.url ?? "";
+            const commaIdx = dataUrl.indexOf(",");
+            if (commaIdx === -1) continue;
+            base64Data = dataUrl.slice(commaIdx + 1);
+            const mimeMatch = dataUrl.match(/^data:([^;]+);/);
+            mimeType = mimeMatch ? mimeMatch[1] : "image/jpeg";
+          }
+          const buffer = Buffer.from(base64Data, "base64");
+          const mediaId = await client.twitterClient.uploadMedia(buffer, { mimeType });
+          tweetMediaIds.push(mediaId);
+        } catch (mediaErr) {
+          logger14.warn("Failed to upload tweet media attachment:", mediaErr);
+        }
+      }
+      const result = await client.twitterClient.sendTweet(
+        finalTweetText,
+        void 0,
+        void 0,
+        void 0,
+        tweetMediaIds.length > 0 ? tweetMediaIds : void 0
+      );`;
+
+  // v2 is uniquely identified by reading from att._data (not att.url)
+  const twitterV2Marker = `if (att._data) {`;
+  if (twitterSrc.includes(twitterV2Marker)) {
+    console.log(
+      "[patch-deps] twitter POST_TWEET media patch (v2) already present.",
+    );
+  } else if (twitterSrc.includes(twitterV1Fixed.slice(0, 80))) {
+    twitterSrc = twitterSrc.replace(twitterV1Fixed, twitterFixed);
+    writeFileSync(twitterTarget, twitterSrc, "utf8");
+    console.log("[patch-deps] Upgraded twitter POST_TWEET media patch to v2.");
+  } else if (twitterSrc.includes(twitterBuggy)) {
+    twitterSrc = twitterSrc.replace(twitterBuggy, twitterFixed);
+    writeFileSync(twitterTarget, twitterSrc, "utf8");
+    console.log(
+      "[patch-deps] Applied twitter POST_TWEET media upload patch (v2).",
+    );
+  } else {
+    console.log(
+      "[patch-deps] twitter POST_TWEET sendTweet call changed — media patch may no longer be needed.",
+    );
+  }
+}

--- a/src/api/__tests__/chat-image-validation.test.ts
+++ b/src/api/__tests__/chat-image-validation.test.ts
@@ -1,0 +1,400 @@
+import { ChannelType } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  buildChatAttachments,
+  buildUserMessages,
+  validateChatImages,
+} from "../server";
+
+type UUID = `${string}-${string}-${string}-${string}-${string}`;
+
+describe("validateChatImages", () => {
+  describe("absence / empty", () => {
+    it("returns null for undefined", () => {
+      expect(validateChatImages(undefined)).toBeNull();
+    });
+
+    it("returns null for null", () => {
+      expect(validateChatImages(null)).toBeNull();
+    });
+
+    it("returns null for empty array", () => {
+      expect(validateChatImages([])).toBeNull();
+    });
+
+    it("returns null for non-array (object)", () => {
+      expect(
+        validateChatImages({ data: "x", mimeType: "image/png", name: "x.png" }),
+      ).toBeNull();
+    });
+  });
+
+  describe("valid images", () => {
+    const valid = {
+      data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ",
+      mimeType: "image/png",
+      name: "test.png",
+    };
+
+    it("accepts a single valid image", () => {
+      expect(validateChatImages([valid])).toBeNull();
+    });
+
+    it("accepts up to 4 images", () => {
+      expect(validateChatImages([valid, valid, valid, valid])).toBeNull();
+    });
+
+    it("accepts image/jpeg", () => {
+      expect(
+        validateChatImages([{ ...valid, mimeType: "image/jpeg" }]),
+      ).toBeNull();
+    });
+
+    it("accepts image/gif", () => {
+      expect(
+        validateChatImages([{ ...valid, mimeType: "image/gif" }]),
+      ).toBeNull();
+    });
+
+    it("accepts image/webp", () => {
+      expect(
+        validateChatImages([{ ...valid, mimeType: "image/webp" }]),
+      ).toBeNull();
+    });
+
+    it("accepts image/png", () => {
+      expect(
+        validateChatImages([{ ...valid, mimeType: "image/png" }]),
+      ).toBeNull();
+    });
+  });
+
+  describe("count limit", () => {
+    const valid = { data: "abc", mimeType: "image/png", name: "x.png" };
+
+    it("rejects more than 4 images", () => {
+      const err = validateChatImages([valid, valid, valid, valid, valid]);
+      expect(err).toMatch(/Too many images/);
+    });
+  });
+
+  describe("item shape", () => {
+    it("rejects a non-object item", () => {
+      expect(validateChatImages(["string"])).toMatch(/object/);
+    });
+
+    it("rejects a null item", () => {
+      expect(validateChatImages([null])).toMatch(/object/);
+    });
+  });
+
+  describe("data field", () => {
+    it("rejects missing data", () => {
+      expect(
+        validateChatImages([{ mimeType: "image/png", name: "x.png" }]),
+      ).toMatch(/data/);
+    });
+
+    it("rejects empty data string", () => {
+      expect(
+        validateChatImages([
+          { data: "", mimeType: "image/png", name: "x.png" },
+        ]),
+      ).toMatch(/data/);
+    });
+
+    it("rejects data URL prefix (data:image/...;base64,...)", () => {
+      expect(
+        validateChatImages([
+          {
+            data: "data:image/png;base64,abc",
+            mimeType: "image/png",
+            name: "x.png",
+          },
+        ]),
+      ).toMatch(/raw base64/);
+    });
+
+    it("rejects data exceeding 5 MB", () => {
+      const oversized = "a".repeat(5 * 1_048_576 + 1);
+      expect(
+        validateChatImages([
+          { data: oversized, mimeType: "image/png", name: "x.png" },
+        ]),
+      ).toMatch(/too large/i);
+    });
+
+    it("accepts data exactly at the 5 MB limit", () => {
+      const atLimit = "a".repeat(5 * 1_048_576);
+      expect(
+        validateChatImages([
+          { data: atLimit, mimeType: "image/png", name: "x.png" },
+        ]),
+      ).toBeNull();
+    });
+
+    it("rejects non-string data", () => {
+      expect(
+        validateChatImages([
+          { data: 123, mimeType: "image/png", name: "x.png" },
+        ]),
+      ).toMatch(/data/);
+    });
+
+    it("rejects malformed base64 (invalid characters)", () => {
+      expect(
+        validateChatImages([
+          { data: "abc!@#$%", mimeType: "image/png", name: "x.png" },
+        ]),
+      ).toMatch(/invalid base64/i);
+    });
+
+    it("accepts valid base64 with padding", () => {
+      expect(
+        validateChatImages([
+          { data: "aGVsbG8=", mimeType: "image/png", name: "x.png" },
+        ]),
+      ).toBeNull();
+    });
+  });
+
+  describe("mimeType field", () => {
+    it("rejects missing mimeType", () => {
+      expect(validateChatImages([{ data: "abc", name: "x.png" }])).toMatch(
+        /mimeType/,
+      );
+    });
+
+    it("rejects empty mimeType", () => {
+      expect(
+        validateChatImages([{ data: "abc", mimeType: "", name: "x.png" }]),
+      ).toMatch(/mimeType/);
+    });
+
+    it("rejects text/plain", () => {
+      expect(
+        validateChatImages([
+          { data: "abc", mimeType: "text/plain", name: "x.txt" },
+        ]),
+      ).toMatch(/Unsupported image type/);
+    });
+
+    it("rejects image/svg+xml", () => {
+      expect(
+        validateChatImages([
+          { data: "abc", mimeType: "image/svg+xml", name: "x.svg" },
+        ]),
+      ).toMatch(/Unsupported image type/);
+    });
+
+    it("rejects application/octet-stream", () => {
+      expect(
+        validateChatImages([
+          { data: "abc", mimeType: "application/octet-stream", name: "x.bin" },
+        ]),
+      ).toMatch(/Unsupported image type/);
+    });
+
+    it("accepts mixed-case mimeType (Image/PNG) — case-insensitive allowlist", () => {
+      expect(
+        validateChatImages([
+          { data: "abc", mimeType: "Image/PNG", name: "x.png" },
+        ]),
+      ).toBeNull();
+    });
+
+    it("accepts mixed-case mimeType (IMAGE/JPEG)", () => {
+      expect(
+        validateChatImages([
+          { data: "abc", mimeType: "IMAGE/JPEG", name: "x.jpg" },
+        ]),
+      ).toBeNull();
+    });
+  });
+
+  describe("name field", () => {
+    it("rejects missing name", () => {
+      expect(
+        validateChatImages([{ data: "abc", mimeType: "image/png" }]),
+      ).toMatch(/name/);
+    });
+
+    it("rejects empty name", () => {
+      expect(
+        validateChatImages([{ data: "abc", mimeType: "image/png", name: "" }]),
+      ).toMatch(/name/);
+    });
+
+    it("rejects non-string name", () => {
+      expect(
+        validateChatImages([{ data: "abc", mimeType: "image/png", name: 42 }]),
+      ).toMatch(/name/);
+    });
+
+    it("rejects name exceeding 255 characters", () => {
+      const longName = `${"a".repeat(256)}.png`;
+      expect(
+        validateChatImages([
+          { data: "abc", mimeType: "image/png", name: longName },
+        ]),
+      ).toMatch(/name/);
+    });
+
+    it("accepts name at exactly 255 characters", () => {
+      const maxName = "a".repeat(255);
+      expect(
+        validateChatImages([
+          { data: "abc", mimeType: "image/png", name: maxName },
+        ]),
+      ).toBeNull();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildChatAttachments
+// ---------------------------------------------------------------------------
+
+describe("buildChatAttachments", () => {
+  const img = { data: "abc123", mimeType: "image/png", name: "photo.png" };
+
+  it("returns undefined for both when images is undefined", () => {
+    const { attachments, compactAttachments } = buildChatAttachments(undefined);
+    expect(attachments).toBeUndefined();
+    expect(compactAttachments).toBeUndefined();
+  });
+
+  it("returns undefined for both when images is empty", () => {
+    const { attachments, compactAttachments } = buildChatAttachments([]);
+    expect(attachments).toBeUndefined();
+    expect(compactAttachments).toBeUndefined();
+  });
+
+  it("builds in-memory attachments with the correct shape", () => {
+    const { attachments } = buildChatAttachments([img]);
+    expect(attachments).toHaveLength(1);
+    expect(attachments?.[0]).toMatchObject({
+      id: "img-0",
+      url: "attachment:img-0",
+      title: "photo.png",
+      source: "client_chat",
+      _data: "abc123",
+      _mimeType: "image/png",
+    });
+  });
+
+  it("strips _data and _mimeType from compactAttachments", () => {
+    const { compactAttachments } = buildChatAttachments([img]);
+    expect(compactAttachments).toHaveLength(1);
+    expect(compactAttachments?.[0]).not.toHaveProperty("_data");
+    expect(compactAttachments?.[0]).not.toHaveProperty("_mimeType");
+    expect(compactAttachments?.[0]).toMatchObject({
+      id: "img-0",
+      url: "attachment:img-0",
+      title: "photo.png",
+    });
+  });
+
+  it("assigns sequential ids for multiple images", () => {
+    const { attachments } = buildChatAttachments([img, img]);
+    expect(attachments?.[0]?.id).toBe("img-0");
+    expect(attachments?.[1]?.id).toBe("img-1");
+    expect(attachments?.[0]?.url).toBe("attachment:img-0");
+    expect(attachments?.[1]?.url).toBe("attachment:img-1");
+  });
+
+  it("produces matching lengths for attachments and compactAttachments", () => {
+    const { attachments, compactAttachments } = buildChatAttachments([
+      img,
+      img,
+      img,
+    ]);
+    expect(attachments).toHaveLength(3);
+    expect(compactAttachments).toHaveLength(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildUserMessages
+// ---------------------------------------------------------------------------
+
+describe("buildUserMessages", () => {
+  const TEST_USER_ID = "00000000-0000-0000-0000-000000000001" as UUID;
+  const TEST_ROOM_ID = "00000000-0000-0000-0000-000000000002" as UUID;
+  const img = { data: "abc123", mimeType: "image/png", name: "photo.png" };
+
+  const baseParams = {
+    prompt: "hello world",
+    userId: TEST_USER_ID,
+    roomId: TEST_ROOM_ID,
+    channelType: ChannelType.DM,
+  };
+
+  it("userMessage.content.attachments carries _data when images provided", () => {
+    const { userMessage } = buildUserMessages({ ...baseParams, images: [img] });
+    const atts = userMessage.content.attachments as Array<
+      Record<string, unknown>
+    >;
+    expect(atts).toHaveLength(1);
+    expect(atts[0]._data).toBe("abc123");
+    expect(atts[0]._mimeType).toBe("image/png");
+  });
+
+  it("messageToStore.content.attachments strips _data and _mimeType", () => {
+    const { messageToStore } = buildUserMessages({
+      ...baseParams,
+      images: [img],
+    });
+    const atts = messageToStore.content.attachments as Array<
+      Record<string, unknown>
+    >;
+    expect(atts).toHaveLength(1);
+    expect(atts[0]).not.toHaveProperty("_data");
+    expect(atts[0]).not.toHaveProperty("_mimeType");
+  });
+
+  it("userMessage and messageToStore share the same id", () => {
+    const { userMessage, messageToStore } = buildUserMessages({
+      ...baseParams,
+      images: [img],
+    });
+    expect(userMessage.id).toBe(messageToStore.id);
+  });
+
+  it("messageToStore is the same reference as userMessage when no images", () => {
+    const { userMessage, messageToStore } = buildUserMessages({
+      ...baseParams,
+      images: undefined,
+    });
+    expect(messageToStore).toBe(userMessage);
+  });
+
+  it("sets prompt text on userMessage", () => {
+    const { userMessage } = buildUserMessages({
+      ...baseParams,
+      images: undefined,
+    });
+    expect(userMessage.content.text).toBe("hello world");
+  });
+
+  it("sets prompt text on messageToStore when images provided", () => {
+    const { messageToStore } = buildUserMessages({
+      ...baseParams,
+      images: [img],
+    });
+    expect(messageToStore.content.text).toBe("hello world");
+  });
+
+  it("compactAttachments retain url and title but drop raw data", () => {
+    const { messageToStore } = buildUserMessages({
+      ...baseParams,
+      images: [img],
+    });
+    const att = (
+      messageToStore.content.attachments as Array<Record<string, unknown>>
+    )[0];
+    expect(att.url).toBe("attachment:img-0");
+    expect(att.title).toBe("photo.png");
+    expect(att).not.toHaveProperty("_data");
+  });
+});


### PR DESCRIPTION
Ports #335 into a repo-owned branch and resolves conflicts against develop.\n\nWhat it adds:\n- UI: attach images via paperclip or drag-and-drop (preview + remove)\n- API: accept `images[]` on chat endpoints with strict server-side validation\n- Runtime: keep raw base64 out of DB/LLM context via compact attachment placeholders + in-memory _data/_mimeType side-channel for action handlers\n- Twitter: patch POST_TWEET to upload attached images (supports v1 and v2 markers)\n\nTests:\n- src/api/__tests__/chat-image-validation.test.ts\n- apps/app/test/app/chat-view.test.tsx\n\nValidation:\n- bun run check\n- bun run test\n