### PR TITLE
fix(electron): use file:// URLs for dynamic imports on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ irm https://milady-ai.github.io/milady/install.ps1 | iex
 
 NPM global:
 ```bash
-npm install -g milady
+npm install -g milaidy
 milady setup
 ```
 

--- a/apps/app/electron/src/native/agent.ts
+++ b/apps/app/electron/src/native/agent.ts
@@ -14,6 +14,7 @@
  */
 
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { app, type BrowserWindow, ipcMain } from "electron";
 import type { IpcValue } from "./ipc-types";
 
@@ -86,7 +87,7 @@ export class AgentManager {
       //    (or MILADY_PORT if set)
       const apiPort = Number(process.env.MILADY_PORT) || 2138;
       const serverModule = await dynamicImport(
-        path.join(miladyDist, "server.js"),
+        pathToFileURL(path.join(miladyDist, "server.js")).href,
       ).catch((err: unknown) => {
         console.warn(
           "[Agent] Could not load server.js:",
@@ -197,7 +198,7 @@ export class AgentManager {
 
       // 2. Resolve runtime bootstrap entry (may be slow on cold boot).
       const elizaModule = await dynamicImport(
-        path.join(miladyDist, "eliza.js"),
+        pathToFileURL(path.join(miladyDist, "eliza.js")).href,
       );
       const resolvedStartEliza = (elizaModule.startEliza ??
         (elizaModule.default as Record<string, unknown>)?.startEliza) as

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "milady",
+  "name": "milaidy",
   "version": "2.0.0-alpha.26",
   "description": "Cute agents for the acceleration",
   "homepage": "https://github.com/milady-ai/milady",


### PR DESCRIPTION
## Summary
- Wrap `dynamicImport()` paths in `pathToFileURL()` so the Electron app loads `server.js` and `eliza.js` correctly on Windows
- Windows paths like `C:\path\to\server.js` are rejected by Node's ESM loader because the drive letter (`c:`) is treated as a URL scheme
- This is the established pattern used elsewhere in the codebase (`src/runtime/eliza.ts`, `src/cli/plugins-cli.ts`, `src/hooks/loader.ts`)
- Also fixes `package.json` name and README npm install command to use the correct published package name (`milaidy`)

Fixes #388
Relates to #324, #390

## Test plan
- [ ] Verify Electron app starts on Windows without "Received protocol 'c:'" error
- [ ] Verify Electron app still works on macOS/Linux (pathToFileURL is cross-platform)
- [ ] `npx milaidy` installs the correct package
- [ ] CI: lint, typecheck, unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)