### PR TITLE
api: block MCP interpreter bootstrap execution flags

### DIFF
--- a/src/api/server.mcp-config-validation.test.ts
+++ b/src/api/server.mcp-config-validation.test.ts
@@ -88,6 +88,22 @@ describe("validateMcpServerConfig", () => {
     expect(uvEval).toContain('Flag "-c" is not allowed');
   });
 
+  it("rejects interpreter bootstrap flags that can execute preload code", () => {
+    const nodeImport = validateMcpServerConfig({
+      type: "stdio",
+      command: "node",
+      args: ["--import", "data:text/javascript,console.log('pwn')"],
+    });
+    const nodeRequireAttached = validateMcpServerConfig({
+      type: "stdio",
+      command: "node",
+      args: ["-r./bootstrap.js", "server.js"],
+    });
+
+    expect(nodeImport).toContain('Flag "--import" is not allowed');
+    expect(nodeRequireAttached).toContain('Flag "-r" is not allowed');
+  });
+
   it("rejects inline-exec flags for package runner commands", () => {
     const rejection = validateMcpServerConfig({
       type: "stdio",

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -2646,6 +2646,12 @@ const BLOCKED_INTERPRETER_FLAGS = new Set([
   "--eval",
   "-p",
   "--print",
+  "-r",
+  "--require",
+  "--import",
+  "--loader",
+  "--experimental-loader",
+  "--preload",
   "-c",
   "-m",
 ]);


### PR DESCRIPTION
## Summary
- harden MCP stdio validation by blocking interpreter bootstrap flags that can preload/execute arbitrary code
- add blocked flags: -r/--require, --import, --loader, --experimental-loader, --preload
- add regression tests for node --import and attached -r payload forms

## Testing
- bun x biome check src/api/server.ts src/api/server.mcp-config-validation.test.ts
- bun run vitest src/api/server.mcp-config-validation.test.ts