### PR TITLE
runtime: forward API token for shell custom actions

### DIFF
--- a/src/runtime/custom-actions.ts
+++ b/src/runtime/custom-actions.ts
@@ -223,7 +223,18 @@ function buildHandler(
           `http://localhost:${API_PORT}/api/terminal/run`,
           {
             method: "POST",
-            headers: { "Content-Type": "application/json" },
+            headers: (() => {
+              const headers: Record<string, string> = {
+                "Content-Type": "application/json",
+              };
+              const token = process.env.MILADY_API_TOKEN?.trim();
+              if (token) {
+                headers.Authorization = /^Bearer\s+/i.test(token)
+                  ? token
+                  : `Bearer ${token}`;
+              }
+              return headers;
+            })(),
             body: JSON.stringify({ command }),
           },
         );


### PR DESCRIPTION
## Summary
- forward `MILADY_API_TOKEN` on shell custom-action calls to `/api/terminal/run`
- preserve existing behavior when token is unset
- add regression coverage for auth-header forwarding

## Validation
- bun run vitest src/runtime/custom-actions.test.ts
- bun x biome check src/runtime/custom-actions.ts src/runtime/custom-actions.test.ts
