### PR TITLE
api: scope terminal output streams by client id

### DIFF
--- a/src/actions/__tests__/terminal.test.ts
+++ b/src/actions/__tests__/terminal.test.ts
@@ -46,7 +46,13 @@ describe("terminalAction", () => {
     expect(result.text).toBe("");
     expect(vi.mocked(fetch)).toHaveBeenCalledWith(
       "http://localhost:2138/api/terminal/run",
-      expect.objectContaining({ method: "POST" }),
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          command: "ls -la",
+          clientId: "runtime-terminal-action",
+        }),
+      }),
     );
   });
 

--- a/src/actions/terminal.ts
+++ b/src/actions/terminal.ts
@@ -49,7 +49,10 @@ export const terminalAction: Action = {
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ command }),
+          body: JSON.stringify({
+            command,
+            clientId: "runtime-terminal-action",
+          }),
         },
       );
 

--- a/src/api/server.terminal-client-scope.test.ts
+++ b/src/api/server.terminal-client-scope.test.ts
@@ -1,0 +1,57 @@
+import type http from "node:http";
+import { describe, expect, it } from "vitest";
+import { createMockHeadersRequest } from "../test-support/test-helpers";
+import { normalizeWsClientId, resolveTerminalRunClientId } from "./server";
+
+function req(
+  headers: http.IncomingHttpHeaders = {},
+): Pick<http.IncomingMessage, "headers"> {
+  return createMockHeadersRequest(headers) as Pick<
+    http.IncomingMessage,
+    "headers"
+  >;
+}
+
+describe("normalizeWsClientId", () => {
+  it("accepts safe client ids and trims whitespace", () => {
+    expect(normalizeWsClientId("  ui-abc_123.xyz  ")).toBe("ui-abc_123.xyz");
+  });
+
+  it("rejects empty, unsafe, and overly long ids", () => {
+    expect(normalizeWsClientId("")).toBeNull();
+    expect(normalizeWsClientId("bad$id")).toBeNull();
+    expect(normalizeWsClientId("a".repeat(129))).toBeNull();
+    expect(normalizeWsClientId(undefined)).toBeNull();
+  });
+});
+
+describe("resolveTerminalRunClientId", () => {
+  it("prefers X-Milady-Client-Id header over request body", () => {
+    const request = req({ "x-milady-client-id": "header-client" });
+    expect(
+      resolveTerminalRunClientId(request, { clientId: "body-client" }),
+    ).toBe("header-client");
+  });
+
+  it("accepts first value from multi-value header", () => {
+    const request = req({
+      "x-milady-client-id": ["first-client", "second-client"],
+    });
+    expect(resolveTerminalRunClientId(request, null)).toBe("first-client");
+  });
+
+  it("falls back to body client id when header is invalid", () => {
+    const request = req({ "x-milady-client-id": "bad$id" });
+    expect(
+      resolveTerminalRunClientId(request, { clientId: "body-client" }),
+    ).toBe("body-client");
+  });
+
+  it("returns null when neither header nor body has a valid client id", () => {
+    const request = req();
+    expect(
+      resolveTerminalRunClientId(request, { clientId: "bad$id" }),
+    ).toBeNull();
+    expect(resolveTerminalRunClientId(request, null)).toBeNull();
+  });
+});

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -230,6 +230,10 @@ interface ServerState {
   broadcastStatus: (() => void) | null;
   /** Broadcast an arbitrary JSON message to all WebSocket clients. Set by startApiServer. */
   broadcastWs: ((data: Record<string, unknown>) => void) | null;
+  /** Broadcast a JSON payload to WebSocket clients bound to a specific client id. */
+  broadcastWsToClientId:
+    | ((clientId: string, data: Record<string, unknown>) => number)
+    | null;
   /** Currently active conversation ID from the frontend (sent via WS). */
   activeConversationId: string | null;
   /** Transient OAuth flow state for subscription auth. */
@@ -3750,7 +3754,7 @@ function applyCors(
     );
     res.setHeader(
       "Access-Control-Allow-Headers",
-      "Content-Type, Authorization, X-Milady-Token, X-Api-Key, X-Milady-Export-Token",
+      "Content-Type, Authorization, X-Milady-Token, X-Api-Key, X-Milady-Export-Token, X-Milady-Client-Id",
     );
   }
 
@@ -3837,6 +3841,42 @@ function extractAuthToken(req: http.IncomingMessage): string | null {
   if (typeof header === "string" && header.trim()) return header.trim();
 
   return null;
+}
+
+const SAFE_WS_CLIENT_ID_RE = /^[A-Za-z0-9._-]{1,128}$/;
+
+export function normalizeWsClientId(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (!SAFE_WS_CLIENT_ID_RE.test(trimmed)) return null;
+  return trimmed;
+}
+
+function firstHeaderValue(value: string | string[] | undefined): string | null {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value) && typeof value[0] === "string") return value[0];
+  return null;
+}
+
+export function resolveTerminalRunClientId(
+  req: Pick<http.IncomingMessage, "headers">,
+  body: { clientId?: unknown } | null | undefined,
+): string | null {
+  const headerClientId = normalizeWsClientId(
+    firstHeaderValue(req.headers["x-milady-client-id"]),
+  );
+  if (headerClientId) return headerClientId;
+  return normalizeWsClientId(body?.clientId);
+}
+
+const SHARED_TERMINAL_CLIENT_IDS = new Set([
+  "runtime-terminal-action",
+  "runtime-shell-action",
+]);
+
+function isSharedTerminalClientId(clientId: string): boolean {
+  return SHARED_TERMINAL_CLIENT_IDS.has(clientId);
 }
 
 function tokenMatches(expected: string, provided: string): boolean {
@@ -10941,7 +10981,10 @@ async function handleRequest(
       return;
     }
 
-    const body = await readJsonBody<{ command?: string }>(req, res);
+    const body = await readJsonBody<{ command?: string; clientId?: unknown }>(
+      req,
+      res,
+    );
     if (!body) return;
     const command = typeof body.command === "string" ? body.command.trim() : "";
     if (!command) {
@@ -10970,6 +11013,25 @@ async function handleRequest(
       return;
     }
 
+    const targetClientId = resolveTerminalRunClientId(req, body);
+    if (!targetClientId) {
+      error(
+        res,
+        "Missing client id. Provide X-Milady-Client-Id header or clientId in the request body.",
+        400,
+      );
+      return;
+    }
+
+    const emitTerminalEvent = (payload: Record<string, unknown>) => {
+      if (isSharedTerminalClientId(targetClientId)) {
+        state.broadcastWs?.(payload);
+        return;
+      }
+      if (typeof state.broadcastWsToClientId !== "function") return;
+      state.broadcastWsToClientId(targetClientId, payload);
+    };
+
     const { maxConcurrent, maxDurationMs } = resolveTerminalRunLimits();
     if (activeTerminalRunCount >= maxConcurrent) {
       error(
@@ -10987,7 +11049,7 @@ async function handleRequest(
     const { spawn } = await import("node:child_process");
     const runId = `run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
-    state.broadcastWs?.({
+    emitTerminalEvent({
       type: "terminal-output",
       runId,
       event: "start",
@@ -11013,7 +11075,7 @@ async function handleRequest(
     const timeoutHandle = setTimeout(() => {
       if (proc.killed) return;
       proc.kill("SIGTERM");
-      state.broadcastWs?.({
+      emitTerminalEvent({
         type: "terminal-output",
         runId,
         event: "timeout",
@@ -11026,7 +11088,7 @@ async function handleRequest(
     }, maxDurationMs);
 
     proc.stdout?.on("data", (chunk: Buffer) => {
-      state.broadcastWs?.({
+      emitTerminalEvent({
         type: "terminal-output",
         runId,
         event: "stdout",
@@ -11035,7 +11097,7 @@ async function handleRequest(
     });
 
     proc.stderr?.on("data", (chunk: Buffer) => {
-      state.broadcastWs?.({
+      emitTerminalEvent({
         type: "terminal-output",
         runId,
         event: "stderr",
@@ -11045,7 +11107,7 @@ async function handleRequest(
 
     proc.on("close", (code: number | null) => {
       finalize();
-      state.broadcastWs?.({
+      emitTerminalEvent({
         type: "terminal-output",
         runId,
         event: "exit",
@@ -11055,7 +11117,7 @@ async function handleRequest(
 
     proc.on("error", (err: Error) => {
       finalize();
-      state.broadcastWs?.({
+      emitTerminalEvent({
         type: "terminal-output",
         runId,
         event: "error",
@@ -11473,6 +11535,7 @@ export async function startApiServer(opts?: {
     shareIngestQueue: [],
     broadcastStatus: null,
     broadcastWs: null,
+    broadcastWsToClientId: null,
     activeConversationId: null,
     permissionStates: {},
     shellEnabled: config.features?.shellEnabled !== false,
@@ -11871,6 +11934,7 @@ export async function startApiServer(opts?: {
   // ── WebSocket Server ─────────────────────────────────────────────────────
   const wss = new WebSocketServer({ noServer: true });
   const wsClients = new Set<WebSocket>();
+  const wsClientIds = new WeakMap<WebSocket, string>();
   bindRuntimeStreams(opts?.runtime ?? null);
   bindTrainingStream();
 
@@ -11898,7 +11962,18 @@ export async function startApiServer(opts?: {
   });
 
   // Handle WebSocket connections
-  wss.on("connection", (ws: WebSocket) => {
+  wss.on("connection", (ws: WebSocket, request: http.IncomingMessage) => {
+    try {
+      const wsUrl = new URL(
+        request.url ?? "/",
+        `http://${request.headers.host ?? "localhost"}`,
+      );
+      const clientId = normalizeWsClientId(wsUrl.searchParams.get("clientId"));
+      if (clientId) wsClientIds.set(ws, clientId);
+    } catch {
+      // Ignore malformed WS URL metadata; auth/path were already validated.
+    }
+
     wsClients.add(ws);
     addLog("info", "WebSocket client connected", "websocket", [
       "server",
@@ -11988,6 +12063,27 @@ export async function startApiServer(opts?: {
         }
       }
     }
+  };
+
+  state.broadcastWsToClientId = (
+    clientId: string,
+    data: Record<string, unknown>,
+  ) => {
+    const message = JSON.stringify(data);
+    let delivered = 0;
+    for (const client of wsClients) {
+      if (client.readyState !== 1) continue;
+      if (wsClientIds.get(client) !== clientId) continue;
+      try {
+        client.send(message);
+        delivered += 1;
+      } catch (err) {
+        logger.error(
+          `[milady-api] WebSocket targeted send error: ${err instanceof Error ? err.message : err}`,
+        );
+      }
+    }
+    return delivered;
   };
 
   // Broadcast status every 5 seconds

--- a/src/runtime/custom-actions.ts
+++ b/src/runtime/custom-actions.ts
@@ -224,7 +224,7 @@ function buildHandler(
           {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ command }),
+            body: JSON.stringify({ command, clientId: "runtime-shell-action" }),
           },
         );
 


### PR DESCRIPTION
## Summary
- scope `/api/terminal/run` websocket output by client id to avoid cross-client terminal output leaks
- require a valid client id on terminal-run requests (`X-Milady-Client-Id` header or `clientId` body field)
- include client id from the app client on HTTP + websocket connections
- preserve runtime terminal visibility by treating reserved runtime client ids as shared streams
- add focused tests for client-id normalization/resolution and runtime terminal caller payloads

## Validation
- bun run vitest src/api/server.terminal-client-scope.test.ts src/api/server.websocket-auth.test.ts src/runtime/custom-actions.test.ts src/actions/__tests__/terminal.test.ts
- bun run vitest src/api/server.terminal-limits.test.ts
- bun x biome check src/api/server.ts src/api/server.terminal-client-scope.test.ts apps/app/src/api-client.ts src/runtime/custom-actions.ts src/runtime/custom-actions.test.ts src/actions/terminal.ts src/actions/__tests__/terminal.test.ts
