### PR TITLE
fix(api): serve dashboard static files before auth gate

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -4941,6 +4941,13 @@ async function handleRequest(
     return;
   }
 
+  // Serve dashboard static assets before the auth gate.  serveStaticUi
+  // already refuses /api/, /v1/, and /ws paths, so API endpoints remain
+  // fully protected by the token check below.
+  if (method === "GET" || method === "HEAD") {
+    if (serveStaticUi(req, res, pathname)) return;
+  }
+
   if (method !== "OPTIONS" && !isAuthEndpoint && !isAuthorized(req)) {
     json(res, { error: "Unauthorized" }, 401);
     return;
@@ -11364,11 +11371,6 @@ async function handleRequest(
 
     json(res, { ok: true });
     return;
-  }
-
-  // ── Static UI serving (production) ──────────────────────────────────────
-  if (method === "GET" || method === "HEAD") {
-    if (serveStaticUi(req, res, pathname)) return;
   }
 
   // ── Fallback ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- When `MILADY_API_TOKEN` is set, the auth check blocks **all** requests — including browser fetches for dashboard HTML/CSS/JS
- The `serveStaticUi()` call was located 6,400 lines below the auth gate in `handleRequest`, so it was never reached
- Moved static file serving **before** the auth check, and removed the now-redundant duplicate call at the bottom

**Why this is safe:** `serveStaticUi` already refuses to serve any path under `/api/`, `/v1/`, or `/ws` (lines 1744-1747). All API endpoints remain fully protected by the token check.

## Test plan

- [ ] Set `MILADY_API_TOKEN=test` in env, start server, open `http://localhost:2138` — dashboard should load
- [ ] Verify `curl http://localhost:2138/api/status` still returns 401 without the token
- [ ] Verify `curl -H "Authorization: Bearer test" http://localhost:2138/api/status` returns 200

Fixes #400