### PR TITLE
runtime: guard code action fetch against SSRF

### DIFF
--- a/src/runtime/custom-actions.test.ts
+++ b/src/runtime/custom-actions.test.ts
@@ -26,6 +26,23 @@ function makeHttpAction(url: string): CustomActionDef {
   };
 }
 
+function makeCodeAction(code: string): CustomActionDef {
+  return {
+    id: "test-code-action",
+    name: "TEST_CODE_ACTION",
+    description: "test code",
+    similes: [],
+    parameters: [],
+    handler: {
+      type: "code",
+      code,
+    },
+    enabled: true,
+    createdAt: new Date(0).toISOString(),
+    updatedAt: new Date(0).toISOString(),
+  };
+}
+
 describe("custom action SSRF guard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -131,6 +148,67 @@ describe("custom action SSRF guard", () => {
     const result = await handler({});
     expect(result.ok).toBe(false);
     expect(result.output).toContain("redirects are not allowed");
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://example.com/redirect",
+      expect.objectContaining({ redirect: "manual" }),
+    );
+  });
+
+  it("blocks code handlers from fetching internal addresses", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const handler = buildTestHandler(
+      makeCodeAction(`
+        await fetch("http://127.0.0.1:9999/private");
+        return "unexpected";
+      `),
+    );
+
+    await expect(handler({})).rejects.toThrow("Blocked");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("allows code handlers to fetch public URLs", async () => {
+    vi.mocked(dnsLookup).mockResolvedValue([
+      { address: "93.184.216.34", family: 4 },
+    ]);
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue({ status: 200, text: async () => "ok" } as Response);
+    const handler = buildTestHandler(
+      makeCodeAction(`
+        const response = await fetch("https://example.com/data");
+        return await response.text();
+      `),
+    );
+
+    const result = await handler({});
+    expect(result.ok).toBe(true);
+    expect(result.output).toBe("ok");
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://example.com/data",
+      expect.objectContaining({ redirect: "manual" }),
+    );
+  });
+
+  it("blocks redirects for code handlers", async () => {
+    vi.mocked(dnsLookup).mockResolvedValue([
+      { address: "93.184.216.34", family: 4 },
+    ]);
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      status: 302,
+      headers: new Headers({ location: "http://169.254.169.254/latest" }),
+      text: async () => "",
+    } as Response);
+    const handler = buildTestHandler(
+      makeCodeAction(`
+        const response = await fetch("https://example.com/redirect");
+        return String(response.status);
+      `),
+    );
+
+    await expect(handler({})).rejects.toThrow(
+      "redirects are not allowed for code custom actions",
+    );
     expect(fetchSpy).toHaveBeenCalledWith(
       "https://example.com/redirect",
       expect.objectContaining({ redirect: "manual" }),


### PR DESCRIPTION
## Summary
- replace raw `fetch` in code custom actions with a guarded wrapper
- apply existing private-network SSRF checks to code action fetch calls
- force manual redirects and block 3xx redirect responses for code actions
- add regression tests for blocked internal targets, allowed public targets, and redirect blocking

## Validation
- bun run vitest src/runtime/custom-actions.test.ts
- bun run vitest src/runtime/custom-actions.test.ts -t "blocks code handlers|allows code handlers|blocks redirects"
- bun x biome check src/runtime/custom-actions.ts src/runtime/custom-actions.test.ts
