### PR TITLE
api: scope terminal output streams by client id

### DIFF
--- a/src/actions/__tests__/terminal.test.ts
+++ b/src/actions/__tests__/terminal.test.ts
@@ -46,7 +46,13 @@ describe("terminalAction", () => {
     expect(result.text).toBe("");
     expect(vi.mocked(fetch)).toHaveBeenCalledWith(
       "http://localhost:2138/api/terminal/run",
-      expect.objectContaining({ method: "POST" }),
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          command: "ls -la",
+          clientId: "runtime-terminal-action",
+        }),
+      }),
     );
   });
 

--- a/src/actions/terminal.ts
+++ b/src/actions/terminal.ts
@@ -49,7 +49,10 @@ export const terminalAction: Action = {
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ command }),
+          body: JSON.stringify({
+            command,
+            clientId: "runtime-terminal-action",
+          }),
         },
       );
 

--- a/src/api/server.terminal-client-scope.test.ts
+++ b/src/api/server.terminal-client-scope.test.ts
@@ -1,0 +1,57 @@
+import type http from "node:http";
+import { describe, expect, it } from "vitest";
+import { createMockHeadersRequest } from "../test-support/test-helpers";
+import { normalizeWsClientId, resolveTerminalRunClientId } from "./server";
+
+function req(
+  headers: http.IncomingHttpHeaders = {},
+): Pick<http.IncomingMessage, "headers"> {
+  return createMockHeadersRequest(headers) as Pick<
+    http.IncomingMessage,
+    "headers"
+  >;
+}
+
+describe("normalizeWsClientId", () => {
+  it("accepts safe client ids and trims whitespace", () => {
+    expect(normalizeWsClientId("  ui-abc_123.xyz  ")).toBe("ui-abc_123.xyz");
+  });
+
+  it("rejects empty, unsafe, and overly long ids", () => {
+    expect(normalizeWsClientId("")).toBeNull();
+    expect(normalizeWsClientId("bad$id")).toBeNull();
+    expect(normalizeWsClientId("a".repeat(129))).toBeNull();
+    expect(normalizeWsClientId(undefined)).toBeNull();
+  });
+});
+
+describe("resolveTerminalRunClientId", () => {
+  it("prefers X-Milady-Client-Id header over request body", () => {
+    const request = req({ "x-milady-client-id": "header-client" });
+    expect(
+      resolveTerminalRunClientId(request, { clientId: "body-client" }),
+    ).toBe("header-client");
+  });
+
+  it("accepts first value from multi-value header", () => {
+    const request = req({
+      "x-milady-client-id": ["first-client", "second-client"],
+    });
+    expect(resolveTerminalRunClientId(request, null)).toBe("first-client");
+  });
+
+  it("falls back to body client id when header is invalid", () => {
+    const request = req({ "x-milady-client-id": "bad$id" });
+    expect(
+      resolveTerminalRunClientId(request, { clientId: "body-client" }),
+    ).toBe("body-client");
+  });
+
+  it("returns null when neither header nor body has a valid client id", () => {
+    const request = req();
+    expect(
+      resolveTerminalRunClientId(request, { clientId: "bad$id" }),
+    ).toBeNull();
+    expect(resolveTerminalRunClientId(request, null)).toBeNull();
+  });
+});

--- a/src/runtime/custom-actions.test.ts
+++ b/src/runtime/custom-actions.test.ts
@@ -43,6 +43,23 @@ function makeCodeAction(code: string): CustomActionDef {
   };
 }
 
+function makeShellAction(command: string): CustomActionDef {
+  return {
+    id: "test-shell-action",
+    name: "TEST_SHELL_ACTION",
+    description: "test shell",
+    similes: [],
+    parameters: [],
+    handler: {
+      type: "shell",
+      command,
+    },
+    enabled: true,
+    createdAt: new Date(0).toISOString(),
+    updatedAt: new Date(0).toISOString(),
+  };
+}
+
 describe("custom action SSRF guard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -212,6 +229,26 @@ describe("custom action SSRF guard", () => {
     expect(fetchSpy).toHaveBeenCalledWith(
       "https://example.com/redirect",
       expect.objectContaining({ redirect: "manual" }),
+    );
+  });
+
+  it("includes a scoped clientId for shell terminal runs", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue({ ok: true, text: async () => "ok" } as Response);
+    const handler = buildTestHandler(makeShellAction("echo hello"));
+
+    const result = await handler({});
+    expect(result.ok).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "http://localhost:2138/api/terminal/run",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          command: "echo hello",
+          clientId: "runtime-shell-action",
+        }),
+      }),
     );
   });
 });

--- a/src/runtime/custom-actions.ts
+++ b/src/runtime/custom-actions.ts
@@ -254,7 +254,7 @@ function buildHandler(
           {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ command }),
+            body: JSON.stringify({ command, clientId: "runtime-shell-action" }),
           },
         );
 

--- a/test/terminal-run-limits.e2e.test.ts
+++ b/test/terminal-run-limits.e2e.test.ts
@@ -66,6 +66,7 @@ function saveEnv(...keys: string[]): { restore: () => void } {
 }
 
 describe("Terminal run validation and limit guards", () => {
+  const TEST_CLIENT_ID = "terminal-run-limits-e2e";
   let port: number;
   let close: () => Promise<void>;
   let envBackup: { restore: () => void };
@@ -98,6 +99,7 @@ describe("Terminal run validation and limit guards", () => {
   it("rejects commands longer than 4096 characters", async () => {
     const { status, data } = await req(port, "POST", "/api/terminal/run", {
       command: "x".repeat(4097),
+      clientId: TEST_CLIENT_ID,
     });
 
     expect(status).toBe(400);
@@ -112,6 +114,7 @@ describe("Terminal run validation and limit guards", () => {
 
     const first = await req(port, "POST", "/api/terminal/run", {
       command: 'node -e "setTimeout(() => process.exit(0), 1200)"',
+      clientId: TEST_CLIENT_ID,
     });
     expect(first.status).toBe(200);
 
@@ -119,6 +122,7 @@ describe("Terminal run validation and limit guards", () => {
 
     const second = await req(port, "POST", "/api/terminal/run", {
       command: "echo second",
+      clientId: TEST_CLIENT_ID,
     });
     expect(second.status).toBe(429);
     expect(second.data.error).toContain("Too many active terminal runs");


### PR DESCRIPTION
## Summary
- scope `/api/terminal/run` WebSocket output to the initiating client id instead of broadcasting to all clients
- require a valid client id via `X-Milady-Client-Id` header or request-body `clientId`
- wire client id through app API client and runtime terminal/shell actions
- add terminal client-id parsing/selection tests and update terminal e2e coverage

## Validation
- `bunx vitest run src/api/server.terminal-client-scope.test.ts src/actions/__tests__/terminal.test.ts src/runtime/custom-actions.test.ts`
- `bunx vitest run --config apps/app/vitest.config.ts apps/app/test/app/api-client-ws.test.ts`
- `bunx vitest run --config vitest.e2e.config.ts test/terminal-run-limits.e2e.test.ts test/permissions-api.e2e.test.ts`
- `bunx vitest run --config vitest.e2e.config.ts test/api-auth.e2e.test.ts`
- `bunx @biomejs/biome check apps/app/src/api-client.ts src/actions/__tests__/terminal.test.ts src/actions/terminal.ts src/api/server.terminal-client-scope.test.ts src/api/server.ts src/runtime/custom-actions.test.ts src/runtime/custom-actions.ts test/terminal-run-limits.e2e.test.ts`
