### PR TITLE
fix: use Bun-compatible test APIs in credentials and stealth tests

### DIFF
--- a/src/auth/apply-stealth.test.ts
+++ b/src/auth/apply-stealth.test.ts
@@ -9,7 +9,7 @@ const OPENAI_STEALTH_GUARD = Symbol.for("milady.openaiCodexStealthInstalled");
 
 describe("applyClaudeCodeStealth", () => {
   beforeEach(() => {
-    vi.resetModules();
+    vi.clearAllMocks();
     delete process.env.ANTHROPIC_API_KEY;
   });
 


### PR DESCRIPTION
## Summary
- Replace `vi.resetModules()` with `vi.clearAllMocks()` in apply-stealth tests (Bun doesn't support resetModules)
- Replace `importOriginal()` with direct mock factory in credentials tests (Bun doesn't support importOriginal parameter)
- Replace `resolves.not.toThrow()` with `resolves.toBeUndefined()` (Bun-compatible matcher)

## Test plan
- [x] `bun test src/auth/apply-stealth.test.ts` — 9 pass
- [x] `bun test src/auth/credentials.test.ts` — 6 pass
- [x] `bun run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)