### PR TITLE
api: harden ElevenLabs TTS proxy against OOM and hung upstream

### DIFF
--- a/src/api/server.elevenlabs-proxy-guard.test.ts
+++ b/src/api/server.elevenlabs-proxy-guard.test.ts
@@ -1,0 +1,153 @@
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  fetchWithTimeoutGuard,
+  streamResponseBodyWithByteLimit,
+} from "./server";
+
+class MockStreamResponseWriter extends EventEmitter {
+  readonly chunks: Buffer[] = [];
+  writableEnded = false;
+  destroyed = false;
+
+  write(chunk: Uint8Array | Buffer): boolean {
+    this.chunks.push(Buffer.from(chunk));
+    return true;
+  }
+
+  bytes(): Buffer {
+    return Buffer.concat(this.chunks);
+  }
+}
+
+function asStreamableResponse(
+  writer: MockStreamResponseWriter,
+): Parameters<typeof streamResponseBodyWithByteLimit>[1] {
+  return writer as unknown as Parameters<
+    typeof streamResponseBodyWithByteLimit
+  >[1];
+}
+
+describe("ElevenLabs proxy guards", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("rejects oversized responses from declared content-length", async () => {
+    const response = new Response(new Uint8Array([1, 2, 3]), {
+      headers: { "content-length": "11" },
+    });
+    const writer = new MockStreamResponseWriter();
+
+    await expect(
+      streamResponseBodyWithByteLimit(
+        response,
+        asStreamableResponse(writer),
+        10,
+      ),
+    ).rejects.toThrow("Upstream response exceeds maximum size of 10 bytes");
+  });
+
+  it("rejects oversized streamed responses when content-length is absent", async () => {
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array(8));
+          controller.enqueue(new Uint8Array(8));
+          controller.close();
+        },
+      }),
+    );
+    const writer = new MockStreamResponseWriter();
+
+    await expect(
+      streamResponseBodyWithByteLimit(
+        response,
+        asStreamableResponse(writer),
+        10,
+      ),
+    ).rejects.toThrow("Upstream response exceeds maximum size of 10 bytes");
+  });
+
+  it("streams bounded upstream responses without buffering the full payload", async () => {
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(Uint8Array.from([1, 2, 3]));
+          controller.enqueue(Uint8Array.from([4, 5]));
+          controller.close();
+        },
+      }),
+    );
+    const writer = new MockStreamResponseWriter();
+
+    await expect(
+      streamResponseBodyWithByteLimit(
+        response,
+        asStreamableResponse(writer),
+        10,
+      ),
+    ).resolves.toBe(5);
+    expect(writer.bytes()).toEqual(Buffer.from([1, 2, 3, 4, 5]));
+  });
+
+  it("times out upstream fetches", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (_input: string | URL | Request, init?: RequestInit) => {
+        const signal = init?.signal;
+        return await new Promise<Response>((_resolve, reject) => {
+          if (!signal) {
+            reject(new Error("Missing abort signal"));
+            return;
+          }
+          if (signal.aborted) {
+            reject(new DOMException("Aborted", "AbortError"));
+            return;
+          }
+          signal.addEventListener(
+            "abort",
+            () => {
+              reject(new DOMException("Aborted", "AbortError"));
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+
+    const pending = fetchWithTimeoutGuard("https://example.com/tts", {}, 250);
+    vi.advanceTimersByTime(250);
+
+    await expect(pending).rejects.toMatchObject({
+      message: "Upstream request timed out after 250ms",
+      name: "TimeoutError",
+    });
+  });
+
+  it("times out stalled upstream body streams", async () => {
+    vi.useFakeTimers();
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start() {
+          // Intentionally stall without enqueueing or closing.
+        },
+      }),
+    );
+    const writer = new MockStreamResponseWriter();
+
+    const pending = streamResponseBodyWithByteLimit(
+      response,
+      asStreamableResponse(writer),
+      1024,
+      250,
+    );
+    vi.advanceTimersByTime(250);
+
+    await expect(pending).rejects.toMatchObject({
+      message: "Upstream response body timed out after 250ms",
+      name: "TimeoutError",
+    });
+  });
+});

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -1618,6 +1618,203 @@ const MAX_BODY_BYTES = 1_048_576;
  * (~3–7 MB base64); 20 MB accommodates up to 4 images with room to spare.
  */
 const CHAT_MAX_BODY_BYTES = 20 * 1_048_576;
+const ELEVENLABS_FETCH_TIMEOUT_MS = 20_000;
+const ELEVENLABS_AUDIO_MAX_BYTES = 20 * 1_048_576;
+
+type StreamableServerResponse = Pick<
+  http.ServerResponse,
+  "write" | "once" | "off" | "removeListener"
+> & {
+  writableEnded?: boolean;
+  destroyed?: boolean;
+};
+
+function removeResponseListener(
+  res: StreamableServerResponse,
+  event: "drain" | "error",
+  handler: (...args: unknown[]) => void,
+): void {
+  if (typeof res.off === "function") {
+    res.off(event, handler);
+    return;
+  }
+  if (typeof res.removeListener === "function") {
+    res.removeListener(event, handler);
+  }
+}
+
+function responseContentLength(headers: Pick<Headers, "get">): number | null {
+  const raw = headers.get("content-length");
+  if (!raw) return null;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) return null;
+  return parsed;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException
+    ? error.name === "AbortError" || error.name === "TimeoutError"
+    : error instanceof Error &&
+        (error.name === "AbortError" || error.name === "TimeoutError");
+}
+
+function createTimeoutError(message: string): Error {
+  const timeoutError = new Error(message);
+  timeoutError.name = "TimeoutError";
+  return timeoutError;
+}
+
+export async function fetchWithTimeoutGuard(
+  input: string | URL,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<Response> {
+  const controller = new AbortController();
+  const upstreamSignal = init.signal;
+  let timedOut = false;
+
+  const onAbort = () => {
+    controller.abort();
+  };
+
+  if (upstreamSignal) {
+    if (upstreamSignal.aborted) {
+      controller.abort();
+    } else {
+      upstreamSignal.addEventListener("abort", onAbort, { once: true });
+    }
+  }
+
+  const timeoutHandle = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, timeoutMs);
+
+  try {
+    return await fetch(input, {
+      ...init,
+      signal: controller.signal,
+    });
+  } catch (err) {
+    if (timedOut && isAbortError(err)) {
+      throw createTimeoutError(
+        `Upstream request timed out after ${timeoutMs}ms`,
+      );
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeoutHandle);
+    if (upstreamSignal) {
+      upstreamSignal.removeEventListener("abort", onAbort);
+    }
+  }
+}
+
+async function waitForDrain(res: StreamableServerResponse): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const onDrain = () => {
+      cleanup();
+      resolve();
+    };
+    const onError = (err: unknown) => {
+      cleanup();
+      reject(err instanceof Error ? err : new Error(String(err)));
+    };
+    const cleanup = () => {
+      removeResponseListener(
+        res,
+        "drain",
+        onDrain as (...args: unknown[]) => void,
+      );
+      removeResponseListener(
+        res,
+        "error",
+        onError as (...args: unknown[]) => void,
+      );
+    };
+
+    res.once("drain", onDrain);
+    res.once("error", onError);
+  });
+}
+
+/**
+ * Stream a web Response body to an HTTP response while enforcing a strict byte cap.
+ * Returns the number of bytes forwarded.
+ */
+export async function streamResponseBodyWithByteLimit(
+  upstream: Response,
+  res: StreamableServerResponse,
+  maxBytes: number,
+  timeoutMs?: number,
+): Promise<number> {
+  const declaredLength = responseContentLength(upstream.headers);
+  if (declaredLength !== null && declaredLength > maxBytes) {
+    throw new Error(
+      `Upstream response exceeds maximum size of ${maxBytes} bytes`,
+    );
+  }
+
+  if (!upstream.body) {
+    throw new Error("Upstream response did not include a body stream");
+  }
+
+  const reader = upstream.body.getReader();
+  let totalBytes = 0;
+  let streamTimeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  const streamTimeoutPromise =
+    typeof timeoutMs === "number" && timeoutMs > 0
+      ? new Promise<never>((_resolve, reject) => {
+          streamTimeoutHandle = setTimeout(() => {
+            reject(
+              createTimeoutError(
+                `Upstream response body timed out after ${timeoutMs}ms`,
+              ),
+            );
+          }, timeoutMs);
+        })
+      : null;
+
+  try {
+    while (true) {
+      const { done, value } = streamTimeoutPromise
+        ? await Promise.race([reader.read(), streamTimeoutPromise])
+        : await reader.read();
+      if (done) break;
+      if (!value || value.byteLength === 0) continue;
+
+      totalBytes += value.byteLength;
+      if (totalBytes > maxBytes) {
+        throw new Error(
+          `Upstream response exceeds maximum size of ${maxBytes} bytes`,
+        );
+      }
+
+      if (res.writableEnded || res.destroyed) {
+        throw new Error("Client connection closed while streaming response");
+      }
+
+      const canContinue = res.write(Buffer.from(value));
+      if (!canContinue) {
+        await waitForDrain(res);
+      }
+    }
+  } catch (err) {
+    try {
+      await reader.cancel(err);
+    } catch {
+      // Best effort cleanup; keep original error.
+    }
+    throw err;
+  } finally {
+    if (streamTimeoutHandle !== null) {
+      clearTimeout(streamTimeoutHandle);
+    }
+    reader.releaseLock();
+  }
+
+  return totalBytes;
+}
 
 /**
  * Read and parse a JSON request body with size limits and error handling.
@@ -8479,15 +8676,19 @@ async function handleRequest(
       );
       upstreamUrl.searchParams.set("output_format", outputFormat);
 
-      const upstream = await fetch(upstreamUrl.toString(), {
-        method: "POST",
-        headers: {
-          "xi-api-key": resolvedApiKey,
-          "Content-Type": "application/json",
-          Accept: "audio/mpeg",
+      const upstream = await fetchWithTimeoutGuard(
+        upstreamUrl.toString(),
+        {
+          method: "POST",
+          headers: {
+            "xi-api-key": resolvedApiKey,
+            "Content-Type": "application/json",
+            Accept: "audio/mpeg",
+          },
+          body: JSON.stringify(payload),
         },
-        body: JSON.stringify(payload),
-      });
+        ELEVENLABS_FETCH_TIMEOUT_MS,
+      );
 
       if (!upstream.ok) {
         const upstreamBody = await upstream.text().catch(() => "");
@@ -8499,20 +8700,51 @@ async function handleRequest(
         return;
       }
 
-      const audio = Buffer.from(await upstream.arrayBuffer());
       const contentType = upstream.headers.get("content-type") || "audio/mpeg";
+      const contentLength = responseContentLength(upstream.headers);
+      if (
+        contentLength !== null &&
+        contentLength > ELEVENLABS_AUDIO_MAX_BYTES
+      ) {
+        error(
+          res,
+          `ElevenLabs response exceeds maximum size of ${ELEVENLABS_AUDIO_MAX_BYTES} bytes`,
+          502,
+        );
+        return;
+      }
+
       res.writeHead(200, {
         "Content-Type": contentType,
-        "Content-Length": String(audio.byteLength),
         "Cache-Control": "no-store",
+        ...(contentLength !== null
+          ? { "Content-Length": String(contentLength) }
+          : {}),
       });
-      res.end(audio);
+
+      await streamResponseBodyWithByteLimit(
+        upstream,
+        res,
+        ELEVENLABS_AUDIO_MAX_BYTES,
+        ELEVENLABS_FETCH_TIMEOUT_MS,
+      );
+      res.end();
       return;
     } catch (err) {
+      if (res.headersSent) {
+        res.destroy(
+          err instanceof Error
+            ? err
+            : new Error(
+                `ElevenLabs proxy error: ${typeof err === "string" ? err : String(err)}`,
+              ),
+        );
+        return;
+      }
       error(
         res,
         `ElevenLabs proxy error: ${err instanceof Error ? err.message : String(err)}`,
-        502,
+        isAbortError(err) ? 504 : 502,
       );
       return;
     }


### PR DESCRIPTION
## Summary
- stream ElevenLabs upstream audio instead of buffering full payload in memory
- enforce strict upstream audio byte caps (declared content-length and streamed overflow)
- enforce timeout for both initial fetch and full upstream body streaming window
- return 504 for upstream timeout conditions
- add regression tests for capped reads and stalled stream timeout

## Validation
- bunx @biomejs/biome check src/api/server.ts src/api/server.elevenlabs-proxy-guard.test.ts
- bun test src/api/server.elevenlabs-proxy-guard.test.ts
- bun test src/api/server.hyperscape-auth-header.test.ts
- bun test src/api/server.terminal-client-scope.test.ts