### PR TITLE
fix(pre-review): avoid false failures on no-diff branches

### DIFF
--- a/scripts/pre-review-local.mjs
+++ b/scripts/pre-review-local.mjs
@@ -224,6 +224,21 @@ export function runChecks() {
     };
   }
 
+  if (changed.files.length === 0) {
+    return {
+      classification: "other",
+      scopeVerdict: "in scope",
+      codeQuality: "pass",
+      security: "clear",
+      tests: "not applicable: no files changed compared to base branch.",
+      decision: "APPROVE",
+      checklist: [],
+      details: [],
+      changedFiles: [],
+      exitCode: 0,
+    };
+  }
+
   const issues = scanForBlockedDiffPatterns(base, changed.files);
 
   const checks = [


### PR DESCRIPTION
## Summary
- return `APPROVE` when `pre-review:local` sees no `BASE...HEAD` file changes
- classify this path as `other` with explicit non-applicable test message
- add regression test that creates a temp git repo and verifies no-diff branches are approved

## Why
`pre-review:local` previously returned `REQUEST CHANGES` for fresh branches with no commits, which created false negatives during local review loops.

## Validation
- `bun run lint`
- `bun run typecheck`
- `bunx vitest run src/runtime/pre-review-local.test.ts`
- `bun run pre-review:local`
