### PR TITLE
app: improve chat send and image remove controls

### DIFF
--- a/apps/app/src/components/ChatView.tsx
+++ b/apps/app/src/components/ChatView.tsx
@@ -494,8 +494,9 @@ export function ChatView() {
               <button
                 type="button"
                 title="Remove image"
+                aria-label={`Remove image ${img.name}`}
                 onClick={() => removeImage(i)}
-                className="absolute -top-1.5 -right-1.5 w-4 h-4 rounded-full bg-danger text-white text-[10px] flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
+                className="absolute -top-1.5 -right-1.5 w-4 h-4 rounded-full bg-danger text-white text-[10px] flex items-center justify-center opacity-100 sm:opacity-0 sm:group-hover:opacity-100 focus-visible:opacity-100 transition-opacity cursor-pointer"
               >
                 ×
               </button>
@@ -650,7 +651,7 @@ export function ChatView() {
             type="button"
             className="h-[38px] shrink-0 px-4 sm:px-6 py-2 border border-accent bg-accent text-accent-fg text-sm cursor-pointer hover:bg-accent-hover disabled:opacity-40 disabled:cursor-not-allowed self-end"
             onClick={() => void handleChatSend()}
-            disabled={chatSending}
+            disabled={chatSending || !chatInput.trim()}
           >
             Send
           </button>

--- a/apps/app/test/app/chat-view.test.tsx
+++ b/apps/app/test/app/chat-view.test.tsx
@@ -427,6 +427,47 @@ describe("ChatView", () => {
     );
     expect(micButton.props["aria-pressed"]).toBe(false);
   });
+
+  it("disables send when chat input is empty or whitespace", async () => {
+    mockUseApp.mockReturnValue(createContext({ chatInput: "   " }));
+
+    let tree: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      tree = TestRenderer.create(React.createElement(ChatView));
+    });
+    await flush();
+
+    const sendButton = tree?.root.find(
+      (node) => node.type === "button" && text(node) === "Send",
+    );
+    expect(sendButton.props.disabled).toBe(true);
+  });
+
+  it("renders a labeled pending-image remove button that stays visible on mobile", async () => {
+    mockUseApp.mockReturnValue(
+      createContext({
+        chatPendingImages: [
+          { data: "abc123", mimeType: "image/png", name: "receipt.png" },
+        ],
+      }),
+    );
+
+    let tree: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      tree = TestRenderer.create(React.createElement(ChatView));
+    });
+    await flush();
+
+    const removeButton = tree?.root.find(
+      (node) =>
+        node.type === "button" &&
+        node.props["aria-label"] === "Remove image receipt.png",
+    );
+
+    expect(removeButton.props["aria-label"]).toBe("Remove image receipt.png");
+    expect(String(removeButton.props.className)).toContain("opacity-100");
+    expect(String(removeButton.props.className)).toContain("sm:opacity-0");
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary\n- disable chat Send when input is empty/whitespace so UI matches submit behavior\n- improve pending-image remove control usability on touch/mobile and keyboard focus\n- add ChatView tests covering both behaviors\n\n## Testing\n- bunx vitest run apps/app/test/app/chat-view.test.tsx