### PR TITLE
feat: add claude-code-workbench plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "@lunchtable/plugin-ltcg": "0.1.0",
     "@mariozechner/pi-ai": "0.52.12",
     "@mariozechner/pi-tui": "0.54.0",
+    "@milaidy/plugin-claude-code-workbench": "workspace:*",
     "@milaidy/plugin-coding-agent": "workspace:*",
     "@noble/curves": "^2.0.1",
     "adze": "^2.2.5",

--- a/packages/plugin-claude-code-workbench/README.md
+++ b/packages/plugin-claude-code-workbench/README.md
@@ -1,0 +1,59 @@
+# @milaidy/plugin-claude-code-workbench
+
+Claude Code companion plugin for Milady/ElizaOS.
+
+This plugin provides an allowlisted, policy-controlled workflow runner for this repository so agents can execute common quality/build/test/review tasks safely.
+
+## What it adds
+
+- **Service**: `claude_code_workbench` (`ClaudeCodeWorkbenchService`)
+- **Actions**:
+  - `CLAUDE_CODE_WORKBENCH_RUN`
+  - `CLAUDE_CODE_WORKBENCH_LIST`
+- **Provider**: `CLAUDE_CODE_WORKBENCH_STATUS`
+- **Routes**:
+  - `GET /claude-code-workbench/status`
+  - `GET /claude-code-workbench/workflows`
+  - `POST /claude-code-workbench/run`
+
+## Default workflows
+
+Includes repo-specific workflows such as:
+
+- `repo_status`, `repo_diff_stat`, `recent_commits`
+- `check`, `typecheck`, `lint`
+- `test_once`, `test_e2e`
+- `pre_review_local`
+- `build_local_plugins`, `build`, `docs_build`
+- `format_fix`, `lint_fix` (mutating; disabled by default)
+
+## Configuration
+
+Set via plugin config or environment variables:
+
+- `CLAUDE_CODE_WORKBENCH_WORKSPACE_ROOT` (default: process cwd)
+- `CLAUDE_CODE_WORKBENCH_TIMEOUT_MS` (default: `600000`)
+- `CLAUDE_CODE_WORKBENCH_MAX_OUTPUT_CHARS` (default: `120000`)
+- `CLAUDE_CODE_WORKBENCH_MAX_STDIN_BYTES` (default: `65536`)
+- `CLAUDE_CODE_WORKBENCH_ALLOWED_WORKFLOWS` (default: `*`)
+- `CLAUDE_CODE_WORKBENCH_ENABLE_MUTATING_WORKFLOWS` (default: `false`)
+
+## Action usage
+
+You can invoke through options or natural text:
+
+- `workbench run check`
+- `ccw pre_review_local`
+
+## Security model
+
+- Uses `spawn` with `shell: false`
+- Enforces workflow allowlist
+- Enforces workspace-root cwd boundaries
+- Enforces timeout and output caps
+- Serializes runs to avoid overlapping command execution
+- Mutating workflows require explicit opt-in
+
+## Claude Code construction notes
+
+Claude Code extension points are primarily MCP servers, hooks, custom slash commands, settings/policies, and subagents. This plugin is designed as a runtime-side companion that can back those extension points with deterministic repository workflows.

--- a/packages/plugin-claude-code-workbench/build.ts
+++ b/packages/plugin-claude-code-workbench/build.ts
@@ -1,0 +1,92 @@
+#!/usr/bin/env bun
+/**
+ * Self-contained build script for Claude Code workbench plugin
+ */
+
+import { existsSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { $ } from "bun";
+
+async function cleanBuild(outdir = "dist") {
+  if (existsSync(outdir)) {
+    await rm(outdir, { recursive: true, force: true });
+    console.log(`✓ Cleaned ${outdir} directory`);
+  }
+}
+
+async function build() {
+  const start = performance.now();
+  console.log("🚀 Building plugin-claude-code-workbench...");
+
+  try {
+    await cleanBuild("dist");
+
+    console.log("Starting build tasks...");
+
+    const [buildResult] = await Promise.all([
+      (async () => {
+        console.log("📦 Bundling with Bun...");
+        const result = await Bun.build({
+          entrypoints: ["./src/index.ts"],
+          outdir: "./dist",
+          target: "node",
+          format: "esm",
+          sourcemap: true,
+          minify: false,
+          external: ["node:*", "@elizaos/core", "zod"],
+          naming: {
+            entry: "[dir]/[name].[ext]",
+          },
+        });
+
+        if (!result.success) {
+          console.error("✗ Build failed:", result.logs);
+          return { success: false, outputs: [] };
+        }
+
+        const totalSize = result.outputs.reduce(
+          (sum, output) => sum + output.size,
+          0,
+        );
+        const sizeMB = (totalSize / 1024 / 1024).toFixed(2);
+        console.log(`✓ Built ${result.outputs.length} file(s) - ${sizeMB}MB`);
+
+        return result;
+      })(),
+
+      (async () => {
+        console.log("📝 Generating TypeScript declarations...");
+        try {
+          await $`bunx tsc --emitDeclarationOnly --incremental --project ./tsconfig.build.json`.quiet();
+          console.log("✓ TypeScript declarations generated");
+          return { success: true };
+        } catch {
+          console.warn("⚠ Failed to generate TypeScript declarations");
+          return { success: false };
+        }
+      })(),
+    ]);
+
+    if (!buildResult.success) {
+      return false;
+    }
+
+    const elapsed = ((performance.now() - start) / 1000).toFixed(2);
+    console.log(`✅ Build complete! (${elapsed}s)`);
+    return true;
+  } catch (error) {
+    console.error("Build error:", error);
+    return false;
+  }
+}
+
+build()
+  .then((success) => {
+    if (!success) {
+      process.exit(1);
+    }
+  })
+  .catch((error) => {
+    console.error("Build script error:", error);
+    process.exit(1);
+  });

--- a/packages/plugin-claude-code-workbench/bunfig.toml
+++ b/packages/plugin-claude-code-workbench/bunfig.toml
@@ -1,0 +1,10 @@
+[test]
+timeout = 60000
+coverage = true
+
+[test.env]
+NODE_ENV = "test"
+
+coverage-exclude = [
+  "**/dist/**",
+]

--- a/packages/plugin-claude-code-workbench/package.json
+++ b/packages/plugin-claude-code-workbench/package.json
@@ -1,0 +1,92 @@
+{
+  "name": "@milaidy/plugin-claude-code-workbench",
+  "description": "Claude Code companion workflow plugin for Milady/ElizaOS",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "packageType": "plugin",
+  "platform": "node",
+  "license": "MIT",
+  "keywords": [
+    "plugin",
+    "elizaos",
+    "claude-code",
+    "workflow",
+    "milady"
+  ],
+  "homepage": "https://github.com/milady-ai/milady",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "package.json"
+  ],
+  "dependencies": {
+    "@elizaos/core": "next",
+    "zod": "^4.3.5"
+  },
+  "devDependencies": {
+    "dotenv": "^17.2.3",
+    "prettier": "^3.7.4",
+    "typescript": "^5.9.3"
+  },
+  "scripts": {
+    "start": "elizaos start",
+    "dev": "elizaos dev",
+    "build": "bun run build.ts",
+    "build:watch": "bun run build.ts --watch",
+    "test": "bun test",
+    "format": "prettier --write ./src"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "resolutions": {
+    "zod": "4.3.5"
+  },
+  "agentConfig": {
+    "pluginType": "elizaos:plugin:1.0.0",
+    "pluginParameters": {
+      "CLAUDE_CODE_WORKBENCH_WORKSPACE_ROOT": {
+        "type": "string",
+        "description": "Workspace root for workflow execution (default: cwd)",
+        "required": false
+      },
+      "CLAUDE_CODE_WORKBENCH_TIMEOUT_MS": {
+        "type": "number",
+        "description": "Timeout per workflow run in milliseconds",
+        "required": false
+      },
+      "CLAUDE_CODE_WORKBENCH_MAX_OUTPUT_CHARS": {
+        "type": "number",
+        "description": "Maximum stdout/stderr characters captured per run",
+        "required": false
+      },
+      "CLAUDE_CODE_WORKBENCH_MAX_STDIN_BYTES": {
+        "type": "number",
+        "description": "Maximum stdin bytes accepted per run",
+        "required": false
+      },
+      "CLAUDE_CODE_WORKBENCH_ALLOWED_WORKFLOWS": {
+        "type": "string",
+        "description": "Comma-separated allowlist of workflow ids. Use '*' for all.",
+        "required": false
+      },
+      "CLAUDE_CODE_WORKBENCH_ENABLE_MUTATING_WORKFLOWS": {
+        "type": "boolean",
+        "description": "Allow workflows that can change repository files",
+        "required": false
+      }
+    }
+  }
+}

--- a/packages/plugin-claude-code-workbench/src/__tests__/actions.test.ts
+++ b/packages/plugin-claude-code-workbench/src/__tests__/actions.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test";
+import type { Memory } from "@elizaos/core";
+import { extractRunInput } from "../actions/run-workflow.ts";
+
+function makeMemory(text: string): Memory {
+  return {
+    id: "memory-id",
+    content: {
+      text,
+      source: "test",
+    },
+  } as unknown as Memory;
+}
+
+describe("workbench actions", () => {
+  it("extractRunInput prefers explicit workflow options", () => {
+    const input = extractRunInput(makeMemory("ignored"), {
+      workflow: "check",
+      cwd: "/tmp/workspace",
+    });
+
+    expect(input).toEqual({
+      workflow: "check",
+      cwd: "/tmp/workspace",
+      stdin: undefined,
+    });
+  });
+
+  it("extractRunInput parses workbench command text", () => {
+    const input = extractRunInput(
+      makeMemory("workbench run pre_review_local"),
+      {},
+    );
+
+    expect(input).toEqual({
+      workflow: "pre_review_local",
+      cwd: undefined,
+      stdin: undefined,
+    });
+  });
+
+  it("extractRunInput parses shorthand alias", () => {
+    const input = extractRunInput(makeMemory("ccw check"), {});
+
+    expect(input).toEqual({
+      workflow: "check",
+      cwd: undefined,
+      stdin: undefined,
+    });
+  });
+
+  it("extractRunInput returns null for unrelated text", () => {
+    expect(extractRunInput(makeMemory("hello world"), {})).toBeNull();
+  });
+});

--- a/packages/plugin-claude-code-workbench/src/__tests__/config.test.ts
+++ b/packages/plugin-claude-code-workbench/src/__tests__/config.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test";
+import {
+  DEFAULT_WORKBENCH_WORKFLOWS,
+  isWorkflowAllowed,
+  loadClaudeCodeWorkbenchConfig,
+} from "../config.ts";
+
+describe("plugin-claude-code-workbench config", () => {
+  it("uses defaults when config is empty", () => {
+    const config = loadClaudeCodeWorkbenchConfig({});
+
+    expect(config.timeoutMs).toBe(10 * 60_000);
+    expect(config.maxOutputChars).toBe(120_000);
+    expect(config.maxStdinBytes).toBe(64 * 1024);
+    expect(config.allowedWorkflowIds).toEqual(["*"]);
+    expect(config.enableMutatingWorkflows).toBe(false);
+  });
+
+  it("parses allowlist values", () => {
+    const config = loadClaudeCodeWorkbenchConfig({
+      CLAUDE_CODE_WORKBENCH_ALLOWED_WORKFLOWS: " check , Pre.Review Local ",
+    });
+
+    expect(config.allowedWorkflowIds).toEqual(["check", "pre_review_local"]);
+  });
+
+  it("parses boolean for mutating workflows", () => {
+    const config = loadClaudeCodeWorkbenchConfig({
+      CLAUDE_CODE_WORKBENCH_ENABLE_MUTATING_WORKFLOWS: "true",
+    });
+
+    expect(config.enableMutatingWorkflows).toBe(true);
+  });
+
+  it("rejects invalid timeout values", () => {
+    expect(() =>
+      loadClaudeCodeWorkbenchConfig({
+        CLAUDE_CODE_WORKBENCH_TIMEOUT_MS: "100",
+      }),
+    ).toThrow();
+  });
+
+  it("exports default workflow ids", () => {
+    expect(DEFAULT_WORKBENCH_WORKFLOWS.length).toBeGreaterThan(5);
+  });
+});
+
+describe("workflow allowlist helper", () => {
+  it("supports wildcard allowlist", () => {
+    expect(isWorkflowAllowed("check", ["*"])).toBe(true);
+  });
+
+  it("matches normalized workflow ids", () => {
+    expect(isWorkflowAllowed("Pre.Review Local", ["pre_review_local"])).toBe(
+      true,
+    );
+    expect(isWorkflowAllowed("check", ["pre_review_local"])).toBe(false);
+  });
+});

--- a/packages/plugin-claude-code-workbench/src/__tests__/plugin.test.ts
+++ b/packages/plugin-claude-code-workbench/src/__tests__/plugin.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import type { IAgentRuntime } from "@elizaos/core";
+import { loadClaudeCodeWorkbenchConfig } from "../config.ts";
+import { claudeCodeWorkbenchPlugin } from "../plugin.ts";
+
+const runtime = {} as IAgentRuntime;
+
+describe("claudeCodeWorkbenchPlugin", () => {
+  beforeEach(() => {
+    delete process.env.CLAUDE_CODE_WORKBENCH_WORKSPACE_ROOT;
+    delete process.env.CLAUDE_CODE_WORKBENCH_TIMEOUT_MS;
+    delete process.env.CLAUDE_CODE_WORKBENCH_ALLOWED_WORKFLOWS;
+    delete process.env.CLAUDE_CODE_WORKBENCH_ENABLE_MUTATING_WORKFLOWS;
+  });
+
+  it("exposes expected plugin metadata and wiring", () => {
+    expect(claudeCodeWorkbenchPlugin.name).toBe("claude-code-workbench");
+    expect(claudeCodeWorkbenchPlugin.description).toContain("Claude Code");
+    expect(claudeCodeWorkbenchPlugin.services?.length).toBe(1);
+    expect(claudeCodeWorkbenchPlugin.actions?.length).toBe(2);
+    expect(claudeCodeWorkbenchPlugin.providers?.[0]?.name).toBe(
+      "CLAUDE_CODE_WORKBENCH_STATUS",
+    );
+    expect(claudeCodeWorkbenchPlugin.routes?.length).toBe(3);
+  });
+
+  it("initializes config values and writes only prefixed env vars", async () => {
+    if (!claudeCodeWorkbenchPlugin.init) {
+      throw new Error("claudeCodeWorkbenchPlugin.init missing");
+    }
+
+    await claudeCodeWorkbenchPlugin.init(
+      {
+        CLAUDE_CODE_WORKBENCH_TIMEOUT_MS: "30000",
+        CLAUDE_CODE_WORKBENCH_ALLOWED_WORKFLOWS: "check,pre_review_local",
+        NODE_OPTIONS: "--inspect=0.0.0.0:9229",
+      },
+      runtime,
+    );
+
+    expect(process.env.CLAUDE_CODE_WORKBENCH_TIMEOUT_MS).toBe("30000");
+    expect(process.env.NODE_OPTIONS).toBeUndefined();
+
+    const loaded = loadClaudeCodeWorkbenchConfig(process.env);
+    expect(loaded.timeoutMs).toBe(30_000);
+    expect(loaded.allowedWorkflowIds).toEqual(["check", "pre_review_local"]);
+  });
+
+  it("throws config error when values are invalid", async () => {
+    if (!claudeCodeWorkbenchPlugin.init) {
+      throw new Error("claudeCodeWorkbenchPlugin.init missing");
+    }
+
+    await expect(
+      claudeCodeWorkbenchPlugin.init(
+        {
+          CLAUDE_CODE_WORKBENCH_TIMEOUT_MS: "10",
+        },
+        runtime,
+      ),
+    ).rejects.toThrow("configuration error");
+  });
+});

--- a/packages/plugin-claude-code-workbench/src/__tests__/routes.test.ts
+++ b/packages/plugin-claude-code-workbench/src/__tests__/routes.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "bun:test";
+import type { IAgentRuntime, RouteRequest, RouteResponse } from "@elizaos/core";
+import { claudeCodeWorkbenchRoutes } from "../routes.ts";
+import type { WorkbenchRunResult } from "../services/workbench-service.ts";
+
+function createResponseRecorder(): {
+  res: RouteResponse;
+  statusCode: () => number;
+  body: () => unknown;
+} {
+  let code = 200;
+  let payload: unknown;
+
+  const res: RouteResponse = {
+    status(nextCode: number) {
+      code = nextCode;
+      return this;
+    },
+    json(data: unknown) {
+      payload = data;
+      return this;
+    },
+    send(data: unknown) {
+      payload = data;
+      return this;
+    },
+    end() {
+      return this;
+    },
+  };
+
+  return {
+    res,
+    statusCode: () => code,
+    body: () => payload,
+  };
+}
+
+function findRoute(path: string) {
+  const route = claudeCodeWorkbenchRoutes.find((entry) => entry.path === path);
+  if (!route || !route.handler) {
+    throw new Error(`Missing route: ${path}`);
+  }
+  return route;
+}
+
+describe("claudeCodeWorkbenchRoutes", () => {
+  it("declares routes as private", () => {
+    for (const route of claudeCodeWorkbenchRoutes) {
+      expect(route.public).toBe(false);
+    }
+  });
+
+  it("returns status data", async () => {
+    const route = findRoute("/status");
+    const recorder = createResponseRecorder();
+
+    const runtime = {
+      getService: () => ({
+        getStatus: () => ({ available: true, timeoutMs: 1000 }),
+      }),
+    } as unknown as IAgentRuntime;
+
+    await route.handler({} as RouteRequest, recorder.res, runtime);
+
+    expect(recorder.statusCode()).toBe(200);
+    expect(recorder.body()).toEqual({
+      ok: true,
+      status: { available: true, timeoutMs: 1000 },
+    });
+  });
+
+  it("returns workflows data", async () => {
+    const route = findRoute("/workflows");
+    const recorder = createResponseRecorder();
+
+    const runtime = {
+      getService: () => ({
+        listWorkflows: () => [{ id: "check", enabled: true }],
+      }),
+    } as unknown as IAgentRuntime;
+
+    await route.handler({} as RouteRequest, recorder.res, runtime);
+
+    expect(recorder.statusCode()).toBe(200);
+    expect(recorder.body()).toEqual({
+      ok: true,
+      workflows: [{ id: "check", enabled: true }],
+    });
+  });
+
+  it("returns 400 for invalid run payload", async () => {
+    const route = findRoute("/run");
+    const recorder = createResponseRecorder();
+
+    const runtime = {
+      getService: () => ({
+        run: async () => {
+          throw new Error("should not run");
+        },
+      }),
+    } as unknown as IAgentRuntime;
+
+    await route.handler({ body: {} } as RouteRequest, recorder.res, runtime);
+
+    expect(recorder.statusCode()).toBe(400);
+    expect(recorder.body()).toEqual({
+      ok: false,
+      error:
+        "Invalid run request. Provide non-empty `workflow` in request body.",
+    });
+  });
+
+  it("runs workflow and returns result", async () => {
+    const route = findRoute("/run");
+    const recorder = createResponseRecorder();
+
+    const result: WorkbenchRunResult = {
+      ok: true,
+      workflow: "check",
+      command: "bun",
+      args: ["run", "check"],
+      exitCode: 0,
+      stdout: "ok",
+      stderr: "",
+      durationMs: 12,
+      timedOut: false,
+      stdoutTruncated: false,
+      stderrTruncated: false,
+    };
+
+    const runtime = {
+      getService: () => ({
+        run: async () => result,
+      }),
+    } as unknown as IAgentRuntime;
+
+    await route.handler(
+      { body: { workflow: "check" } } as RouteRequest,
+      recorder.res,
+      runtime,
+    );
+
+    expect(recorder.statusCode()).toBe(200);
+    expect(recorder.body()).toEqual({ ok: true, result });
+  });
+});

--- a/packages/plugin-claude-code-workbench/src/__tests__/service.test.ts
+++ b/packages/plugin-claude-code-workbench/src/__tests__/service.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "bun:test";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { IAgentRuntime } from "@elizaos/core";
+import type { ClaudeCodeWorkbenchConfig } from "../config.ts";
+import { ClaudeCodeWorkbenchService } from "../services/workbench-service.ts";
+import type { WorkbenchWorkflow } from "../workflows.ts";
+
+const mockRuntime = {} as IAgentRuntime;
+
+function makeWorkflow(
+  overrides: Partial<WorkbenchWorkflow>,
+): WorkbenchWorkflow {
+  return {
+    id: "echo_ok",
+    title: "Echo",
+    description: "Echo test",
+    category: "test",
+    command: process.execPath,
+    args: ["-e", "process.stdout.write('ok')"],
+    mutatesRepo: false,
+    ...overrides,
+  };
+}
+
+function makeConfig(
+  workspaceRoot: string,
+  overrides: Partial<ClaudeCodeWorkbenchConfig> = {},
+): ClaudeCodeWorkbenchConfig {
+  return {
+    workspaceRoot,
+    timeoutMs: 2_000,
+    maxOutputChars: 5_000,
+    maxStdinBytes: 8_192,
+    allowedWorkflowIds: ["*"],
+    enableMutatingWorkflows: false,
+    ...overrides,
+  };
+}
+
+describe("ClaudeCodeWorkbenchService", () => {
+  it("runs allowed workflows and captures output", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "ccw-root-"));
+    const service = new ClaudeCodeWorkbenchService(
+      mockRuntime,
+      makeConfig(root),
+      [makeWorkflow({})],
+    );
+
+    const result = await service.run({ workflow: "echo_ok" });
+
+    expect(result.ok).toBe(true);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("ok");
+  });
+
+  it("rejects unknown workflows", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "ccw-root-"));
+    const service = new ClaudeCodeWorkbenchService(
+      mockRuntime,
+      makeConfig(root),
+      [makeWorkflow({})],
+    );
+
+    await expect(service.run({ workflow: "missing" })).rejects.toThrow(
+      "Unknown workflow",
+    );
+  });
+
+  it("blocks mutating workflows when disabled", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "ccw-root-"));
+    const service = new ClaudeCodeWorkbenchService(
+      mockRuntime,
+      makeConfig(root, { enableMutatingWorkflows: false }),
+      [makeWorkflow({ id: "mutating", mutatesRepo: true })],
+    );
+
+    await expect(service.run({ workflow: "mutating" })).rejects.toThrow(
+      "mutates the repository",
+    );
+  });
+
+  it("allows mutating workflows when explicitly enabled", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "ccw-root-"));
+    const service = new ClaudeCodeWorkbenchService(
+      mockRuntime,
+      makeConfig(root, { enableMutatingWorkflows: true }),
+      [makeWorkflow({ id: "mutating", mutatesRepo: true })],
+    );
+
+    const result = await service.run({ workflow: "mutating" });
+    expect(result.ok).toBe(true);
+  });
+
+  it("enforces timeout and marks result as timed out", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "ccw-root-"));
+    const service = new ClaudeCodeWorkbenchService(
+      mockRuntime,
+      makeConfig(root, { timeoutMs: 100 }),
+      [
+        makeWorkflow({
+          id: "slow",
+          args: ["-e", 'setTimeout(() => process.stdout.write("done"), 3000)'],
+        }),
+      ],
+    );
+
+    const result = await service.run({ workflow: "slow" });
+
+    expect(result.ok).toBe(false);
+    expect(result.timedOut).toBe(true);
+    expect(result.stderr).toContain("timed out");
+  });
+
+  it("caps output size and flags truncation", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "ccw-root-"));
+    const service = new ClaudeCodeWorkbenchService(
+      mockRuntime,
+      makeConfig(root, { maxOutputChars: 20 }),
+      [
+        makeWorkflow({
+          id: "large",
+          args: [
+            "-e",
+            "process.stdout.write('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')",
+          ],
+        }),
+      ],
+    );
+
+    const result = await service.run({ workflow: "large" });
+
+    expect(result.ok).toBe(true);
+    expect(result.stdoutTruncated).toBe(true);
+    expect(result.stdout).toContain(
+      "[truncated by plugin-claude-code-workbench]",
+    );
+  });
+
+  it("rejects cwd outside workspace root", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "ccw-root-"));
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), "ccw-outside-"));
+    const service = new ClaudeCodeWorkbenchService(
+      mockRuntime,
+      makeConfig(root),
+      [makeWorkflow({})],
+    );
+
+    await expect(
+      service.run({ workflow: "echo_ok", cwd: outside }),
+    ).rejects.toThrow("CLAUDE_CODE_WORKBENCH_WORKSPACE_ROOT");
+  });
+
+  it("exposes last run metadata in status", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "ccw-root-"));
+    const service = new ClaudeCodeWorkbenchService(
+      mockRuntime,
+      makeConfig(root),
+      [makeWorkflow({})],
+    );
+
+    const before = service.getStatus();
+    expect(before.lastRunAt).toBeUndefined();
+
+    await service.run({ workflow: "echo_ok" });
+
+    const after = service.getStatus();
+    expect(after.lastRunAt).toBeNumber();
+    expect(after.lastWorkflow).toBe("echo_ok");
+    expect(after.lastExitCode).toBe(0);
+  });
+});

--- a/packages/plugin-claude-code-workbench/src/__tests__/workflows.test.ts
+++ b/packages/plugin-claude-code-workbench/src/__tests__/workflows.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "bun:test";
+import {
+  getDefaultWorkflowIds,
+  listDefaultWorkflows,
+  normalizeWorkflowId,
+} from "../workflows.ts";
+
+describe("plugin-claude-code-workbench workflows", () => {
+  it("contains unique workflow ids", () => {
+    const ids = getDefaultWorkflowIds();
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("includes key repo workflows", () => {
+    const ids = getDefaultWorkflowIds();
+    expect(ids).toContain("check");
+    expect(ids).toContain("pre_review_local");
+    expect(ids).toContain("build_local_plugins");
+  });
+
+  it("returns cloned workflow args", () => {
+    const workflows = listDefaultWorkflows();
+    const first = workflows[0];
+    first.args.push("--x");
+
+    const fresh = listDefaultWorkflows()[0];
+    expect(fresh.args).not.toContain("--x");
+  });
+
+  it("normalizes workflow ids", () => {
+    expect(normalizeWorkflowId(" Pre.Review Local ")).toBe("pre_review_local");
+  });
+});

--- a/packages/plugin-claude-code-workbench/src/actions/list-workflows.ts
+++ b/packages/plugin-claude-code-workbench/src/actions/list-workflows.ts
@@ -1,0 +1,92 @@
+import type {
+  Action,
+  ActionResult,
+  HandlerCallback,
+  IAgentRuntime,
+  Memory,
+  State,
+} from "@elizaos/core";
+import type { ClaudeCodeWorkbenchService } from "../services/workbench-service.ts";
+
+function toText(service: ClaudeCodeWorkbenchService): string {
+  const workflows = service.listWorkflows();
+  if (workflows.length === 0) {
+    return "No workbench workflows are available.";
+  }
+
+  const lines = ["Available workbench workflows:"];
+  for (const workflow of workflows) {
+    const mutating = workflow.mutatesRepo ? " [mutates repo]" : "";
+    const disabled = workflow.enabled ? "" : " [disabled]";
+    lines.push(
+      `- ${workflow.id}${mutating}${disabled}: ${workflow.description}`,
+    );
+  }
+
+  return lines.join("\n");
+}
+
+export const claudeCodeWorkbenchListAction: Action = {
+  name: "CLAUDE_CODE_WORKBENCH_LIST",
+  similes: ["LIST_WORKBENCH_WORKFLOWS", "WORKBENCH_LIST", "CCW_LIST"],
+  description: "List available Claude Code workbench workflows.",
+
+  validate: async (
+    runtime: IAgentRuntime,
+    _message: Memory,
+    _state: State | undefined,
+  ): Promise<boolean> => {
+    return Boolean(runtime.getService("claude_code_workbench"));
+  },
+
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    _state: State | undefined,
+    _options: Record<string, unknown> = {},
+    callback?: HandlerCallback,
+  ): Promise<ActionResult> => {
+    const service = runtime.getService(
+      "claude_code_workbench",
+    ) as ClaudeCodeWorkbenchService | null;
+
+    if (!service) {
+      const error =
+        "Claude Code workbench service is not available. Ensure plugin-claude-code-workbench is enabled.";
+      if (callback) {
+        await callback({ text: error, source: message.content.source });
+      }
+      return { success: false, error };
+    }
+
+    const text = toText(service);
+
+    if (callback) {
+      await callback({ text, source: message.content.source });
+    }
+
+    return {
+      success: true,
+      text,
+      data: { workflows: service.listWorkflows() },
+    };
+  },
+
+  examples: [
+    [
+      {
+        name: "{{name1}}",
+        content: {
+          text: "List workbench workflows",
+        },
+      },
+      {
+        name: "{{name2}}",
+        content: {
+          text: "Available workbench workflows:",
+          actions: ["CLAUDE_CODE_WORKBENCH_LIST"],
+        },
+      },
+    ],
+  ],
+};

--- a/packages/plugin-claude-code-workbench/src/actions/run-workflow.ts
+++ b/packages/plugin-claude-code-workbench/src/actions/run-workflow.ts
@@ -1,0 +1,185 @@
+import {
+  type Action,
+  type ActionResult,
+  type HandlerCallback,
+  type IAgentRuntime,
+  logger,
+  type Memory,
+  type State,
+} from "@elizaos/core";
+import type {
+  ClaudeCodeWorkbenchService,
+  WorkbenchRunInput,
+  WorkbenchRunResult,
+} from "../services/workbench-service.ts";
+
+interface WorkbenchRunActionOptions extends Record<string, unknown> {
+  workflow?: string;
+  cwd?: string;
+  stdin?: string;
+}
+
+function normalizeString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+export function extractRunInput(
+  message: Memory,
+  options: WorkbenchRunActionOptions,
+): WorkbenchRunInput | null {
+  const workflow = normalizeString(options.workflow);
+  const base: WorkbenchRunInput = {
+    workflow: workflow ?? "",
+    cwd: normalizeString(options.cwd),
+    stdin: normalizeString(options.stdin),
+  };
+
+  if (workflow) {
+    return base;
+  }
+
+  const rawText = normalizeString(message.content?.text);
+  if (!rawText) {
+    return null;
+  }
+
+  const match = rawText.match(
+    /^(?:\/)?(?:workbench|claude-workbench|ccw)\s+(?:run\s+)?([a-zA-Z0-9._-]+)/i,
+  );
+  if (!match?.[1]) {
+    return null;
+  }
+
+  return {
+    ...base,
+    workflow: match[1],
+  };
+}
+
+function summarizeResult(result: WorkbenchRunResult): string {
+  const status = result.ok
+    ? `✅ Workflow ${result.workflow} completed.`
+    : `❌ Workflow ${result.workflow} failed.`;
+
+  const outputSource = (
+    result.ok ? result.stdout : result.stderr || result.stdout
+  ).trim();
+
+  if (!outputSource) {
+    return status;
+  }
+
+  const preview = outputSource.slice(0, 800);
+  const suffix = outputSource.length > 800 ? "\n…" : "";
+  return `${status}\n\n${preview}${suffix}`;
+}
+
+export const claudeCodeWorkbenchRunAction: Action = {
+  name: "CLAUDE_CODE_WORKBENCH_RUN",
+  similes: ["RUN_WORKBENCH_WORKFLOW", "WORKBENCH_RUN", "CCW_RUN"],
+  description:
+    "Run an allowlisted repo workflow through the Claude Code workbench service.",
+
+  validate: async (
+    runtime: IAgentRuntime,
+    _message: Memory,
+    _state: State | undefined,
+  ): Promise<boolean> => {
+    return Boolean(runtime.getService("claude_code_workbench"));
+  },
+
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    _state: State | undefined,
+    options: Record<string, unknown> = {},
+    callback?: HandlerCallback,
+  ): Promise<ActionResult> => {
+    const service = runtime.getService(
+      "claude_code_workbench",
+    ) as ClaudeCodeWorkbenchService | null;
+
+    if (!service) {
+      const error =
+        "Claude Code workbench service is not available. Ensure plugin-claude-code-workbench is enabled.";
+      if (callback) {
+        await callback({ text: error, source: message.content.source });
+      }
+      return { success: false, error };
+    }
+
+    const runInput = extractRunInput(
+      message,
+      options as WorkbenchRunActionOptions,
+    );
+
+    if (!runInput) {
+      const error =
+        "No workflow provided. Pass `workflow` in options or use message text like `workbench run check`.";
+      if (callback) {
+        await callback({ text: error, source: message.content.source });
+      }
+      return { success: false, error };
+    }
+
+    try {
+      const result = await service.run(runInput);
+      const text = summarizeResult(result);
+
+      if (callback) {
+        await callback({ text, source: message.content.source });
+      }
+
+      return {
+        success: result.ok,
+        text,
+        data: { ...result },
+        ...(result.ok
+          ? {}
+          : {
+              error:
+                result.stderr ||
+                `Workflow ${result.workflow} exited with code ${String(result.exitCode)}`,
+            }),
+      };
+    } catch (error) {
+      const messageText =
+        error instanceof Error
+          ? error.message
+          : `Unknown workbench error: ${String(error)}`;
+      logger.error(`CLAUDE_CODE_WORKBENCH_RUN failed: ${messageText}`);
+
+      if (callback) {
+        await callback({ text: messageText, source: message.content.source });
+      }
+
+      return {
+        success: false,
+        error: messageText,
+      };
+    }
+  },
+
+  examples: [
+    [
+      {
+        name: "{{name1}}",
+        content: {
+          text: "workbench run check",
+        },
+      },
+      {
+        name: "{{name2}}",
+        content: {
+          text: "✅ Workflow check completed.",
+          actions: ["CLAUDE_CODE_WORKBENCH_RUN"],
+        },
+      },
+    ],
+  ],
+};

--- a/packages/plugin-claude-code-workbench/src/config.ts
+++ b/packages/plugin-claude-code-workbench/src/config.ts
@@ -1,0 +1,136 @@
+import path from "node:path";
+import { z } from "zod";
+import { getDefaultWorkflowIds, normalizeWorkflowId } from "./workflows.ts";
+
+const DEFAULT_TIMEOUT_MS = 10 * 60_000;
+const DEFAULT_MAX_OUTPUT_CHARS = 120_000;
+const DEFAULT_MAX_STDIN_BYTES = 64 * 1024;
+
+const MIN_TIMEOUT_MS = 500;
+const MAX_TIMEOUT_MS = 60 * 60_000;
+const MIN_OUTPUT_CHARS = 512;
+const MAX_OUTPUT_CHARS = 1_000_000;
+const MIN_STDIN_BYTES = 0;
+const MAX_STDIN_BYTES = 5 * 1024 * 1024;
+
+function parseBoolean(value: unknown): boolean | undefined {
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (typeof value === "number") {
+    if (value === 1) return true;
+    if (value === 0) return false;
+    throw new Error(
+      "CLAUDE_CODE_WORKBENCH_ENABLE_MUTATING_WORKFLOWS must be 0 or 1 when set as a number.",
+    );
+  }
+
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["1", "true", "yes", "on"].includes(normalized)) return true;
+    if (["0", "false", "no", "off"].includes(normalized)) return false;
+  }
+
+  throw new Error(
+    "CLAUDE_CODE_WORKBENCH_ENABLE_MUTATING_WORKFLOWS must be a boolean-like value.",
+  );
+}
+
+const allowedWorkflowsSchema = z
+  .union([z.array(z.string()), z.string()])
+  .optional()
+  .transform((value): string[] => {
+    if (!value) {
+      return ["*"];
+    }
+
+    const raw = Array.isArray(value) ? value : value.split(",");
+    const normalized = raw
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0)
+      .map((entry) => (entry === "*" ? "*" : normalizeWorkflowId(entry)));
+
+    if (normalized.length === 0) {
+      return ["*"];
+    }
+
+    return Array.from(new Set(normalized));
+  });
+
+export const claudeCodeWorkbenchConfigSchema = z.object({
+  CLAUDE_CODE_WORKBENCH_WORKSPACE_ROOT: z.string().trim().min(1).optional(),
+  CLAUDE_CODE_WORKBENCH_TIMEOUT_MS: z.coerce
+    .number()
+    .int()
+    .min(MIN_TIMEOUT_MS)
+    .max(MAX_TIMEOUT_MS)
+    .default(DEFAULT_TIMEOUT_MS),
+  CLAUDE_CODE_WORKBENCH_MAX_OUTPUT_CHARS: z.coerce
+    .number()
+    .int()
+    .min(MIN_OUTPUT_CHARS)
+    .max(MAX_OUTPUT_CHARS)
+    .default(DEFAULT_MAX_OUTPUT_CHARS),
+  CLAUDE_CODE_WORKBENCH_MAX_STDIN_BYTES: z.coerce
+    .number()
+    .int()
+    .min(MIN_STDIN_BYTES)
+    .max(MAX_STDIN_BYTES)
+    .default(DEFAULT_MAX_STDIN_BYTES),
+  CLAUDE_CODE_WORKBENCH_ALLOWED_WORKFLOWS: allowedWorkflowsSchema,
+  CLAUDE_CODE_WORKBENCH_ENABLE_MUTATING_WORKFLOWS: z
+    .preprocess(parseBoolean, z.boolean())
+    .default(false),
+});
+
+export interface ClaudeCodeWorkbenchConfig {
+  workspaceRoot: string;
+  timeoutMs: number;
+  maxOutputChars: number;
+  maxStdinBytes: number;
+  allowedWorkflowIds: string[];
+  enableMutatingWorkflows: boolean;
+}
+
+export function isWorkflowAllowed(
+  workflowId: string,
+  allowedWorkflowIds: string[],
+): boolean {
+  const normalized = normalizeWorkflowId(workflowId);
+  return allowedWorkflowIds.some((entry) => {
+    if (entry === "*") {
+      return true;
+    }
+    return normalizeWorkflowId(entry) === normalized;
+  });
+}
+
+export function loadClaudeCodeWorkbenchConfig(
+  raw: Record<string, string | undefined>,
+): ClaudeCodeWorkbenchConfig {
+  const parsed = claudeCodeWorkbenchConfigSchema.parse(raw);
+
+  const allowedWorkflowIds =
+    parsed.CLAUDE_CODE_WORKBENCH_ALLOWED_WORKFLOWS?.length > 0
+      ? parsed.CLAUDE_CODE_WORKBENCH_ALLOWED_WORKFLOWS
+      : ["*"];
+
+  return {
+    workspaceRoot: path.resolve(
+      parsed.CLAUDE_CODE_WORKBENCH_WORKSPACE_ROOT ?? process.cwd(),
+    ),
+    timeoutMs: parsed.CLAUDE_CODE_WORKBENCH_TIMEOUT_MS,
+    maxOutputChars: parsed.CLAUDE_CODE_WORKBENCH_MAX_OUTPUT_CHARS,
+    maxStdinBytes: parsed.CLAUDE_CODE_WORKBENCH_MAX_STDIN_BYTES,
+    allowedWorkflowIds,
+    enableMutatingWorkflows:
+      parsed.CLAUDE_CODE_WORKBENCH_ENABLE_MUTATING_WORKFLOWS,
+  };
+}
+
+export const DEFAULT_WORKBENCH_WORKFLOWS = getDefaultWorkflowIds();

--- a/packages/plugin-claude-code-workbench/src/index.ts
+++ b/packages/plugin-claude-code-workbench/src/index.ts
@@ -1,0 +1,34 @@
+import { claudeCodeWorkbenchPlugin } from "./plugin.ts";
+
+export { claudeCodeWorkbenchListAction } from "./actions/list-workflows.ts";
+export { claudeCodeWorkbenchRunAction } from "./actions/run-workflow.ts";
+export type { ClaudeCodeWorkbenchConfig } from "./config.ts";
+export {
+  claudeCodeWorkbenchConfigSchema,
+  DEFAULT_WORKBENCH_WORKFLOWS,
+  isWorkflowAllowed,
+  loadClaudeCodeWorkbenchConfig,
+} from "./config.ts";
+export { claudeCodeWorkbenchPlugin } from "./plugin.ts";
+export { claudeCodeWorkbenchStatusProvider } from "./providers/status.ts";
+export { claudeCodeWorkbenchRoutes } from "./routes.ts";
+
+export type {
+  WorkbenchRunInput,
+  WorkbenchRunResult,
+  WorkbenchStatus,
+  WorkbenchWorkflowSummary,
+} from "./services/workbench-service.ts";
+export { ClaudeCodeWorkbenchService } from "./services/workbench-service.ts";
+export type {
+  WorkbenchWorkflow,
+  WorkbenchWorkflowCategory,
+} from "./workflows.ts";
+export {
+  findDefaultWorkflowById,
+  getDefaultWorkflowIds,
+  listDefaultWorkflows,
+  normalizeWorkflowId,
+} from "./workflows.ts";
+
+export default claudeCodeWorkbenchPlugin;

--- a/packages/plugin-claude-code-workbench/src/plugin.ts
+++ b/packages/plugin-claude-code-workbench/src/plugin.ts
@@ -1,0 +1,74 @@
+import type { Plugin } from "@elizaos/core";
+import { logger } from "@elizaos/core";
+import { z } from "zod";
+import { claudeCodeWorkbenchListAction } from "./actions/list-workflows.ts";
+import { claudeCodeWorkbenchRunAction } from "./actions/run-workflow.ts";
+import { loadClaudeCodeWorkbenchConfig } from "./config.ts";
+import { claudeCodeWorkbenchStatusProvider } from "./providers/status.ts";
+import { claudeCodeWorkbenchRoutes } from "./routes.ts";
+import { ClaudeCodeWorkbenchService } from "./services/workbench-service.ts";
+
+export const claudeCodeWorkbenchPlugin: Plugin = {
+  name: "claude-code-workbench",
+  description:
+    "Claude Code companion for this repository. Adds secure, allowlisted repo workflows via service, actions, provider, and API routes.",
+
+  get config() {
+    return {
+      CLAUDE_CODE_WORKBENCH_WORKSPACE_ROOT:
+        process.env.CLAUDE_CODE_WORKBENCH_WORKSPACE_ROOT ?? null,
+      CLAUDE_CODE_WORKBENCH_TIMEOUT_MS:
+        process.env.CLAUDE_CODE_WORKBENCH_TIMEOUT_MS ?? null,
+      CLAUDE_CODE_WORKBENCH_MAX_OUTPUT_CHARS:
+        process.env.CLAUDE_CODE_WORKBENCH_MAX_OUTPUT_CHARS ?? null,
+      CLAUDE_CODE_WORKBENCH_MAX_STDIN_BYTES:
+        process.env.CLAUDE_CODE_WORKBENCH_MAX_STDIN_BYTES ?? null,
+      CLAUDE_CODE_WORKBENCH_ALLOWED_WORKFLOWS:
+        process.env.CLAUDE_CODE_WORKBENCH_ALLOWED_WORKFLOWS ?? null,
+      CLAUDE_CODE_WORKBENCH_ENABLE_MUTATING_WORKFLOWS:
+        process.env.CLAUDE_CODE_WORKBENCH_ENABLE_MUTATING_WORKFLOWS ?? null,
+    };
+  },
+
+  async init(config: Record<string, string>) {
+    logger.info("Claude Code workbench: initializing plugin");
+
+    try {
+      const normalized = loadClaudeCodeWorkbenchConfig(config);
+
+      for (const [key, value] of Object.entries(config)) {
+        if (!key.startsWith("CLAUDE_CODE_WORKBENCH_")) {
+          continue;
+        }
+
+        if (value) {
+          process.env[key] = value;
+        }
+      }
+
+      logger.info(
+        `Claude Code workbench: initialized (root=${normalized.workspaceRoot}, workflows=${normalized.allowedWorkflowIds.join(",")})`,
+      );
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        const issues =
+          error.issues?.map((issue) => issue.message).join(", ") ||
+          "Unknown validation error";
+        throw new Error(`Claude Code workbench configuration error: ${issues}`);
+      }
+
+      throw new Error(
+        `Claude Code workbench initialization failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  },
+
+  services: [ClaudeCodeWorkbenchService],
+  actions: [claudeCodeWorkbenchRunAction, claudeCodeWorkbenchListAction],
+  providers: [claudeCodeWorkbenchStatusProvider],
+  routes: claudeCodeWorkbenchRoutes,
+};
+
+export default claudeCodeWorkbenchPlugin;

--- a/packages/plugin-claude-code-workbench/src/providers/status.ts
+++ b/packages/plugin-claude-code-workbench/src/providers/status.ts
@@ -1,0 +1,62 @@
+import type {
+  IAgentRuntime,
+  Memory,
+  Provider,
+  ProviderResult,
+  State,
+} from "@elizaos/core";
+import type { ClaudeCodeWorkbenchService } from "../services/workbench-service.ts";
+
+export const claudeCodeWorkbenchStatusProvider: Provider = {
+  name: "CLAUDE_CODE_WORKBENCH_STATUS",
+  description:
+    "Provides Claude Code workbench availability, workflow policy, and recent run metadata.",
+
+  get: async (
+    runtime: IAgentRuntime,
+    _message: Memory,
+    _state: State | undefined,
+  ): Promise<ProviderResult> => {
+    const service = runtime.getService(
+      "claude_code_workbench",
+    ) as ClaudeCodeWorkbenchService | null;
+
+    if (!service) {
+      return {
+        text: "Claude Code workbench plugin is not active (service not found).",
+        values: { workbenchAvailable: false },
+        data: { available: false },
+      };
+    }
+
+    const status = service.getStatus();
+
+    const lines = [
+      `Workbench availability: ${status.available ? "available" : "unavailable"}`,
+      `Workflow count: ${status.workflows.length}`,
+      `Workspace root: ${status.workspaceRoot}`,
+      `Timeout: ${status.timeoutMs}ms`,
+      `Output cap: ${status.maxOutputChars} chars`,
+      `Mutating workflows: ${status.enableMutatingWorkflows ? "enabled" : "disabled"}`,
+    ];
+
+    if (status.lastRunAt) {
+      lines.push(`Last run: ${new Date(status.lastRunAt).toISOString()}`);
+    }
+    if (status.lastWorkflow) {
+      lines.push(`Last workflow: ${status.lastWorkflow}`);
+    }
+    if (typeof status.lastExitCode !== "undefined") {
+      lines.push(`Last exit code: ${String(status.lastExitCode)}`);
+    }
+
+    return {
+      text: lines.join("\n"),
+      values: {
+        workbenchAvailable: status.available,
+        workbenchRunning: status.running,
+      },
+      data: { ...status },
+    };
+  },
+};

--- a/packages/plugin-claude-code-workbench/src/routes.ts
+++ b/packages/plugin-claude-code-workbench/src/routes.ts
@@ -1,0 +1,131 @@
+import {
+  type IAgentRuntime,
+  logger,
+  type Route,
+  type RouteRequest,
+  type RouteResponse,
+} from "@elizaos/core";
+import type {
+  ClaudeCodeWorkbenchService,
+  WorkbenchRunInput,
+} from "./services/workbench-service.ts";
+
+function getService(runtime: IAgentRuntime): ClaudeCodeWorkbenchService {
+  const service = runtime.getService(
+    "claude_code_workbench",
+  ) as ClaudeCodeWorkbenchService | null;
+  if (!service) {
+    throw new Error("Claude Code workbench service not available");
+  }
+  return service;
+}
+
+function toStringOrUndefined(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function parseRunInput(body: unknown): WorkbenchRunInput | null {
+  if (!body || typeof body !== "object") {
+    return null;
+  }
+
+  const record = body as Record<string, unknown>;
+  const workflow = toStringOrUndefined(record.workflow);
+
+  if (!workflow) {
+    return null;
+  }
+
+  return {
+    workflow,
+    cwd: toStringOrUndefined(record.cwd),
+    stdin: toStringOrUndefined(record.stdin),
+  };
+}
+
+const statusRoute: Route = {
+  name: "claude-code-workbench-status",
+  public: false,
+  path: "/status",
+  type: "GET",
+  handler: async (
+    _req: RouteRequest,
+    res: RouteResponse,
+    runtime: IAgentRuntime,
+  ) => {
+    try {
+      const service = getService(runtime);
+      res.json({ ok: true, status: service.getStatus() });
+    } catch (error) {
+      res.status(500).json({
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  },
+};
+
+const workflowsRoute: Route = {
+  name: "claude-code-workbench-workflows",
+  public: false,
+  path: "/workflows",
+  type: "GET",
+  handler: async (
+    _req: RouteRequest,
+    res: RouteResponse,
+    runtime: IAgentRuntime,
+  ) => {
+    try {
+      const service = getService(runtime);
+      res.json({ ok: true, workflows: service.listWorkflows() });
+    } catch (error) {
+      res.status(500).json({
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  },
+};
+
+const runRoute: Route = {
+  name: "claude-code-workbench-run",
+  public: false,
+  path: "/run",
+  type: "POST",
+  handler: async (
+    req: RouteRequest,
+    res: RouteResponse,
+    runtime: IAgentRuntime,
+  ) => {
+    try {
+      const input = parseRunInput(req.body);
+      if (!input) {
+        res.status(400).json({
+          ok: false,
+          error:
+            "Invalid run request. Provide non-empty `workflow` in request body.",
+        });
+        return;
+      }
+
+      const service = getService(runtime);
+      const result = await service.run(input);
+      res.status(result.ok ? 200 : 500).json({ ok: result.ok, result });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(`Claude Code workbench route error: ${message}`);
+      res.status(500).json({ ok: false, error: message });
+    }
+  },
+};
+
+export const claudeCodeWorkbenchRoutes: Route[] = [
+  statusRoute,
+  workflowsRoute,
+  runRoute,
+];

--- a/packages/plugin-claude-code-workbench/src/services/workbench-service.ts
+++ b/packages/plugin-claude-code-workbench/src/services/workbench-service.ts
@@ -1,0 +1,453 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { type IAgentRuntime, Service } from "@elizaos/core";
+import {
+  type ClaudeCodeWorkbenchConfig,
+  isWorkflowAllowed,
+  loadClaudeCodeWorkbenchConfig,
+} from "../config.ts";
+import {
+  listDefaultWorkflows,
+  normalizeWorkflowId,
+  type WorkbenchWorkflow,
+} from "../workflows.ts";
+
+export interface WorkbenchWorkflowSummary {
+  id: string;
+  title: string;
+  description: string;
+  category: string;
+  mutatesRepo: boolean;
+  enabled: boolean;
+  commandPreview: string;
+}
+
+export interface WorkbenchRunInput {
+  workflow: string;
+  cwd?: string;
+  stdin?: string;
+}
+
+export interface WorkbenchRunResult {
+  ok: boolean;
+  workflow: string;
+  command: string;
+  args: string[];
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  durationMs: number;
+  timedOut: boolean;
+  stdoutTruncated: boolean;
+  stderrTruncated: boolean;
+}
+
+export interface WorkbenchStatus {
+  available: boolean;
+  running: boolean;
+  workspaceRoot: string;
+  timeoutMs: number;
+  maxOutputChars: number;
+  maxStdinBytes: number;
+  allowedWorkflowIds: string[];
+  enableMutatingWorkflows: boolean;
+  workflows: WorkbenchWorkflowSummary[];
+  lastRunAt?: number;
+  lastWorkflow?: string;
+  lastExitCode?: number | null;
+  lastDurationMs?: number;
+  lastError?: string;
+}
+
+function appendWithLimit(
+  current: string,
+  chunk: Buffer | string,
+  limit: number,
+): { value: string; truncated: boolean } {
+  if (current.length >= limit) {
+    return { value: current, truncated: true };
+  }
+
+  const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+  const remaining = limit - current.length;
+
+  if (text.length <= remaining) {
+    return { value: current + text, truncated: false };
+  }
+
+  return {
+    value: current + text.slice(0, remaining),
+    truncated: true,
+  };
+}
+
+function withTruncationSuffix(value: string, truncated: boolean): string {
+  if (!truncated) {
+    return value;
+  }
+
+  const suffix = "\n...[truncated by plugin-claude-code-workbench]";
+  return value.endsWith(suffix) ? value : `${value}${suffix}`;
+}
+
+function cleanOptionalValue(value: string | undefined): string | undefined {
+  const cleaned = value?.trim();
+  return cleaned && cleaned.length > 0 ? cleaned : undefined;
+}
+
+function isPathInside(baseDir: string, targetDir: string): boolean {
+  if (baseDir === targetDir) {
+    return true;
+  }
+
+  const normalizedBase =
+    process.platform === "win32" ? baseDir.toLowerCase() : baseDir;
+  const normalizedTarget =
+    process.platform === "win32" ? targetDir.toLowerCase() : targetDir;
+  return normalizedTarget.startsWith(`${normalizedBase}${path.sep}`);
+}
+
+function toSummary(
+  workflow: WorkbenchWorkflow,
+  enableMutatingWorkflows: boolean,
+): WorkbenchWorkflowSummary {
+  return {
+    id: workflow.id,
+    title: workflow.title,
+    description: workflow.description,
+    category: workflow.category,
+    mutatesRepo: workflow.mutatesRepo,
+    enabled: !workflow.mutatesRepo || enableMutatingWorkflows,
+    commandPreview: `${workflow.command} ${workflow.args.join(" ")}`.trim(),
+  };
+}
+
+export class ClaudeCodeWorkbenchService extends Service {
+  static override serviceType = "claude_code_workbench";
+
+  override capabilityDescription =
+    "Run allowlisted repository workflows for this monorepo with safe process controls.";
+
+  private readonly runtimeConfig: ClaudeCodeWorkbenchConfig;
+  private readonly workflows: Map<string, WorkbenchWorkflow>;
+  private runQueue: Promise<unknown> = Promise.resolve();
+  private running = false;
+  private available = true;
+  private lastRunAt?: number;
+  private lastWorkflow?: string;
+  private lastExitCode?: number | null;
+  private lastDurationMs?: number;
+  private lastError?: string;
+
+  constructor(
+    runtime?: IAgentRuntime,
+    config?: ClaudeCodeWorkbenchConfig,
+    workflows?: WorkbenchWorkflow[],
+  ) {
+    super(runtime);
+    this.runtimeConfig = config ?? loadClaudeCodeWorkbenchConfig(process.env);
+
+    const sourceWorkflows = workflows ?? listDefaultWorkflows();
+    const filtered = sourceWorkflows.filter((workflow) =>
+      isWorkflowAllowed(workflow.id, this.runtimeConfig.allowedWorkflowIds),
+    );
+
+    this.workflows = new Map(
+      filtered.map((workflow) => [
+        normalizeWorkflowId(workflow.id),
+        {
+          ...workflow,
+          id: normalizeWorkflowId(workflow.id),
+          args: [...workflow.args],
+        },
+      ]),
+    );
+  }
+
+  static async start(runtime: IAgentRuntime): Promise<Service> {
+    return new ClaudeCodeWorkbenchService(runtime);
+  }
+
+  static async stop(runtime: IAgentRuntime): Promise<void> {
+    const service = runtime.getService(ClaudeCodeWorkbenchService.serviceType);
+    if (service && "stop" in service && typeof service.stop === "function") {
+      await service.stop();
+    }
+  }
+
+  async stop(): Promise<void> {
+    this.running = false;
+  }
+
+  listWorkflows(): WorkbenchWorkflowSummary[] {
+    return Array.from(this.workflows.values())
+      .sort((left, right) => left.id.localeCompare(right.id))
+      .map((workflow) =>
+        toSummary(workflow, this.runtimeConfig.enableMutatingWorkflows),
+      );
+  }
+
+  getStatus(): WorkbenchStatus {
+    return {
+      available: this.available,
+      running: this.running,
+      workspaceRoot: this.runtimeConfig.workspaceRoot,
+      timeoutMs: this.runtimeConfig.timeoutMs,
+      maxOutputChars: this.runtimeConfig.maxOutputChars,
+      maxStdinBytes: this.runtimeConfig.maxStdinBytes,
+      allowedWorkflowIds: [...this.runtimeConfig.allowedWorkflowIds],
+      enableMutatingWorkflows: this.runtimeConfig.enableMutatingWorkflows,
+      workflows: this.listWorkflows(),
+      lastRunAt: this.lastRunAt,
+      lastWorkflow: this.lastWorkflow,
+      lastExitCode: this.lastExitCode,
+      lastDurationMs: this.lastDurationMs,
+      lastError: this.lastError,
+    };
+  }
+
+  async run(input: WorkbenchRunInput): Promise<WorkbenchRunResult> {
+    const task = this.runQueue.then(
+      () => this.executeRun(input),
+      () => this.executeRun(input),
+    );
+
+    this.runQueue = task.then(
+      () => undefined,
+      () => undefined,
+    );
+
+    return task;
+  }
+
+  private resolveWorkingDirectory(inputCwd?: string): string {
+    const workspaceRootPath = path.resolve(this.runtimeConfig.workspaceRoot);
+    const requestedPath = path.resolve(
+      cleanOptionalValue(inputCwd) ?? workspaceRootPath,
+    );
+
+    let workspaceRoot: string;
+    let requested: string;
+
+    try {
+      workspaceRoot = fs.realpathSync(workspaceRootPath);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `CLAUDE_CODE_WORKBENCH_WORKSPACE_ROOT is not accessible (${workspaceRootPath}): ${message}`,
+      );
+    }
+
+    try {
+      requested = fs.realpathSync(requestedPath);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `Workbench cwd is not accessible (${requestedPath}): ${message}`,
+      );
+    }
+
+    if (!isPathInside(workspaceRoot, requested)) {
+      throw new Error(
+        `Workbench cwd must stay within CLAUDE_CODE_WORKBENCH_WORKSPACE_ROOT (${workspaceRoot}). Received: ${requested}`,
+      );
+    }
+
+    return requested;
+  }
+
+  private buildChildEnv(): NodeJS.ProcessEnv {
+    const env: NodeJS.ProcessEnv = {};
+    const baseKeys = [
+      "PATH",
+      "HOME",
+      "USERPROFILE",
+      "SHELL",
+      "COMSPEC",
+      "PATHEXT",
+      "SystemRoot",
+      "TMP",
+      "TEMP",
+      "TERM",
+      "CI",
+      "FORCE_COLOR",
+    ];
+
+    for (const key of baseKeys) {
+      const value = process.env[key];
+      if (typeof value === "string" && value.length > 0) {
+        env[key] = value;
+      }
+    }
+
+    for (const [key, value] of Object.entries(process.env)) {
+      if (
+        key.startsWith("CLAUDE_CODE_WORKBENCH_") &&
+        typeof value === "string" &&
+        value.length > 0
+      ) {
+        env[key] = value;
+      }
+    }
+
+    return env;
+  }
+
+  private resolveWorkflow(workflowId: string): WorkbenchWorkflow {
+    const normalized = normalizeWorkflowId(workflowId);
+    const workflow = this.workflows.get(normalized);
+
+    if (!workflow) {
+      const allowed = this.listWorkflows()
+        .map((entry) => entry.id)
+        .join(", ");
+      throw new Error(
+        `Unknown workflow "${workflowId}". Allowed workflows: ${allowed || "none"}.`,
+      );
+    }
+
+    if (workflow.mutatesRepo && !this.runtimeConfig.enableMutatingWorkflows) {
+      throw new Error(
+        `Workflow "${workflow.id}" mutates the repository and is disabled. Set CLAUDE_CODE_WORKBENCH_ENABLE_MUTATING_WORKFLOWS=true to enable it.`,
+      );
+    }
+
+    return workflow;
+  }
+
+  private async executeRun(
+    input: WorkbenchRunInput,
+  ): Promise<WorkbenchRunResult> {
+    const workflow = this.resolveWorkflow(input.workflow);
+
+    if (
+      input.stdin &&
+      Buffer.byteLength(input.stdin, "utf8") > this.runtimeConfig.maxStdinBytes
+    ) {
+      throw new Error(
+        `Workbench stdin exceeds limit (${this.runtimeConfig.maxStdinBytes} bytes).`,
+      );
+    }
+
+    const cwd = this.resolveWorkingDirectory(input.cwd);
+    this.running = true;
+    this.lastWorkflow = workflow.id;
+
+    const startedAt = Date.now();
+    let stdout = "";
+    let stderr = "";
+    let stdoutTruncated = false;
+    let stderrTruncated = false;
+    let timedOut = false;
+
+    try {
+      const child = spawn(workflow.command, workflow.args, {
+        cwd,
+        env: this.buildChildEnv(),
+        stdio: ["pipe", "pipe", "pipe"],
+        shell: false,
+      });
+
+      if (input.stdin) {
+        child.stdin?.write(input.stdin);
+      }
+      child.stdin?.end();
+
+      child.stdout?.on("data", (chunk) => {
+        const next = appendWithLimit(
+          stdout,
+          chunk,
+          this.runtimeConfig.maxOutputChars,
+        );
+        stdout = next.value;
+        stdoutTruncated = stdoutTruncated || next.truncated;
+      });
+
+      child.stderr?.on("data", (chunk) => {
+        const next = appendWithLimit(
+          stderr,
+          chunk,
+          this.runtimeConfig.maxOutputChars,
+        );
+        stderr = next.value;
+        stderrTruncated = stderrTruncated || next.truncated;
+      });
+
+      const timeoutHandle = setTimeout(() => {
+        timedOut = true;
+        try {
+          child.kill("SIGTERM");
+        } catch {
+          // ignore
+        }
+
+        setTimeout(() => {
+          try {
+            child.kill("SIGKILL");
+          } catch {
+            // ignore
+          }
+        }, 250);
+      }, this.runtimeConfig.timeoutMs);
+
+      const exitCode = await new Promise<number | null>((resolve, reject) => {
+        child.once("error", reject);
+        child.once("close", (code) => resolve(code));
+      }).finally(() => {
+        clearTimeout(timeoutHandle);
+      });
+
+      if (timedOut) {
+        const timeoutMessage = `Workflow timed out after ${this.runtimeConfig.timeoutMs}ms.`;
+        const next = appendWithLimit(
+          stderr,
+          timeoutMessage,
+          this.runtimeConfig.maxOutputChars,
+        );
+        stderr = next.value;
+        stderrTruncated = stderrTruncated || next.truncated;
+      }
+
+      const durationMs = Date.now() - startedAt;
+      const ok = !timedOut && exitCode === 0;
+
+      this.available = true;
+      this.lastRunAt = startedAt;
+      this.lastExitCode = exitCode;
+      this.lastDurationMs = durationMs;
+      this.lastError = ok
+        ? undefined
+        : stderr || `Process exited with code ${String(exitCode)}`;
+
+      return {
+        ok,
+        workflow: workflow.id,
+        command: workflow.command,
+        args: [...workflow.args],
+        exitCode,
+        stdout: withTruncationSuffix(stdout, stdoutTruncated),
+        stderr: withTruncationSuffix(stderr, stderrTruncated),
+        durationMs,
+        timedOut,
+        stdoutTruncated,
+        stderrTruncated,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.lastRunAt = startedAt;
+      this.lastExitCode = null;
+      this.lastDurationMs = Date.now() - startedAt;
+      this.lastError = message;
+
+      const maybeErrno = error as NodeJS.ErrnoException;
+      if (maybeErrno?.code === "ENOENT") {
+        this.available = false;
+      }
+
+      throw error;
+    } finally {
+      this.running = false;
+    }
+  }
+}

--- a/packages/plugin-claude-code-workbench/src/workflows.ts
+++ b/packages/plugin-claude-code-workbench/src/workflows.ts
@@ -1,0 +1,181 @@
+export type WorkbenchWorkflowCategory =
+  | "repo"
+  | "quality"
+  | "test"
+  | "build"
+  | "docs"
+  | "plugins";
+
+export interface WorkbenchWorkflow {
+  id: string;
+  title: string;
+  description: string;
+  category: WorkbenchWorkflowCategory;
+  command: string;
+  args: string[];
+  mutatesRepo: boolean;
+}
+
+const DEFAULT_WORKFLOWS: readonly WorkbenchWorkflow[] = [
+  {
+    id: "repo_status",
+    title: "Repo Status",
+    description: "Show git status with branch summary.",
+    category: "repo",
+    command: "git",
+    args: ["status", "--short", "--branch"],
+    mutatesRepo: false,
+  },
+  {
+    id: "repo_diff_stat",
+    title: "Repo Diff Stat",
+    description: "Show unstaged diff statistics.",
+    category: "repo",
+    command: "git",
+    args: ["diff", "--stat"],
+    mutatesRepo: false,
+  },
+  {
+    id: "repo_diff_cached",
+    title: "Repo Diff Cached",
+    description: "Show staged diff statistics.",
+    category: "repo",
+    command: "git",
+    args: ["diff", "--cached", "--stat"],
+    mutatesRepo: false,
+  },
+  {
+    id: "recent_commits",
+    title: "Recent Commits",
+    description: "Show recent commit history.",
+    category: "repo",
+    command: "git",
+    args: ["log", "--oneline", "-n", "20"],
+    mutatesRepo: false,
+  },
+  {
+    id: "check",
+    title: "Check",
+    description: "Run project check (typecheck + lint).",
+    category: "quality",
+    command: "bun",
+    args: ["run", "check"],
+    mutatesRepo: false,
+  },
+  {
+    id: "typecheck",
+    title: "Typecheck",
+    description: "Run TypeScript typecheck.",
+    category: "quality",
+    command: "bun",
+    args: ["run", "typecheck"],
+    mutatesRepo: false,
+  },
+  {
+    id: "lint",
+    title: "Lint",
+    description: "Run Biome lint checks.",
+    category: "quality",
+    command: "bun",
+    args: ["run", "lint"],
+    mutatesRepo: false,
+  },
+  {
+    id: "test_once",
+    title: "Test Once",
+    description: "Run Vitest suite one time.",
+    category: "test",
+    command: "bun",
+    args: ["run", "test:once"],
+    mutatesRepo: false,
+  },
+  {
+    id: "test_e2e",
+    title: "Test E2E",
+    description: "Run E2E tests.",
+    category: "test",
+    command: "bun",
+    args: ["run", "test:e2e"],
+    mutatesRepo: false,
+  },
+  {
+    id: "pre_review_local",
+    title: "Pre-Review Local",
+    description: "Run local pre-review parity workflow.",
+    category: "quality",
+    command: "bun",
+    args: ["run", "pre-review:local"],
+    mutatesRepo: false,
+  },
+  {
+    id: "build_local_plugins",
+    title: "Build Local Plugins",
+    description: "Build local plugin packages used by this repo.",
+    category: "plugins",
+    command: "bun",
+    args: ["run", "build:local-plugins"],
+    mutatesRepo: false,
+  },
+  {
+    id: "build",
+    title: "Build",
+    description: "Run full monorepo build.",
+    category: "build",
+    command: "bun",
+    args: ["run", "build"],
+    mutatesRepo: false,
+  },
+  {
+    id: "docs_build",
+    title: "Docs Build",
+    description: "Validate docs build and broken links.",
+    category: "docs",
+    command: "bun",
+    args: ["run", "docs:build"],
+    mutatesRepo: false,
+  },
+  {
+    id: "format_fix",
+    title: "Format Fix",
+    description: "Apply Biome formatting changes.",
+    category: "quality",
+    command: "bun",
+    args: ["run", "format:fix"],
+    mutatesRepo: true,
+  },
+  {
+    id: "lint_fix",
+    title: "Lint Fix",
+    description: "Apply Biome lint autofixes.",
+    category: "quality",
+    command: "bun",
+    args: ["run", "lint:fix"],
+    mutatesRepo: true,
+  },
+];
+
+export function normalizeWorkflowId(workflowId: string): string {
+  return workflowId
+    .trim()
+    .toLowerCase()
+    .replace(/[\s.]+/g, "_")
+    .replace(/[^a-z0-9_-]/g, "");
+}
+
+export function listDefaultWorkflows(): WorkbenchWorkflow[] {
+  return DEFAULT_WORKFLOWS.map((workflow) => ({
+    ...workflow,
+    args: [...workflow.args],
+  }));
+}
+
+export function getDefaultWorkflowIds(): string[] {
+  return DEFAULT_WORKFLOWS.map((workflow) => workflow.id);
+}
+
+export function findDefaultWorkflowById(
+  workflowId: string,
+): WorkbenchWorkflow | undefined {
+  const normalized = normalizeWorkflowId(workflowId);
+  return DEFAULT_WORKFLOWS.find((workflow) => workflow.id === normalized);
+}

--- a/packages/plugin-claude-code-workbench/tsconfig.build.json
+++ b/packages/plugin-claude-code-workbench/tsconfig.build.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "sourceMap": true,
+    "inlineSources": true,
+    "declaration": true,
+    "noEmit": false
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "src/__tests__/**/*"
+  ]
+}

--- a/packages/plugin-claude-code-workbench/tsconfig.json
+++ b/packages/plugin-claude-code-workbench/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "lib": ["ESNext", "dom"],
+    "target": "ESNext",
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "incremental": true,
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "forceConsistentCasingInFileNames": false,
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "noImplicitAny": true,
+    "allowJs": true,
+    "checkJs": false,
+    "noEmitOnError": false,
+    "moduleDetection": "force",
+    "allowArbitraryExtensions": true,
+    "jsx": "react",
+    "isolatedModules": false,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/__tests__/**/*", "e2e/**/*", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/scripts/build-local-plugins.mjs
+++ b/scripts/build-local-plugins.mjs
@@ -5,32 +5,44 @@ import path from "node:path";
 
 const root = process.cwd();
 
-const candidates = [
-  path.join(root, "node_modules", "@elizaos", "plugin-pi-ai"),
-  path.join(root, "packages", "plugin-pi-ai"),
+const pluginSpecs = [
+  {
+    name: "@elizaos/plugin-pi-ai",
+    candidates: [
+      path.join(root, "node_modules", "@elizaos", "plugin-pi-ai"),
+      path.join(root, "packages", "plugin-pi-ai"),
+    ],
+  },
+  {
+    name: "@milaidy/plugin-claude-code-workbench",
+    candidates: [path.join(root, "packages", "plugin-claude-code-workbench")],
+  },
 ];
 
-const uniqueDirs = [];
+const buildTargets = [];
 const seen = new Set();
-for (const dir of candidates) {
-  if (!existsSync(dir)) continue;
-  const resolved = realpathSync(dir);
-  if (seen.has(resolved)) continue;
-  seen.add(resolved);
-  uniqueDirs.push(dir);
+
+for (const spec of pluginSpecs) {
+  for (const dir of spec.candidates) {
+    if (!existsSync(dir)) continue;
+    const resolved = realpathSync(dir);
+    if (seen.has(resolved)) continue;
+    seen.add(resolved);
+    buildTargets.push({ name: spec.name, dir });
+  }
 }
 
-if (uniqueDirs.length === 0) {
+if (buildTargets.length === 0) {
   console.log(
     "[build-local-plugins] No local plugin directories found, skipping.",
   );
   process.exit(0);
 }
 
-for (const dir of uniqueDirs) {
-  console.log(`[build-local-plugins] Building @elizaos/plugin-pi-ai in ${dir}`);
+for (const target of buildTargets) {
+  console.log(`[build-local-plugins] Building ${target.name} in ${target.dir}`);
   const result = spawnSync("bun", ["run", "build"], {
-    cwd: dir,
+    cwd: target.dir,
     stdio: "inherit",
     shell: process.platform === "win32",
   });

--- a/src/config/plugin-auto-enable.test.ts
+++ b/src/config/plugin-auto-enable.test.ts
@@ -236,6 +236,18 @@ describe("applyPluginAutoEnable — env vars", () => {
     expect(changes.some((c) => c.includes("REPOPROMPT_CLI_PATH"))).toBe(true);
   });
 
+  it("enables claude code workbench plugin when CLAUDE_CODE_WORKBENCH_ENABLED is set", () => {
+    const params = makeParams({
+      env: { CLAUDE_CODE_WORKBENCH_ENABLED: "1" },
+    });
+    const { config, changes } = applyPluginAutoEnable(params);
+
+    expect(config.plugins?.allow).toContain("claude-code-workbench");
+    expect(
+      changes.some((c) => c.includes("CLAUDE_CODE_WORKBENCH_ENABLED")),
+    ).toBe(true);
+  });
+
   it("enables pi-ai plugin when MILAIDY_USE_PI_AI is set", () => {
     const params = makeParams({
       env: { MILAIDY_USE_PI_AI: "1" },
@@ -368,6 +380,18 @@ describe("applyPluginAutoEnable — features", () => {
 
     expect(config.plugins?.allow).toContain("repoprompt");
     expect(changes.some((c) => c.includes("feature: repoprompt"))).toBe(true);
+  });
+
+  it("enables claude code workbench plugin when feature flag is enabled", () => {
+    const params = makeParams({
+      config: { features: { claudeCodeWorkbench: true } },
+    });
+    const { config, changes } = applyPluginAutoEnable(params);
+
+    expect(config.plugins?.allow).toContain("claude-code-workbench");
+    expect(
+      changes.some((c) => c.includes("feature: claudeCodeWorkbench")),
+    ).toBe(true);
   });
 
   it("enables plugin when feature is an object with enabled not false", () => {

--- a/src/config/plugin-auto-enable.ts
+++ b/src/config/plugin-auto-enable.ts
@@ -81,6 +81,7 @@ export const AUTH_PROVIDER_PLUGINS: Record<string, string> = {
   OBSIDIAN_VAULT_PATH: "@elizaos/plugin-obsidian",
   OBSIDAN_VAULT_PATH: "@elizaos/plugin-obsidian",
   REPOPROMPT_CLI_PATH: "@elizaos/plugin-repoprompt",
+  CLAUDE_CODE_WORKBENCH_ENABLED: "@milaidy/plugin-claude-code-workbench",
 };
 
 const FEATURE_PLUGINS: Record<string, string> = {
@@ -108,6 +109,7 @@ const FEATURE_PLUGINS: Record<string, string> = {
   vision: "@elizaos/plugin-vision",
   computeruse: "@elizaos/plugin-computeruse",
   repoprompt: "@elizaos/plugin-repoprompt",
+  claudeCodeWorkbench: "@milaidy/plugin-claude-code-workbench",
 };
 
 function isConnectorConfigured(

--- a/src/runtime/core-plugins.ts
+++ b/src/runtime/core-plugins.ts
@@ -34,6 +34,7 @@ export const OPTIONAL_CORE_PLUGINS: readonly string[] = [
   // "@elizaos/plugin-cli", // CLI interface
   "@elizaos/plugin-code", // code writing and file operations
   "@elizaos/plugin-repoprompt", // RepoPrompt CLI integration and workflow orchestration
+  "@milaidy/plugin-claude-code-workbench", // Claude Code companion workflows for this monorepo
   // "@elizaos/plugin-edge-tts", // text-to-speech
   // "@elizaos/plugin-mcp", // MCP protocol support
   // "@elizaos/plugin-computeruse", // computer use automation


### PR DESCRIPTION
## Summary

- Adds `@milaidy/plugin-claude-code-workbench` — a companion plugin that exposes Claude Code workflows (pre-review, test, lint, build) as agent actions and REST routes for the admin panel
- Auto-enables via `CLAUDE_CODE_WORKBENCH_ENABLED` env var or `features.claudeCodeWorkbench` config flag
- Registered in `OPTIONAL_CORE_PLUGINS` (not loaded by default)
- Extends `build-local-plugins.mjs` to support multiple local workspace plugins
- Includes unit tests for all plugin components (actions, config, plugin, routes, service, workflows)

## Test plan

- [x] `bun run typecheck` — passes
- [x] `bun run lint` — passes
- [x] `bun run format` — passes
- [x] `bunx vitest run --config vitest.unit.config.ts` — 159 files, 2208 tests pass
- [x] Plugin auto-enable tests cover both env var and feature flag paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)