### PR TITLE
test: add deterministic tx/registry/drop service coverage

### DIFF
--- a/src/api/drop-service.test.ts
+++ b/src/api/drop-service.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
-import type { TxService } from "./tx-service";
 import { DropService } from "./drop-service";
+import type { TxService } from "./tx-service";
 
 interface MockTxService {
   address: string;

--- a/src/api/registry-service.test.ts
+++ b/src/api/registry-service.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
-import type { TxService } from "./tx-service";
 import { RegistryService } from "./registry-service";
+import type { TxService } from "./tx-service";
 
 interface MockTxService {
   address: string;
@@ -111,11 +111,9 @@ describe("registry-service", () => {
 
     const txHash = await service.updateTokenURI("ipfs://updated");
 
-    expect(contract.updateTokenURI).toHaveBeenCalledWith(
-      9,
-      "ipfs://updated",
-      { nonce: 99 },
-    );
+    expect(contract.updateTokenURI).toHaveBeenCalledWith(9, "ipfs://updated", {
+      nonce: 99,
+    });
     expect(wait).toHaveBeenCalledTimes(1);
     expect(txHash).toBe("0xupdate");
   });

--- a/src/api/tx-service.test.ts
+++ b/src/api/tx-service.test.ts
@@ -38,15 +38,17 @@ describe("tx-service", () => {
 
   it("throws when waiting for a transaction times out", async () => {
     const service = createService();
-    const provider = (service as unknown as {
-      provider: {
-        waitForTransaction: (
-          txHash: string,
-          confirmations: number,
-          timeoutMs: number,
-        ) => Promise<ethers.TransactionReceipt | null>;
-      };
-    }).provider;
+    const provider = (
+      service as unknown as {
+        provider: {
+          waitForTransaction: (
+            txHash: string,
+            confirmations: number,
+            timeoutMs: number,
+          ) => Promise<ethers.TransactionReceipt | null>;
+        };
+      }
+    ).provider;
 
     vi.spyOn(provider, "waitForTransaction").mockResolvedValue(null);
 
@@ -57,15 +59,17 @@ describe("tx-service", () => {
 
   it("throws when a mined transaction reverted", async () => {
     const service = createService();
-    const provider = (service as unknown as {
-      provider: {
-        waitForTransaction: (
-          txHash: string,
-          confirmations: number,
-          timeoutMs: number,
-        ) => Promise<ethers.TransactionReceipt | null>;
-      };
-    }).provider;
+    const provider = (
+      service as unknown as {
+        provider: {
+          waitForTransaction: (
+            txHash: string,
+            confirmations: number,
+            timeoutMs: number,
+          ) => Promise<ethers.TransactionReceipt | null>;
+        };
+      }
+    ).provider;
 
     const revertedReceipt = {
       status: 0,
@@ -82,15 +86,17 @@ describe("tx-service", () => {
 
   it("returns the receipt for successful transactions", async () => {
     const service = createService();
-    const provider = (service as unknown as {
-      provider: {
-        waitForTransaction: (
-          txHash: string,
-          confirmations: number,
-          timeoutMs: number,
-        ) => Promise<ethers.TransactionReceipt | null>;
-      };
-    }).provider;
+    const provider = (
+      service as unknown as {
+        provider: {
+          waitForTransaction: (
+            txHash: string,
+            confirmations: number,
+            timeoutMs: number,
+          ) => Promise<ethers.TransactionReceipt | null>;
+        };
+      }
+    ).provider;
 
     const receipt = {
       status: 1,
@@ -100,6 +106,8 @@ describe("tx-service", () => {
 
     vi.spyOn(provider, "waitForTransaction").mockResolvedValue(receipt);
 
-    await expect(service.waitForTransaction("0xsuccess")).resolves.toBe(receipt);
+    await expect(service.waitForTransaction("0xsuccess")).resolves.toBe(
+      receipt,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add focused unit coverage for `TxService` timeout/revert/success flows plus fresh nonce lookup behavior
- add deterministic `RegistryService` tests for unregistered status, nonce usage, registration fallback tokenId lookup, and tokenURI update guard paths
- add deterministic `DropService` tests for disabled defaults and nonce/value handling across public, shiny, and whitelist mint flows

## Validation
- `bunx vitest run src/api/tx-service.test.ts src/api/registry-service.test.ts src/api/drop-service.test.ts`
- `bun run typecheck`

## MW Mapping
- MW-02 On-chain service hardening
