### PR TITLE
milady: connector parity and subscription OAuth reliability tests

### DIFF
--- a/src/config/connector-parity.test.ts
+++ b/src/config/connector-parity.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { CHANNEL_PLUGIN_MAP } from "../runtime/eliza";
+import { CONNECTOR_PLUGINS } from "./plugin-auto-enable";
+import { CONNECTOR_IDS } from "./schema";
+
+function sorted(values: Iterable<string>): string[] {
+  return [...values].sort();
+}
+
+describe("connector map parity", () => {
+  it("keeps connector IDs aligned across schema, runtime, and auto-enable", () => {
+    const autoEnableIds = sorted(Object.keys(CONNECTOR_PLUGINS));
+    const runtimeIds = sorted(Object.keys(CHANNEL_PLUGIN_MAP));
+    const schemaIds = sorted(CONNECTOR_IDS);
+
+    expect(runtimeIds).toEqual(autoEnableIds);
+    expect(schemaIds).toEqual(autoEnableIds);
+  });
+
+  it("keeps runtime and auto-enable package mappings aligned", () => {
+    for (const [connectorId, pluginName] of Object.entries(CONNECTOR_PLUGINS)) {
+      expect(CHANNEL_PLUGIN_MAP[connectorId]).toBe(pluginName);
+    }
+  });
+});

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,16 +1,24 @@
 import { VERSION } from "../runtime/version";
 
-/** Known connector IDs for config schema generation */
-const CONNECTOR_IDS = [
-  "discord",
+/** Known connector IDs for config schema generation. Keep in sync with runtime/plugin maps. */
+export const CONNECTOR_IDS = [
   "telegram",
+  "discord",
   "slack",
+  "twitter",
   "whatsapp",
   "signal",
+  "bluebubbles",
   "imessage",
-  "matrix",
+  "farcaster",
+  "lens",
   "msteams",
+  "mattermost",
   "googlechat",
+  "feishu",
+  "matrix",
+  "nostr",
+  "retake",
 ] as const;
 
 import { MiladySchema } from "./zod-schema";

--- a/src/runtime/eliza.ts
+++ b/src/runtime/eliza.ts
@@ -409,8 +409,8 @@ const _OPTIONAL_NATIVE_PLUGINS: readonly string[] = [
   "@elizaos/plugin-computeruse", // requires platform-specific binaries
 ];
 
-/** Maps Milady channel names to ElizaOS plugin package names. */
-const CHANNEL_PLUGIN_MAP: Readonly<Record<string, string>> = {
+/** Maps Milady channel names to plugin package names. */
+export const CHANNEL_PLUGIN_MAP: Readonly<Record<string, string>> = {
   discord: "@elizaos/plugin-discord",
   telegram: "@elizaos/plugin-telegram",
   slack: "@elizaos/plugin-slack",
@@ -419,9 +419,15 @@ const CHANNEL_PLUGIN_MAP: Readonly<Record<string, string>> = {
   signal: "@elizaos/plugin-signal",
   imessage: "@elizaos/plugin-imessage",
   bluebubbles: "@elizaos/plugin-bluebubbles",
+  farcaster: "@elizaos/plugin-farcaster",
+  lens: "@elizaos/plugin-lens",
   msteams: "@elizaos/plugin-msteams",
   mattermost: "@elizaos/plugin-mattermost",
   googlechat: "@elizaos/plugin-google-chat",
+  feishu: "@elizaos/plugin-feishu",
+  matrix: "@elizaos/plugin-matrix",
+  nostr: "@elizaos/plugin-nostr",
+  retake: "@milady/plugin-retake",
 };
 
 const PI_AI_PLUGIN_PACKAGE = "@elizaos/plugin-pi-ai";

--- a/test/subscription-auth.e2e.test.ts
+++ b/test/subscription-auth.e2e.test.ts
@@ -1,0 +1,247 @@
+import fs from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { startApiServer } from "../src/api/server";
+import type { OAuthCredentials } from "../src/auth/types";
+
+const getSubscriptionStatus = vi.fn(() => [{ id: "openai-codex" }]);
+const startAnthropicLogin = vi.fn();
+const startCodexLogin = vi.fn();
+const saveCredentials = vi.fn();
+const applySubscriptionCredentials = vi.fn(async () => undefined);
+const deleteCredentials = vi.fn();
+
+vi.mock("../src/auth/index", () => ({
+  getSubscriptionStatus,
+  startAnthropicLogin,
+  startCodexLogin,
+  saveCredentials,
+  applySubscriptionCredentials,
+  deleteCredentials,
+}));
+
+interface ReqResponse {
+  status: number;
+  data: Record<string, unknown>;
+}
+
+function req(
+  port: number,
+  method: string,
+  requestPath: string,
+  body?: Record<string, unknown>,
+): Promise<ReqResponse> {
+  return new Promise((resolve, reject) => {
+    const payload = body ? JSON.stringify(body) : undefined;
+    const request = http.request(
+      {
+        hostname: "127.0.0.1",
+        port,
+        path: requestPath,
+        method,
+        headers: {
+          "Content-Type": "application/json",
+          ...(payload ? { "Content-Length": Buffer.byteLength(payload) } : {}),
+        },
+      },
+      (response) => {
+        const chunks: Buffer[] = [];
+        response.on("data", (chunk: Buffer) => chunks.push(chunk));
+        response.on("end", () => {
+          const raw = Buffer.concat(chunks).toString("utf-8");
+          let data: Record<string, unknown> = {};
+          try {
+            data = JSON.parse(raw) as Record<string, unknown>;
+          } catch {
+            data = { _raw: raw };
+          }
+          resolve({ status: response.statusCode ?? 0, data });
+        });
+      },
+    );
+
+    request.on("error", reject);
+    if (payload) request.write(payload);
+    request.end();
+  });
+}
+
+function saveEnv(...keys: string[]): { restore: () => void } {
+  const saved: Record<string, string | undefined> = {};
+  for (const key of keys) {
+    saved[key] = process.env[key];
+  }
+  return {
+    restore() {
+      for (const key of keys) {
+        if (saved[key] === undefined) delete process.env[key];
+        else process.env[key] = saved[key];
+      }
+    },
+  };
+}
+
+function makeCredentials(expires = Date.now() + 60_000): OAuthCredentials {
+  return {
+    access: "access-token",
+    refresh: "refresh-token",
+    expires,
+  };
+}
+
+describe("subscription auth routes (e2e contract)", () => {
+  let port = 0;
+  let closeServer: (() => Promise<void>) | null = null;
+  let stateDir = "";
+  let envBackup: { restore: () => void };
+
+  beforeAll(async () => {
+    envBackup = saveEnv(
+      "MILADY_STATE_DIR",
+      "MILADY_CONFIG_PATH",
+      "MILADY_API_TOKEN",
+      "MILADY_PAIRING_DISABLED",
+      "ANTHROPIC_API_KEY",
+    );
+
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "milady-subscription-"));
+    process.env.MILADY_STATE_DIR = stateDir;
+    delete process.env.MILADY_CONFIG_PATH;
+    delete process.env.MILADY_API_TOKEN;
+    delete process.env.MILADY_PAIRING_DISABLED;
+    delete process.env.ANTHROPIC_API_KEY;
+
+    const server = await startApiServer({ port: 0 });
+    port = server.port;
+    closeServer = server.close;
+  }, 60_000);
+
+  afterAll(async () => {
+    if (closeServer) {
+      await closeServer();
+    }
+    await fs.rm(stateDir, { recursive: true, force: true });
+    envBackup.restore();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.ANTHROPIC_API_KEY;
+  });
+
+  it("runs anthropic start->exchange and applies credentials", async () => {
+    const submitCode = vi.fn();
+    const credentials = makeCredentials();
+
+    startAnthropicLogin.mockResolvedValueOnce({
+      authUrl: "https://auth.example/anthropic",
+      submitCode,
+      credentials: Promise.resolve(credentials),
+    });
+
+    const startRes = await req(
+      port,
+      "POST",
+      "/api/subscription/anthropic/start",
+    );
+    expect(startRes.status).toBe(200);
+    expect(startRes.data.authUrl).toBe("https://auth.example/anthropic");
+
+    const exchangeRes = await req(
+      port,
+      "POST",
+      "/api/subscription/anthropic/exchange",
+      { code: "code#state" },
+    );
+
+    expect(exchangeRes.status).toBe(200);
+    expect(exchangeRes.data.success).toBe(true);
+    expect(exchangeRes.data.expiresAt).toBe(credentials.expires);
+    expect(submitCode).toHaveBeenCalledWith("code#state");
+    expect(saveCredentials).toHaveBeenCalledWith(
+      "anthropic-subscription",
+      credentials,
+    );
+    expect(applySubscriptionCredentials).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists anthropic setup token to config file and env", async () => {
+    const token = "sk-ant-oat01-integration-test";
+
+    const setupRes = await req(
+      port,
+      "POST",
+      "/api/subscription/anthropic/setup-token",
+      { token },
+    );
+    expect(setupRes.status).toBe(200);
+    expect(setupRes.data.success).toBe(true);
+    expect(process.env.ANTHROPIC_API_KEY).toBe(token);
+
+    const configPath = path.join(stateDir, "milady.json");
+    const rawConfig = await fs.readFile(configPath, "utf-8");
+    const parsed = JSON.parse(rawConfig) as { env?: Record<string, string> };
+    expect(parsed.env?.ANTHROPIC_API_KEY).toBe(token);
+  });
+
+  it("cleans up failed openai exchange flow and supports retry start", async () => {
+    const firstFlowClose = vi.fn();
+    const firstFlowSubmitCode = vi.fn();
+    const firstCredentials = Promise.reject(new Error("callback timeout"));
+    void firstCredentials.catch(() => {});
+
+    const secondFlowClose = vi.fn();
+
+    startCodexLogin
+      .mockResolvedValueOnce({
+        authUrl: "https://auth.example/openai?state=first",
+        state: "first",
+        submitCode: firstFlowSubmitCode,
+        credentials: firstCredentials,
+        close: firstFlowClose,
+      })
+      .mockResolvedValueOnce({
+        authUrl: "https://auth.example/openai?state=second",
+        state: "second",
+        submitCode: vi.fn(),
+        credentials: Promise.resolve(makeCredentials()),
+        close: secondFlowClose,
+      });
+
+    const firstStart = await req(port, "POST", "/api/subscription/openai/start");
+    expect(firstStart.status).toBe(200);
+    expect(firstStart.data.authUrl).toBe(
+      "https://auth.example/openai?state=first",
+    );
+
+    const exchangeFail = await req(
+      port,
+      "POST",
+      "/api/subscription/openai/exchange",
+      { code: "invalid-code" },
+    );
+    expect(exchangeFail.status).toBe(500);
+    expect(exchangeFail.data.error).toBe("OpenAI exchange failed");
+    expect(firstFlowSubmitCode).toHaveBeenCalledWith("invalid-code");
+    expect(saveCredentials).not.toHaveBeenCalled();
+
+    const exchangeAfterCleanup = await req(
+      port,
+      "POST",
+      "/api/subscription/openai/exchange",
+      { waitForCallback: true },
+    );
+    expect(exchangeAfterCleanup.status).toBe(400);
+    expect(exchangeAfterCleanup.data.error).toContain("No active flow");
+
+    const retryStart = await req(port, "POST", "/api/subscription/openai/start");
+    expect(retryStart.status).toBe(200);
+    expect(retryStart.data.authUrl).toBe(
+      "https://auth.example/openai?state=second",
+    );
+    expect(firstFlowClose).toHaveBeenCalledTimes(1);
+    expect(secondFlowClose).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- align connector IDs/package mappings across schema, auto-enable, and runtime maps
- add dedicated connector parity tests to prevent future drift
- add `test/subscription-auth.e2e.test.ts` contract coverage for subscription OAuth start/exchange, token persistence, and failure cleanup/retry

## Scope
- `src/config/schema.ts`
- `src/runtime/eliza.ts`
- `src/config/connector-parity.test.ts`
- `test/subscription-auth.e2e.test.ts`

## Validation
- `bunx vitest run src/config/connector-parity.test.ts src/config/plugin-auto-enable.test.ts src/runtime/eliza.test.ts`
- `bunx vitest run --config vitest.e2e.config.ts test/subscription-auth.e2e.test.ts`
- `bun run typecheck`
- `bun run check`

## Mapping
- addresses PR-4 from Integration DoD plan (`MW-05`, `MW-06`)
