### PR TITLE
obs: add integration telemetry baseline for cloud, wallet, marketplace, and MCP

### DIFF
--- a/src/api/cloud-routes.observability.test.ts
+++ b/src/api/cloud-routes.observability.test.ts
@@ -1,0 +1,122 @@
+import type http from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createMockHttpResponse,
+  createMockIncomingMessage,
+} from "../test-support/test-helpers";
+import type { CloudRouteState } from "./cloud-routes";
+import { handleCloudRoute } from "./cloud-routes";
+
+const {
+  createSpanMock,
+  spanSuccessMock,
+  spanFailureMock,
+  validateCloudBaseUrlMock,
+  saveMiladyConfigMock,
+} = vi.hoisted(() => ({
+  createSpanMock: vi.fn(),
+  spanSuccessMock: vi.fn(),
+  spanFailureMock: vi.fn(),
+  validateCloudBaseUrlMock: vi.fn<(rawUrl: string) => Promise<string | null>>(),
+  saveMiladyConfigMock: vi.fn<(config: unknown) => void>(),
+}));
+
+vi.mock("../diagnostics/integration-observability", () => ({
+  createIntegrationTelemetrySpan: createSpanMock,
+}));
+
+vi.mock("../cloud/validate-url", () => ({
+  validateCloudBaseUrl: validateCloudBaseUrlMock,
+}));
+
+vi.mock("../config/config", () => ({
+  saveMiladyConfig: saveMiladyConfigMock,
+}));
+
+function cloudState(): CloudRouteState {
+  return {
+    config: {},
+    runtime: null,
+    cloudManager: null,
+  } as CloudRouteState;
+}
+
+describe("cloud routes observability", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    validateCloudBaseUrlMock.mockResolvedValue(null);
+    createSpanMock.mockReturnValue({
+      success: spanSuccessMock,
+      failure: spanFailureMock,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("records success for cloud login create-session flow", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        json: async () => ({}),
+      } as Response),
+    );
+
+    const req = createMockIncomingMessage({
+      method: "POST",
+      url: "/api/cloud/login",
+    }) as http.IncomingMessage;
+    const { res, getStatus } = createMockHttpResponse();
+
+    const handled = await handleCloudRoute(
+      req,
+      res,
+      "/api/cloud/login",
+      "POST",
+      cloudState(),
+    );
+
+    expect(handled).toBe(true);
+    expect(getStatus()).toBe(200);
+    expect(createSpanMock).toHaveBeenCalledWith({
+      boundary: "cloud",
+      operation: "login_create_session",
+      timeoutMs: 10_000,
+    });
+    expect(spanSuccessMock).toHaveBeenCalledWith({ statusCode: 200 });
+    expect(spanFailureMock).not.toHaveBeenCalled();
+  });
+
+  it("records failure when cloud login create-session times out", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("request timeout")),
+    );
+
+    const req = createMockIncomingMessage({
+      method: "POST",
+      url: "/api/cloud/login",
+    }) as http.IncomingMessage;
+    const { res, getStatus, getJson } = createMockHttpResponse();
+
+    const handled = await handleCloudRoute(
+      req,
+      res,
+      "/api/cloud/login",
+      "POST",
+      cloudState(),
+    );
+
+    expect(handled).toBe(true);
+    expect(getStatus()).toBe(504);
+    expect(getJson()).toEqual({ error: "Eliza Cloud login request timed out" });
+    expect(spanFailureMock).toHaveBeenCalledWith(
+      expect.objectContaining({ statusCode: 504 }),
+    );
+  });
+});

--- a/src/api/wallet-routes.observability.test.ts
+++ b/src/api/wallet-routes.observability.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MiladyConfig } from "../config/config";
+import {
+  handleWalletRoutes,
+  type WalletRouteDependencies,
+} from "./wallet-routes";
+
+const { createSpanMock, spanSuccessMock, spanFailureMock } = vi.hoisted(() => ({
+  createSpanMock: vi.fn(),
+  spanSuccessMock: vi.fn(),
+  spanFailureMock: vi.fn(),
+}));
+
+vi.mock("../diagnostics/integration-observability", () => ({
+  createIntegrationTelemetrySpan: createSpanMock,
+}));
+
+const ENV_KEYS = ["ALCHEMY_API_KEY", "HELIUS_API_KEY"] as const;
+const ORIGINAL_ENV = Object.fromEntries(
+  ENV_KEYS.map((key) => [key, process.env[key]]),
+) as Record<(typeof ENV_KEYS)[number], string | undefined>;
+
+function baseDeps(): WalletRouteDependencies {
+  return {
+    getWalletAddresses: vi.fn(() => ({
+      evmAddress: "0xabc",
+      solanaAddress: "So111",
+    })),
+    fetchEvmBalances: vi.fn(async () => []),
+    fetchSolanaBalances: vi.fn(async () => ({
+      solBalance: "1",
+      solValueUsd: "100",
+      tokens: [],
+    })),
+    fetchEvmNfts: vi.fn(async () => []),
+    fetchSolanaNfts: vi.fn(async () => []),
+    validatePrivateKey: vi.fn(() => ({
+      valid: true,
+      chain: "evm" as const,
+      address: "0xabc",
+      error: null,
+    })),
+    importWallet: vi.fn(() => ({
+      success: true,
+      chain: "evm" as const,
+      address: "0xabc",
+      error: null,
+    })),
+    generateWalletForChain: vi.fn((chain) => ({
+      chain,
+      address: chain === "evm" ? "0xgenerated" : "SoGenerated",
+      privateKey: chain === "evm" ? "evm-key" : "sol-key",
+    })),
+  };
+}
+
+async function invokeBalances(deps: WalletRouteDependencies): Promise<void> {
+  await handleWalletRoutes({
+    req: {} as never,
+    res: {} as never,
+    method: "GET",
+    pathname: "/api/wallet/balances",
+    config: { env: {} } as MiladyConfig,
+    saveConfig: vi.fn(),
+    ensureWalletKeysInEnvAndConfig: vi.fn(),
+    resolveWalletExportRejection: () => null,
+    deps,
+    readJsonBody: vi.fn(async () => null),
+    json: vi.fn(),
+    error: vi.fn(),
+  });
+}
+
+describe("wallet routes observability", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createSpanMock.mockReturnValue({
+      success: spanSuccessMock,
+      failure: spanFailureMock,
+    });
+    process.env.ALCHEMY_API_KEY = "alchemy";
+    process.env.HELIUS_API_KEY = "helius";
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      const value = ORIGINAL_ENV[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("records success spans for wallet balance fetches", async () => {
+    const deps = baseDeps();
+
+    await invokeBalances(deps);
+
+    expect(createSpanMock).toHaveBeenCalledWith({
+      boundary: "wallet",
+      operation: "fetch_evm_balances",
+    });
+    expect(createSpanMock).toHaveBeenCalledWith({
+      boundary: "wallet",
+      operation: "fetch_solana_balances",
+    });
+    expect(spanSuccessMock).toHaveBeenCalledTimes(2);
+    expect(spanFailureMock).not.toHaveBeenCalled();
+  });
+
+  it("records failure spans when wallet providers fail", async () => {
+    const deps = baseDeps();
+    deps.fetchEvmBalances = vi.fn(async () => {
+      throw new Error("provider down");
+    });
+    delete process.env.HELIUS_API_KEY;
+
+    await invokeBalances(deps);
+
+    expect(createSpanMock).toHaveBeenCalledWith({
+      boundary: "wallet",
+      operation: "fetch_evm_balances",
+    });
+    expect(spanFailureMock).toHaveBeenCalledTimes(1);
+    expect(spanFailureMock).toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.any(Error) }),
+    );
+  });
+});

--- a/src/api/wallet-routes.ts
+++ b/src/api/wallet-routes.ts
@@ -1,6 +1,7 @@
 import type http from "node:http";
 import { logger } from "@elizaos/core";
 import type { MiladyConfig } from "../config/config";
+import { createIntegrationTelemetrySpan } from "../diagnostics/integration-observability";
 import type { RouteHelpers, RouteRequestMeta } from "./route-helpers";
 import {
   fetchEvmBalances,
@@ -96,25 +97,37 @@ export async function handleWalletRoutes(
     const result: WalletBalancesResponse = { evm: null, solana: null };
 
     if (addresses.evmAddress && alchemyKey) {
+      const evmBalancesSpan = createIntegrationTelemetrySpan({
+        boundary: "wallet",
+        operation: "fetch_evm_balances",
+      });
       try {
         const chains = await deps.fetchEvmBalances(
           addresses.evmAddress,
           alchemyKey,
         );
         result.evm = { address: addresses.evmAddress, chains };
+        evmBalancesSpan.success();
       } catch (err) {
+        evmBalancesSpan.failure({ error: err });
         logger.warn(`[wallet] EVM balance fetch failed: ${err}`);
       }
     }
 
     if (addresses.solanaAddress && heliusKey) {
+      const solanaBalancesSpan = createIntegrationTelemetrySpan({
+        boundary: "wallet",
+        operation: "fetch_solana_balances",
+      });
       try {
         const solanaData = await deps.fetchSolanaBalances(
           addresses.solanaAddress,
           heliusKey,
         );
         result.solana = { address: addresses.solanaAddress, ...solanaData };
+        solanaBalancesSpan.success();
       } catch (err) {
+        solanaBalancesSpan.failure({ error: err });
         logger.warn(`[wallet] Solana balance fetch failed: ${err}`);
       }
     }
@@ -132,21 +145,33 @@ export async function handleWalletRoutes(
     const result: WalletNftsResponse = { evm: [], solana: null };
 
     if (addresses.evmAddress && alchemyKey) {
+      const evmNftsSpan = createIntegrationTelemetrySpan({
+        boundary: "wallet",
+        operation: "fetch_evm_nfts",
+      });
       try {
         result.evm = await deps.fetchEvmNfts(addresses.evmAddress, alchemyKey);
+        evmNftsSpan.success();
       } catch (err) {
+        evmNftsSpan.failure({ error: err });
         logger.warn(`[wallet] EVM NFT fetch failed: ${err}`);
       }
     }
 
     if (addresses.solanaAddress && heliusKey) {
+      const solanaNftsSpan = createIntegrationTelemetrySpan({
+        boundary: "wallet",
+        operation: "fetch_solana_nfts",
+      });
       try {
         const nfts = await deps.fetchSolanaNfts(
           addresses.solanaAddress,
           heliusKey,
         );
         result.solana = { nfts };
+        solanaNftsSpan.success();
       } catch (err) {
+        solanaNftsSpan.failure({ error: err });
         logger.warn(`[wallet] Solana NFT fetch failed: ${err}`);
       }
     }

--- a/src/diagnostics/integration-observability.test.ts
+++ b/src/diagnostics/integration-observability.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { loggerMock } = vi.hoisted(() => ({
+  loggerMock: {
+    info: vi.fn<(message: string) => void>(),
+    warn: vi.fn<(message: string) => void>(),
+  },
+}));
+
+vi.mock("@elizaos/core", () => ({
+  logger: loggerMock,
+}));
+
+import { createIntegrationTelemetrySpan } from "./integration-observability";
+
+const EVENT_PREFIX = "[integration] ";
+
+function parseEvent(line: string) {
+  return JSON.parse(line.slice(EVENT_PREFIX.length)) as Record<string, unknown>;
+}
+
+describe("createIntegrationTelemetrySpan", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("emits success events with duration and status code", () => {
+    const now = vi
+      .fn(() => 100)
+      .mockReturnValueOnce(100)
+      .mockReturnValueOnce(148);
+    const span = createIntegrationTelemetrySpan(
+      {
+        boundary: "cloud",
+        operation: "login_create_session",
+        timeoutMs: 10_000,
+      },
+      { now },
+    );
+
+    span.success({ statusCode: 200 });
+
+    expect(loggerMock.info).toHaveBeenCalledOnce();
+    expect(loggerMock.warn).not.toHaveBeenCalled();
+    const [line] = loggerMock.info.mock.calls[0] as [string];
+    expect(line.startsWith(EVENT_PREFIX)).toBe(true);
+    expect(parseEvent(line)).toEqual({
+      schema: "integration_boundary_v1",
+      boundary: "cloud",
+      operation: "login_create_session",
+      outcome: "success",
+      durationMs: 48,
+      timeoutMs: 10_000,
+      statusCode: 200,
+    });
+  });
+
+  it("emits failure events with timeout error kind", () => {
+    const now = vi
+      .fn(() => 200)
+      .mockReturnValueOnce(200)
+      .mockReturnValueOnce(235);
+    const span = createIntegrationTelemetrySpan(
+      {
+        boundary: "wallet",
+        operation: "fetch_evm_balances",
+      },
+      { now },
+    );
+
+    span.failure({
+      statusCode: 504,
+      error: new Error("request timed out"),
+    });
+
+    expect(loggerMock.warn).toHaveBeenCalledOnce();
+    expect(loggerMock.info).not.toHaveBeenCalled();
+    const [line] = loggerMock.warn.mock.calls[0] as [string];
+    expect(line.startsWith(EVENT_PREFIX)).toBe(true);
+    expect(parseEvent(line)).toEqual({
+      schema: "integration_boundary_v1",
+      boundary: "wallet",
+      operation: "fetch_evm_balances",
+      outcome: "failure",
+      durationMs: 35,
+      statusCode: 504,
+      errorKind: "timeout",
+    });
+  });
+
+  it("records only once even if called multiple times", () => {
+    const now = vi
+      .fn(() => 0)
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(5);
+    const span = createIntegrationTelemetrySpan(
+      {
+        boundary: "marketplace",
+        operation: "search_skills_marketplace",
+      },
+      { now },
+    );
+
+    span.success();
+    span.failure({ errorKind: "late_failure" });
+
+    expect(loggerMock.info).toHaveBeenCalledOnce();
+    expect(loggerMock.warn).not.toHaveBeenCalled();
+  });
+});

--- a/src/diagnostics/integration-observability.ts
+++ b/src/diagnostics/integration-observability.ts
@@ -1,0 +1,132 @@
+import { logger } from "@elizaos/core";
+
+export type IntegrationBoundary = "cloud" | "wallet" | "marketplace" | "mcp";
+export type IntegrationOutcome = "success" | "failure";
+
+export interface IntegrationObservabilityEvent {
+  schema: "integration_boundary_v1";
+  boundary: IntegrationBoundary;
+  operation: string;
+  outcome: IntegrationOutcome;
+  durationMs: number;
+  timeoutMs?: number;
+  statusCode?: number;
+  errorKind?: string;
+}
+
+interface IntegrationLogger {
+  info: (message: string) => void;
+  warn: (message: string) => void;
+}
+
+interface IntegrationSpanMeta {
+  boundary: IntegrationBoundary;
+  operation: string;
+  timeoutMs?: number;
+}
+
+interface IntegrationSpanSuccessArgs {
+  statusCode?: number;
+}
+
+interface IntegrationSpanFailureArgs {
+  statusCode?: number;
+  error?: unknown;
+  errorKind?: string;
+}
+
+interface CreateSpanOptions {
+  now?: () => number;
+  sink?: IntegrationLogger;
+}
+
+export interface IntegrationTelemetrySpan {
+  success: (args?: IntegrationSpanSuccessArgs) => void;
+  failure: (args?: IntegrationSpanFailureArgs) => void;
+}
+
+const EVENT_PREFIX = "[integration]";
+
+function inferErrorKind(error: unknown): string | undefined {
+  if (error instanceof Error) {
+    const message = error.message.toLowerCase();
+    if (
+      error.name === "AbortError" ||
+      error.name === "TimeoutError" ||
+      message.includes("timeout") ||
+      message.includes("timed out")
+    ) {
+      return "timeout";
+    }
+    return sanitizeToken(error.name);
+  }
+  if (typeof error === "string") return sanitizeToken(error);
+  return undefined;
+}
+
+function sanitizeToken(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const token = value.toLowerCase().replace(/[^a-z0-9_-]/g, "_");
+  const normalized = token.replace(/_+/g, "_").replace(/^_+|_+$/g, "");
+  return normalized ? normalized.slice(0, 64) : undefined;
+}
+
+function emitEvent(
+  sink: IntegrationLogger,
+  event: IntegrationObservabilityEvent,
+): void {
+  const line = `${EVENT_PREFIX} ${JSON.stringify(event)}`;
+  if (event.outcome === "success") {
+    sink.info(line);
+    return;
+  }
+  sink.warn(line);
+}
+
+export function createIntegrationTelemetrySpan(
+  meta: IntegrationSpanMeta,
+  options: CreateSpanOptions = {},
+): IntegrationTelemetrySpan {
+  const now = options.now ?? Date.now;
+  const sink = options.sink ?? logger;
+  const startedAt = now();
+  let settled = false;
+
+  const finalize = (
+    outcome: IntegrationOutcome,
+    args?: IntegrationSpanSuccessArgs | IntegrationSpanFailureArgs,
+  ): void => {
+    if (settled) return;
+    settled = true;
+
+    const durationMs = Math.max(0, now() - startedAt);
+    const event: IntegrationObservabilityEvent = {
+      schema: "integration_boundary_v1",
+      boundary: meta.boundary,
+      operation: meta.operation,
+      outcome,
+      durationMs,
+    };
+
+    if (typeof meta.timeoutMs === "number") {
+      event.timeoutMs = meta.timeoutMs;
+    }
+    if (typeof args?.statusCode === "number") {
+      event.statusCode = args.statusCode;
+    }
+
+    if (outcome === "failure") {
+      const failureArgs = args as IntegrationSpanFailureArgs | undefined;
+      event.errorKind =
+        sanitizeToken(failureArgs?.errorKind) ??
+        inferErrorKind(failureArgs?.error);
+    }
+
+    emitEvent(sink, event);
+  };
+
+  return {
+    success: (args) => finalize("success", args),
+    failure: (args) => finalize("failure", args),
+  };
+}

--- a/src/services/mcp-marketplace.observability.test.ts
+++ b/src/services/mcp-marketplace.observability.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createSpanMock, spanSuccessMock, spanFailureMock } = vi.hoisted(() => ({
+  createSpanMock: vi.fn(),
+  spanSuccessMock: vi.fn(),
+  spanFailureMock: vi.fn(),
+}));
+
+vi.mock("../diagnostics/integration-observability", () => ({
+  createIntegrationTelemetrySpan: createSpanMock,
+}));
+
+import { getMcpServerDetails, searchMcpMarketplace } from "./mcp-marketplace";
+
+describe("mcp marketplace observability", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    createSpanMock.mockReturnValue({
+      success: spanSuccessMock,
+      failure: spanFailureMock,
+    });
+  });
+
+  it("records success for MCP registry search", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ servers: [] }),
+      }),
+    );
+
+    await expect(searchMcpMarketplace("github")).resolves.toEqual({
+      results: [],
+    });
+
+    expect(createSpanMock).toHaveBeenCalledWith({
+      boundary: "mcp",
+      operation: "search_registry_servers",
+    });
+    expect(spanSuccessMock).toHaveBeenCalledWith({ statusCode: 200 });
+    expect(spanFailureMock).not.toHaveBeenCalled();
+  });
+
+  it("records failure for MCP details fetch errors", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: async () => ({}),
+      }),
+    );
+
+    await expect(getMcpServerDetails("broken/server")).rejects.toThrow(
+      /registry api error/i,
+    );
+
+    expect(createSpanMock).toHaveBeenCalledWith({
+      boundary: "mcp",
+      operation: "get_registry_server_details",
+    });
+    expect(spanFailureMock).toHaveBeenCalledWith({
+      statusCode: 500,
+      errorKind: "http_error",
+    });
+  });
+});

--- a/src/services/skill-marketplace.observability.test.ts
+++ b/src/services/skill-marketplace.observability.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createSpanMock, spanSuccessMock, spanFailureMock } = vi.hoisted(() => ({
+  createSpanMock: vi.fn(),
+  spanSuccessMock: vi.fn(),
+  spanFailureMock: vi.fn(),
+}));
+
+vi.mock("../diagnostics/integration-observability", () => ({
+  createIntegrationTelemetrySpan: createSpanMock,
+}));
+
+vi.mock("@elizaos/core", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { searchSkillsMarketplace } from "./skill-marketplace";
+
+describe("skills marketplace observability", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    createSpanMock.mockReturnValue({
+      success: spanSuccessMock,
+      failure: spanFailureMock,
+    });
+  });
+
+  it("records success for marketplace search", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ results: [] }),
+      }),
+    );
+
+    await expect(searchSkillsMarketplace("agent")).resolves.toEqual([]);
+
+    expect(createSpanMock).toHaveBeenCalledWith({
+      boundary: "marketplace",
+      operation: "search_skills_marketplace",
+      timeoutMs: 30_000,
+    });
+    expect(spanSuccessMock).toHaveBeenCalledWith({ statusCode: 200 });
+    expect(spanFailureMock).not.toHaveBeenCalled();
+  });
+
+  it("records failure for non-OK marketplace responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        json: async () => ({}),
+      }),
+    );
+
+    await expect(searchSkillsMarketplace("agent")).rejects.toThrow(
+      /request failed/i,
+    );
+
+    expect(spanFailureMock).toHaveBeenCalledWith({
+      statusCode: 503,
+      errorKind: "http_error",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared integration observability contract (`integration_boundary_v1`) with deterministic `success/failure/latency` event emission
- instrument cloud login routes, wallet external fetch paths, skills marketplace search, and MCP registry fetch boundaries
- add focused observability wiring tests for each boundary plus helper contract tests

## Why
This closes MW-09 from `INTEGRATION_DOD_MAP.md` by making boundary-level observability concrete and test-verified instead of ad-hoc logs.

## What changed
- Added helper:
  - `src/diagnostics/integration-observability.ts`
  - `src/diagnostics/integration-observability.test.ts`
- Cloud boundary instrumentation:
  - `src/api/cloud-routes.ts`
  - `src/api/cloud-routes.observability.test.ts`
- Wallet boundary instrumentation:
  - `src/api/wallet-routes.ts`
  - `src/api/wallet-routes.observability.test.ts`
- Skills marketplace boundary instrumentation:
  - `src/services/skill-marketplace.ts`
  - `src/services/skill-marketplace.observability.test.ts`
- MCP boundary instrumentation:
  - `src/services/mcp-marketplace.ts`
  - `src/services/mcp-marketplace.observability.test.ts`

## Verification
```bash
bunx vitest run src/diagnostics/integration-observability.test.ts src/api/cloud-routes.observability.test.ts src/api/cloud-routes.test.ts src/api/wallet-routes.observability.test.ts src/api/wallet-routes.test.ts src/services/skill-marketplace.observability.test.ts src/services/skill-marketplace.test.ts src/services/mcp-marketplace.observability.test.ts src/services/mcp-marketplace.test.ts
bun run typecheck
bun run check
bunx vitest run src/diagnostics/integration-observability.test.ts src/api/cloud-routes.observability.test.ts src/api/wallet-routes.observability.test.ts src/services/skill-marketplace.observability.test.ts src/services/mcp-marketplace.observability.test.ts
```
