### PR TITLE
fix: harden tx, registry, and drop failure coverage

### DIFF
--- a/src/api/tx-service.test.ts
+++ b/src/api/tx-service.test.ts
@@ -36,6 +36,22 @@ describe("tx-service", () => {
     expect(destroySpy).toHaveBeenCalledTimes(1);
   });
 
+  it("destroys the fresh provider even when nonce lookup fails", async () => {
+    const nonceError = new Error("nonce fetch failed");
+    vi.spyOn(
+      ethers.JsonRpcProvider.prototype,
+      "getTransactionCount",
+    ).mockRejectedValue(nonceError);
+    const destroySpy = vi
+      .spyOn(ethers.JsonRpcProvider.prototype, "destroy")
+      .mockImplementation(() => undefined);
+
+    const service = createService();
+
+    await expect(service.getFreshNonce()).rejects.toThrow("nonce fetch failed");
+    expect(destroySpy).toHaveBeenCalledTimes(1);
+  });
+
   it("throws when waiting for a transaction times out", async () => {
     const service = createService();
     const provider = (

--- a/src/api/tx-service.ts
+++ b/src/api/tx-service.ts
@@ -57,12 +57,15 @@ export class TxService {
   async getFreshNonce(): Promise<number> {
     // Use a fresh provider for each nonce lookup to avoid ethers.js v6 caching
     const freshProvider = new ethers.JsonRpcProvider(this.rpcUrl);
-    const nonce = await freshProvider.getTransactionCount(
-      this.wallet.address,
-      "pending",
-    );
-    freshProvider.destroy();
-    return nonce;
+    try {
+      const nonce = await freshProvider.getTransactionCount(
+        this.wallet.address,
+        "pending",
+      );
+      return nonce;
+    } finally {
+      freshProvider.destroy();
+    }
   }
 
   get address(): string {


### PR DESCRIPTION
## Summary
- harden nonce reliability in `TxService.getFreshNonce()` by ensuring fresh-provider cleanup runs on both success and failure paths
- expand deterministic service tests for tx/registry/drop failure-paths and nonce usage across profile/update/mint operations
- add minted-out status coverage for drop status computation at max supply

## What changed
- `src/api/tx-service.ts`
- `src/api/tx-service.test.ts`
- `src/api/registry-service.test.ts`
- `src/api/drop-service.test.ts`

## Validation
- `bunx vitest run src/api/tx-service.test.ts src/api/registry-service.test.ts src/api/drop-service.test.ts`
- `bun run lint`
- `bun run pre-review:local` (APPROVE)
