### PR TITLE
fix: harden x402 and cua auto-enable regression coverage

### DIFF
--- a/src/config/plugin-auto-enable.test.ts
+++ b/src/config/plugin-auto-enable.test.ts
@@ -311,6 +311,38 @@ describe("applyPluginAutoEnable — env vars", () => {
     const anthropicEntries = allow.filter((p) => p === "anthropic");
     expect(anthropicEntries).toHaveLength(1);
   });
+
+  it("auto-enables cua plugin when CUA_API_KEY is set", () => {
+    const params = makeParams({
+      env: { CUA_API_KEY: "cua-key" },
+    });
+    const { config, changes } = applyPluginAutoEnable(params);
+
+    expect(config.plugins?.allow).toContain("cua");
+    expect(changes.some((c) => c.includes("CUA_API_KEY"))).toBe(true);
+  });
+
+  it("auto-enables cua plugin when CUA_HOST is set", () => {
+    const params = makeParams({
+      env: { CUA_HOST: "https://cua.example" },
+    });
+    const { config, changes } = applyPluginAutoEnable(params);
+
+    expect(config.plugins?.allow).toContain("cua");
+    expect(changes.some((c) => c.includes("CUA_HOST"))).toBe(true);
+  });
+
+  it("respects cua enabled=false override for env auto-enable", () => {
+    const params = makeParams({
+      config: {
+        plugins: { entries: { cua: { enabled: false } } },
+      },
+      env: { CUA_API_KEY: "cua-key" },
+    });
+    const { config } = applyPluginAutoEnable(params);
+
+    expect(config.plugins?.allow ?? []).not.toContain("cua");
+  });
 });
 
 // ============================================================================
@@ -372,6 +404,36 @@ describe("applyPluginAutoEnable — features", () => {
     const { config } = applyPluginAutoEnable(params);
 
     expect(config.plugins?.allow).toContain("obsidian");
+  });
+
+  it("enables x402 plugin when features.x402 = true", () => {
+    const params = makeParams({
+      config: { features: { x402: true } },
+    });
+    const { config, changes } = applyPluginAutoEnable(params);
+
+    expect(config.plugins?.allow).toContain("x402");
+    expect(changes.some((c) => c.includes("feature: x402"))).toBe(true);
+  });
+
+  it("enables cua plugin when features.cua = true", () => {
+    const params = makeParams({
+      config: { features: { cua: true } },
+    });
+    const { config, changes } = applyPluginAutoEnable(params);
+
+    expect(config.plugins?.allow).toContain("cua");
+    expect(changes.some((c) => c.includes("feature: cua"))).toBe(true);
+  });
+
+  it("enables computeruse plugin when features.computeruse = true", () => {
+    const params = makeParams({
+      config: { features: { computeruse: true } },
+    });
+    const { config, changes } = applyPluginAutoEnable(params);
+
+    expect(config.plugins?.allow).toContain("computeruse");
+    expect(changes.some((c) => c.includes("feature: computeruse"))).toBe(true);
   });
 });
 
@@ -523,6 +585,11 @@ describe("AUTH_PROVIDER_PLUGINS", () => {
     expect(AUTH_PROVIDER_PLUGINS.MILAIDY_USE_PI_AI).toBe(
       "@elizaos/plugin-pi-ai",
     );
+  });
+
+  it("maps CUA env keys to cua plugin", () => {
+    expect(AUTH_PROVIDER_PLUGINS.CUA_API_KEY).toBe("@elizaos/plugin-cua");
+    expect(AUTH_PROVIDER_PLUGINS.CUA_HOST).toBe("@elizaos/plugin-cua");
   });
 });
 


### PR DESCRIPTION
## Summary
- add explicit x402/CUA/computeruse auto-enable regression tests in `plugin-auto-enable.test.ts`
- validate env-triggered CUA enablement (`CUA_API_KEY`, `CUA_HOST`) and `enabled:false` override behavior
- validate feature-flag mappings for `x402`, `cua`, and `computeruse`, and assert CUA env-key mapping constants

## Why
- strengthens MW-03 runtime boundary coverage by locking config-to-plugin mapping behavior with deterministic tests
- reduces risk of silent plugin loading regressions for payment and computer-use integrations

## Validation
- `bunx vitest run src/config/plugin-auto-enable.test.ts`
- `bun run lint`
- `bun run pre-review:local` (APPROVE)
