### PR TITLE
app: prevent settings modal close on enter/space

### DIFF
--- a/apps/app/src/components/SettingsView.tsx
+++ b/apps/app/src/components/SettingsView.tsx
@@ -26,7 +26,7 @@ import { VoiceConfigView } from "./VoiceConfigView";
 
 /* ── Modal shell ─────────────────────────────────────────────────────── */
 
-function Modal({
+export function Modal({
   open,
   onClose,
   title,
@@ -45,7 +45,7 @@ function Modal({
         if (e.target === e.currentTarget) onClose();
       }}
       onKeyDown={(e) => {
-        if (e.key === "Escape" || e.key === "Enter" || e.key === " ") {
+        if (e.key === "Escape") {
           e.preventDefault();
           onClose();
         }

--- a/apps/app/test/app/settings-modal.test.tsx
+++ b/apps/app/test/app/settings-modal.test.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { describe, expect, it, vi } from "vitest";
+import { Modal } from "../../src/components/SettingsView";
+
+function renderModal(onClose: () => void) {
+  return TestRenderer.create(
+    React.createElement(
+      Modal,
+      {
+        open: true,
+        onClose,
+        title: "Test Modal",
+      },
+      React.createElement("div", null, "body"),
+    ),
+  );
+}
+
+describe("Settings modal keyboard handling", () => {
+  it("closes on Escape", () => {
+    const onClose = vi.fn();
+    let tree!: TestRenderer.ReactTestRenderer;
+    act(() => {
+      tree = renderModal(onClose);
+    });
+
+    const dialog = tree.root.findByProps({ role: "dialog" });
+    const preventDefault = vi.fn();
+    act(() => {
+      dialog.props.onKeyDown({ key: "Escape", preventDefault });
+    });
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not close on Enter or Space", () => {
+    const onClose = vi.fn();
+    let tree!: TestRenderer.ReactTestRenderer;
+    act(() => {
+      tree = renderModal(onClose);
+    });
+
+    const dialog = tree.root.findByProps({ role: "dialog" });
+    act(() => {
+      dialog.props.onKeyDown({ key: "Enter", preventDefault: vi.fn() });
+      dialog.props.onKeyDown({ key: " ", preventDefault: vi.fn() });
+    });
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary\n- restrict settings modal keyboard close behavior to Escape only\n- prevent accidental modal dismissal from Enter/Space while interacting with modal controls\n- add focused tests for Escape close and Enter/Space no-close behavior\n\n## Validation\n- bunx vitest run apps/app/test/app/chat-view.test.tsx\n- bunx vitest run apps/app/test/app/settings-modal.test.tsx