### PR TITLE
milady app: backport Electron API base injection race fix to develop

### DIFF
--- a/apps/app/electron/src/api-base.ts
+++ b/apps/app/electron/src/api-base.ts
@@ -1,0 +1,129 @@
+type ExternalApiBaseEnvKey =
+  | "MILADY_API_BASE_URL"
+  | "MILADY_API_BASE"
+  | "MILADY_ELECTRON_API_BASE"
+  | "MILADY_ELECTRON_TEST_API_BASE";
+
+const EXTERNAL_API_BASE_ENV_KEYS: readonly ExternalApiBaseEnvKey[] = [
+  // Test override must win so e2e runs are deterministic regardless of host env.
+  "MILADY_ELECTRON_TEST_API_BASE",
+  "MILADY_ELECTRON_API_BASE",
+  "MILADY_API_BASE_URL",
+  "MILADY_API_BASE",
+];
+
+export interface ExternalApiBaseResolution {
+  base: string | null;
+  source: ExternalApiBaseEnvKey | null;
+  invalidSources: ExternalApiBaseEnvKey[];
+}
+
+interface ApiBaseInjectionTarget {
+  isDestroyed: () => boolean;
+  executeJavaScript: (script: string) => Promise<unknown>;
+}
+
+interface CreateApiBaseInjectorOptions {
+  getApiToken?: () => string | undefined;
+  onInjected?: () => void;
+  onInjectionError?: (error: unknown) => void;
+}
+
+export interface ApiBaseInjector {
+  inject: (base: string | null) => Promise<boolean>;
+  getLastInjectedBase: () => string | null;
+}
+
+function readEnvValue(
+  env: Record<string, string | undefined>,
+  key: ExternalApiBaseEnvKey,
+): string | undefined {
+  const value = env[key];
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export function normalizeApiBase(raw: string | undefined): string | null {
+  if (!raw) return null;
+  try {
+    const parsed = new URL(raw);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+    return parsed.origin;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveExternalApiBase(
+  env: Record<string, string | undefined>,
+): ExternalApiBaseResolution {
+  const invalidSources: ExternalApiBaseEnvKey[] = [];
+
+  for (const key of EXTERNAL_API_BASE_ENV_KEYS) {
+    const rawValue = readEnvValue(env, key);
+    if (!rawValue) continue;
+
+    const normalized = normalizeApiBase(rawValue);
+    if (normalized) {
+      return {
+        base: normalized,
+        source: key,
+        invalidSources,
+      };
+    }
+
+    invalidSources.push(key);
+  }
+
+  return {
+    base: null,
+    source: null,
+    invalidSources,
+  };
+}
+
+export function createApiBaseInjectionScript(
+  base: string,
+  apiToken?: string,
+): string {
+  const trimmedToken = apiToken?.trim();
+  const tokenSnippet = trimmedToken
+    ? `window.__MILADY_API_TOKEN__ = ${JSON.stringify(trimmedToken)};`
+    : "";
+  const baseSnippet = `window.__MILADY_API_BASE__ = ${JSON.stringify(base)};`;
+  return `${baseSnippet}${tokenSnippet}`;
+}
+
+export function createApiBaseInjector(
+  target: ApiBaseInjectionTarget,
+  options: CreateApiBaseInjectorOptions = {},
+): ApiBaseInjector {
+  let lastInjectedBase: string | null = null;
+
+  return {
+    async inject(base: string | null): Promise<boolean> {
+      if (!base || target.isDestroyed()) return false;
+      const script = createApiBaseInjectionScript(
+        base,
+        options.getApiToken?.(),
+      );
+
+      try {
+        await target.executeJavaScript(script);
+        lastInjectedBase = base;
+        options.onInjected?.();
+        return true;
+      } catch (err) {
+        options.onInjectionError?.(err);
+        return false;
+      }
+    },
+
+    getLastInjectedBase(): string | null {
+      return lastInjectedBase;
+    },
+  };
+}

--- a/apps/app/test/electron/api-base.test.ts
+++ b/apps/app/test/electron/api-base.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createApiBaseInjectionScript,
+  createApiBaseInjector,
+  normalizeApiBase,
+  resolveExternalApiBase,
+} from "../../electron/src/api-base";
+
+describe("normalizeApiBase", () => {
+  it("accepts http/https URLs and returns origin", () => {
+    expect(normalizeApiBase("https://example.com/api/v1")).toBe(
+      "https://example.com",
+    );
+    expect(normalizeApiBase("http://127.0.0.1:2138/path")).toBe(
+      "http://127.0.0.1:2138",
+    );
+  });
+
+  it("rejects non-http protocols", () => {
+    expect(normalizeApiBase("ws://localhost:2138")).toBeNull();
+    expect(normalizeApiBase("file:///tmp/test")).toBeNull();
+  });
+});
+
+describe("resolveExternalApiBase", () => {
+  it("prefers the test override when provided", () => {
+    const resolved = resolveExternalApiBase({
+      MILADY_API_BASE_URL: "https://api.prod.milady.ai",
+      MILADY_ELECTRON_TEST_API_BASE: "http://127.0.0.1:9999",
+    });
+
+    expect(resolved.base).toBe("http://127.0.0.1:9999");
+    expect(resolved.source).toBe("MILADY_ELECTRON_TEST_API_BASE");
+    expect(resolved.invalidSources).toEqual([]);
+  });
+
+  it("skips invalid higher-priority values and keeps searching", () => {
+    const resolved = resolveExternalApiBase({
+      MILADY_API_BASE_URL: "not a url",
+      MILADY_API_BASE: "http://127.0.0.1:31337",
+    });
+
+    expect(resolved.base).toBe("http://127.0.0.1:31337");
+    expect(resolved.source).toBe("MILADY_API_BASE");
+    expect(resolved.invalidSources).toEqual(["MILADY_API_BASE_URL"]);
+  });
+});
+
+describe("createApiBaseInjector", () => {
+  it("retries the same base after an early executeJavaScript failure", async () => {
+    const executeJavaScript = vi
+      .fn<(script: string) => Promise<unknown>>()
+      .mockRejectedValueOnce(new Error("not ready"))
+      .mockResolvedValueOnce(undefined);
+
+    const injector = createApiBaseInjector(
+      {
+        isDestroyed: () => false,
+        executeJavaScript,
+      },
+      {
+        getApiToken: () => "  desktop-token  ",
+      },
+    );
+
+    await expect(injector.inject("http://localhost:31337")).resolves.toBe(
+      false,
+    );
+    await expect(injector.inject("http://localhost:31337")).resolves.toBe(true);
+
+    expect(executeJavaScript).toHaveBeenCalledTimes(2);
+    expect(injector.getLastInjectedBase()).toBe("http://localhost:31337");
+  });
+
+  it("reinjects the same base on subsequent calls (renderer reload safe)", async () => {
+    const executeJavaScript = vi
+      .fn<(script: string) => Promise<unknown>>()
+      .mockResolvedValue(undefined);
+
+    const injector = createApiBaseInjector({
+      isDestroyed: () => false,
+      executeJavaScript,
+    });
+
+    await injector.inject("http://localhost:2138");
+    await injector.inject("http://localhost:2138");
+
+    expect(executeJavaScript).toHaveBeenCalledTimes(2);
+  });
+
+  it("no-ops when the target window is destroyed", async () => {
+    const executeJavaScript = vi
+      .fn<(script: string) => Promise<unknown>>()
+      .mockResolvedValue(undefined);
+
+    const injector = createApiBaseInjector({
+      isDestroyed: () => true,
+      executeJavaScript,
+    });
+
+    await expect(injector.inject("http://localhost:2138")).resolves.toBe(false);
+    expect(executeJavaScript).not.toHaveBeenCalled();
+  });
+});
+
+describe("createApiBaseInjectionScript", () => {
+  it("embeds base and optional token globals", () => {
+    const withToken = createApiBaseInjectionScript(
+      "http://localhost:2138",
+      "  abc123  ",
+    );
+    expect(withToken).toContain(
+      'window.__MILADY_API_BASE__ = "http://localhost:2138";',
+    );
+    expect(withToken).toContain('window.__MILADY_API_TOKEN__ = "abc123";');
+
+    const withoutToken = createApiBaseInjectionScript("http://localhost:2138");
+    expect(withoutToken).not.toContain("__MILADY_API_TOKEN__");
+  });
+});


### PR DESCRIPTION
## Summary
Cherry-picks the Electron API base injection race fix from #451 into `develop` so both `main` and `develop` have the same startup behavior.

## What this includes
- `apps/app/electron/src/api-base.ts` (new helper module)
- `apps/app/electron/src/index.ts` updates for retry-safe API base/token injection
- `apps/app/test/electron/api-base.test.ts` regression tests

## Why
Without this, Electron renderer startup can miss `window.__MILADY_API_BASE__` when first injection runs before renderer readiness, causing API connection failures after local build/start.

## Testing
- `bun run --cwd apps/app vitest run test/electron/api-base.test.ts test/electron/electron-startup.e2e.test.ts test/electron/web-assets.test.ts`

## Notes
I also attempted `bun run --cwd apps/app/electron build` on current `develop`, which currently fails in `apps/app/electron/src/native/camera.ts` due an existing unrelated `mainWindow` property typing issue. This PR does not touch camera module code.
