### PR TITLE
fix: eliminate agent loading hangs and startup retry traps

### DIFF
--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -26,6 +26,7 @@ import { PairingView } from "./components/PairingView";
 import { RestartBanner } from "./components/RestartBanner";
 import { SaveCommandModal } from "./components/SaveCommandModal";
 import { SettingsView } from "./components/SettingsView";
+import { StartupFailureView } from "./components/StartupFailureView";
 import { TerminalPanel } from "./components/TerminalPanel";
 import { useContextMenu } from "./hooks/useContextMenu";
 
@@ -70,8 +71,10 @@ export function App() {
   const {
     onboardingLoading,
     startupPhase,
+    startupError,
     authRequired,
     onboardingComplete,
+    retryStartup,
     tab,
     actionNotice,
     agentStatus,
@@ -251,6 +254,10 @@ export function App() {
   }, [isChat]);
 
   const agentStarting = agentStatus?.state === "starting";
+
+  if (startupError) {
+    return <StartupFailureView error={startupError} onRetry={retryStartup} />;
+  }
 
   if (onboardingLoading || agentStarting) {
     return (

--- a/apps/app/src/AppContext.tsx
+++ b/apps/app/src/AppContext.tsx
@@ -14,6 +14,7 @@ import {
   useState,
 } from "react";
 import {
+  type AgentStartupDiagnostics,
   type AgentStatus,
   type AppViewerAuthMessage,
   type CatalogSkill,
@@ -321,13 +322,33 @@ function parseAgentStatusEvent(
   const startedAt =
     typeof data.startedAt === "number" ? data.startedAt : undefined;
   const uptime = typeof data.uptime === "number" ? data.uptime : undefined;
+  const startup = parseAgentStartupDiagnostics(data.startup);
   return {
     state: state as AgentStatus["state"],
     agentName,
     model,
     startedAt,
     uptime,
+    startup,
   };
+}
+
+function parseAgentStartupDiagnostics(
+  value: unknown,
+): AgentStartupDiagnostics | undefined {
+  if (!isRecord(value)) return undefined;
+  const phase = value.phase;
+  const attempt = value.attempt;
+  if (typeof phase !== "string" || typeof attempt !== "number") {
+    return undefined;
+  }
+  const startup: AgentStartupDiagnostics = { phase, attempt };
+  if (typeof value.lastError === "string") startup.lastError = value.lastError;
+  if (typeof value.lastErrorAt === "number")
+    startup.lastErrorAt = value.lastErrorAt;
+  if (typeof value.nextRetryAt === "number")
+    startup.nextRetryAt = value.nextRetryAt;
+  return startup;
 }
 
 function parseStreamEventEnvelopeEvent(
@@ -444,6 +465,65 @@ type LoadConversationMessagesResult =
 
 export type StartupPhase = "starting-backend" | "initializing-agent";
 
+export type StartupErrorReason =
+  | "backend-timeout"
+  | "backend-unreachable"
+  | "agent-timeout"
+  | "agent-error";
+
+export interface StartupErrorState {
+  reason: StartupErrorReason;
+  phase: StartupPhase;
+  message: string;
+  detail?: string;
+  status?: number;
+  path?: string;
+}
+
+const BACKEND_STARTUP_TIMEOUT_MS = 30_000;
+const AGENT_READY_TIMEOUT_MS = 90_000;
+
+interface ApiLikeError {
+  kind?: string;
+  status?: number;
+  path?: string;
+  message?: string;
+}
+
+function asApiLikeError(err: unknown): ApiLikeError | null {
+  if (!isRecord(err)) return null;
+  const kind = err.kind;
+  const status = err.status;
+  const path = err.path;
+  const message = err.message;
+  const hasApiShape =
+    typeof kind === "string" ||
+    typeof status === "number" ||
+    typeof path === "string";
+  if (!hasApiShape) return null;
+  return {
+    kind: typeof kind === "string" ? kind : undefined,
+    status: typeof status === "number" ? status : undefined,
+    path: typeof path === "string" ? path : undefined,
+    message: typeof message === "string" ? message : undefined,
+  };
+}
+
+function formatStartupErrorDetail(err: unknown): string | undefined {
+  const apiErr = asApiLikeError(err);
+  if (apiErr) {
+    const parts: string[] = [];
+    if (apiErr.path) parts.push(apiErr.path);
+    if (typeof apiErr.status === "number") parts.push(`HTTP ${apiErr.status}`);
+    if (apiErr.message) parts.push(apiErr.message);
+    return parts.filter(Boolean).join(" - ");
+  }
+  if (err instanceof Error && err.message.trim()) {
+    return err.message.trim();
+  }
+  return undefined;
+}
+
 // ── Context value type ─────────────────────────────────────────────────
 
 export interface AppState {
@@ -455,6 +535,7 @@ export interface AppState {
   onboardingComplete: boolean;
   onboardingLoading: boolean;
   startupPhase: StartupPhase;
+  startupError: StartupErrorState | null;
   authRequired: boolean;
   actionNotice: ActionNotice | null;
   lifecycleBusy: boolean;
@@ -730,6 +811,7 @@ export interface AppActions {
   handlePauseResume: () => Promise<void>;
   handleRestart: () => Promise<void>;
   handleReset: () => Promise<void>;
+  retryStartup: () => void;
   dismissRestartBanner: () => void;
   triggerRestart: () => Promise<void>;
 
@@ -879,6 +961,10 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const [onboardingLoading, setOnboardingLoading] = useState(true);
   const [startupPhase, setStartupPhase] =
     useState<StartupPhase>("starting-backend");
+  const [startupError, setStartupError] = useState<StartupErrorState | null>(
+    null,
+  );
+  const [startupRetryNonce, setStartupRetryNonce] = useState(0);
   const [authRequired, setAuthRequired] = useState(false);
   const [actionNotice, setActionNoticeState] = useState<ActionNotice | null>(
     null,
@@ -1980,6 +2066,14 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const triggerRestart = useCallback(async () => {
     await handleRestart();
   }, [handleRestart]);
+
+  const retryStartup = useCallback(() => {
+    setStartupError(null);
+    setAuthRequired(false);
+    setOnboardingLoading(true);
+    setStartupPhase("starting-backend");
+    setStartupRetryNonce((prev) => prev + 1);
+  }, []);
 
   const handleReset = useCallback(async () => {
     if (lifecycleBusyRef.current) {
@@ -3676,6 +3770,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
         chatAvatarVisible: setChatAvatarVisible,
         chatAgentVoiceMuted: setChatAgentVoiceMuted,
         chatAvatarSpeaking: setChatAvatarSpeaking,
+        startupError: setStartupError,
         pairingCodeInput: setPairingCodeInput,
         pluginFilter: setPluginFilter,
         pluginStatusFilter: setPluginStatusFilter,
@@ -3791,25 +3886,113 @@ export function AppProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     applyTheme(currentTheme);
+    const startupRunId = startupRetryNonce;
     let unbindStatus: (() => void) | null = null;
     let unbindAgentEvents: (() => void) | null = null;
     let unbindHeartbeatEvents: (() => void) | null = null;
     let unbindProactiveMessages: (() => void) | null = null;
     let cancelled = false;
+    const describeBackendFailure = (
+      err: unknown,
+      timedOut: boolean,
+    ): StartupErrorState => {
+      const apiErr = asApiLikeError(err);
+      if (apiErr?.kind === "http" && apiErr.status === 404) {
+        return {
+          reason: "backend-unreachable",
+          phase: "starting-backend",
+          message:
+            "Backend API routes are unavailable on this origin (received 404).",
+          detail: formatStartupErrorDetail(err),
+          status: apiErr.status,
+          path: apiErr.path,
+        };
+      }
+      if (timedOut || apiErr?.kind === "timeout") {
+        return {
+          reason: "backend-timeout",
+          phase: "starting-backend",
+          message: `Backend did not become reachable within ${Math.round(
+            BACKEND_STARTUP_TIMEOUT_MS / 1000,
+          )}s.`,
+          detail: formatStartupErrorDetail(err),
+          status: apiErr?.status,
+          path: apiErr?.path,
+        };
+      }
+      return {
+        reason: "backend-unreachable",
+        phase: "starting-backend",
+        message: "Failed to reach backend during startup.",
+        detail: formatStartupErrorDetail(err),
+        status: apiErr?.status,
+        path: apiErr?.path,
+      };
+    };
+    const describeAgentFailure = (
+      err: unknown,
+      timedOut: boolean,
+      diagnostics?: AgentStartupDiagnostics,
+    ): StartupErrorState => {
+      const detail =
+        diagnostics?.lastError ||
+        formatStartupErrorDetail(err) ||
+        "Agent runtime did not report a reason.";
+      if (timedOut) {
+        return {
+          reason: "agent-timeout",
+          phase: "initializing-agent",
+          message: `Agent did not reach running or paused within ${Math.round(
+            AGENT_READY_TIMEOUT_MS / 1000,
+          )}s.`,
+          detail,
+        };
+      }
+      return {
+        reason: "agent-error",
+        phase: "initializing-agent",
+        message: "Agent runtime reported a startup error.",
+        detail,
+      };
+    };
 
     const initApp = async () => {
+      if (import.meta.env.DEV && startupRunId > 0) {
+        console.debug(`[milady] Retrying startup run #${startupRunId}`);
+      }
       const BASE_DELAY_MS = 250;
       const MAX_DELAY_MS = 1000;
-      const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+      const sleep = (ms: number) =>
+        new Promise<void>((resolve) => setTimeout(resolve, ms));
       let onboardingNeedsOptions = false;
       let requiresAuth = false;
+      let latestAuth: {
+        required: boolean;
+        pairingEnabled: boolean;
+        expiresAt: number | null;
+      } = {
+        required: false,
+        pairingEnabled: false,
+        expiresAt: null,
+      };
+      setStartupError(null);
       setStartupPhase("starting-backend");
+      setAuthRequired(false);
+      setConnected(false);
+      const backendDeadlineAt = Date.now() + BACKEND_STARTUP_TIMEOUT_MS;
+      let lastBackendError: unknown = null;
 
       // Keep the splash screen up until the backend is reachable.
       let backendAttempts = 0;
       while (!cancelled) {
+        if (Date.now() >= backendDeadlineAt) {
+          setStartupError(describeBackendFailure(lastBackendError, true));
+          setOnboardingLoading(false);
+          return;
+        }
         try {
           const auth = await client.getAuthStatus();
+          latestAuth = auth;
           if (auth.required && !client.hasToken()) {
             setAuthRequired(true);
             setPairingEnabled(auth.pairingEnabled);
@@ -3821,7 +4004,17 @@ export function AppProvider({ children }: { children: ReactNode }) {
           setOnboardingComplete(complete);
           onboardingNeedsOptions = !complete;
           break;
-        } catch {
+        } catch (err) {
+          const apiErr = asApiLikeError(err);
+          if (apiErr?.status === 401 && client.hasToken()) {
+            client.setToken(null);
+            setAuthRequired(true);
+            setPairingEnabled(latestAuth.pairingEnabled);
+            setPairingExpiresAt(latestAuth.expiresAt);
+            requiresAuth = true;
+            break;
+          }
+          lastBackendError = err;
           backendAttempts += 1;
           const delay = Math.min(
             BASE_DELAY_MS * 2 ** Math.min(backendAttempts, 2),
@@ -3839,34 +4032,58 @@ export function AppProvider({ children }: { children: ReactNode }) {
         return;
       }
 
-      setStartupPhase("initializing-agent");
-
       // On fresh installs, unblock to onboarding as soon as options are available.
       if (onboardingNeedsOptions) {
-        let optionsLoaded = false;
-        while (!cancelled && !optionsLoaded) {
+        const optionsDeadlineAt = Date.now() + BACKEND_STARTUP_TIMEOUT_MS;
+        let optionsError: unknown = null;
+        while (!cancelled) {
+          if (Date.now() >= optionsDeadlineAt) {
+            setStartupError(describeBackendFailure(optionsError, true));
+            setOnboardingLoading(false);
+            return;
+          }
           try {
             const options = await client.getOnboardingOptions();
             setOnboardingOptions(options);
-            optionsLoaded = true;
-          } catch {
+            setOnboardingLoading(false);
+            return;
+          } catch (err) {
+            const apiErr = asApiLikeError(err);
+            if (apiErr?.status === 401 && client.hasToken()) {
+              client.setToken(null);
+              setAuthRequired(true);
+              setPairingEnabled(latestAuth.pairingEnabled);
+              setPairingExpiresAt(latestAuth.expiresAt);
+              setOnboardingLoading(false);
+              return;
+            }
+            optionsError = err;
             await sleep(500);
           }
-        }
-        if (!cancelled) {
-          setOnboardingLoading(false);
         }
         return;
       }
 
+      setStartupPhase("initializing-agent");
+
       // Existing installs: keep loading until the runtime reports ready.
       let agentReady = false;
-      let _agentAttempts = 0;
+      const agentDeadlineAt = Date.now() + AGENT_READY_TIMEOUT_MS;
+      let lastAgentError: unknown = null;
+      let lastAgentDiagnostics: AgentStartupDiagnostics | undefined;
       while (!cancelled) {
+        if (Date.now() >= agentDeadlineAt) {
+          setStartupError(
+            describeAgentFailure(lastAgentError, true, lastAgentDiagnostics),
+          );
+          setOnboardingLoading(false);
+          return;
+        }
         try {
           let status = await client.getStatus();
           setAgentStatus(status);
           setConnected(true);
+          lastAgentDiagnostics = status.startup;
 
           // Hydrate deferred restart state
           if (status.pendingRestart) {
@@ -3878,8 +4095,9 @@ export function AppProvider({ children }: { children: ReactNode }) {
             try {
               status = await client.startAgent();
               setAgentStatus(status);
-            } catch {
-              /* ignore */
+              lastAgentDiagnostics = status.startup;
+            } catch (err) {
+              lastAgentError = err;
             }
           }
 
@@ -3889,24 +4107,38 @@ export function AppProvider({ children }: { children: ReactNode }) {
           }
 
           if (status.state === "error") {
-            break;
+            setStartupError(
+              describeAgentFailure(lastAgentError, false, status.startup),
+            );
+            setOnboardingLoading(false);
+            return;
           }
-        } catch {
+        } catch (err) {
+          const apiErr = asApiLikeError(err);
+          if (apiErr?.status === 401 && client.hasToken()) {
+            client.setToken(null);
+            setAuthRequired(true);
+            setPairingEnabled(latestAuth.pairingEnabled);
+            setPairingExpiresAt(latestAuth.expiresAt);
+            setOnboardingLoading(false);
+            return;
+          }
+          lastAgentError = err;
           setConnected(false);
         }
-        _agentAttempts += 1;
         await sleep(500);
       }
       if (cancelled) return;
 
       if (!agentReady) {
-        if (import.meta.env.DEV) {
-          console.debug(
-            "[milady] Agent did not reach running/paused state during startup.",
-          );
-        }
+        setStartupError(
+          describeAgentFailure(lastAgentError, true, lastAgentDiagnostics),
+        );
+        setOnboardingLoading(false);
+        return;
       }
 
+      setStartupError(null);
       setOnboardingLoading(false);
 
       // Auto-launch LTCG game viewer (autonomous mode)
@@ -4230,6 +4462,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
     loadWorkbench, // Cloud polling
     pollCloudCredits,
     setSelectedVrmIndex,
+    startupRetryNonce,
   ]);
 
   // When agent transitions to "running", send a greeting if conversation is empty
@@ -4274,6 +4507,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
     onboardingComplete,
     onboardingLoading,
     startupPhase,
+    startupError,
     authRequired,
     actionNotice,
     lifecycleBusy,
@@ -4486,6 +4720,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
     handlePauseResume,
     handleRestart,
     handleReset,
+    retryStartup,
     dismissRestartBanner,
     triggerRestart,
     handleChatSend,

--- a/apps/app/src/components/StartupFailureView.tsx
+++ b/apps/app/src/components/StartupFailureView.tsx
@@ -1,0 +1,41 @@
+import type { StartupErrorState } from "../AppContext";
+
+const REASON_LABELS: Record<StartupErrorState["reason"], string> = {
+  "backend-timeout": "Backend Timeout",
+  "backend-unreachable": "Backend Unreachable",
+  "agent-timeout": "Agent Timeout",
+  "agent-error": "Agent Error",
+};
+
+interface StartupFailureViewProps {
+  error: StartupErrorState;
+  onRetry: () => void;
+}
+
+export function StartupFailureView({
+  error,
+  onRetry,
+}: StartupFailureViewProps) {
+  return (
+    <div className="max-w-[680px] mx-auto mt-15 p-6 border border-border bg-card rounded-[10px]">
+      <h1 className="text-lg font-semibold mb-2 text-danger">
+        Startup failed: {REASON_LABELS[error.reason]}
+      </h1>
+      <p className="text-txt-strong mb-3 leading-relaxed">{error.message}</p>
+      {error.detail && (
+        <pre className="mb-4 p-3 border border-border rounded bg-bg-muted text-xs text-muted whitespace-pre-wrap break-words">
+          {error.detail}
+        </pre>
+      )}
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          className="px-4 py-2 border border-accent bg-accent text-accent-fg text-sm cursor-pointer hover:bg-accent-hover"
+          onClick={onRetry}
+        >
+          Retry Startup
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/app/test/app/api-client-timeout.test.ts
+++ b/apps/app/test/app/api-client-timeout.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ApiError, MiladyClient } from "../../src/api-client";
+
+describe("MiladyClient request timeout handling", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, "fetch", {
+      value: originalFetch,
+      writable: true,
+      configurable: true,
+    });
+    vi.useRealTimers();
+  });
+
+  it("raises typed timeout error for hung requests", async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi.fn(
+      (_url: string, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+        }),
+    );
+    Object.defineProperty(globalThis, "fetch", {
+      value: fetchMock,
+      writable: true,
+      configurable: true,
+    });
+
+    const client = new MiladyClient("http://localhost:2138");
+    const request = client.getStatus().catch((err: unknown) => err);
+    await vi.advanceTimersByTimeAsync(10_001);
+
+    const error = await request;
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error).toMatchObject({
+      kind: "timeout",
+      path: "/api/status",
+    });
+  });
+});

--- a/apps/app/test/app/lifecycle-lock.test.ts
+++ b/apps/app/test/app/lifecycle-lock.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment jsdom
+
 import React, { useEffect } from "react";
 import TestRenderer, { act } from "react-test-renderer";
 import { beforeEach, describe, expect, it, vi } from "vitest";

--- a/apps/app/test/app/startup-backend-missing.e2e.test.ts
+++ b/apps/app/test/app/startup-backend-missing.e2e.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+
+import React, { useEffect } from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockClient } = vi.hoisted(() => ({
+  mockClient: {
+    hasToken: vi.fn(() => false),
+    setToken: vi.fn(),
+    getAuthStatus: vi.fn(async () => ({
+      required: false,
+      pairingEnabled: false,
+      expiresAt: null,
+    })),
+    getOnboardingStatus: vi.fn(async () => ({ complete: true })),
+    disconnectWs: vi.fn(),
+  },
+}));
+
+vi.mock("../../src/api-client", () => ({
+  client: mockClient,
+  SkillScanReportSummary: {},
+}));
+
+import { AppProvider, useApp } from "../../src/AppContext";
+
+interface StartupSnapshot {
+  onboardingLoading: boolean;
+  authRequired: boolean;
+  startupError: ReturnType<typeof useApp>["startupError"];
+}
+
+function Probe(props: { onChange: (snapshot: StartupSnapshot) => void }) {
+  const app = useApp();
+  useEffect(() => {
+    props.onChange({
+      onboardingLoading: app.onboardingLoading,
+      authRequired: app.authRequired,
+      startupError: app.startupError,
+    });
+  }, [
+    app.onboardingLoading,
+    app.authRequired,
+    app.startupError,
+    props.onChange,
+  ]);
+  return null;
+}
+
+describe("startup failure: backend missing", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.assign(document.documentElement, { setAttribute: vi.fn() });
+    mockClient.hasToken.mockReturnValue(false);
+    mockClient.disconnectWs.mockImplementation(() => {});
+    mockClient.getAuthStatus.mockResolvedValue({
+      required: false,
+      pairingEnabled: false,
+      expiresAt: null,
+    });
+    const err = Object.assign(
+      new Error("Backend API routes are unavailable on this origin"),
+      {
+        kind: "http",
+        status: 404,
+        path: "/api/onboarding/status",
+      },
+    );
+    mockClient.getOnboardingStatus.mockRejectedValue(err);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("stops loading and surfaces backend-unreachable instead of spinning forever", async () => {
+    let latest: StartupSnapshot | null = null;
+    let tree: TestRenderer.ReactTestRenderer | null = null;
+
+    await act(async () => {
+      tree = TestRenderer.create(
+        React.createElement(
+          AppProvider,
+          null,
+          React.createElement(Probe, {
+            onChange: (snapshot) => {
+              latest = snapshot;
+            },
+          }),
+        ),
+      );
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(31_000);
+    });
+
+    expect(latest).not.toBeNull();
+    expect(latest?.onboardingLoading).toBe(false);
+    expect(latest?.authRequired).toBe(false);
+    expect(latest?.startupError?.reason).toBe("backend-unreachable");
+    expect(latest?.startupError?.phase).toBe("starting-backend");
+    expect(latest?.startupError?.status).toBe(404);
+    expect(latest?.startupError?.path).toBe("/api/onboarding/status");
+    expect(mockClient.getOnboardingStatus).toHaveBeenCalled();
+
+    await act(async () => {
+      tree?.unmount();
+    });
+  });
+});

--- a/apps/app/test/app/startup-failure-view.test.tsx
+++ b/apps/app/test/app/startup-failure-view.test.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { describe, expect, it, vi } from "vitest";
+
+import { StartupFailureView } from "../../src/components/StartupFailureView";
+
+describe("StartupFailureView", () => {
+  it("renders details and triggers retry", async () => {
+    const onRetry = vi.fn();
+    let tree: TestRenderer.ReactTestRenderer | null = null;
+
+    await act(async () => {
+      tree = TestRenderer.create(
+        React.createElement(StartupFailureView, {
+          error: {
+            reason: "backend-unreachable",
+            phase: "starting-backend",
+            message: "Backend unavailable",
+            detail: "/api/status - HTTP 404 - Not found",
+            status: 404,
+            path: "/api/status",
+          },
+          onRetry,
+        }),
+      );
+    });
+
+    if (!tree) throw new Error("failed to render StartupFailureView");
+
+    const heading = tree.root.findByType("h1").children.join("");
+    const body = tree.root.findAllByType("p")[0]?.children.join("") ?? "";
+    expect(body).toContain("Backend unavailable");
+    expect(heading).toContain("Backend Unreachable");
+
+    const retryButton = tree.root.findByType("button");
+    await act(async () => {
+      retryButton.props.onClick();
+    });
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/app/test/app/startup-token-401.e2e.test.ts
+++ b/apps/app/test/app/startup-token-401.e2e.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+
+import React, { useEffect } from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockClient } = vi.hoisted(() => ({
+  mockClient: {
+    hasToken: vi.fn(() => true),
+    setToken: vi.fn(),
+    getAuthStatus: vi.fn(async () => ({
+      required: true,
+      pairingEnabled: true,
+      expiresAt: null,
+    })),
+    getOnboardingStatus: vi.fn(async () => ({ complete: true })),
+    disconnectWs: vi.fn(),
+  },
+}));
+
+vi.mock("../../src/api-client", () => ({
+  client: mockClient,
+  SkillScanReportSummary: {},
+}));
+
+import { AppProvider, useApp } from "../../src/AppContext";
+
+interface StartupSnapshot {
+  onboardingLoading: boolean;
+  authRequired: boolean;
+  startupError: ReturnType<typeof useApp>["startupError"];
+}
+
+function Probe(props: { onChange: (snapshot: StartupSnapshot) => void }) {
+  const app = useApp();
+  useEffect(() => {
+    props.onChange({
+      onboardingLoading: app.onboardingLoading,
+      authRequired: app.authRequired,
+      startupError: app.startupError,
+    });
+  }, [
+    app.onboardingLoading,
+    app.authRequired,
+    app.startupError,
+    props.onChange,
+  ]);
+  return null;
+}
+
+describe("startup stale token handling", () => {
+  beforeEach(() => {
+    Object.assign(document.documentElement, { setAttribute: vi.fn() });
+    mockClient.hasToken.mockReturnValue(true);
+    mockClient.disconnectWs.mockImplementation(() => {});
+    mockClient.getAuthStatus.mockResolvedValue({
+      required: true,
+      pairingEnabled: true,
+      expiresAt: null,
+    });
+    const err = Object.assign(new Error("Unauthorized"), {
+      kind: "http",
+      status: 401,
+      path: "/api/onboarding/status",
+    });
+    mockClient.getOnboardingStatus.mockRejectedValue(err);
+  });
+
+  it("clears stale token and exits to pairing/auth instead of retry loop", async () => {
+    let latest: StartupSnapshot | null = null;
+    let tree: TestRenderer.ReactTestRenderer | null = null;
+
+    await act(async () => {
+      tree = TestRenderer.create(
+        React.createElement(
+          AppProvider,
+          null,
+          React.createElement(Probe, {
+            onChange: (snapshot) => {
+              latest = snapshot;
+            },
+          }),
+        ),
+      );
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockClient.setToken).toHaveBeenCalledWith(null);
+    expect(latest).not.toBeNull();
+    expect(latest?.onboardingLoading).toBe(false);
+    expect(latest?.authRequired).toBe(true);
+    expect(latest?.startupError).toBeNull();
+
+    await act(async () => {
+      tree?.unmount();
+    });
+  });
+});

--- a/apps/app/test/electron-ui/electron-startup-failure.e2e.spec.ts
+++ b/apps/app/test/electron-ui/electron-startup-failure.e2e.spec.ts
@@ -1,0 +1,109 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { __electronTestState } from "electron";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { AgentManager } from "../../electron/src/native/agent";
+
+interface StartupTestState {
+  started: boolean;
+  starts: number;
+  closes: number;
+  elizaCalls: number;
+}
+
+declare global {
+  var __miladyAgentStartupTestState: StartupTestState | undefined;
+}
+
+function writeTestDist(appPath: string): void {
+  const distDir = path.join(appPath, "milady-dist");
+  writeFileSync(
+    path.join(distDir, "server.js"),
+    `export async function startApiServer() {
+  const state = (globalThis.__miladyAgentStartupTestState ??= {
+    started: false,
+    starts: 0,
+    closes: 0,
+    elizaCalls: 0,
+  });
+  if (state.started) {
+    const err = new Error("Port already in use");
+    err.code = "EADDRINUSE";
+    throw err;
+  }
+  state.started = true;
+  state.starts += 1;
+  return {
+    port: 42138,
+    close: async () => {
+      state.started = false;
+      state.closes += 1;
+    },
+    updateRuntime: () => {},
+    updateStartup: () => {},
+  };
+}
+`,
+    { encoding: "utf8" },
+  );
+  writeFileSync(
+    path.join(distDir, "eliza.js"),
+    `export async function startEliza() {
+  const state = (globalThis.__miladyAgentStartupTestState ??= {
+    started: false,
+    starts: 0,
+    closes: 0,
+    elizaCalls: 0,
+  });
+  state.elizaCalls += 1;
+  if (state.elizaCalls === 1) {
+    throw new Error("runtime bootstrap failed");
+  }
+  return {
+    character: { name: "Milady" },
+    stop: async () => {},
+  };
+}
+`,
+    { encoding: "utf8" },
+  );
+}
+
+describe("electron agent startup failure cleanup", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    globalThis.__miladyAgentStartupTestState = undefined;
+    __electronTestState.appPath = "";
+    __electronTestState.isPackaged = true;
+  });
+
+  it("closes API listener after failed start so next start does not hit EADDRINUSE", async () => {
+    const appPath = mkdtempSync(path.join(os.tmpdir(), "milady-agent-start-"));
+    tempDirs.push(appPath);
+    const distDir = path.join(appPath, "milady-dist");
+    rmSync(distDir, { recursive: true, force: true });
+    mkdirSync(distDir, { recursive: true });
+    writeTestDist(appPath);
+    __electronTestState.appPath = appPath;
+    __electronTestState.isPackaged = true;
+
+    const manager = new AgentManager();
+
+    const first = await manager.start();
+    expect(first.state).toBe("error");
+    expect(globalThis.__miladyAgentStartupTestState?.closes).toBe(1);
+
+    const second = await manager.start();
+    expect(second.state).toBe("running");
+    expect(globalThis.__miladyAgentStartupTestState?.starts).toBe(2);
+
+    await manager.stop();
+    expect(globalThis.__miladyAgentStartupTestState?.closes).toBeGreaterThan(1);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "publish:all:next": "echo 'Use npm publish or bun publish directly'",
     "publish:plugins:next": "cd plugins && bun run publish:next",
     "release:check": "node --import tsx scripts/release-check.ts",
+    "smoke:api-status": "node scripts/smoke-api-status.mjs",
     "start": "scripts/rt.sh scripts/run-node.mjs start",
     "start:desktop": "cd apps/app && ../../scripts/rt.sh run build:electron && cd electron && ../../../scripts/rt.sh run electron:start",
     "start:eliza": "node --import tsx src/runtime/eliza.ts",

--- a/scripts/smoke-api-status.mjs
+++ b/scripts/smoke-api-status.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+/**
+ * Deployment smoke check for app origins.
+ *
+ * Fails fast when /api/status is missing (for example when an app shell is
+ * accidentally deployed to a marketing/static origin).
+ *
+ * Usage:
+ *   node scripts/smoke-api-status.mjs https://milady.ai
+ * or
+ *   MILADY_DEPLOY_BASE_URL=https://milady.ai node scripts/smoke-api-status.mjs
+ */
+
+const baseArg = process.argv[2]?.trim();
+const baseEnv = process.env.MILADY_DEPLOY_BASE_URL?.trim();
+const base = baseArg || baseEnv;
+
+if (!base) {
+  console.error(
+    "[smoke-api-status] Missing base URL. Pass arg or set MILADY_DEPLOY_BASE_URL.",
+  );
+  process.exit(2);
+}
+
+const timeoutMs = 10_000;
+const controller = new AbortController();
+const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+try {
+  const url = new URL("/api/status", base).toString();
+  const res = await fetch(url, {
+    method: "GET",
+    headers: { Accept: "application/json" },
+    signal: controller.signal,
+  });
+  if (!res.ok) {
+    console.error(
+      `[smoke-api-status] FAIL ${url} returned HTTP ${res.status} ${res.statusText}`,
+    );
+    process.exit(1);
+  }
+
+  const body = await res.json().catch(() => null);
+  if (!body || typeof body.state !== "string") {
+    console.error(
+      `[smoke-api-status] FAIL ${url} responded without expected status payload.`,
+    );
+    process.exit(1);
+  }
+
+  console.log(`[smoke-api-status] OK ${url} state=${body.state}`);
+} catch (err) {
+  const timedOut = controller.signal.aborted;
+  const msg = err instanceof Error ? err.message : String(err);
+  if (timedOut) {
+    console.error(
+      `[smoke-api-status] FAIL request timed out after ${timeoutMs}ms`,
+    );
+  } else {
+    console.error(`[smoke-api-status] FAIL ${msg}`);
+  }
+  process.exit(1);
+} finally {
+  clearTimeout(timer);
+}

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -204,6 +204,14 @@ interface ConversationMeta {
   updatedAt: string;
 }
 
+interface AgentStartupDiagnostics {
+  phase: string;
+  attempt: number;
+  lastError?: string;
+  lastErrorAt?: number;
+  nextRetryAt?: number;
+}
+
 interface ServerState {
   runtime: AgentRuntime | null;
   config: MiladyConfig;
@@ -218,6 +226,7 @@ interface ServerState {
   agentName: string;
   model: string | undefined;
   startedAt: number | undefined;
+  startup: AgentStartupDiagnostics;
   plugins: PluginEntry[];
   skills: SkillEntry[];
   logBuffer: LogEntry[];
@@ -5786,6 +5795,7 @@ async function handleRequest(
       agentName: state.agentName,
       model: state.model,
       uptime,
+      startup: state.startup,
       cloud: cloudStatus,
       pendingRestart: state.pendingRestartReasons.length > 0,
       pendingRestartReasons: state.pendingRestartReasons,
@@ -12417,6 +12427,13 @@ export async function startApiServer(opts?: {
   port: number;
   close: () => Promise<void>;
   updateRuntime: (rt: AgentRuntime) => void;
+  updateStartup: (
+    update: Partial<AgentStartupDiagnostics> & {
+      phase?: string;
+      attempt?: number;
+      state?: ServerState["agentState"];
+    },
+  ) => void;
 }> {
   const apiStartTime = Date.now();
   console.log(`[milady-api] startApiServer called`);
@@ -12481,6 +12498,12 @@ export async function startApiServer(opts?: {
   const initialAgentState = hasRuntime
     ? "running"
     : (opts?.initialAgentState ?? "not_started");
+  const initialStartup: AgentStartupDiagnostics =
+    initialAgentState === "running"
+      ? { phase: "running", attempt: 0 }
+      : initialAgentState === "starting"
+        ? { phase: "starting", attempt: 0 }
+        : { phase: "idle", attempt: 0 };
   const agentName = hasRuntime
     ? (opts.runtime?.character.name ?? "Milady")
     : (config.agents?.list?.[0]?.name ??
@@ -12495,6 +12518,7 @@ export async function startApiServer(opts?: {
     model: hasRuntime ? "provided" : undefined,
     startedAt:
       hasRuntime || initialAgentState === "starting" ? Date.now() : undefined,
+    startup: initialStartup,
     plugins,
     // Filled asynchronously after server start to keep startup latency low.
     skills: [],
@@ -13005,6 +13029,7 @@ export async function startApiServer(opts?: {
           agentName: state.agentName,
           model: state.model,
           startedAt: state.startedAt,
+          startup: state.startup,
         }),
       );
       const replay = state.eventBuffer.slice(-120);
@@ -13057,6 +13082,7 @@ export async function startApiServer(opts?: {
       agentName: state.agentName,
       model: state.model,
       startedAt: state.startedAt,
+      startup: state.startup,
       pendingRestart: state.pendingRestartReasons.length > 0,
       pendingRestartReasons: state.pendingRestartReasons,
     });
@@ -13184,6 +13210,10 @@ export async function startApiServer(opts?: {
     state.agentState = "running";
     state.agentName = rt.character.name ?? "Milady";
     state.startedAt = Date.now();
+    state.startup = {
+      phase: "running",
+      attempt: 0,
+    };
     addLog("info", `Runtime restarted — agent: ${state.agentName}`, "system", [
       "system",
       "agent",
@@ -13193,6 +13223,32 @@ export async function startApiServer(opts?: {
     void restoreConversationsFromDb(rt);
 
     // Broadcast status update immediately after restart
+    broadcastStatus();
+  };
+
+  const updateStartup = (
+    update: Partial<AgentStartupDiagnostics> & {
+      phase?: string;
+      attempt?: number;
+      state?: ServerState["agentState"];
+    },
+  ): void => {
+    const { state: nextState, ...startupUpdate } = update;
+    state.startup = {
+      ...state.startup,
+      ...startupUpdate,
+    };
+    if (nextState) {
+      state.agentState = nextState;
+      if (nextState === "error") {
+        state.startedAt = undefined;
+      } else if (
+        (nextState === "starting" || nextState === "running") &&
+        !state.startedAt
+      ) {
+        state.startedAt = Date.now();
+      }
+    }
     broadcastStatus();
   };
 
@@ -13283,6 +13339,7 @@ export async function startApiServer(opts?: {
             server.close(finalize);
           }),
         updateRuntime,
+        updateStartup,
       });
     });
   });

--- a/test/stubs/electron-module.ts
+++ b/test/stubs/electron-module.ts
@@ -1,0 +1,17 @@
+export const __electronTestState = {
+  appPath: "",
+  isPackaged: true,
+};
+
+export const app = {
+  get isPackaged(): boolean {
+    return __electronTestState.isPackaged;
+  },
+  getAppPath(): string {
+    return __electronTestState.appPath;
+  },
+};
+
+export const ipcMain = {
+  handle: () => undefined,
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
         "stubs",
         "empty-module.mjs",
       ),
+      electron: path.join(repoRoot, "test", "stubs", "electron-module.ts"),
     },
   },
   test: {
@@ -32,6 +33,12 @@ export default defineConfig({
       "src/**/*.test.ts",
       "scripts/**/*.test.ts",
       "apps/**/*.test.tsx",
+      "apps/app/test/app/lifecycle-lock.test.ts",
+      "apps/app/test/app/api-client-timeout.test.ts",
+      "apps/app/test/app/startup-backend-missing.e2e.test.ts",
+      "apps/app/test/app/startup-token-401.e2e.test.ts",
+      "apps/app/test/electron-ui/electron-startup-failure.e2e.spec.ts",
+      "test/api-server.e2e.test.ts",
       "test/format-error.test.ts",
     ],
     setupFiles: ["test/setup.ts"],
@@ -39,7 +46,6 @@ export default defineConfig({
       "dist/**",
       "**/node_modules/**",
       "**/*.live.test.ts",
-      "**/*.e2e.test.ts",
     ],
     coverage: {
       provider: "v8",


### PR DESCRIPTION
This PR will be reviewed by an AI agent. Provide clear context to help it assess your changes.

Aesthetic/UI changes that don't improve agent capability are out of scope and will be rejected.

## Category
- [x] Bug fix
- [ ] Security fix
- [ ] Performance improvement
- [ ] New feature
- [ ] Documentation
- [x] Test coverage
- [ ] Other

## What
Eliminates startup dead-loops that could leave users stuck on `STARTING BACKEND` and adds deterministic startup failure handling across web + Electron paths.

## Why
Users were getting trapped on an infinite loading screen when backend/status routes were unavailable, startup calls hung, tokens were stale, runtime bootstrap failed repeatedly, or Electron startup left stale listeners behind.

## How
- Made startup finite in app shell with explicit failure states and retry UI.
- Added `StartupFailureView` and `startupError` flow to exit spinner-only states.
- Added API client timeout + typed `ApiError` classification (`timeout` / `network` / `http`).
- Stopped stale-token 401 startup loops by clearing invalid token and routing to auth/pairing.
- Extended `/api/status` (and WS status payload) with additive startup diagnostics:
  - `startup.phase`
  - `startup.attempt`
  - `startup.lastError`
  - `startup.lastErrorAt`
  - `startup.nextRetryAt`
- Added terminal runtime-error surfacing after retry threshold while retaining background retries.
- Hardened Electron startup cleanup to avoid leaked API handles and `EADDRINUSE` on retry.
- Expanded DB recoverable-init signature handling for additional lock/corruption variants.
- Added deploy smoke helper for `/api/status` reachability.

## Testing
Validated with targeted and full test runs before push:

```bash
bunx vitest run apps/app/test/app/lifecycle-lock.test.ts
bunx vitest run apps/app/test/app/startup-backend-missing.e2e.test.ts apps/app/test/app/startup-token-401.e2e.test.ts
bunx vitest run test/api-server.e2e.test.ts -t "startup status"
bunx vitest run apps/app/test/electron-ui/electron-startup-failure.e2e.spec.ts
bun run check
bun run test
```

Additional tests added/updated include:
- `apps/app/test/app/api-client-timeout.test.ts`
- `apps/app/test/app/startup-backend-missing.e2e.test.ts`
- `apps/app/test/app/startup-token-401.e2e.test.ts`
- `apps/app/test/app/startup-failure-view.test.tsx`
- `apps/app/test/electron-ui/electron-startup-failure.e2e.spec.ts`
- `test/api-server.e2e.test.ts` (startup status coverage)
