### PR TITLE
fix(app): unify raw API timeout handling and startup warnings

### DIFF
--- a/apps/app/test/app/api-client-timeout.test.ts
+++ b/apps/app/test/app/api-client-timeout.test.ts
@@ -42,4 +42,35 @@ describe("MiladyClient request timeout handling", () => {
       path: "/api/status",
     });
   });
+
+  it("raises typed timeout error for raw export requests", async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi.fn(
+      (_url: string, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+        }),
+    );
+    Object.defineProperty(globalThis, "fetch", {
+      value: fetchMock,
+      writable: true,
+      configurable: true,
+    });
+
+    const client = new MiladyClient("http://localhost:2138");
+    const request = client
+      .exportTrajectories({ format: "json" })
+      .catch((err: unknown) => err);
+    await vi.advanceTimersByTimeAsync(10_001);
+
+    const error = await request;
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error).toMatchObject({
+      kind: "timeout",
+      path: "/api/trajectories/export",
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add shared raw request path in API client with timeout/auth/typed `ApiError` parity
- migrate raw callsites (`hasCustomVrm`, `exportAgent`, `importAgent`, chat stream requester, trajectory export)
- replace startup init silent catches with structured non-fatal warnings (`[milady][startup:init] ...`)
- extend API client timeout/stream tests

## Validation
- bun run lint
- bunx vitest run apps/app/test/app/api-client-timeout.test.ts apps/app/test/app/chat-stream-api-client.test.tsx apps/app/test/app/startup-backend-missing.e2e.test.ts
