### PR TITLE
fix(ci): harden deploy origin smoke checks with tests and runbook

### DIFF
--- a/.github/workflows/deploy-origin-smoke.yml
+++ b/.github/workflows/deploy-origin-smoke.yml
@@ -27,6 +27,7 @@ jobs:
   smoke-api-status:
     name: Smoke /api/status on deploy origins
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       MARKETING_ORIGIN: ${{ github.event.inputs.marketing_origin || github.event.client_payload.marketing_origin || 'https://milady.ai' }}
       APP_ORIGIN: ${{ github.event.inputs.app_origin || github.event.client_payload.app_origin || 'https://app.milady.ai' }}
@@ -45,7 +46,9 @@ jobs:
           bun-version: latest
 
       - name: Run deploy smoke checks
-        run: bun run smoke:api-status -- "$MARKETING_ORIGIN" "$APP_ORIGIN"
+        env:
+          MILADY_DEPLOY_BASE_URLS: ${{ env.MARKETING_ORIGIN }},${{ env.APP_ORIGIN }}
+        run: bun run smoke:api-status
 
       - name: Summarize checked origins
         if: always()
@@ -54,3 +57,4 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- Marketing origin: \`$MARKETING_ORIGIN\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- App origin: \`$APP_ORIGIN\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Runbook: \`docs/DEPLOY_ORIGIN_SMOKE.md\`" >> "$GITHUB_STEP_SUMMARY"

--- a/docs/DEPLOY_ORIGIN_SMOKE.md
+++ b/docs/DEPLOY_ORIGIN_SMOKE.md
@@ -1,0 +1,63 @@
+# Deploy Origin Smoke Runbook
+
+This smoke check prevents cutovers where the app shell is served from an origin
+that does not have working `/api/*` routes.
+
+## What It Checks
+
+- `GET /api/status` on each target origin
+- Response status is `2xx`
+- Response body is valid JSON with a string `state` field
+- Per-origin timeout: `10s`
+
+## Local Commands
+
+```bash
+bun run smoke:api-status -- https://milady.ai https://app.milady.ai
+```
+
+```bash
+MILADY_DEPLOY_BASE_URLS=https://milady.ai,https://app.milady.ai bun run smoke:api-status
+```
+
+Exit codes:
+
+- `0`: all origins passed
+- `1`: at least one origin failed
+- `2`: no origins were provided
+
+## GitHub Workflow
+
+Workflow file:
+
+- `.github/workflows/deploy-origin-smoke.yml`
+
+Triggers:
+
+- `workflow_dispatch`
+- `repository_dispatch` with event type `pre-cutover-smoke`
+
+### Manual Dispatch
+
+Run **Deploy Origin Smoke** in Actions and override origins if needed.
+
+### Repository Dispatch Example
+
+```bash
+gh api repos/milady-ai/milady/dispatches \
+  -f event_type=pre-cutover-smoke \
+  -f client_payload:='{"marketing_origin":"https://milady.ai","app_origin":"https://app.milady.ai"}'
+```
+
+## Expected Failure Output
+
+Examples from `scripts/smoke-api-status.mjs`:
+
+- `[smoke-api-status] FAIL https://milady.ai/api/status returned HTTP 404 Not Found`
+- `[smoke-api-status] FAIL https://app.milady.ai timed out after 10000ms`
+- `[smoke-api-status] FAIL https://milady.ai/api/status responded without expected status payload.`
+
+## Cutover Rule
+
+Do not cut traffic to an origin unless this smoke check is green for all target
+origins.

--- a/scripts/smoke-api-status.mjs
+++ b/scripts/smoke-api-status.mjs
@@ -12,70 +12,98 @@
  *   MILADY_DEPLOY_BASE_URLS=https://milady.ai,https://app.milady.ai node scripts/smoke-api-status.mjs
  */
 
-const argvBases = process.argv
-  .slice(2)
-  .map((value) => value.trim())
-  .filter(Boolean);
-const envList =
-  process.env.MILADY_DEPLOY_BASE_URLS?.split(",")
-    .map((value) => value.trim())
-    .filter(Boolean) ?? [];
-const legacyEnv = process.env.MILADY_DEPLOY_BASE_URL?.trim();
-if (legacyEnv) envList.push(legacyEnv);
-const bases = argvBases.length > 0 ? argvBases : envList;
+import { pathToFileURL } from "node:url";
 
-if (bases.length === 0) {
-  console.error(
-    "[smoke-api-status] Missing base URLs. Pass args or set MILADY_DEPLOY_BASE_URLS.",
-  );
-  process.exit(2);
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+export function resolveBaseUrls(
+  argv = process.argv.slice(2),
+  env = process.env,
+) {
+  const argvBases = argv.map((value) => value.trim()).filter(Boolean);
+  const envList =
+    env.MILADY_DEPLOY_BASE_URLS?.split(",")
+      .map((value) => value.trim())
+      .filter(Boolean) ?? [];
+  const legacyEnv = env.MILADY_DEPLOY_BASE_URL?.trim();
+  if (legacyEnv) envList.push(legacyEnv);
+  return argvBases.length > 0 ? argvBases : envList;
 }
 
-const timeoutMs = 10_000;
-let hasFailure = false;
+export async function runSmokeApiStatus(options = {}) {
+  const {
+    argv = process.argv.slice(2),
+    env = process.env,
+    fetchImpl = globalThis.fetch,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    log = console.log,
+    error = console.error,
+  } = options;
 
-for (const base of bases) {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    const url = new URL("/api/status", base).toString();
-    const res = await fetch(url, {
-      method: "GET",
-      headers: { Accept: "application/json" },
-      signal: controller.signal,
-    });
-    if (!res.ok) {
-      console.error(
-        `[smoke-api-status] FAIL ${url} returned HTTP ${res.status} ${res.statusText}`,
-      );
+  const bases = resolveBaseUrls(argv, env);
+  if (bases.length === 0) {
+    error(
+      "[smoke-api-status] Missing base URLs. Pass args or set MILADY_DEPLOY_BASE_URLS.",
+    );
+    return 2;
+  }
+
+  let hasFailure = false;
+
+  for (const base of bases) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const url = new URL("/api/status", base).toString();
+      const res = await fetchImpl(url, {
+        method: "GET",
+        headers: { Accept: "application/json" },
+        signal: controller.signal,
+      });
+      if (!res.ok) {
+        error(
+          `[smoke-api-status] FAIL ${url} returned HTTP ${res.status} ${res.statusText}`,
+        );
+        hasFailure = true;
+        continue;
+      }
+
+      const body = await res.json().catch(() => null);
+      if (!body || typeof body.state !== "string") {
+        error(
+          `[smoke-api-status] FAIL ${url} responded without expected status payload.`,
+        );
+        hasFailure = true;
+        continue;
+      }
+
+      log(`[smoke-api-status] OK ${url} state=${body.state}`);
+    } catch (err) {
+      const timedOut = controller.signal.aborted;
+      const msg = err instanceof Error ? err.message : String(err);
+      if (timedOut) {
+        error(`[smoke-api-status] FAIL ${base} timed out after ${timeoutMs}ms`);
+      } else {
+        error(`[smoke-api-status] FAIL ${base} ${msg}`);
+      }
       hasFailure = true;
-      continue;
+    } finally {
+      clearTimeout(timer);
     }
+  }
 
-    const body = await res.json().catch(() => null);
-    if (!body || typeof body.state !== "string") {
-      console.error(
-        `[smoke-api-status] FAIL ${url} responded without expected status payload.`,
-      );
-      hasFailure = true;
-      continue;
-    }
+  return hasFailure ? 1 : 0;
+}
 
-    console.log(`[smoke-api-status] OK ${url} state=${body.state}`);
-  } catch (err) {
-    const timedOut = controller.signal.aborted;
-    const msg = err instanceof Error ? err.message : String(err);
-    if (timedOut) {
-      console.error(
-        `[smoke-api-status] FAIL ${base} timed out after ${timeoutMs}ms`,
-      );
-    } else {
-      console.error(`[smoke-api-status] FAIL ${base} ${msg}`);
-    }
-    hasFailure = true;
-  } finally {
-    clearTimeout(timer);
+const isMain = (() => {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  return import.meta.url === pathToFileURL(entry).href;
+})();
+
+if (isMain) {
+  const exitCode = await runSmokeApiStatus();
+  if (exitCode !== 0) {
+    process.exit(exitCode);
   }
 }
-
-if (hasFailure) process.exit(1);

--- a/scripts/smoke-api-status.test.ts
+++ b/scripts/smoke-api-status.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { resolveBaseUrls, runSmokeApiStatus } from "./smoke-api-status.mjs";
+
+describe("smoke-api-status script", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns exit code 0 when all origins pass", async () => {
+    const logs: string[] = [];
+    const errors: string[] = [];
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ state: "running" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+
+    const code = await runSmokeApiStatus({
+      argv: ["https://milady.ai", "https://app.milady.ai"],
+      fetchImpl,
+      log: (line: string) => logs.push(line),
+      error: (line: string) => errors.push(line),
+    });
+
+    expect(code).toBe(0);
+    expect(errors).toHaveLength(0);
+    expect(logs).toHaveLength(2);
+    expect(logs[0]).toContain("OK");
+    expect(logs[1]).toContain("OK");
+  });
+
+  it("returns exit code 1 when any origin returns 404", async () => {
+    const errors: string[] = [];
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.includes("milady.ai/api/status")) {
+        return new Response(JSON.stringify({ error: "Not Found" }), {
+          status: 404,
+          statusText: "Not Found",
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify({ state: "running" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const code = await runSmokeApiStatus({
+      argv: ["https://milady.ai", "https://app.milady.ai"],
+      fetchImpl,
+      error: (line: string) => errors.push(line),
+      log: () => {},
+    });
+
+    expect(code).toBe(1);
+    expect(errors.join("\n")).toContain("HTTP 404");
+  });
+
+  it("returns exit code 1 on timeout", async () => {
+    vi.useFakeTimers();
+    const errors: string[] = [];
+    const fetchImpl = vi.fn(
+      (_url: string, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+        }),
+    );
+
+    const pending = runSmokeApiStatus({
+      argv: ["https://app.milady.ai"],
+      fetchImpl,
+      timeoutMs: 50,
+      error: (line: string) => errors.push(line),
+      log: () => {},
+    });
+    await vi.advanceTimersByTimeAsync(51);
+
+    const code = await pending;
+    expect(code).toBe(1);
+    expect(errors.join("\n")).toContain("timed out after 50ms");
+  });
+
+  it("returns exit code 1 for non-JSON status payloads", async () => {
+    const errors: string[] = [];
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response("<html>ok</html>", {
+          status: 200,
+          headers: { "Content-Type": "text/html" },
+        }),
+    );
+
+    const code = await runSmokeApiStatus({
+      argv: ["https://app.milady.ai"],
+      fetchImpl,
+      error: (line: string) => errors.push(line),
+      log: () => {},
+    });
+
+    expect(code).toBe(1);
+    expect(errors.join("\n")).toContain(
+      "responded without expected status payload",
+    );
+  });
+
+  it("parses comma-separated env origins and legacy fallback", () => {
+    const resolved = resolveBaseUrls([], {
+      MILADY_DEPLOY_BASE_URLS: "https://milady.ai, https://app.milady.ai",
+      MILADY_DEPLOY_BASE_URL: "https://legacy.milady.ai",
+    } as NodeJS.ProcessEnv);
+
+    expect(resolved).toEqual([
+      "https://milady.ai",
+      "https://app.milady.ai",
+      "https://legacy.milady.ai",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- refactor `scripts/smoke-api-status.mjs` into testable helpers with unchanged CLI behavior
- add deterministic script coverage for pass/404/timeout/non-JSON scenarios
- keep deploy-only workflow trigger model and wire env-based multi-origin input
- add deploy runbook at `docs/DEPLOY_ORIGIN_SMOKE.md` with dispatch examples

## Validation
- bunx vitest run scripts/smoke-api-status.test.ts
- bun run lint
