### PR TITLE
fix(pre-review): make feature classification advisory instead of hard fail

### DIFF
--- a/scripts/pre-review-local.mjs
+++ b/scripts/pre-review-local.mjs
@@ -105,6 +105,12 @@ export function scopeVerdictFor(classification) {
   return "in scope";
 }
 
+export function decisionFromFindings({ classification, issues }) {
+  return classification === "aesthetic" || issues.length > 0
+    ? "REQUEST CHANGES"
+    : "APPROVE";
+}
+
 export function scanDiffTextForBlockedPatterns(diffChunks) {
   const issues = [];
 
@@ -287,16 +293,7 @@ export function runChecks() {
     }
   }
 
-  if (classification === "feature") {
-    issues.push(
-      "Feature work generally needs deeper review and explicit test expectations.",
-    );
-  }
-
-  const decision =
-    classification === "aesthetic" || issues.length
-      ? "REQUEST CHANGES"
-      : "APPROVE";
+  const decision = decisionFromFindings({ classification, issues });
 
   if (classification === "aesthetic") {
     checklist.push(

--- a/src/runtime/pre-review-local.test.ts
+++ b/src/runtime/pre-review-local.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   classificationFromInputs,
+  decisionFromFindings,
   runChecks,
   scanDiffTextForBlockedPatterns,
   scopeVerdictFor,
@@ -46,6 +47,29 @@ describe("pre-review-local helpers", () => {
     expect(scopeVerdictFor("feature")).toBe("needs deep review");
     expect(scopeVerdictFor("bugfix")).toBe("in scope");
     expect(scopeVerdictFor("security")).toBe("in scope");
+  });
+
+  it("treats feature classification as advisory when objective checks pass", () => {
+    expect(
+      decisionFromFindings({
+        classification: "feature",
+        issues: [],
+      }),
+    ).toBe("APPROVE");
+
+    expect(
+      decisionFromFindings({
+        classification: "feature",
+        issues: ["bun run lint failed."],
+      }),
+    ).toBe("REQUEST CHANGES");
+
+    expect(
+      decisionFromFindings({
+        classification: "aesthetic",
+        issues: [],
+      }),
+    ).toBe("REQUEST CHANGES");
   });
 
   it("flags TypeScript any usage without matching plain English text", () => {


### PR DESCRIPTION
## Summary
- remove automatic `feature`-classification issue injection from pre-review local gate
- keep scope signal (`needs deep review`) without forcing `REQUEST CHANGES` on wording alone
- add explicit decision helper and unit tests covering feature/advisory behavior

## Validation
- bunx vitest run src/runtime/pre-review-local.test.ts
- bun run lint
- bun run pre-review:local
