### PR TITLE
test(api): add table-driven twitter-verify unit suite (MW-10, #475)

### DIFF
--- a/src/api/twitter-verify.test.ts
+++ b/src/api/twitter-verify.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { verifyTweet } from "./twitter-verify";
+import { generateVerificationMessage, verifyTweet } from "./twitter-verify";
 
 const WALLET = "0x1234567890abcdef1234567890abcdef12345678";
 const VALID_TWEET_URL = "https://x.com/miladyai/status/1234567890";
@@ -28,154 +28,329 @@ describe("twitter-verify", () => {
     vi.unstubAllGlobals();
   });
 
-  it.each([
-    "https://example.com/not-twitter",
-    "https://x.com/miladyai/post/123",
-    "https://twitter.com/miladyai/status/not-a-number",
-  ])("rejects invalid tweet URL format: %s", async (url) => {
-    const result = await verifyTweet(url, WALLET);
-    expect(result).toEqual({
-      verified: false,
-      error: "Invalid tweet URL. Use a twitter.com or x.com status URL.",
-      handle: null,
+  // ── generateVerificationMessage ─────────────────────────────────────
+
+  describe("generateVerificationMessage", () => {
+    it.each([
+      {
+        agent: "Milady",
+        wallet: "0xAbCdEf1234567890AbCdEf1234567890AbCdEf12",
+        expected:
+          'Verifying my Milady agent "Milady" | 0xAbCd...Ef12 #MiladyAgent',
+      },
+      {
+        agent: "TestBot",
+        wallet: "0x0000000000000000000000000000000000000000",
+        expected:
+          'Verifying my Milady agent "TestBot" | 0x0000...0000 #MiladyAgent',
+      },
+      {
+        agent: "",
+        wallet: "0x1111111111111111111111111111111111111111",
+        expected:
+          'Verifying my Milady agent "" | 0x1111...1111 #MiladyAgent',
+      },
+    ])(
+      "formats message for agent=$agent wallet=$wallet",
+      ({ agent, wallet, expected }) => {
+        expect(generateVerificationMessage(agent, wallet)).toBe(expected);
+      },
+    );
+  });
+
+  // ── URL parsing (table-driven) ──────────────────────────────────────
+
+  describe("parseTweetUrl (via verifyTweet)", () => {
+    it.each([
+      { url: "https://example.com/not-twitter", label: "wrong domain" },
+      { url: "https://x.com/miladyai/post/123", label: "wrong path segment" },
+      {
+        url: "https://twitter.com/miladyai/status/not-a-number",
+        label: "non-numeric status ID",
+      },
+      { url: "", label: "empty string" },
+      { url: "https://x.com//status/123", label: "missing screen name" },
+    ])("rejects invalid URL ($label): $url", async ({ url }) => {
+      const result = await verifyTweet(url, WALLET);
+      expect(result).toEqual({
+        verified: false,
+        error: "Invalid tweet URL. Use a twitter.com or x.com status URL.",
+        handle: null,
+      });
+    });
+
+    it.each([
+      {
+        url: "https://x.com/miladyai/status/1234567890",
+        expectedApi: "https://api.fxtwitter.com/miladyai/status/1234567890",
+        label: "x.com URL",
+      },
+      {
+        url: "https://twitter.com/miladyai/status/9876543210",
+        expectedApi: "https://api.fxtwitter.com/miladyai/status/9876543210",
+        label: "twitter.com URL",
+      },
+      {
+        url: "https://x.com/user_name/status/111",
+        expectedApi: "https://api.fxtwitter.com/user_name/status/111",
+        label: "underscore in screen name",
+      },
+    ])("parses valid URL ($label) and calls correct API", async ({ url, expectedApi }) => {
+      const fetchMock = mockFetchResponse({
+        ok: true,
+        status: 200,
+        body: {
+          tweet: {
+            text: `0x1234...5678 #MiladyAgent`,
+            author: { screen_name: "miladyai" },
+          },
+        },
+      });
+
+      await verifyTweet(url, WALLET);
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expectedApi,
+        expect.objectContaining({
+          headers: { "User-Agent": "MiladyVerifier/1.0" },
+        }),
+      );
     });
   });
 
-  it("handles fetch failures with a user-facing retry message", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockRejectedValue(new Error("network timeout")),
+  // ── Fetch / timeout failures (table-driven) ────────────────────────
+
+  describe("fetch failures", () => {
+    it.each([
+      { error: new Error("network timeout"), label: "network timeout" },
+      { error: new TypeError("Failed to fetch"), label: "TypeError fetch failure" },
+      { error: new DOMException("The operation was aborted", "AbortError"), label: "AbortError (timeout)" },
+    ])("returns retry message on $label", async ({ error }) => {
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(error));
+
+      const result = await verifyTweet(VALID_TWEET_URL, WALLET);
+
+      expect(result).toEqual({
+        verified: false,
+        error: "Could not reach tweet verification service. Try again later.",
+        handle: null,
+      });
+    });
+
+    it.each([
+      { status: 404, expected: "Tweet not found. Make sure the URL is correct and the tweet is public.", label: "404" },
+      { status: 500, expected: "Tweet fetch failed (HTTP 500)", label: "500" },
+      { status: 503, expected: "Tweet fetch failed (HTTP 503)", label: "503" },
+      { status: 429, expected: "Tweet fetch failed (HTTP 429)", label: "429 rate-limit" },
+    ])("maps HTTP $label to appropriate error", async ({ status, expected }) => {
+      mockFetchResponse({ ok: false, status });
+
+      const result = await verifyTweet(VALID_TWEET_URL, WALLET);
+
+      expect(result).toEqual({
+        verified: false,
+        error: expected,
+        handle: null,
+      });
+    });
+
+    it("handles invalid JSON from verification service", async () => {
+      mockFetchResponse({ ok: true, status: 200, jsonReject: true });
+
+      const result = await verifyTweet(VALID_TWEET_URL, WALLET);
+
+      expect(result).toEqual({
+        verified: false,
+        error: "Invalid response from verification service",
+        handle: null,
+      });
+    });
+
+    it("fails when tweet object has no text field", async () => {
+      mockFetchResponse({ ok: true, status: 200, body: { tweet: {} } });
+
+      const result = await verifyTweet(VALID_TWEET_URL, WALLET);
+
+      expect(result).toEqual({
+        verified: false,
+        error: "Could not read tweet content",
+        handle: null,
+      });
+    });
+
+    it("fails when response has no tweet object at all", async () => {
+      mockFetchResponse({ ok: true, status: 200, body: {} });
+
+      const result = await verifyTweet(VALID_TWEET_URL, WALLET);
+
+      expect(result).toEqual({
+        verified: false,
+        error: "Could not read tweet content",
+        handle: null,
+      });
+    });
+  });
+
+  // ── Message mismatch (table-driven) ────────────────────────────────
+
+  describe("message mismatch", () => {
+    it.each([
+      {
+        text: "Verifying my Milady agent #MiladyAgent",
+        label: "no wallet address at all",
+      },
+      {
+        text: "Random tweet with #MiladyAgent but wrong address 0xDEAD...BEEF",
+        label: "wrong short address",
+      },
+      {
+        text: "#MiladyAgent 0xFFFF567890abcdef",
+        label: "wrong address prefix (no partial match)",
+      },
+    ])(
+      "rejects tweet missing wallet evidence ($label)",
+      async ({ text }) => {
+        mockFetchResponse({
+          ok: true,
+          status: 200,
+          body: { tweet: { text, author: { screen_name: "user1" } } },
+        });
+
+        const result = await verifyTweet(VALID_TWEET_URL, WALLET);
+
+        expect(result).toEqual({
+          verified: false,
+          error:
+            "Tweet does not contain your wallet address. Make sure you copied the full verification message.",
+          handle: "user1",
+        });
+      },
     );
 
-    const result = await verifyTweet(VALID_TWEET_URL, WALLET);
-
-    expect(result).toEqual({
-      verified: false,
-      error: "Could not reach tweet verification service. Try again later.",
-      handle: null,
-    });
-  });
-
-  it("maps 404 responses to tweet-not-found guidance", async () => {
-    mockFetchResponse({ ok: false, status: 404 });
-
-    const result = await verifyTweet(VALID_TWEET_URL, WALLET);
-
-    expect(result).toEqual({
-      verified: false,
-      error:
-        "Tweet not found. Make sure the URL is correct and the tweet is public.",
-      handle: null,
-    });
-  });
-
-  it("maps other non-OK responses to status-aware error messages", async () => {
-    mockFetchResponse({ ok: false, status: 503 });
-
-    const result = await verifyTweet(VALID_TWEET_URL, WALLET);
-
-    expect(result).toEqual({
-      verified: false,
-      error: "Tweet fetch failed (HTTP 503)",
-      handle: null,
-    });
-  });
-
-  it("handles invalid JSON from verification service", async () => {
-    mockFetchResponse({ ok: true, status: 200, jsonReject: true });
-
-    const result = await verifyTweet(VALID_TWEET_URL, WALLET);
-
-    expect(result).toEqual({
-      verified: false,
-      error: "Invalid response from verification service",
-      handle: null,
-    });
-  });
-
-  it("fails verification when tweet content is missing", async () => {
-    mockFetchResponse({
-      ok: true,
-      status: 200,
-      body: { tweet: {} },
-    });
-
-    const result = await verifyTweet(VALID_TWEET_URL, WALLET);
-
-    expect(result).toEqual({
-      verified: false,
-      error: "Could not read tweet content",
-      handle: null,
-    });
-  });
-
-  it("fails verification when tweet message is missing wallet evidence", async () => {
-    mockFetchResponse({
-      ok: true,
-      status: 200,
-      body: {
-        tweet: {
-          text: "Verifying my Milady agent #MiladyAgent",
-          author: { screen_name: "miladyai" },
-        },
+    it.each([
+      {
+        text: "Verifying wallet 0x1234...5678 without hashtag",
+        label: "short address present but no hashtag",
       },
-    });
-
-    const result = await verifyTweet(VALID_TWEET_URL, WALLET);
-
-    expect(result).toEqual({
-      verified: false,
-      error:
-        "Tweet does not contain your wallet address. Make sure you copied the full verification message.",
-      handle: "miladyai",
-    });
-  });
-
-  it("fails verification when hashtag is missing", async () => {
-    mockFetchResponse({
-      ok: true,
-      status: 200,
-      body: {
-        tweet: {
-          text: `Verifying wallet 0x1234...5678 without hashtag`,
-          author: { screen_name: "miladyai" },
-        },
+      {
+        text: "0x1234567890 partial address present, no tag",
+        label: "partial address present but no hashtag",
       },
-    });
+    ])(
+      "rejects tweet missing hashtag ($label)",
+      async ({ text }) => {
+        mockFetchResponse({
+          ok: true,
+          status: 200,
+          body: { tweet: { text, author: { screen_name: "user2" } } },
+        });
 
-    const result = await verifyTweet(VALID_TWEET_URL, WALLET);
+        const result = await verifyTweet(VALID_TWEET_URL, WALLET);
 
-    expect(result).toEqual({
-      verified: false,
-      error: "Tweet is missing #MiladyAgent hashtag.",
-      handle: "miladyai",
-    });
-  });
-
-  it("verifies tweets that include address evidence and hashtag", async () => {
-    const fetchMock = mockFetchResponse({
-      ok: true,
-      status: 200,
-      body: {
-        tweet: {
-          text: `Verifying my Milady agent "Milady" | 0x1234...5678 #MiladyAgent`,
-          author: { screen_name: "miladyai" },
-        },
+        expect(result).toEqual({
+          verified: false,
+          error: "Tweet is missing #MiladyAgent hashtag.",
+          handle: "user2",
+        });
       },
-    });
-
-    const result = await verifyTweet(VALID_TWEET_URL, WALLET);
-
-    expect(result).toEqual({
-      verified: true,
-      error: null,
-      handle: "miladyai",
-    });
-    expect(fetchMock).toHaveBeenCalledWith(
-      "https://api.fxtwitter.com/miladyai/status/1234567890",
-      expect.objectContaining({
-        headers: { "User-Agent": "MiladyVerifier/1.0" },
-      }),
     );
+  });
+
+  // ── Successful verification paths ──────────────────────────────────
+
+  describe("successful verification", () => {
+    it("verifies via short address format (0x1234...5678)", async () => {
+      const fetchMock = mockFetchResponse({
+        ok: true,
+        status: 200,
+        body: {
+          tweet: {
+            text: 'Verifying my Milady agent "Milady" | 0x1234...5678 #MiladyAgent',
+            author: { screen_name: "miladyai" },
+          },
+        },
+      });
+
+      const result = await verifyTweet(VALID_TWEET_URL, WALLET);
+
+      expect(result).toEqual({
+        verified: true,
+        error: null,
+        handle: "miladyai",
+      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.fxtwitter.com/miladyai/status/1234567890",
+        expect.objectContaining({
+          headers: { "User-Agent": "MiladyVerifier/1.0" },
+        }),
+      );
+    });
+
+    it("verifies via partial address prefix (first 10 chars)", async () => {
+      mockFetchResponse({
+        ok: true,
+        status: 200,
+        body: {
+          tweet: {
+            text: "Check out 0x12345678 something #MiladyAgent",
+            author: { screen_name: "altuser" },
+          },
+        },
+      });
+
+      // walletAddress.toLowerCase().slice(0, 10) = "0x12345678"
+      const result = await verifyTweet(VALID_TWEET_URL, WALLET);
+
+      expect(result).toEqual({
+        verified: true,
+        error: null,
+        handle: "altuser",
+      });
+    });
+
+    it("falls back to screen name from URL when author.screen_name is absent", async () => {
+      mockFetchResponse({
+        ok: true,
+        status: 200,
+        body: {
+          tweet: {
+            text: '0x1234...5678 #MiladyAgent',
+            author: {},
+          },
+        },
+      });
+
+      const result = await verifyTweet(
+        "https://x.com/urluser/status/999",
+        WALLET,
+      );
+
+      expect(result).toEqual({
+        verified: true,
+        error: null,
+        handle: "urluser",
+      });
+    });
+
+    it("address matching is case-insensitive", async () => {
+      mockFetchResponse({
+        ok: true,
+        status: 200,
+        body: {
+          tweet: {
+            text: "0X12345678 uppercase prefix #MiladyAgent",
+            author: { screen_name: "caseuser" },
+          },
+        },
+      });
+
+      const result = await verifyTweet(VALID_TWEET_URL, WALLET);
+
+      expect(result).toEqual({
+        verified: true,
+        error: null,
+        handle: "caseuser",
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Expand `twitter-verify.test.ts` from 9 to 30 table-driven tests covering all acceptance criteria for MW-10
- Add `generateVerificationMessage` tests (3): agent name/wallet formatting with various inputs
- Expand URL parse tests (5→8): valid twitter.com/x.com URLs, empty string, missing screen name
- Add fetch failure table (7): network timeout, TypeError, AbortError, HTTP 404/500/503/429, invalid JSON, missing tweet object
- Add message mismatch table (5): missing wallet (3 variants), missing hashtag (2 variants)
- Add successful verification paths (4): short address, partial prefix match, handle fallback, case-insensitive matching

### New coverage for previously untested code paths
- `generateVerificationMessage` — was completely untested
- Alternative wallet match via `walletAddress.slice(0, 10)` prefix
- Handle fallback to URL screen name when `author.screen_name` is absent
- Case-insensitive address matching

## Test plan
- [x] `bunx vitest run src/api/twitter-verify.test.ts` — 30 tests pass

Closes #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)