### PR TITLE
docs: close runbook gaps for high-risk integrations (MW-11)

### DIFF
--- a/INTEGRATION_DOD_MAP.md
+++ b/INTEGRATION_DOD_MAP.md
@@ -464,7 +464,7 @@ Prioritization order applied: correctness/security first, then reliability/obser
 | MW-08 | P1 | API | API | Skills/plugin installer flows | Missing e2e install/uninstall workflow tests | Add sandboxed integration tests with fixture registry and install/uninstall assertions | `bunx vitest run --config vitest.e2e.config.ts test/plugin-install.e2e.test.ts test/skills-marketplace.e2e.test.ts` | `test/plugin-install.e2e.test.ts`, `test/skills-marketplace.e2e.test.ts` | Runtime install path regressions |
 | MW-09 | P1 | DX/Tooling | DX/Tooling | Observability baseline | No standardized metrics/traces for integration boundaries | Define minimal metrics contract (success/failure/latency) for cloud, wallet, marketplace, and MCP boundaries | `bun run typecheck && bunx vitest run <observability-tests>` | `src/services/*`, `src/api/*`, optional `src/diagnostics/*` | Hard incident triage and SLO blind spots |
 | MW-10 | P2 | API | API | Twitter whitelist | No dedicated tests for `twitter-verify.ts` parser/error cases | Add table-driven unit tests for URL parse, timeout/fetch fail, and message mismatch | `bunx vitest run src/api/twitter-verify.test.ts` | `src/api/twitter-verify.test.ts` | Verification false positives/negatives |
-| MW-11 | P2 | Docs | Docs | Docs completeness | Missing or partial docs for registry/drop, skill catalog, media provider runbooks, connector specifics, and CUA operations | Add setup + failure-mode + verification sections per integration boundary | `bun run docs:build` | `docs/rest/*`, `docs/guides/*`, `README.md` | Slower onboarding and misconfigurations |
+| MW-11 | P2 | Docs | Docs | Docs completeness | Resolved — runbooks expanded for registry/drop, skill catalog, connectors, and CUA operations with setup, failure modes, recovery, and verification sections | Add setup + failure-mode + verification sections per integration boundary | `bun run docs:build` | `docs/guides/registry.md`, `docs/plugins/skills.md`, `docs/guides/connectors.md`, `docs/plugin-registry/computeruse.md` | Slower onboarding and misconfigurations |
 | MW-12 | P2 | DX/Tooling | DX/Tooling | Migration checks | No explicit DB migration verification command surfaced in scripts | Define and add minimal migration check script or explicit N/A policy | `bun run db:check` (proposed) | `package.json`, `scripts/` | Schema drift not caught early |
 
 ---
@@ -610,6 +610,13 @@ Prioritization order applied: correctness/security first, then reliability/obser
 - Title: `Close docs/runbook gaps for high-risk integrations`
 - Labels: `priority:P2`, `area:Docs`
 - Owner: `Docs`
+- Status: **Resolved**
+- Resolution: Expanded runbook sections across four docs:
+  - `docs/guides/registry.md` — added on-chain registry/drop failure modes, NPM resolution errors, recovery procedures, and expanded verification commands.
+  - `docs/plugins/skills.md` — added Skill Operations Runbook covering catalog, marketplace, and skill loading failure modes with recovery procedures.
+  - `docs/guides/connectors.md` — added platform-specific failure modes for Discord, Telegram, Slack, and WhatsApp with recovery procedures.
+  - `docs/plugin-registry/computeruse.md` — added vision model selection, action failure taxonomy, sandbox configuration, cross-platform guidance, and recovery procedures.
+  - `docs/guides/media-generation.md` — already comprehensive (no changes needed).
 - Acceptance criteria:
   - Registry/drop, skill catalog, media provider, connector specifics, and CUA operations have setup, failure, and verify guidance.
 - Verification commands:

--- a/docs/guides/registry.md
+++ b/docs/guides/registry.md
@@ -473,8 +473,12 @@ pnpm add elizaos-plugin-custom-feature
 1. Ensure plugin metadata exists and is valid in `plugins.json`.
 2. Ensure installable packages resolve from npm or your internal registry.
 3. Ensure required env keys for each plugin are documented in the manifest.
+4. For on-chain registry operations, set `EVM_PRIVATE_KEY` and configure `mainnetRpc`, `registryAddress`, and `collectionAddress` in agent config.
+5. Verify the plugin install directory is writable: `ls -ld ~/.milady/plugins/installed/`.
 
 ### Failure Modes
+
+**Plugin registry lookup:**
 
 - Registry lookup returns no results:
   Confirm `plugins.json` is current and plugin IDs are spelled correctly.
@@ -483,10 +487,44 @@ pnpm add elizaos-plugin-custom-feature
 - Version drift between manifest and package:
   Regenerate registry metadata and commit updated manifest.
 
+**NPM resolution and install:**
+
+- `npm pack` or `bun install` fails during plugin install:
+  Check network connectivity to the npm registry. The installer falls back from npm to direct git clone — if both fail, the package spec is likely invalid.
+- Entry point not found after install:
+  The installer checks for `package.json` in the target directory. Confirm the package has a valid `main` or `module` field, or that `index.js`/`index.ts` exists at the package root.
+- Concurrent install corruption:
+  The installer uses a serialisation lock. If a previous install crashed, stale lock state may block new installs. Restart the agent to clear in-memory locks.
+
+**On-chain registry/drop operations:**
+
+- Transaction reverts or times out:
+  Check that `EVM_PRIVATE_KEY` has sufficient gas balance. Verify `mainnetRpc` is reachable and not rate-limited. The tx-service retries with escalating gas — if all retries fail, the error includes the revert reason.
+- Registry contract call returns empty data:
+  Confirm `registryAddress` and `collectionAddress` point to deployed contracts on the correct chain. Use a block explorer to verify contract state.
+- Nonce conflict on rapid sequential transactions:
+  The tx-service manages nonce locally. If an external wallet transaction changes the nonce, restart the agent to re-sync.
+
+### Recovery Procedures
+
+1. **Stale plugin state:** Delete `~/.milady/plugins/installed/<plugin-name>/` and remove the entry from `milady.json` under `plugins.installs`, then re-install.
+2. **Registry metadata out of sync:** Run `milady plugin sync` or manually update `plugins.json` from the upstream registry.
+3. **On-chain tx stuck:** Check the pending transaction on a block explorer. If stuck, the agent will retry with higher gas on next attempt. Manual speed-up via wallet is safe — the agent re-reads nonce on next call.
+
 ### Verification Commands
 
 ```bash
+# Plugin registry and installer tests
 bunx vitest run src/services/plugin-installer.test.ts src/services/skill-marketplace.test.ts src/services/mcp-marketplace.test.ts
+
+# Plugin install e2e lifecycle
+bunx vitest run --config vitest.e2e.config.ts test/plugin-install.e2e.test.ts test/skills-marketplace.e2e.test.ts
+
+# On-chain service tests
+bunx vitest run src/api/tx-service.test.ts src/api/registry-service.test.ts src/api/drop-service.test.ts
+
+# API server e2e (includes registry routes)
 bunx vitest run --config vitest.e2e.config.ts test/api-server.e2e.test.ts
+
 bun run typecheck
 ```


### PR DESCRIPTION
## Summary
- Expanded **registry runbook** (`docs/guides/registry.md`) with on-chain registry/drop failure modes, NPM resolution errors, concurrent install handling, recovery procedures, and expanded verification commands
- Added **Skill Operations Runbook** to `docs/plugins/skills.md` covering catalog load failures, marketplace connectivity, security scan blocking, git clone failures, skill loading issues, and recovery procedures
- Expanded **connector runbook** (`docs/guides/connectors.md`) with platform-specific failure modes for Discord (token revocation, rate limits, intent permissions), Telegram (webhook/polling, token expiry, message buffering), Slack (token revocation, Events API), and WhatsApp (QR pairing, session drops)
- Expanded **CUA runbook** (`docs/plugin-registry/computeruse.md`) with vision model selection, action failure taxonomy (coordinate mapping, click loops, tool schema), sandbox configuration, cross-platform guidance (macOS/Linux/Windows permissions), and recovery procedures
- Media provider runbook (`docs/guides/media-generation.md`) already comprehensive — no changes needed
- Updated `INTEGRATION_DOD_MAP.md` to mark MW-11 as resolved

## Test plan
- [ ] Verify docs build: `bun run docs:build`
- [ ] Review each runbook section for accuracy against source code
- [ ] Confirm all referenced verification commands are valid

Closes #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)