### PR TITLE
feat(streaming): cross-platform capture, audio sources & volume control

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -8607,6 +8607,53 @@
       }
     },
     {
+      "id": "retake",
+      "dirName": "plugin-retake",
+      "name": "Retake.tv",
+      "npmName": "@milady/plugin-retake",
+      "description": "Live video streaming connector for retake.tv",
+      "category": "connector",
+      "envKey": null,
+      "configKeys": [],
+      "pluginParameters": {
+        "RETAKE_ACCESS_TOKEN": {
+          "type": "string",
+          "description": "Access token for retake.tv API",
+          "required": false,
+          "sensitive": true
+        },
+        "RETAKE_API_URL": {
+          "type": "string",
+          "description": "Retake.tv API base URL",
+          "required": false,
+          "sensitive": false
+        },
+        "RETAKE_CAPTURE_URL": {
+          "type": "string",
+          "description": "Capture URL for retake.tv stream",
+          "required": false,
+          "sensitive": false
+        }
+      },
+      "configUiHints": {
+        "RETAKE_ACCESS_TOKEN": {
+          "label": "Access Token",
+          "group": "Authentication",
+          "width": "full"
+        },
+        "RETAKE_API_URL": {
+          "label": "API URL",
+          "group": "Connection",
+          "width": "half"
+        },
+        "RETAKE_CAPTURE_URL": {
+          "label": "Capture URL",
+          "group": "Connection",
+          "width": "half"
+        }
+      }
+    },
+    {
       "id": "vercel-ai-gateway",
       "dirName": "plugin-vercel-ai-gateway",
       "name": "Vercel Ai Gateway",

--- a/src/api/retake-routes.test.ts
+++ b/src/api/retake-routes.test.ts
@@ -1,12 +1,29 @@
-import { describe, expect, it, vi } from "vitest";
+/**
+ * Tests for retake-routes.ts
+ *
+ * Covers:
+ *   - detectCaptureMode() — env-driven mode selection
+ *   - ensureXvfb()        — display-format validation and Linux-only guard
+ *   - handleRetakeRoute() — individual API endpoint behaviour
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createMockHttpResponse,
   createMockIncomingMessage,
 } from "../test-support/test-helpers";
-import type { RetakeRouteState } from "./retake-routes";
-import { handleRetakeRoute } from "./retake-routes";
+import {
+  detectCaptureMode,
+  ensureXvfb,
+  handleRetakeRoute,
+  type RetakeRouteState,
+} from "./retake-routes";
 
-/** Build a minimal mock RetakeRouteState. */
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a fully-wired mock RetakeRouteState. */
 function mockState(
   overrides: Partial<RetakeRouteState> = {},
 ): RetakeRouteState {
@@ -16,13 +33,186 @@ function mockState(
       writeFrame: vi.fn(() => true),
       start: vi.fn(async () => {}),
       stop: vi.fn(async () => ({ uptime: 0 })),
+      getHealth: vi.fn(() => ({
+        running: true,
+        ffmpegAlive: true,
+        uptime: 300,
+        frameCount: 1000,
+        volume: 80,
+        muted: false,
+        audioSource: "silent",
+        inputMode: "pipe",
+      })),
+      getVolume: vi.fn(() => 80),
+      isMuted: vi.fn(() => false),
+      setVolume: vi.fn(async () => {}),
+      mute: vi.fn(async () => {}),
+      unmute: vi.fn(async () => {}),
     },
     port: 2138,
     ...overrides,
   };
 }
 
+// ---------------------------------------------------------------------------
+// detectCaptureMode()
+// ---------------------------------------------------------------------------
+
+describe("detectCaptureMode()", () => {
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = { ...process.env };
+  });
+
+  afterEach(() => {
+    // Remove keys added during the test then restore originals.
+    for (const key of Object.keys(process.env)) {
+      if (!(key in savedEnv)) delete process.env[key];
+    }
+    Object.assign(process.env, savedEnv);
+  });
+
+  it('returns "pipe" when RETAKE_STREAM_MODE=ui', () => {
+    process.env.RETAKE_STREAM_MODE = "ui";
+    expect(detectCaptureMode()).toBe("pipe");
+  });
+
+  it('returns "pipe" when RETAKE_STREAM_MODE=pipe', () => {
+    process.env.RETAKE_STREAM_MODE = "pipe";
+    expect(detectCaptureMode()).toBe("pipe");
+  });
+
+  it('returns "x11grab" when RETAKE_STREAM_MODE=x11grab', () => {
+    process.env.RETAKE_STREAM_MODE = "x11grab";
+    expect(detectCaptureMode()).toBe("x11grab");
+  });
+
+  it('returns "avfoundation" when RETAKE_STREAM_MODE=avfoundation', () => {
+    process.env.RETAKE_STREAM_MODE = "avfoundation";
+    expect(detectCaptureMode()).toBe("avfoundation");
+  });
+
+  it('returns "avfoundation" when RETAKE_STREAM_MODE=screen', () => {
+    process.env.RETAKE_STREAM_MODE = "screen";
+    expect(detectCaptureMode()).toBe("avfoundation");
+  });
+
+  it('returns "file" when RETAKE_STREAM_MODE=file', () => {
+    process.env.RETAKE_STREAM_MODE = "file";
+    expect(detectCaptureMode()).toBe("file");
+  });
+
+  it("env var overrides platform detection (pipe takes priority over platform)", () => {
+    // Confirm env-var path runs unconditionally regardless of platform.
+    process.env.RETAKE_STREAM_MODE = "pipe";
+    expect(detectCaptureMode()).toBe("pipe");
+  });
+
+  it('returns "avfoundation" on macOS without env var (platform-conditional)', () => {
+    delete process.env.RETAKE_STREAM_MODE;
+    if (process.platform === "darwin") {
+      expect(detectCaptureMode()).toBe("avfoundation");
+    }
+    // Non-darwin: platform path differs — no assertion required.
+  });
+
+  it('returns "x11grab" on Linux when DISPLAY is set (platform-conditional)', () => {
+    delete process.env.RETAKE_STREAM_MODE;
+    if (process.platform === "linux") {
+      process.env.DISPLAY = ":0";
+      expect(detectCaptureMode()).toBe("x11grab");
+    }
+    // Not on Linux — no assertion required.
+  });
+
+  it('returns "file" as fallback on non-darwin non-linux without DISPLAY (platform-conditional)', () => {
+    delete process.env.RETAKE_STREAM_MODE;
+    if (
+      process.platform !== "darwin" &&
+      process.platform !== "linux" &&
+      !process.versions.electron
+    ) {
+      delete process.env.DISPLAY;
+      expect(detectCaptureMode()).toBe("file");
+    }
+    // Platform-specific result on darwin/linux — no assertion required.
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ensureXvfb()
+// ---------------------------------------------------------------------------
+
+describe("ensureXvfb()", () => {
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = { ...process.env };
+  });
+
+  afterEach(() => {
+    for (const key of Object.keys(process.env)) {
+      if (!(key in savedEnv)) delete process.env[key];
+    }
+    Object.assign(process.env, savedEnv);
+  });
+
+  it("returns false on non-Linux platforms without attempting syscalls", async () => {
+    if (process.platform !== "linux") {
+      const result = await ensureXvfb(":99", "1280x720");
+      expect(result).toBe(false);
+    }
+  });
+
+  it("returns false for display string containing semicolons (command injection)", async () => {
+    const result = await ensureXvfb(":99;rm -rf /", "1280x720");
+    expect(result).toBe(false);
+  });
+
+  it("returns false for display with no leading colon", async () => {
+    const result = await ensureXvfb("abc", "1280x720");
+    expect(result).toBe(false);
+  });
+
+  it("returns false for display containing spaces", async () => {
+    const result = await ensureXvfb(": 0", "1280x720");
+    expect(result).toBe(false);
+  });
+
+  it("returns false for display with alphabetic suffix", async () => {
+    const result = await ensureXvfb(":0x", "1280x720");
+    expect(result).toBe(false);
+  });
+
+  it("accepts :0 without throwing (valid format — platform determines outcome)", async () => {
+    const result = await ensureXvfb(":0", "1280x720");
+    // On non-Linux this is false; on Linux it may be true or false depending on Xvfb state.
+    expect(typeof result).toBe("boolean");
+  });
+
+  it("accepts :99 without throwing (valid format — platform determines outcome)", async () => {
+    const result = await ensureXvfb(":99", "1280x720");
+    expect(typeof result).toBe("boolean");
+  });
+
+  it("returns false for invalid resolution on Linux (platform-conditional)", async () => {
+    if (process.platform === "linux") {
+      // Use a display different from DISPLAY so the early-return shortcut is skipped.
+      process.env.DISPLAY = ":0";
+      const result = await ensureXvfb(":99", "abc");
+      expect(result).toBe(false);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleRetakeRoute() — endpoint tests
+// ---------------------------------------------------------------------------
+
 describe("handleRetakeRoute", () => {
+  // ── Non-retake paths ────────────────────────────────────────────────────
+
   it("returns false for non-retake paths", async () => {
     const { res } = createMockHttpResponse();
     const req = createMockIncomingMessage({
@@ -39,6 +229,31 @@ describe("handleRetakeRoute", () => {
     expect(result).toBe(false);
   });
 
+  it("returns false for /api/retake (missing trailing slash prefix)", async () => {
+    const { res } = createMockHttpResponse();
+    const req = createMockIncomingMessage({
+      method: "GET",
+      url: "/api/retake",
+    });
+    const result = await handleRetakeRoute(
+      req,
+      res,
+      "/api/retake",
+      "GET",
+      mockState(),
+    );
+    expect(result).toBe(false);
+  });
+
+  it("returns false for empty pathname", async () => {
+    const { res } = createMockHttpResponse();
+    const req = createMockIncomingMessage({ method: "GET", url: "" });
+    const result = await handleRetakeRoute(req, res, "", "GET", mockState());
+    expect(result).toBe(false);
+  });
+
+  // ── POST /api/retake/frame ───────────────────────────────────────────────
+
   describe("POST /api/retake/frame", () => {
     it("returns 503 when StreamManager is not running", async () => {
       const { res, getStatus, getJson } = createMockHttpResponse();
@@ -48,9 +263,7 @@ describe("handleRetakeRoute", () => {
         body: Buffer.from("jpeg-data"),
       });
       const state = mockState();
-      (
-        state.streamManager.isRunning as ReturnType<typeof vi.fn>
-      ).mockReturnValue(false);
+      vi.mocked(state.streamManager.isRunning).mockReturnValue(false);
 
       const handled = await handleRetakeRoute(
         req,
@@ -69,16 +282,14 @@ describe("handleRetakeRoute", () => {
       );
     });
 
-    it("returns 400 for empty frame body", async () => {
+    it("returns 400 for an empty frame body when stream is running", async () => {
       const { res, getStatus, getJson } = createMockHttpResponse();
       const req = createMockIncomingMessage({
         method: "POST",
         url: "/api/retake/frame",
       });
       const state = mockState();
-      (
-        state.streamManager.isRunning as ReturnType<typeof vi.fn>
-      ).mockReturnValue(true);
+      vi.mocked(state.streamManager.isRunning).mockReturnValue(true);
 
       const handled = await handleRetakeRoute(
         req,
@@ -95,7 +306,7 @@ describe("handleRetakeRoute", () => {
       );
     });
 
-    it("writes frame and returns 200 when running", async () => {
+    it("writes frame and returns 200 for a non-empty frame when running", async () => {
       const { res, getStatus } = createMockHttpResponse();
       const frameData = Buffer.from("fake-jpeg-data");
       const req = createMockIncomingMessage({
@@ -104,9 +315,7 @@ describe("handleRetakeRoute", () => {
         body: frameData,
       });
       const state = mockState();
-      (
-        state.streamManager.isRunning as ReturnType<typeof vi.fn>
-      ).mockReturnValue(true);
+      vi.mocked(state.streamManager.isRunning).mockReturnValue(true);
 
       const handled = await handleRetakeRoute(
         req,
@@ -122,17 +331,321 @@ describe("handleRetakeRoute", () => {
     });
   });
 
+  // ── GET /api/retake/status ───────────────────────────────────────────────
+
+  describe("GET /api/retake/status", () => {
+    it("returns ok:true with all health fields", async () => {
+      const { res, getStatus, getJson } = createMockHttpResponse();
+      const req = createMockIncomingMessage({
+        method: "GET",
+        url: "/api/retake/status",
+      });
+      const state = mockState();
+
+      const handled = await handleRetakeRoute(
+        req,
+        res,
+        "/api/retake/status",
+        "GET",
+        state,
+      );
+
+      expect(handled).toBe(true);
+      expect(getStatus()).toBe(200);
+      expect(state.streamManager.getHealth).toHaveBeenCalledOnce();
+      expect(getJson()).toEqual(
+        expect.objectContaining({
+          ok: true,
+          running: true,
+          ffmpegAlive: true,
+          uptime: 300,
+          frameCount: 1000,
+          volume: 80,
+          muted: false,
+          audioSource: "silent",
+          inputMode: "pipe",
+        }),
+      );
+    });
+  });
+
+  // ── POST /api/retake/volume ─────────────────────────────────────────────
+
+  describe("POST /api/retake/volume", () => {
+    it("calls setVolume(50) and returns ok with volume and muted state", async () => {
+      const { res, getStatus, getJson } = createMockHttpResponse();
+      const req = createMockIncomingMessage({
+        method: "POST",
+        url: "/api/retake/volume",
+        body: JSON.stringify({ volume: 50 }),
+      });
+      const state = mockState();
+
+      const handled = await handleRetakeRoute(
+        req,
+        res,
+        "/api/retake/volume",
+        "POST",
+        state,
+      );
+
+      expect(handled).toBe(true);
+      expect(getStatus()).toBe(200);
+      expect(state.streamManager.setVolume).toHaveBeenCalledWith(50);
+      expect(getJson()).toEqual(
+        expect.objectContaining({ ok: true, volume: 80, muted: false }),
+      );
+    });
+
+    it("accepts boundary minimum volume=0", async () => {
+      const { res, getStatus } = createMockHttpResponse();
+      const req = createMockIncomingMessage({
+        method: "POST",
+        url: "/api/retake/volume",
+        body: JSON.stringify({ volume: 0 }),
+      });
+      const state = mockState();
+
+      await handleRetakeRoute(req, res, "/api/retake/volume", "POST", state);
+
+      expect(getStatus()).toBe(200);
+      expect(state.streamManager.setVolume).toHaveBeenCalledWith(0);
+    });
+
+    it("accepts boundary maximum volume=100", async () => {
+      const { res, getStatus } = createMockHttpResponse();
+      const req = createMockIncomingMessage({
+        method: "POST",
+        url: "/api/retake/volume",
+        body: JSON.stringify({ volume: 100 }),
+      });
+      const state = mockState();
+
+      await handleRetakeRoute(req, res, "/api/retake/volume", "POST", state);
+
+      expect(getStatus()).toBe(200);
+      expect(state.streamManager.setVolume).toHaveBeenCalledWith(100);
+    });
+
+    it("returns 400 for volume=150 (above maximum)", async () => {
+      const { res, getStatus } = createMockHttpResponse();
+      const req = createMockIncomingMessage({
+        method: "POST",
+        url: "/api/retake/volume",
+        body: JSON.stringify({ volume: 150 }),
+      });
+      const state = mockState();
+
+      const handled = await handleRetakeRoute(
+        req,
+        res,
+        "/api/retake/volume",
+        "POST",
+        state,
+      );
+
+      expect(handled).toBe(true);
+      expect(getStatus()).toBe(400);
+      expect(state.streamManager.setVolume).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 for negative volume", async () => {
+      const { res, getStatus } = createMockHttpResponse();
+      const req = createMockIncomingMessage({
+        method: "POST",
+        url: "/api/retake/volume",
+        body: JSON.stringify({ volume: -1 }),
+      });
+      const state = mockState();
+
+      await handleRetakeRoute(req, res, "/api/retake/volume", "POST", state);
+
+      expect(getStatus()).toBe(400);
+      expect(state.streamManager.setVolume).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 for non-number volume (string)", async () => {
+      const { res, getStatus } = createMockHttpResponse();
+      const req = createMockIncomingMessage({
+        method: "POST",
+        url: "/api/retake/volume",
+        body: JSON.stringify({ volume: "loud" }),
+      });
+      const state = mockState();
+
+      await handleRetakeRoute(req, res, "/api/retake/volume", "POST", state);
+
+      expect(getStatus()).toBe(400);
+      expect(state.streamManager.setVolume).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 for null volume", async () => {
+      const { res, getStatus } = createMockHttpResponse();
+      const req = createMockIncomingMessage({
+        method: "POST",
+        url: "/api/retake/volume",
+        body: JSON.stringify({ volume: null }),
+      });
+      const state = mockState();
+
+      await handleRetakeRoute(req, res, "/api/retake/volume", "POST", state);
+
+      expect(getStatus()).toBe(400);
+      expect(state.streamManager.setVolume).not.toHaveBeenCalled();
+    });
+
+    it("returns 500 for invalid JSON body", async () => {
+      const { res, getStatus } = createMockHttpResponse();
+      const req = createMockIncomingMessage({
+        method: "POST",
+        url: "/api/retake/volume",
+        body: "not-json{{{",
+      });
+      const state = mockState();
+
+      const handled = await handleRetakeRoute(
+        req,
+        res,
+        "/api/retake/volume",
+        "POST",
+        state,
+      );
+
+      expect(handled).toBe(true);
+      expect(getStatus()).toBe(500);
+      expect(state.streamManager.setVolume).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 or 500 for empty body (no parseable volume)", async () => {
+      const { res, getStatus } = createMockHttpResponse();
+      // An empty string body: JSON.parse("") throws → 500,
+      // or readRequestBody returns null → JSON.parse(null) treats it as volume undefined → 400.
+      const req = createMockIncomingMessage({
+        method: "POST",
+        url: "/api/retake/volume",
+        body: "",
+      });
+      const state = mockState();
+
+      const handled = await handleRetakeRoute(
+        req,
+        res,
+        "/api/retake/volume",
+        "POST",
+        state,
+      );
+
+      expect(handled).toBe(true);
+      expect([400, 500]).toContain(getStatus());
+      expect(state.streamManager.setVolume).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── POST /api/retake/mute ───────────────────────────────────────────────
+
+  describe("POST /api/retake/mute", () => {
+    it("calls mute() and returns ok:true muted:true with volume", async () => {
+      const { res, getStatus, getJson } = createMockHttpResponse();
+      const req = createMockIncomingMessage({
+        method: "POST",
+        url: "/api/retake/mute",
+      });
+      const state = mockState();
+
+      const handled = await handleRetakeRoute(
+        req,
+        res,
+        "/api/retake/mute",
+        "POST",
+        state,
+      );
+
+      expect(handled).toBe(true);
+      expect(getStatus()).toBe(200);
+      expect(state.streamManager.mute).toHaveBeenCalledOnce();
+      expect(getJson()).toEqual(
+        expect.objectContaining({ ok: true, muted: true, volume: 80 }),
+      );
+    });
+
+    it("returns 500 when mute() throws", async () => {
+      const { res, getStatus, getJson } = createMockHttpResponse();
+      const req = createMockIncomingMessage({
+        method: "POST",
+        url: "/api/retake/mute",
+      });
+      const state = mockState();
+      vi.mocked(state.streamManager.mute).mockRejectedValueOnce(
+        new Error("mute failed"),
+      );
+
+      await handleRetakeRoute(req, res, "/api/retake/mute", "POST", state);
+
+      expect(getStatus()).toBe(500);
+      expect(getJson()).toEqual(
+        expect.objectContaining({ error: "mute failed" }),
+      );
+    });
+  });
+
+  // ── POST /api/retake/unmute ─────────────────────────────────────────────
+
+  describe("POST /api/retake/unmute", () => {
+    it("calls unmute() and returns ok:true muted:false with volume", async () => {
+      const { res, getStatus, getJson } = createMockHttpResponse();
+      const req = createMockIncomingMessage({
+        method: "POST",
+        url: "/api/retake/unmute",
+      });
+      const state = mockState();
+
+      const handled = await handleRetakeRoute(
+        req,
+        res,
+        "/api/retake/unmute",
+        "POST",
+        state,
+      );
+
+      expect(handled).toBe(true);
+      expect(getStatus()).toBe(200);
+      expect(state.streamManager.unmute).toHaveBeenCalledOnce();
+      expect(getJson()).toEqual(
+        expect.objectContaining({ ok: true, muted: false, volume: 80 }),
+      );
+    });
+
+    it("returns 500 when unmute() throws", async () => {
+      const { res, getStatus, getJson } = createMockHttpResponse();
+      const req = createMockIncomingMessage({
+        method: "POST",
+        url: "/api/retake/unmute",
+      });
+      const state = mockState();
+      vi.mocked(state.streamManager.unmute).mockRejectedValueOnce(
+        new Error("unmute failed"),
+      );
+
+      await handleRetakeRoute(req, res, "/api/retake/unmute", "POST", state);
+
+      expect(getStatus()).toBe(500);
+      expect(getJson()).toEqual(
+        expect.objectContaining({ error: "unmute failed" }),
+      );
+    });
+  });
+
+  // ── POST /api/retake/live ────────────────────────────────────────────────
+
   describe("POST /api/retake/live", () => {
-    it("returns already-streaming when StreamManager is running", async () => {
+    it("returns already-streaming response when StreamManager is running", async () => {
       const { res, getJson } = createMockHttpResponse();
       const req = createMockIncomingMessage({
         method: "POST",
         url: "/api/retake/live",
       });
       const state = mockState();
-      (
-        state.streamManager.isRunning as ReturnType<typeof vi.fn>
-      ).mockReturnValue(true);
+      vi.mocked(state.streamManager.isRunning).mockReturnValue(true);
 
       const handled = await handleRetakeRoute(
         req,
@@ -158,9 +671,8 @@ describe("handleRetakeRoute", () => {
         method: "POST",
         url: "/api/retake/live",
       });
-      // No config.accessToken, no env var
       const state = mockState({ config: {} });
-      const origEnv = process.env.RETAKE_AGENT_TOKEN;
+      const origToken = process.env.RETAKE_AGENT_TOKEN;
       delete process.env.RETAKE_AGENT_TOKEN;
 
       try {
@@ -179,23 +691,23 @@ describe("handleRetakeRoute", () => {
           }),
         );
       } finally {
-        if (origEnv !== undefined) process.env.RETAKE_AGENT_TOKEN = origEnv;
+        if (origToken !== undefined) process.env.RETAKE_AGENT_TOKEN = origToken;
       }
     });
   });
 
+  // ── POST /api/retake/offline ─────────────────────────────────────────────
+
   describe("POST /api/retake/offline", () => {
-    it("stops StreamManager and returns ok", async () => {
+    it("skips stop() when stream is not running and returns ok:true live:false", async () => {
       const { res, getJson } = createMockHttpResponse();
       const req = createMockIncomingMessage({
         method: "POST",
         url: "/api/retake/offline",
       });
       const state = mockState({ config: {} });
-      (
-        state.streamManager.isRunning as ReturnType<typeof vi.fn>
-      ).mockReturnValue(true);
-      const origEnv = process.env.RETAKE_AGENT_TOKEN;
+      vi.mocked(state.streamManager.isRunning).mockReturnValue(false);
+      const origToken = process.env.RETAKE_AGENT_TOKEN;
       delete process.env.RETAKE_AGENT_TOKEN;
 
       try {
@@ -207,21 +719,51 @@ describe("handleRetakeRoute", () => {
           state,
         );
         expect(handled).toBe(true);
-        expect(state.streamManager.stop).toHaveBeenCalled();
+        expect(state.streamManager.stop).not.toHaveBeenCalled();
         expect(getJson()).toEqual(
           expect.objectContaining({ ok: true, live: false }),
         );
       } finally {
-        if (origEnv !== undefined) process.env.RETAKE_AGENT_TOKEN = origEnv;
+        if (origToken !== undefined) process.env.RETAKE_AGENT_TOKEN = origToken;
+      }
+    });
+
+    it("calls stop() when stream is running and returns ok:true live:false", async () => {
+      const { res, getJson } = createMockHttpResponse();
+      const req = createMockIncomingMessage({
+        method: "POST",
+        url: "/api/retake/offline",
+      });
+      const state = mockState({ config: {} });
+      vi.mocked(state.streamManager.isRunning).mockReturnValue(true);
+      const origToken = process.env.RETAKE_AGENT_TOKEN;
+      delete process.env.RETAKE_AGENT_TOKEN;
+
+      try {
+        const handled = await handleRetakeRoute(
+          req,
+          res,
+          "/api/retake/offline",
+          "POST",
+          state,
+        );
+        expect(handled).toBe(true);
+        expect(state.streamManager.stop).toHaveBeenCalledOnce();
+        expect(getJson()).toEqual(
+          expect.objectContaining({ ok: true, live: false }),
+        );
+      } finally {
+        if (origToken !== undefined) process.env.RETAKE_AGENT_TOKEN = origToken;
       }
     });
   });
 });
 
-describe("resolve() config priority", () => {
-  // We test resolve indirectly via handleRetakeRoute's /live endpoint
-  // which checks the accessToken resolution chain.
+// ---------------------------------------------------------------------------
+// resolve() config priority (tested indirectly via /live endpoint)
+// ---------------------------------------------------------------------------
 
+describe("resolve() config priority", () => {
   it("prefers config.accessToken over RETAKE_AGENT_TOKEN env var", async () => {
     const { res, getStatus } = createMockHttpResponse();
     const req = createMockIncomingMessage({
@@ -231,20 +773,18 @@ describe("resolve() config priority", () => {
     const state = mockState({
       config: { accessToken: "config-token" },
     });
-    // Set env var to a different value — config should win
-    const origEnv = process.env.RETAKE_AGENT_TOKEN;
+    // Set env var to a different value — config should win and proceed past the 400 guard.
+    const origToken = process.env.RETAKE_AGENT_TOKEN;
     process.env.RETAKE_AGENT_TOKEN = "env-token";
 
     try {
-      // This will fail to actually stream (no real retake.tv), but it should
-      // NOT return 400 "not configured" since the config token is present.
       await handleRetakeRoute(req, res, "/api/retake/live", "POST", state);
-      // If we get here, the token was resolved — it attempted startRetakeStream
-      // which will fail on the fetch, giving a 500, NOT a 400.
+      // If the token is resolved, startRetakeStream is attempted and fails
+      // with a 500 (fetch error) — NOT a 400 "not configured".
       expect(getStatus()).not.toBe(400);
     } finally {
-      if (origEnv !== undefined) {
-        process.env.RETAKE_AGENT_TOKEN = origEnv;
+      if (origToken !== undefined) {
+        process.env.RETAKE_AGENT_TOKEN = origToken;
       } else {
         delete process.env.RETAKE_AGENT_TOKEN;
       }

--- a/src/api/retake-routes.ts
+++ b/src/api/retake-routes.ts
@@ -9,7 +9,12 @@ import fs from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { logger } from "@elizaos/core";
 import type { StreamConfig } from "../services/stream-manager";
-import { readRequestBodyBuffer, sendJson, sendJsonError } from "./http-helpers";
+import {
+  readRequestBody,
+  readRequestBodyBuffer,
+  sendJson,
+  sendJsonError,
+} from "./http-helpers";
 
 // ---------------------------------------------------------------------------
 // State interface (subset of ServerState relevant to retake routes)
@@ -21,6 +26,21 @@ export interface RetakeRouteState {
     writeFrame(buf: Buffer): boolean;
     start(config: StreamConfig): Promise<void>;
     stop(): Promise<{ uptime: number }>;
+    getHealth(): {
+      running: boolean;
+      ffmpegAlive: boolean;
+      uptime: number;
+      frameCount: number;
+      volume: number;
+      muted: boolean;
+      audioSource: string;
+      inputMode: string | null;
+    };
+    getVolume(): number;
+    isMuted(): boolean;
+    setVolume(level: number): Promise<void>;
+    mute(): Promise<void>;
+    unmute(): Promise<void>;
   };
   /** Server port — used for building the default capture URL. */
   port?: number;
@@ -55,9 +75,104 @@ function resolve(
   return (state.config?.[configKey] ?? process.env[envKey] ?? fallback).trim();
 }
 
+/**
+ * Detect the best capture mode for the current environment.
+ *
+ * Priority:
+ * 1. RETAKE_STREAM_MODE env var (explicit override: "ui", "x11grab", "file", "avfoundation")
+ * 2. Electron → "pipe" (capturePage → POST /api/retake/frame → FFmpeg stdin)
+ * 3. Linux with DISPLAY or Xvfb → "x11grab" (Hyperscape approach)
+ * 4. macOS → "avfoundation" (native screen capture)
+ * 5. Fallback → "file" (Puppeteer CDP → temp JPEG → FFmpeg)
+ */
+/** @internal Exported for testing. */
+export function detectCaptureMode(): StreamConfig["inputMode"] {
+  const explicit = process.env.RETAKE_STREAM_MODE;
+  if (explicit === "ui" || explicit === "pipe") return "pipe";
+  if (explicit === "x11grab") return "x11grab";
+  if (explicit === "avfoundation" || explicit === "screen")
+    return "avfoundation";
+  if (explicit === "file") return "file";
+
+  // Electron → pipe mode
+  if (process.versions.electron) return "pipe";
+
+  // Linux with a display → x11grab (Xvfb or native X11)
+  if (process.platform === "linux" && process.env.DISPLAY) return "x11grab";
+
+  // macOS → avfoundation screen capture
+  if (process.platform === "darwin") return "avfoundation";
+
+  // Fallback → headless browser capture → file mode
+  return "file";
+}
+
+/**
+ * Try to start Xvfb on the specified display if not already running (Linux only).
+ * Returns true if display is available, false otherwise.
+ */
+/** @internal Exported for testing. */
+export async function ensureXvfb(
+  display: string,
+  resolution: string,
+): Promise<boolean> {
+  if (process.platform !== "linux") return false;
+
+  // Validate display format to prevent command injection (must be :<digits>)
+  if (!/^:\d+$/.test(display)) {
+    logger.warn(
+      `[retake] Invalid display format: ${display} (expected :<number>)`,
+    );
+    return false;
+  }
+
+  // Check if the display is already active
+  if (process.env.DISPLAY === display) return true;
+
+  try {
+    const { execSync } = await import("node:child_process");
+    // Check if Xvfb is already running on this display
+    try {
+      execSync(`xdpyinfo -display ${display}`, {
+        stdio: "ignore",
+        timeout: 3000,
+      });
+      logger.info(`[retake] Xvfb already running on display ${display}`);
+      return true;
+    } catch {
+      // Not running — start it
+    }
+
+    const [w, h] = resolution.split("x");
+    if (!w || !h || !/^\d+$/.test(w) || !/^\d+$/.test(h)) {
+      logger.warn(`[retake] Invalid resolution for Xvfb: ${resolution}`);
+      return false;
+    }
+    const { spawn: spawnProc } = await import("node:child_process");
+    const xvfb = spawnProc(
+      "Xvfb",
+      [display, "-screen", "0", `${w}x${h}x24`, "-ac"],
+      {
+        stdio: "ignore",
+        detached: true,
+      },
+    );
+    xvfb.unref();
+
+    // Wait for Xvfb to be ready
+    await new Promise((r) => setTimeout(r, 1000));
+    logger.info(`[retake] Started Xvfb on display ${display} (${resolution})`);
+    process.env.DISPLAY = display;
+    return true;
+  } catch (err) {
+    logger.warn(`[retake] Failed to start Xvfb: ${err}`);
+    return false;
+  }
+}
+
 async function startRetakeStream(
   state: RetakeRouteState,
-): Promise<{ rtmpUrl: string }> {
+): Promise<{ rtmpUrl: string; inputMode: string; audioSource: string }> {
   const retakeToken = resolve(state, "accessToken", "RETAKE_AGENT_TOKEN");
   if (!retakeToken) {
     throw new Error(
@@ -98,54 +213,144 @@ async function startRetakeStream(
     throw new Error(`retake.tv start failed: ${startRes.status} ${text}`);
   }
 
-  // 3. Start headless browser capture (writes frames to temp file)
-  const captureUrl =
-    resolve(state, "captureUrl", "RETAKE_CAPTURE_URL") ||
-    `http://127.0.0.1:${state.port ?? 2138}`;
+  // 3. Detect capture mode and start the appropriate pipeline
+  const mode = detectCaptureMode();
+  const audioSource = process.env.RETAKE_AUDIO_SOURCE || "silent";
+  const audioDevice = process.env.RETAKE_AUDIO_DEVICE;
+  const volume = parseInt(process.env.RETAKE_VOLUME || "80", 10);
+  const resolution = "1280x720";
 
-  const { startBrowserCapture, FRAME_FILE } = await import(
-    "../services/browser-capture.js"
-  );
-  try {
-    await startBrowserCapture({
-      url: captureUrl,
-      width: 1280,
-      height: 720,
-      quality: 70,
-    });
-    // Wait for first frame file to be written
-    await new Promise((resolve) => {
-      const check = setInterval(() => {
-        try {
-          if (fs.existsSync(FRAME_FILE) && fs.statSync(FRAME_FILE).size > 0) {
-            clearInterval(check);
-            resolve(true);
-          }
-        } catch {
-          // Frame file not yet ready — poll again
-        }
-      }, 200);
-      setTimeout(() => {
-        clearInterval(check);
-        resolve(false);
-      }, 10_000);
-    });
-  } catch (captureErr) {
-    logger.warn(`[retake] Browser capture failed: ${captureErr}`);
-  }
-
-  // 4. Start FFmpeg → RTMP
-  await state.streamManager.start({
+  const baseConfig: StreamConfig = {
     rtmpUrl,
     rtmpKey,
-    inputMode: "file",
-    frameFile: FRAME_FILE,
-    resolution: "1280x720",
-    framerate: 30,
+    resolution,
     bitrate: "1500k",
-  });
+    audioSource,
+    audioDevice,
+    volume,
+  };
 
-  return { rtmpUrl };
+  switch (mode) {
+    case "pipe": {
+      // Electron UI mode: FFmpeg reads frames from stdin via writeFrame().
+      // Frames posted by Electron renderer via POST /api/retake/frame.
+      logger.info("[retake] Capture mode: pipe (Electron UI)");
+      await state.streamManager.start({
+        ...baseConfig,
+        inputMode: "pipe",
+        framerate: 15,
+      });
+      break;
+    }
+
+    case "x11grab": {
+      // Linux Xvfb mode (Hyperscape approach): capture virtual display.
+      const display = process.env.RETAKE_DISPLAY || ":99";
+      logger.info(`[retake] Capture mode: x11grab (display ${display})`);
+
+      // Ensure Xvfb is running
+      await ensureXvfb(display, resolution);
+
+      // Launch a browser on the virtual display so there's something to capture
+      const captureUrl =
+        resolve(state, "captureUrl", "RETAKE_CAPTURE_URL") ||
+        `http://127.0.0.1:${state.port ?? 2138}`;
+
+      try {
+        const { startBrowserCapture } = await import(
+          "../services/browser-capture.js"
+        );
+        // Browser capture in x11grab mode just opens the browser on the display —
+        // we don't need the frame file since FFmpeg captures the display directly.
+        await startBrowserCapture({
+          url: captureUrl,
+          width: 1280,
+          height: 720,
+          quality: 70,
+        });
+      } catch (err) {
+        logger.warn(`[retake] Browser launch on ${display} failed: ${err}`);
+      }
+
+      await state.streamManager.start({
+        ...baseConfig,
+        inputMode: "x11grab",
+        display,
+        framerate: 30,
+      });
+      break;
+    }
+
+    case "avfoundation": {
+      // macOS native screen capture.
+      const videoDevice = process.env.RETAKE_VIDEO_DEVICE || "3";
+      logger.info(
+        `[retake] Capture mode: avfoundation (device ${videoDevice})`,
+      );
+      await state.streamManager.start({
+        ...baseConfig,
+        inputMode: "avfoundation",
+        videoDevice,
+        framerate: 30,
+      });
+      break;
+    }
+
+    default: {
+      // Headless browser capture → temp JPEG file → FFmpeg file mode.
+      const captureUrl =
+        resolve(state, "captureUrl", "RETAKE_CAPTURE_URL") ||
+        `http://127.0.0.1:${state.port ?? 2138}`;
+
+      logger.info(
+        `[retake] Capture mode: file (browser capture → ${captureUrl})`,
+      );
+
+      const { startBrowserCapture, FRAME_FILE } = await import(
+        "../services/browser-capture.js"
+      );
+      try {
+        await startBrowserCapture({
+          url: captureUrl,
+          width: 1280,
+          height: 720,
+          quality: 70,
+        });
+        // Wait for first frame file to be written
+        await new Promise((resolve) => {
+          const check = setInterval(() => {
+            try {
+              if (
+                fs.existsSync(FRAME_FILE) &&
+                fs.statSync(FRAME_FILE).size > 0
+              ) {
+                clearInterval(check);
+                resolve(true);
+              }
+            } catch {
+              // Frame file not yet ready — poll again
+            }
+          }, 200);
+          setTimeout(() => {
+            clearInterval(check);
+            resolve(false);
+          }, 10_000);
+        });
+      } catch (captureErr) {
+        logger.warn(`[retake] Browser capture failed: ${captureErr}`);
+      }
+
+      await state.streamManager.start({
+        ...baseConfig,
+        inputMode: "file",
+        frameFile: FRAME_FILE,
+        framerate: 30,
+      });
+      break;
+    }
+  }
+
+  return { rtmpUrl, inputMode: mode || "file", audioSource };
 }
 
 // ---------------------------------------------------------------------------
@@ -192,7 +397,13 @@ export async function handleRetakeRoute(
   // ── POST /api/retake/live — start retake.tv stream ────────────────────
   if (method === "POST" && pathname === "/api/retake/live") {
     if (state.streamManager.isRunning()) {
-      json(res, { ok: true, live: true, message: "Already streaming" });
+      const health = state.streamManager.getHealth();
+      json(res, {
+        ok: true,
+        live: true,
+        message: "Already streaming",
+        ...health,
+      });
       return true;
     }
     const retakeToken = resolve(state, "accessToken", "RETAKE_AGENT_TOKEN");
@@ -201,8 +412,9 @@ export async function handleRetakeRoute(
       return true;
     }
     try {
-      const { rtmpUrl } = await startRetakeStream(state);
-      json(res, { ok: true, live: true, rtmpUrl });
+      const { rtmpUrl, inputMode, audioSource } =
+        await startRetakeStream(state);
+      json(res, { ok: true, live: true, rtmpUrl, inputMode, audioSource });
     } catch (err) {
       error(res, err instanceof Error ? err.message : "Failed to go live", 500);
     }
@@ -249,6 +461,68 @@ export async function handleRetakeRoute(
         err instanceof Error ? err.message : "Failed to go offline",
         500,
       );
+    }
+    return true;
+  }
+
+  // ── GET /api/retake/status — local stream health ────────────────────
+  if (method === "GET" && pathname === "/api/retake/status") {
+    json(res, { ok: true, ...state.streamManager.getHealth() });
+    return true;
+  }
+
+  // ── POST /api/retake/volume — set stream volume (0–100) ─────────────
+  if (method === "POST" && pathname === "/api/retake/volume") {
+    try {
+      const body = await readRequestBody(req);
+      const parsed = typeof body === "string" ? JSON.parse(body) : body;
+      const level = parsed?.volume;
+      if (typeof level !== "number" || level < 0 || level > 100) {
+        error(res, "volume must be a number between 0 and 100", 400);
+        return true;
+      }
+      await state.streamManager.setVolume(level);
+      json(res, {
+        ok: true,
+        volume: state.streamManager.getVolume(),
+        muted: state.streamManager.isMuted(),
+      });
+    } catch (err) {
+      error(
+        res,
+        err instanceof Error ? err.message : "Failed to set volume",
+        500,
+      );
+    }
+    return true;
+  }
+
+  // ── POST /api/retake/mute — mute stream audio ──────────────────────
+  if (method === "POST" && pathname === "/api/retake/mute") {
+    try {
+      await state.streamManager.mute();
+      json(res, {
+        ok: true,
+        muted: true,
+        volume: state.streamManager.getVolume(),
+      });
+    } catch (err) {
+      error(res, err instanceof Error ? err.message : "Failed to mute", 500);
+    }
+    return true;
+  }
+
+  // ── POST /api/retake/unmute — unmute stream audio ───────────────────
+  if (method === "POST" && pathname === "/api/retake/unmute") {
+    try {
+      await state.streamManager.unmute();
+      json(res, {
+        ok: true,
+        muted: false,
+        volume: state.streamManager.getVolume(),
+      });
+    } catch (err) {
+      error(res, err instanceof Error ? err.message : "Failed to unmute", 500);
     }
     return true;
   }

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -1237,6 +1237,7 @@ function categorizePlugin(
     "twitch",
     "nextcloud-talk",
     "instagram",
+    "retake",
   ];
   const databases = ["sql", "localdb", "inmemorydb"];
 

--- a/src/services/stream-manager.test.ts
+++ b/src/services/stream-manager.test.ts
@@ -1,12 +1,630 @@
-import { describe, expect, it } from "vitest";
+/**
+ * Tests for services/stream-manager.ts
+ *
+ * Tests the StreamManager singleton's observable behaviour:
+ * - getHealth() shape
+ * - setVolume() clamping / rounding
+ * - mute() / unmute() state and getVolume() semantics
+ * - buildVideoInputArgs() indirectly via spawn-captured FFmpeg args
+ * - buildAudioInputArgs() indirectly via spawn-captured FFmpeg args
+ * - Volume filter in FFmpeg args
+ * - x11grab display arg forwarding
+ *
+ * FFmpeg is never actually spawned — child_process.spawn is mocked at the
+ * module level so the import of `spawn` in stream-manager.ts is intercepted.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock child_process before any module that imports it is loaded.
+// Vitest hoists vi.mock() calls to the top of the file automatically.
+// ---------------------------------------------------------------------------
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(),
+}));
+
+// Suppress logger noise in test output.
+vi.mock("@elizaos/core", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { spawn } from "node:child_process";
+import type { StreamConfig } from "./stream-manager";
 import { streamManager } from "./stream-manager";
 
-describe("streamManager", () => {
-  it("is idle by default and rejects frames when stopped", () => {
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal mock ChildProcess whose exitCode stays null so start()
+ * considers FFmpeg alive after the 1500 ms probe delay.
+ */
+function makeMockProc(opts: { exitCode?: number | null } = {}) {
+  const exitCode = opts.exitCode ?? null;
+  return {
+    stdin: {
+      write: vi.fn(),
+      end: vi.fn(),
+      on: vi.fn(),
+    },
+    stdout: { on: vi.fn() },
+    stderr: { on: vi.fn() },
+    on: vi.fn(),
+    kill: vi.fn(),
+    killed: false,
+    exitCode,
+    pid: 12345,
+  };
+}
+
+/**
+ * Install a spawn mock that returns a live (exitCode=null) process, call
+ * start(), and advance fake timers past the 1500 ms probe wait so start()
+ * resolves synchronously in tests.
+ *
+ * Returns the full flattened string[] that was passed to spawn() as its
+ * second argument (i.e. the ffmpeg args including the leading "-y").
+ */
+async function startWithMock(config: StreamConfig): Promise<string[]> {
+  const proc = makeMockProc();
+  // biome-ignore lint/suspicious/noExplicitAny: mock proc shape doesn't fully match ChildProcess
+  vi.mocked(spawn).mockReturnValueOnce(proc as any);
+
+  vi.useFakeTimers();
+
+  const startPromise = streamManager.start(config);
+  await vi.runAllTimersAsync();
+  await startPromise;
+
+  vi.useRealTimers();
+
+  const calls = vi.mocked(spawn).mock.calls;
+  const lastCall = calls[calls.length - 1];
+  // spawn("ffmpeg", ["-y", ...ffmpegArgs], opts)  →  lastCall[1] is the args array
+  return lastCall[1] as string[];
+}
+
+// ---------------------------------------------------------------------------
+// Reset singleton state between every test
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.mocked(spawn).mockReset();
+});
+
+afterEach(async () => {
+  // stop() is a no-op when not running, so calling it unconditionally is safe.
+  await streamManager.stop();
+  vi.useRealTimers();
+});
+
+// ===========================================================================
+// 1. getHealth() shape
+// ===========================================================================
+
+describe("getHealth()", () => {
+  it("returns all expected fields", () => {
     const health = streamManager.getHealth();
+
+    expect(health).toHaveProperty("running");
+    expect(health).toHaveProperty("ffmpegAlive");
+    expect(health).toHaveProperty("uptime");
+    expect(health).toHaveProperty("frameCount");
+    expect(health).toHaveProperty("volume");
+    expect(health).toHaveProperty("muted");
+    expect(health).toHaveProperty("audioSource");
+    expect(health).toHaveProperty("inputMode");
+  });
+
+  it("reports running=false and ffmpegAlive=false before any stream starts", () => {
+    const health = streamManager.getHealth();
+
     expect(health.running).toBe(false);
     expect(health.ffmpegAlive).toBe(false);
-    expect(streamManager.getUptime()).toBe(0);
-    expect(streamManager.writeFrame(Buffer.from("frame"))).toBe(false);
+    expect(health.uptime).toBe(0);
+    expect(health.frameCount).toBe(0);
+  });
+
+  it("reports audioSource='silent' and inputMode=null when no config is set", () => {
+    const health = streamManager.getHealth();
+
+    expect(health.audioSource).toBe("silent");
+    expect(health.inputMode).toBeNull();
+  });
+});
+
+// ===========================================================================
+// 2. setVolume()
+// ===========================================================================
+
+describe("setVolume()", () => {
+  it("sets volume to the given level", async () => {
+    await streamManager.setVolume(60);
+
+    expect(streamManager.getVolume()).toBe(60);
+    expect(streamManager.getHealth().volume).toBe(60);
+  });
+
+  it("clamps negative values to 0", async () => {
+    await streamManager.setVolume(-10);
+
+    expect(streamManager.getHealth().volume).toBe(0);
+  });
+
+  it("clamps values above 100 to 100", async () => {
+    await streamManager.setVolume(150);
+
+    expect(streamManager.getHealth().volume).toBe(100);
+  });
+
+  it("rounds fractional values to nearest integer (0.7 → 1)", async () => {
+    await streamManager.setVolume(73.7);
+
+    expect(streamManager.getHealth().volume).toBe(74);
+  });
+
+  it("rounds 0.4 down to 0", async () => {
+    await streamManager.setVolume(0.4);
+
+    expect(streamManager.getHealth().volume).toBe(0);
+  });
+
+  it("does NOT call spawn when stream is not running", async () => {
+    await streamManager.setVolume(40);
+
+    expect(vi.mocked(spawn)).not.toHaveBeenCalled();
+  });
+});
+
+// ===========================================================================
+// 3. mute() / unmute()
+// ===========================================================================
+
+describe("mute() / unmute()", () => {
+  // Restore a known base state before each test in this suite.
+  beforeEach(async () => {
+    // isMuted() may be true from a previous test — reset to unmuted.
+    if (streamManager.isMuted()) {
+      await streamManager.unmute();
+    }
+    await streamManager.setVolume(80);
+  });
+
+  it("mute() sets muted=true and isMuted() returns true", async () => {
+    await streamManager.mute();
+
+    expect(streamManager.isMuted()).toBe(true);
+    expect(streamManager.getHealth().muted).toBe(true);
+  });
+
+  it("unmute() sets muted=false", async () => {
+    await streamManager.mute();
+    await streamManager.unmute();
+
+    expect(streamManager.isMuted()).toBe(false);
+    expect(streamManager.getHealth().muted).toBe(false);
+  });
+
+  it("getVolume() returns 0 when muted", async () => {
+    await streamManager.setVolume(80);
+    await streamManager.mute();
+
+    expect(streamManager.getVolume()).toBe(0);
+  });
+
+  it("getVolume() returns actual volume when unmuted", async () => {
+    await streamManager.setVolume(65);
+    await streamManager.mute();
+    await streamManager.unmute();
+
+    expect(streamManager.getVolume()).toBe(65);
+  });
+
+  it("double mute() is a no-op and does not throw", async () => {
+    await streamManager.mute();
+
+    await expect(streamManager.mute()).resolves.toBeUndefined();
+    expect(streamManager.isMuted()).toBe(true);
+  });
+
+  it("double unmute() is a no-op and does not throw", async () => {
+    // Already unmuted from beforeEach.
+    await expect(streamManager.unmute()).resolves.toBeUndefined();
+    expect(streamManager.isMuted()).toBe(false);
+  });
+
+  it("mute() does NOT call spawn when stream is not running", async () => {
+    vi.mocked(spawn).mockReset();
+    await streamManager.mute();
+
+    expect(vi.mocked(spawn)).not.toHaveBeenCalled();
+  });
+
+  it("unmute() does NOT call spawn when stream is not running", async () => {
+    await streamManager.mute();
+    vi.mocked(spawn).mockReset();
+    await streamManager.unmute();
+
+    expect(vi.mocked(spawn)).not.toHaveBeenCalled();
+  });
+});
+
+// ===========================================================================
+// 4. buildVideoInputArgs() — tested via spawn args
+// ===========================================================================
+
+const BASE_CONFIG: StreamConfig = {
+  rtmpUrl: "rtmp://live.example.com/live",
+  rtmpKey: "test-key",
+  volume: 80,
+  muted: false,
+};
+
+describe("buildVideoInputArgs() via spawn args", () => {
+  it("pipe mode: contains -f image2pipe, -c:v mjpeg, -i pipe:0", async () => {
+    const args = await startWithMock({ ...BASE_CONFIG, inputMode: "pipe" });
+
+    expect(args).toContain("-f");
+    expect(args).toContain("image2pipe");
+    expect(args).toContain("-c:v");
+    expect(args).toContain("mjpeg");
+    expect(args).toContain("-i");
+    expect(args).toContain("pipe:0");
+  });
+
+  it("pipe mode: contains -probesize 32 and -analyzeduration 0 for fast start", async () => {
+    const args = await startWithMock({ ...BASE_CONFIG, inputMode: "pipe" });
+
+    expect(args).toContain("-probesize");
+    expect(args).toContain("32");
+    expect(args).toContain("-analyzeduration");
+    expect(args).toContain("0");
+  });
+
+  it("x11grab mode: contains -f x11grab and -video_size 1280x720", async () => {
+    const args = await startWithMock({
+      ...BASE_CONFIG,
+      inputMode: "x11grab",
+      display: ":42",
+    });
+
+    expect(args).toContain("-f");
+    expect(args).toContain("x11grab");
+    expect(args).toContain("-video_size");
+    expect(args).toContain("1280x720");
+  });
+
+  it("x11grab mode: passes specified display as video -i argument", async () => {
+    const args = await startWithMock({
+      ...BASE_CONFIG,
+      inputMode: "x11grab",
+      display: ":42",
+    });
+
+    // Walk forward from the x11grab entry to find the first -i after it.
+    const x11Index = args.indexOf("x11grab");
+    let videoIIndex = -1;
+    for (let i = x11Index; i < args.length - 1; i++) {
+      if (args[i] === "-i") {
+        videoIIndex = i;
+        break;
+      }
+    }
+
+    expect(videoIIndex).toBeGreaterThan(-1);
+    expect(args[videoIIndex + 1]).toBe(":42");
+  });
+
+  it("x11grab mode: defaults to display :99 when display is omitted", async () => {
+    const args = await startWithMock({ ...BASE_CONFIG, inputMode: "x11grab" });
+
+    const x11Index = args.indexOf("x11grab");
+    let videoIIndex = -1;
+    for (let i = x11Index; i < args.length - 1; i++) {
+      if (args[i] === "-i") {
+        videoIIndex = i;
+        break;
+      }
+    }
+
+    expect(args[videoIIndex + 1]).toBe(":99");
+  });
+
+  it("avfoundation mode: contains -f avfoundation and <device>:none", async () => {
+    const args = await startWithMock({
+      ...BASE_CONFIG,
+      inputMode: "avfoundation",
+      videoDevice: "3",
+    });
+
+    expect(args).toContain("-f");
+    expect(args).toContain("avfoundation");
+    expect(args).toContain("3:none");
+  });
+
+  it("testsrc mode: contains -f lavfi with color= source string", async () => {
+    const args = await startWithMock({ ...BASE_CONFIG, inputMode: "testsrc" });
+
+    expect(args).toContain("-f");
+    expect(args).toContain("lavfi");
+
+    const iIndex = args.indexOf("-i");
+    expect(iIndex).toBeGreaterThan(-1);
+    expect(args[iIndex + 1]).toMatch(/^color=c=/);
+  });
+
+  it("file mode: contains -loop 1, -f image2, and the frame file path", async () => {
+    const args = await startWithMock({
+      ...BASE_CONFIG,
+      inputMode: "file",
+      frameFile: "/tmp/frame.jpg",
+    });
+
+    expect(args).toContain("-loop");
+    expect(args).toContain("1");
+    expect(args).toContain("-f");
+    expect(args).toContain("image2");
+    expect(args).toContain("/tmp/frame.jpg");
+  });
+});
+
+// ===========================================================================
+// 5. buildAudioInputArgs() — tested via spawn args
+// ===========================================================================
+
+describe("buildAudioInputArgs() via spawn args", () => {
+  it("silent: args contain anullsrc", async () => {
+    const args = await startWithMock({
+      ...BASE_CONFIG,
+      audioSource: "silent",
+    });
+
+    expect(args).toContain("anullsrc=channel_layout=stereo:sample_rate=44100");
+  });
+
+  it("system on darwin: args contain avfoundation and none:<device>", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", {
+      value: "darwin",
+      configurable: true,
+    });
+
+    try {
+      const args = await startWithMock({
+        ...BASE_CONFIG,
+        audioSource: "system",
+        audioDevice: "2",
+      });
+
+      expect(args).toContain("none:2");
+    } finally {
+      Object.defineProperty(process, "platform", {
+        value: originalPlatform,
+        configurable: true,
+      });
+    }
+  });
+
+  it("system on linux: args contain -f pulse", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", {
+      value: "linux",
+      configurable: true,
+    });
+
+    try {
+      const args = await startWithMock({
+        ...BASE_CONFIG,
+        audioSource: "system",
+      });
+
+      expect(args).toContain("-f");
+      expect(args).toContain("pulse");
+    } finally {
+      Object.defineProperty(process, "platform", {
+        value: originalPlatform,
+        configurable: true,
+      });
+    }
+  });
+
+  it("microphone on darwin: args contain avfoundation and none:<device>", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", {
+      value: "darwin",
+      configurable: true,
+    });
+
+    try {
+      const args = await startWithMock({
+        ...BASE_CONFIG,
+        audioSource: "microphone",
+        audioDevice: "1",
+      });
+
+      expect(args).toContain("none:1");
+    } finally {
+      Object.defineProperty(process, "platform", {
+        value: originalPlatform,
+        configurable: true,
+      });
+    }
+  });
+
+  it("microphone on linux: args contain -f pulse", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", {
+      value: "linux",
+      configurable: true,
+    });
+
+    try {
+      const args = await startWithMock({
+        ...BASE_CONFIG,
+        audioSource: "microphone",
+      });
+
+      expect(args).toContain("-f");
+      expect(args).toContain("pulse");
+    } finally {
+      Object.defineProperty(process, "platform", {
+        value: originalPlatform,
+        configurable: true,
+      });
+    }
+  });
+
+  it("absolute file path: args contain -stream_loop -1 and the path", async () => {
+    const args = await startWithMock({
+      ...BASE_CONFIG,
+      audioSource: "/path/to/music.mp3",
+    });
+
+    expect(args).toContain("-stream_loop");
+    expect(args).toContain("-1");
+    expect(args).toContain("/path/to/music.mp3");
+  });
+
+  it("relative file path (./): args contain -stream_loop -1 and the path", async () => {
+    const args = await startWithMock({
+      ...BASE_CONFIG,
+      audioSource: "./music/track.mp3",
+    });
+
+    expect(args).toContain("-stream_loop");
+    expect(args).toContain("-1");
+    expect(args).toContain("./music/track.mp3");
+  });
+
+  it("unknown string source: falls back to anullsrc (silent)", async () => {
+    const args = await startWithMock({
+      ...BASE_CONFIG,
+      // biome-ignore lint/suspicious/noExplicitAny: intentionally testing unrecognized source
+      audioSource: "totally-unknown-source" as any,
+    });
+
+    expect(args).toContain("anullsrc=channel_layout=stereo:sample_rate=44100");
+  });
+});
+
+// ===========================================================================
+// 6. Volume filter in FFmpeg args
+// ===========================================================================
+
+describe("volume filter (-af) in FFmpeg args", () => {
+  it("includes -af volume=0.50 when volume=50 and muted=false", async () => {
+    const args = await startWithMock({
+      ...BASE_CONFIG,
+      volume: 50,
+      muted: false,
+    });
+
+    const afIndex = args.indexOf("-af");
+    expect(afIndex).toBeGreaterThan(-1);
+    expect(args[afIndex + 1]).toBe("volume=0.50");
+  });
+
+  it("includes -af volume=0.00 when muted=true regardless of volume", async () => {
+    const args = await startWithMock({
+      ...BASE_CONFIG,
+      volume: 80,
+      muted: true,
+    });
+
+    const afIndex = args.indexOf("-af");
+    expect(afIndex).toBeGreaterThan(-1);
+    expect(args[afIndex + 1]).toBe("volume=0.00");
+  });
+
+  it("includes -af volume=1.00 when volume=100 and muted=false", async () => {
+    const args = await startWithMock({
+      ...BASE_CONFIG,
+      volume: 100,
+      muted: false,
+    });
+
+    const afIndex = args.indexOf("-af");
+    expect(afIndex).toBeGreaterThan(-1);
+    expect(args[afIndex + 1]).toBe("volume=1.00");
+  });
+
+  it("includes -af volume=0.00 when volume=0 and muted=false", async () => {
+    const args = await startWithMock({
+      ...BASE_CONFIG,
+      volume: 0,
+      muted: false,
+    });
+
+    const afIndex = args.indexOf("-af");
+    expect(afIndex).toBeGreaterThan(-1);
+    expect(args[afIndex + 1]).toBe("volume=0.00");
+  });
+});
+
+// ===========================================================================
+// 7. x11grab mode args (dedicated suite)
+// ===========================================================================
+
+describe("x11grab mode args", () => {
+  it("contains -f x11grab", async () => {
+    const args = await startWithMock({
+      ...BASE_CONFIG,
+      inputMode: "x11grab",
+      display: ":42",
+    });
+
+    expect(args).toContain("-f");
+    expect(args).toContain("x11grab");
+  });
+
+  it("contains -video_size 1280x720 with default resolution", async () => {
+    const args = await startWithMock({
+      ...BASE_CONFIG,
+      inputMode: "x11grab",
+      display: ":42",
+    });
+
+    expect(args).toContain("-video_size");
+    expect(args).toContain("1280x720");
+  });
+
+  it("contains -i :42 for the specified display", async () => {
+    const args = await startWithMock({
+      ...BASE_CONFIG,
+      inputMode: "x11grab",
+      display: ":42",
+    });
+
+    const x11Index = args.indexOf("x11grab");
+    let videoIIndex = -1;
+    for (let i = x11Index; i < args.length - 1; i++) {
+      if (args[i] === "-i") {
+        videoIIndex = i;
+        break;
+      }
+    }
+
+    expect(videoIIndex).toBeGreaterThan(-1);
+    expect(args[videoIIndex + 1]).toBe(":42");
+  });
+
+  it("respects custom resolution in -video_size", async () => {
+    const args = await startWithMock({
+      ...BASE_CONFIG,
+      inputMode: "x11grab",
+      display: ":99",
+      resolution: "1920x1080",
+    });
+
+    expect(args).toContain("-video_size");
+    expect(args).toContain("1920x1080");
   });
 });


### PR DESCRIPTION
## Summary

- **Cross-platform video capture**: Auto-detects best mode per environment — `pipe` (Electron), `x11grab` (Linux/Xvfb, Hyperscape approach), `avfoundation` (macOS), `file` (Puppeteer CDP). Override via `RETAKE_STREAM_MODE` env var.
- **Audio source support**: Silent (`anullsrc`), system audio (PulseAudio/avfoundation), microphone, or audio file playback — configured via `RETAKE_AUDIO_SOURCE` env var.
- **Volume control**: `setVolume(0-100)`, `mute()`, `unmute()` with FFmpeg `-af volume=` filter. Agent can control volume mid-stream via custom actions (`RETAKE_SET_VOLUME`, `RETAKE_MUTE`, `RETAKE_UNMUTE`, `RETAKE_LOCAL_STATUS`).
- **New API endpoints**: `GET /api/retake/status`, `POST /api/retake/volume`, `POST /api/retake/mute`, `POST /api/retake/unmute`.
- **Security**: Display format validation (`/^:\d+$/`) in `ensureXvfb()` prevents command injection; resolution validation; volume range checking at API boundary.

## Test plan

- [x] `stream-manager.test.ts` — 41 tests: getHealth shape, setVolume clamping/rounding, mute/unmute state, all 6 video input modes via spawn args, all audio sources, volume filter in FFmpeg args, x11grab display forwarding
- [x] `retake-routes.test.ts` — 43 tests: detectCaptureMode all env branches, ensureXvfb injection blocking, all new endpoints with error cases, existing endpoints preserved, resolve() config priority
- [x] `server.package-root.test.ts` — 4 tests (2 new: miladyai name, plugins.json fallback)
- [x] Biome lint: 0 errors
- [x] Manual: verify RTMP stream on retake.tv with `RETAKE_STREAM_MODE=x11grab`

🤖 Generated with [Claude Code](https://claude.com/claude-code)