### PR TITLE
feat(retake): add retake.tv plugin to registry

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -8654,6 +8654,57 @@
       }
     },
     {
+      "id": "retake",
+      "dirName": "plugin-retake",
+      "name": "Retake.tv",
+      "npmName": "@milady/plugin-retake",
+      "description": "Live video streaming connector for retake.tv",
+      "category": "connector",
+      "envKey": "RETAKE_ACCESS_TOKEN",
+      "configKeys": [
+        "RETAKE_ACCESS_TOKEN",
+        "RETAKE_API_URL",
+        "RETAKE_CAPTURE_URL"
+      ],
+      "pluginParameters": {
+        "RETAKE_ACCESS_TOKEN": {
+          "type": "string",
+          "description": "Access token for retake.tv API",
+          "required": false,
+          "sensitive": true
+        },
+        "RETAKE_API_URL": {
+          "type": "string",
+          "description": "Retake.tv API base URL",
+          "required": false,
+          "sensitive": false
+        },
+        "RETAKE_CAPTURE_URL": {
+          "type": "string",
+          "description": "Capture URL for retake.tv stream",
+          "required": false,
+          "sensitive": false
+        }
+      },
+      "configUiHints": {
+        "RETAKE_ACCESS_TOKEN": {
+          "label": "Access Token",
+          "group": "Authentication",
+          "width": "full"
+        },
+        "RETAKE_API_URL": {
+          "label": "API URL",
+          "group": "Connection",
+          "width": "half"
+        },
+        "RETAKE_CAPTURE_URL": {
+          "label": "Capture URL",
+          "group": "Connection",
+          "width": "half"
+        }
+      }
+    },
+    {
       "id": "vercel-ai-gateway",
       "dirName": "plugin-vercel-ai-gateway",
       "name": "Vercel Ai Gateway",


### PR DESCRIPTION
## Summary

- Adds retake.tv streaming connector entry to `plugins.json` with proper `configKeys` so the Settings UI can accept and save configuration values
- Declares `RETAKE_ACCESS_TOKEN`, `RETAKE_API_URL`, and `RETAKE_CAPTURE_URL` as plugin parameters
- Sets `envKey` to `RETAKE_ACCESS_TOKEN` for plugin status detection
- Includes `configUiHints` for grouped settings layout

## Test plan

- [x] JSON validates cleanly
- [ ] PUT `/api/plugins/retake` with `{"config":{"RETAKE_ACCESS_TOKEN":"..."}}` returns 200 (previously 422)
- [ ] Plugin appears in Settings UI under Connectors with config fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)