### PR TITLE
fix(retake): populate configKeys so plugin settings UI accepts config

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -8613,8 +8613,12 @@
       "npmName": "@milady/plugin-retake",
       "description": "Live video streaming connector for retake.tv",
       "category": "connector",
-      "envKey": null,
-      "configKeys": [],
+      "envKey": "RETAKE_ACCESS_TOKEN",
+      "configKeys": [
+        "RETAKE_ACCESS_TOKEN",
+        "RETAKE_API_URL",
+        "RETAKE_CAPTURE_URL"
+      ],
       "pluginParameters": {
         "RETAKE_ACCESS_TOKEN": {
           "type": "string",


### PR DESCRIPTION
## Summary

- Populates `configKeys` with `RETAKE_ACCESS_TOKEN`, `RETAKE_API_URL`, `RETAKE_CAPTURE_URL` (was empty `[]`)
- Sets `envKey` to `RETAKE_ACCESS_TOKEN` (was `null`) for plugin status detection

The `validatePluginConfig()` function checks `configKeys` (not `pluginParameters`) to validate allowed config key names on PUT requests. Empty `configKeys` caused all config saves to return 422.

## Test plan

- [ ] PUT `/api/plugins/retake` with `{"config":{"RETAKE_ACCESS_TOKEN":"..."}}` returns 200
- [ ] Plugin appears as configurable in Settings UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)