### PR TITLE
docs(ollama): add troubleshooting section with SDK workaround and failure guidance

### DIFF
--- a/docs/plugin-registry/llm/ollama.md
+++ b/docs/plugin-registry/llm/ollama.md
@@ -146,6 +146,52 @@ export OLLAMA_BASE_URL=http://192.168.1.100:11434
 
 Secure with a reverse proxy (Nginx + TLS) for production.
 
+## Troubleshooting
+
+### "Unsupported model version v1" Error
+
+**Symptoms:** Agent crashes or silently fails on first chat. Terminal shows:
+
+```
+Error: Unsupported model version v1
+```
+
+**Cause:** The `@elizaos/plugin-ollama` depends on `ollama-ai-provider@^1.2.0`, which uses the v1 AI SDK spec. The current runtime ships AI SDK v6, causing a silent version mismatch.
+
+**Workaround — Use Ollama's OpenAI-Compatible Endpoint:**
+
+Ollama exposes an OpenAI-compatible API at `http://localhost:11434/v1`. Route through the OpenAI plugin instead:
+
+```json5
+// ~/.milady/milady.json
+{
+  env: {
+    OPENAI_API_KEY: "ollama",                        // any non-empty string
+    OPENAI_BASE_URL: "http://localhost:11434/v1",     // ollama's openai-compat endpoint
+    SMALL_MODEL: "gemma3:4b",                        // your pulled model
+    LARGE_MODEL: "gemma3:4b",
+  },
+}
+```
+
+This bypasses `plugin-ollama` entirely and uses `plugin-openai` with your local Ollama instance. All models, streaming, and function calling work as expected.
+
+> **Tracking:** [elizaos-plugins/plugin-ollama#18](https://github.com/elizaos-plugins/plugin-ollama/issues/18)
+
+### Ollama Not Detected
+
+If Milady doesn't detect your Ollama instance:
+
+1. Verify Ollama is running: `curl http://localhost:11434/api/tags`
+2. Check you have models pulled: `ollama list`
+3. If using a non-default port, set `OLLAMA_BASE_URL` accordingly
+
+### Slow Responses
+
+- Check available RAM/VRAM — models running on CPU are significantly slower
+- Try a smaller model: `gemma3:4b` or `llama3.2:3b`
+- Close other GPU-intensive applications
+
 ## Related
 
 - [Groq Plugin](/plugin-registry/llm/groq) — Fast cloud inference for Llama models


### PR DESCRIPTION
## What

Adds a **Troubleshooting** section to `docs/plugin-registry/llm/ollama.md` covering setup failures and recovery steps.

## Why

Partially addresses **MW-11** (#476) — the Ollama integration is missing setup, failure, and verify guidance. Users who select Ollama during onboarding hit a cryptic `Unsupported model version v1` error with no documented fix. This is the most common failure path for local model users.

## Changes

Added three troubleshooting entries to the existing Ollama plugin doc:

1. **\"Unsupported model version v1\" error** — root cause (SDK v1/v6 mismatch) and the OpenAI-compatible endpoint workaround with `milady.json` config example
2. **Ollama Not Detected** — checklist for verifying the Ollama server, models, and port config
3. **Slow Responses** — RAM/VRAM debugging and model sizing guidance

Also links to the upstream tracking issue: elizaos-plugins/plugin-ollama#18

## Testing

Verified the workaround config works with `gemma3:4b` and `llama3.2` on macOS Apple Silicon. Agent loads 14/14 plugins and responds correctly.

---

*tested by a human. that's the split.*