### PR TITLE
fix(runtime): restore required @elizaos/plugin-sql dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "@elizaos/plugin-plugin-manager": "next",
     "@elizaos/plugin-rolodex": "next",
     "@elizaos/plugin-secrets-manager": "next",
+    "@elizaos/plugin-sql": "next",
     "@elizaos/plugin-shell": "next",
     "@elizaos/plugin-telegram": "next",
     "@elizaos/plugin-todo": "next",

--- a/src/services/plugin-stability.test.ts
+++ b/src/services/plugin-stability.test.ts
@@ -142,6 +142,20 @@ describe("Plugin Enumeration", () => {
     }
   });
 
+  it("declares every core plugin in root package dependencies", async () => {
+    const { readFile } = await import("node:fs/promises");
+    const { resolve } = await import("node:path");
+    const pkgPath = resolve(process.cwd(), "package.json");
+    const pkg = JSON.parse(await readFile(pkgPath, "utf-8")) as RootPackageJson;
+
+    for (const pluginName of CORE_PLUGINS) {
+      expect(
+        pkg.dependencies[pluginName],
+        `${pluginName} is missing from package.json dependencies`,
+      ).toBeDefined();
+    }
+  });
+
   it("lists all connector plugins", () => {
     expect(Object.keys(CONNECTOR_PLUGINS).length).toBe(10);
     for (const [connector, pluginName] of Object.entries(CONNECTOR_PLUGINS)) {


### PR DESCRIPTION
## Summary
- add `@elizaos/plugin-sql` back to root `package.json` dependencies
- prevent startup failure where runtime requires plugin-sql but module resolution fails
- add regression coverage to assert every `CORE_PLUGINS` entry is declared in root dependencies

## Why
`@elizaos/plugin-sql` is a required core plugin in `src/runtime/core-plugins.ts`.
When it is missing from root dependencies, startup fails with:

- `Failed to load core plugin @elizaos/plugin-sql: Cannot find module`
- `@elizaos/plugin-sql was NOT found among resolved plugins`

## Testing
- `bunx vitest run src/services/plugin-stability.test.ts -t "declares every core plugin in root package dependencies"`
- `node -e "import('@elizaos/plugin-sql').then(() => console.log('plugin-sql import ok'))"`
