### PR TITLE
fix(electron): bundle all deps inline for electron-packaged dist

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -39,8 +39,6 @@ export default defineConfig([
     env,
     fixedExtension: false,
     platform: "node",
-    unbundle: true,
-    inlineOnly: false,
     external: nativeExternals,
   },
   {
@@ -48,8 +46,6 @@ export default defineConfig([
     env,
     fixedExtension: false,
     platform: "node",
-    unbundle: true,
-    inlineOnly: false,
     external: nativeExternals,
   },
   {


### PR DESCRIPTION
Follow-up to PRs #492, #513, #514. Alpha.30 confirmed that ESM import() works from app.asar.unpacked but json5 (and other deps) can't be resolved because ESM ignores NODE_PATH and the ASAR's node_modules is inaccessible from the unpacked directory.

Fix: Remove unbundle/inlineOnly from server.ts and eliza.ts build entries in tsdown.config.ts. This bundles all dependencies (json5, etc.) directly into the dist files, making them fully self-contained with zero external module resolution needed at runtime.