### PR TITLE
fix(electron): auto-discover and copy external deps for ESM resolution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,7 +195,8 @@ jobs:
           set -euo pipefail
           rm -rf milady-dist
           mkdir -p milady-dist
-          # Copy only .js files and package.json (matching the old filter)
+
+          # 1. Copy only .js files and package.json (matching the old filter)
           find ../../../dist -name '*.js' | while read f; do
             rel="${f#../../../dist/}"
             mkdir -p "milady-dist/$(dirname "$rel")"
@@ -203,6 +204,40 @@ jobs:
           done
           echo '{"type":"module"}' > milady-dist/package.json
           echo "Copied $(find milady-dist -name '*.js' | wc -l | tr -d ' ') JS files to milady-dist/"
+
+          # 2. Scan dist for external npm imports and copy needed node_modules
+          #    so ESM import() from app.asar.unpacked can resolve them.
+          #    (ESM ignores NODE_PATH, so deps must be on the real filesystem.)
+          ext_deps=$(grep -rh 'from "' milady-dist/ 2>/dev/null \
+            | grep -v 'from "\.\/' \
+            | grep -v 'from "node:' \
+            | sed 's/.*from "//;s/".*//' \
+            | sed 's|/.*||' \
+            | sort -u)
+
+          # For scoped packages, keep the scope+name together
+          scoped_deps=$(grep -rh 'from "@' milady-dist/ 2>/dev/null \
+            | grep -v 'from "\.\/' \
+            | sed 's/.*from "//;s/".*//' \
+            | sed 's|\(/[^/]*\)/.*|\1|' \
+            | sort -u)
+
+          all_deps=$(echo -e "$ext_deps\n$scoped_deps" | sort -u | grep -v '^$')
+          echo "External deps found: $all_deps"
+
+          node_modules_root="../../../node_modules"
+          for dep in $all_deps; do
+            src="$node_modules_root/$dep"
+            if [ -d "$src" ]; then
+              dest="milady-dist/node_modules/$dep"
+              mkdir -p "$(dirname "$dest")"
+              cp -R "$src" "$dest"
+              echo "  Copied $dep"
+            else
+              echo "  WARN: $dep not found in node_modules (may be bundled inline)"
+            fi
+          done
+          echo "Done copying external deps"
         working-directory: apps/app/electron
 
       - name: Prepare platform electron-builder config

--- a/apps/app/electron/electron-builder.config.json
+++ b/apps/app/electron/electron-builder.config.json
@@ -10,7 +10,8 @@
     "capacitor.config.*",
     "app/**/*",
     "milady-dist/**/*.js",
-    "milady-dist/package.json"
+    "milady-dist/package.json",
+    "milady-dist/node_modules/**/*"
   ],
   "asarUnpack": ["milady-dist/**/*"],
   "publish": {


### PR DESCRIPTION
Follow-up to PRs #492, #513, #514, #515. Alpha.31 showed that shared code-split chunks import external deps (json5, ws, zod, etc.) that ESM import() can't resolve from app.asar.unpacked.

Fix: The release workflow now scans milady-dist for external npm imports and copies the needed node_modules into milady-dist/node_modules/ before packaging, so ESM resolution finds them on the real filesystem.