### PR TITLE
fix(electron): disable tsdown inline warning for bundled node modules

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,6 +221,7 @@ jobs:
               "koffi",
             ],
             fixedExtension: false,
+            inlineOnly: false,
             env: { NODE_ENV: "production" }
           }]);
           EOF


### PR DESCRIPTION
Alpha.34 failed to build for macOS/Windows/Linux because tsdown, by default, emits a fatal error warning the user that they are inlining node module dependencies via `noExternal: [/.*/]` unless explicitly configured. Adding `inlineOnly: false` removes the warning and allows building without errors.