### PR TITLE
fix(electron): use object entries in tsdown to flatten output structure for agent.ts imports

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,14 +198,14 @@ jobs:
           cat << 'EOF' > tsdown.electron.config.ts
           import { defineConfig } from "tsdown";
           export default defineConfig([{
-            entry: [
-              "src/index.ts",
-              "src/entry.ts",
-              "src/runtime/eliza.ts",
-              "src/api/server.ts",
-              "src/plugins/whatsapp/index.ts",
-              "src/plugins/retake/index.ts"
-            ],
+            entry: {
+              "index": "src/index.ts",
+              "entry": "src/entry.ts",
+              "eliza": "src/runtime/eliza.ts",
+              "server": "src/api/server.ts",
+              "plugins/whatsapp/index": "src/plugins/whatsapp/index.ts",
+              "plugins/retake/index": "src/plugins/retake/index.ts"
+            },
             format: "esm",
             platform: "node",
             outDir: "dist-electron",


### PR DESCRIPTION
Alpha.35 successfully compiled the node modules inline, but because the tsdown entrypoints were specified as an array, tsdown preserved the `src/` directory structure resulting in `api/server.js`. This broke the agent.ts import path which expects `server.js` at the root of `milady-dist`. By changing the entries to an object map, tsdown now outputs the files flatly at the root as expected.