### PR TITLE
milady: add pi coding agent support and settings tab

### DIFF
--- a/apps/app/src/components/CodingAgentSettingsSection.tsx
+++ b/apps/app/src/components/CodingAgentSettingsSection.tsx
@@ -2,7 +2,8 @@ import { useCallback, useEffect, useState } from "react";
 import { client } from "../api-client";
 import { ConfigSaveFooter } from "./ConfigSaveFooter";
 
-type AgentTab = "claude" | "gemini" | "codex" | "aider";
+type AgentTab = "claude" | "gemini" | "codex" | "aider" | "pi";
+type ConfigurableAgentTab = Exclude<AgentTab, "pi">;
 type AiderProvider = "anthropic" | "openai" | "google";
 
 interface ModelOption {
@@ -11,7 +12,7 @@ interface ModelOption {
 }
 
 // Maps agent tabs (and aider providers) to the provider IDs used by /api/models
-const AGENT_PROVIDER_MAP: Record<AgentTab, string> = {
+const AGENT_PROVIDER_MAP: Record<ConfigurableAgentTab, string> = {
   claude: "anthropic",
   gemini: "google-genai",
   codex: "openai",
@@ -47,9 +48,10 @@ const AGENT_LABELS: Record<AgentTab, string> = {
   gemini: "Gemini",
   codex: "Codex",
   aider: "Aider",
+  pi: "Pi",
 };
 
-const ENV_PREFIX: Record<AgentTab, string> = {
+const ENV_PREFIX: Record<ConfigurableAgentTab, string> = {
   claude: "PARALLAX_CLAUDE",
   gemini: "PARALLAX_GEMINI",
   codex: "PARALLAX_CODEX",
@@ -157,7 +159,10 @@ export function CodingAgentSettingsSection() {
   }, [prefs]);
 
   // Resolve the provider ID for the current tab
-  const getProviderId = (tab: AgentTab, aiderProv: AiderProvider): string => {
+  const getProviderId = (
+    tab: ConfigurableAgentTab,
+    aiderProv: AiderProvider,
+  ): string => {
     if (tab === "aider") return AIDER_PROVIDER_MAP[aiderProv];
     return AGENT_PROVIDER_MAP[tab];
   };
@@ -175,20 +180,25 @@ export function CodingAgentSettingsSection() {
     );
   }
 
-  const prefix = ENV_PREFIX[activeTab];
+  const isPiTab = activeTab === "pi";
+  const editableTab: ConfigurableAgentTab =
+    activeTab === "pi" ? "claude" : activeTab;
+  const prefix = ENV_PREFIX[editableTab];
   const aiderProvider = (prefs.PARALLAX_AIDER_PROVIDER ||
     "anthropic") as AiderProvider;
-  const providerId = getProviderId(activeTab, aiderProvider);
-  const modelOptions = getModelOptions(providerId);
+  const providerId = !isPiTab
+    ? getProviderId(editableTab, aiderProvider)
+    : undefined;
+  const modelOptions = providerId ? getModelOptions(providerId) : [];
   const powerfulValue = prefs[`${prefix}_MODEL_POWERFUL`] ?? "";
   const fastValue = prefs[`${prefix}_MODEL_FAST`] ?? "";
-  const isDynamic = !!providerModels[providerId];
+  const isDynamic = providerId ? !!providerModels[providerId] : false;
 
   return (
     <div className="flex flex-col gap-4">
       {/* Agent tabs */}
       <div className="flex border border-[var(--border)]">
-        {(["claude", "gemini", "codex", "aider"] as AgentTab[]).map((agent) => {
+        {(["claude", "gemini", "codex", "aider", "pi"] as AgentTab[]).map((agent) => {
           const active = activeTab === agent;
           return (
             <button
@@ -224,46 +234,54 @@ export function CodingAgentSettingsSection() {
       )}
 
       {/* Model selectors — both use the same list, user picks tier preference */}
-      <div className="flex gap-3">
-        <div className="flex-1 flex flex-col gap-1.5">
-          <span className="text-xs font-semibold">Powerful Model</span>
-          <select
-            className="px-2.5 py-1.5 border border-[var(--border)] bg-[var(--card)] text-xs focus:border-[var(--accent)] focus:outline-none"
-            value={powerfulValue}
-            onChange={(e) =>
-              setPref(`${prefix}_MODEL_POWERFUL`, e.target.value)
-            }
-          >
-            <option value="">Default</option>
-            {modelOptions.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
+      {!isPiTab ? (
+        <>
+          <div className="flex gap-3">
+            <div className="flex-1 flex flex-col gap-1.5">
+              <span className="text-xs font-semibold">Powerful Model</span>
+              <select
+                className="px-2.5 py-1.5 border border-[var(--border)] bg-[var(--card)] text-xs focus:border-[var(--accent)] focus:outline-none"
+                value={powerfulValue}
+                onChange={(e) =>
+                  setPref(`${prefix}_MODEL_POWERFUL`, e.target.value)
+                }
+              >
+                <option value="">Default</option>
+                {modelOptions.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="flex-1 flex flex-col gap-1.5">
+              <span className="text-xs font-semibold">Fast Model</span>
+              <select
+                className="px-2.5 py-1.5 border border-[var(--border)] bg-[var(--card)] text-xs focus:border-[var(--accent)] focus:outline-none"
+                value={fastValue}
+                onChange={(e) => setPref(`${prefix}_MODEL_FAST`, e.target.value)}
+              >
+                <option value="">Default</option>
+                {modelOptions.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+          <div className="text-[11px] text-[var(--muted)]">
+            {isDynamic
+              ? "Models fetched from provider API. These are preferences — the CLI may override based on availability."
+              : "Using fallback model list — configure your API key to see all available models."}
+          </div>
+        </>
+      ) : (
+        <div className="text-[11px] text-[var(--muted)] border border-[var(--border)] bg-[var(--card)] p-3">
+          Pi agent runs via the local <code>pi</code> CLI and uses your Pi
+          environment/configuration. Model routing is managed by Pi directly.
         </div>
-        <div className="flex-1 flex flex-col gap-1.5">
-          <span className="text-xs font-semibold">Fast Model</span>
-          <select
-            className="px-2.5 py-1.5 border border-[var(--border)] bg-[var(--card)] text-xs focus:border-[var(--accent)] focus:outline-none"
-            value={fastValue}
-            onChange={(e) => setPref(`${prefix}_MODEL_FAST`, e.target.value)}
-          >
-            <option value="">Default</option>
-            {modelOptions.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
-        </div>
-      </div>
-
-      <div className="text-[11px] text-[var(--muted)]">
-        {isDynamic
-          ? "Models fetched from provider API. These are preferences — the CLI may override based on availability."
-          : "Using fallback model list — configure your API key to see all available models."}
-      </div>
+      )}
 
       <ConfigSaveFooter
         dirty={dirty}

--- a/apps/app/src/components/PermissionsSection.tsx
+++ b/apps/app/src/components/PermissionsSection.tsx
@@ -113,7 +113,7 @@ const CAPABILITIES: CapabilityDef[] = [
     id: "coding-agent",
     label: "Coding Agent Swarms",
     description:
-      "Orchestrate CLI coding agents (Claude Code, Gemini, Codex, Aider)",
+      "Orchestrate CLI coding agents (Claude Code, Gemini, Codex, Aider, Pi)",
     requiredPermissions: [],
   },
 ];

--- a/packages/plugin-coding-agent/README.md
+++ b/packages/plugin-coding-agent/README.md
@@ -1,13 +1,13 @@
 # @milaidy/plugin-coding-agent
 
-Orchestrate CLI-based coding agents (Claude Code, Codex, Gemini CLI, Aider) via PTY sessions and manage git workspaces for autonomous coding tasks.
+Orchestrate CLI-based coding agents (Claude Code, Codex, Gemini CLI, Aider, Pi) via PTY sessions and manage git workspaces for autonomous coding tasks.
 
 ## Features
 
 - **PTY Session Management**: Spawn, control, and monitor coding agents running in pseudo-terminals
 - **Git Workspace Provisioning**: Clone repos, create worktrees, manage branches
 - **PR Workflow**: Commit changes, push to remote, create pull requests
-- **Multi-Agent Support**: Claude Code, Codex, Gemini CLI, Aider, or generic shell
+- **Multi-Agent Support**: Claude Code, Codex, Gemini CLI, Aider, Pi, or generic shell
 
 ## Installation
 

--- a/packages/plugin-coding-agent/src/__tests__/pty-service.test.ts
+++ b/packages/plugin-coding-agent/src/__tests__/pty-service.test.ts
@@ -186,6 +186,7 @@ describe("PTYService", () => {
       expect(session.metadata).toEqual({
         userId: "user-123",
         taskId: "task-456",
+        requestedType: "shell",
         agentType: "shell",
       });
     });
@@ -306,6 +307,10 @@ describe("PTYService", () => {
 
     it("should return false for unknown session blocked check", () => {
       expect(service.isSessionBlocked("unknown-id")).toBe(false);
+    });
+
+    it("should include pi in supported agent types", () => {
+      expect(service.getSupportedAgentTypes()).toContain("pi");
     });
   });
 

--- a/packages/plugin-coding-agent/src/__tests__/spawn-agent.test.ts
+++ b/packages/plugin-coding-agent/src/__tests__/spawn-agent.test.ts
@@ -218,6 +218,32 @@ describe("spawnAgentAction", () => {
       );
     });
 
+    it("should map pi agent type to shell and wrap task as pi command", async () => {
+      const ptyService = createMockPTYService();
+      const runtime = createMockRuntime(ptyService);
+      const message = createMockMessage({
+        agentType: "pi",
+        workdir: validWorkdir,
+        task: "Fix flaky tests",
+      });
+      const callback = jest.fn();
+
+      await spawnAgentAction.handler(
+        runtime as unknown as IAgentRuntime,
+        message as unknown as Memory,
+        undefined,
+        {},
+        callback,
+      );
+
+      expect(mockSpawnSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentType: "shell",
+          initialTask: "pi 'Fix flaky tests'",
+        }),
+      );
+    });
+
     it("should use codex adapter for codex type", async () => {
       const ptyService = createMockPTYService();
       const runtime = createMockRuntime(ptyService);

--- a/packages/plugin-coding-agent/src/actions/start-coding-task.ts
+++ b/packages/plugin-coding-agent/src/actions/start-coding-task.ts
@@ -44,7 +44,7 @@ export const startCodingTaskAction: Action = {
   ],
 
   description:
-    "Start a coding task: optionally clone a repo, then spawn a coding agent (Claude Code, Codex, Gemini, Aider) " +
+    "Start a coding task: optionally clone a repo, then spawn a coding agent (Claude Code, Codex, Gemini, Aider, Pi) " +
     "to work on it. If no repo is provided, the agent runs in a safe scratch directory. " +
     "Use this whenever the user asks to work on code, research something with an agent, or run any agent task.",
 
@@ -209,7 +209,7 @@ export const startCodingTaskAction: Action = {
     {
       name: "agentType",
       description:
-        "Type of coding agent to spawn (default for all agents). Options: claude, codex, gemini, aider, shell.",
+        "Type of coding agent to spawn (default for all agents). Options: claude, codex, gemini, aider, pi, shell.",
       required: false,
       schema: { type: "string" as const, default: "claude" },
     },

--- a/packages/plugin-coding-agent/src/index.ts
+++ b/packages/plugin-coding-agent/src/index.ts
@@ -5,7 +5,7 @@
  * - PTY session management (spawn, control, monitor coding agents)
  * - Git workspace provisioning (clone, branch, PR creation)
  * - GitHub issue management (create, list, update, close)
- * - Integration with Claude Code, Codex, Gemini CLI, Aider, etc.
+ * - Integration with Claude Code, Codex, Gemini CLI, Aider, Pi, etc.
  *
  * @module @milaidy/plugin-coding-agent
  */
@@ -73,7 +73,7 @@ function wireAuthPromptCallback(runtime: IAgentRuntime): void {
 export const codingAgentPlugin: Plugin = {
   name: "@milaidy/plugin-coding-agent",
   description:
-    "Orchestrate CLI coding agents (Claude Code, Codex, etc.) via PTY sessions, " +
+    "Orchestrate CLI coding agents (Claude Code, Codex, Gemini, Aider, Pi, etc.) via PTY sessions, " +
     "manage git workspaces, and handle GitHub issues for autonomous coding tasks",
 
   // Plugin init - wire up deciders and callbacks after services are ready

--- a/packages/plugin-coding-agent/src/providers/action-examples.ts
+++ b/packages/plugin-coding-agent/src/providers/action-examples.ts
@@ -40,6 +40,16 @@ const CODING_AGENT_EXAMPLES: ActionCallExample[] = [
     },
   },
   {
+    user: "Use pi to investigate flaky tests and write findings to FLAKY_TESTS.md",
+    actions: ["REPLY", "START_CODING_TASK"],
+    params: {
+      START_CODING_TASK: {
+        agentType: "pi",
+        task: "Investigate flaky tests, identify likely root causes, and write your findings to FLAKY_TESTS.md",
+      },
+    },
+  },
+  {
     user: "Tell the coding agent to accept those changes",
     actions: ["REPLY", "SEND_TO_CODING_AGENT"],
     params: {

--- a/packages/plugin-coding-agent/src/services/pty-init.ts
+++ b/packages/plugin-coding-agent/src/services/pty-init.ts
@@ -211,7 +211,8 @@ export async function initializePTYManager(
   // Register built-in adapters
   nodeManager.registerAdapter(new ShellAdapter());
 
-  // Register coding agent adapters (claude, gemini, codex, aider)
+  // Register coding agent adapters (claude, gemini, codex, aider).
+  // Pi currently routes through the generic shell adapter.
   if (ctx.serviceConfig.registerCodingAdapters) {
     const codingAdapters = createAllAdapters();
     for (const adapter of codingAdapters) {


### PR DESCRIPTION
This PR will be reviewed by an AI agent. Provide clear context to help it assess your changes.

Aesthetic/UI changes that don't improve agent capability are out of scope and will be rejected.

## Category
- [ ] Bug fix
- [ ] Security fix
- [ ] Performance improvement
- [x] New feature
- [ ] Documentation
- [x] Test coverage
- [ ] Other

## What
Add Pi as a supported coding agent across backend orchestration and Settings → Coding Agents UI.

## Why
Users can now select and run Pi alongside Claude/Codex/Gemini/Aider in the same coding-agent workflow.

## How
- Added Pi alias handling (`pi`, `pi-ai`, etc.) in coding-agent normalization.
- Routed Pi through the existing shell adapter and wrapped initial tasks as `pi '<task>'`.
- Updated spawn/task flows and API route handling to recognize Pi and report it in session metadata/display.
- Added Pi to supported agent lists, docs, and action examples.
- Added Pi tab under Settings → Coding Agents with Pi-specific guidance instead of model tier selectors.
- Updated permissions capability copy to include Pi.

## Testing
- `bun test packages/plugin-coding-agent/src/__tests__/spawn-agent.test.ts packages/plugin-coding-agent/src/__tests__/start-coding-task.test.ts packages/plugin-coding-agent/src/__tests__/pty-service.test.ts`
- `bun run --cwd packages/plugin-coding-agent typecheck`
- Added/updated tests for:
  - Pi mapping in spawn action
  - Pi mapping in start-coding-task (single + multi-agent)
  - PTY supported agent types includes Pi
