### PR TITLE
fix(runtime): fallback to Node for known Bun 1.3.9 Linux crash path

### DIFF
--- a/scripts/run-node-runtime.mjs
+++ b/scripts/run-node-runtime.mjs
@@ -1,0 +1,79 @@
+const KNOWN_UNSTABLE_BUN_LINUX = /^1\.3\.9(?:$|[-+].*)/;
+
+/**
+ * Bun 1.3.9 has known Linux segfault reports in long-running workloads.
+ * Prefer Node by default for this one runtime/version combination.
+ */
+export function isKnownUnstableBunOnLinux({ platform, bunVersion }) {
+  return (
+    platform === "linux" &&
+    typeof bunVersion === "string" &&
+    KNOWN_UNSTABLE_BUN_LINUX.test(bunVersion)
+  );
+}
+
+/**
+ * Runtime selection priority:
+ * 1) Explicit MILADY_RUNTIME override (bun|node)
+ * 2) Safety fallback for known unstable Bun/Linux combo
+ * 3) Default to bun
+ */
+export function chooseMiladyRuntime({
+  requestedRuntime,
+  platform,
+  bunVersion,
+}) {
+  const normalized = requestedRuntime?.trim().toLowerCase();
+  if (normalized === "bun" || normalized === "node") {
+    return { runtime: normalized, warning: null };
+  }
+
+  if (isKnownUnstableBunOnLinux({ platform, bunVersion })) {
+    return {
+      runtime: "node",
+      warning:
+        "Detected Bun 1.3.9 on Linux (known segfault risk). Defaulting runtime to Node.js.",
+    };
+  }
+
+  return { runtime: "bun", warning: null };
+}
+
+export function resolveNodeExecPath({
+  currentExecPath,
+  platform,
+  explicitNodePath,
+}) {
+  const explicit = explicitNodePath?.trim();
+  if (explicit) {
+    return explicit;
+  }
+
+  const normalized =
+    platform === "win32"
+      ? (currentExecPath ?? "").toLowerCase()
+      : (currentExecPath ?? "");
+  const looksLikeBun = /(?:^|[\\/])bun(?:\.exe)?$/.test(normalized);
+
+  if (!looksLikeBun && normalized.length > 0) {
+    return currentExecPath;
+  }
+
+  return platform === "win32" ? "node.exe" : "node";
+}
+
+export function resolveRuntimeExecPath({
+  runtime,
+  currentExecPath,
+  platform,
+  explicitNodePath,
+}) {
+  if (runtime === "bun") {
+    return "bun";
+  }
+  return resolveNodeExecPath({
+    currentExecPath,
+    platform,
+    explicitNodePath,
+  });
+}

--- a/scripts/run-node-runtime.test.ts
+++ b/scripts/run-node-runtime.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import {
+  chooseMiladyRuntime,
+  isKnownUnstableBunOnLinux,
+  resolveNodeExecPath,
+  resolveRuntimeExecPath,
+} from "./run-node-runtime.mjs";
+
+describe("run-node runtime selection", () => {
+  it("detects Bun 1.3.9 on Linux as unstable", () => {
+    expect(
+      isKnownUnstableBunOnLinux({ platform: "linux", bunVersion: "1.3.9" }),
+    ).toBe(true);
+    expect(
+      isKnownUnstableBunOnLinux({
+        platform: "linux",
+        bunVersion: "1.3.9-hotfix",
+      }),
+    ).toBe(true);
+    expect(
+      isKnownUnstableBunOnLinux({ platform: "darwin", bunVersion: "1.3.9" }),
+    ).toBe(false);
+    expect(
+      isKnownUnstableBunOnLinux({ platform: "linux", bunVersion: "1.3.10" }),
+    ).toBe(false);
+  });
+
+  it("honors explicit runtime overrides", () => {
+    expect(
+      chooseMiladyRuntime({
+        requestedRuntime: "node",
+        platform: "linux",
+        bunVersion: "1.3.9",
+      }),
+    ).toEqual({ runtime: "node", warning: null });
+
+    expect(
+      chooseMiladyRuntime({
+        requestedRuntime: "bun",
+        platform: "linux",
+        bunVersion: "1.3.9",
+      }),
+    ).toEqual({ runtime: "bun", warning: null });
+  });
+
+  it("falls back to node for linux Bun 1.3.9 when runtime is not set", () => {
+    const selected = chooseMiladyRuntime({
+      requestedRuntime: undefined,
+      platform: "linux",
+      bunVersion: "1.3.9",
+    });
+    expect(selected.runtime).toBe("node");
+    expect(selected.warning).toContain("Bun 1.3.9");
+  });
+
+  it("defaults to bun otherwise", () => {
+    expect(
+      chooseMiladyRuntime({
+        requestedRuntime: undefined,
+        platform: "linux",
+        bunVersion: "1.3.10",
+      }),
+    ).toEqual({ runtime: "bun", warning: null });
+  });
+});
+
+describe("run-node executable resolution", () => {
+  it("uses node on PATH when current exec is bun", () => {
+    expect(
+      resolveNodeExecPath({
+        currentExecPath: "/Users/home/.bun/bin/bun",
+        platform: "linux",
+      }),
+    ).toBe("node");
+  });
+
+  it("keeps current exec path when it already points to node", () => {
+    expect(
+      resolveNodeExecPath({
+        currentExecPath: "/usr/bin/node",
+        platform: "linux",
+      }),
+    ).toBe("/usr/bin/node");
+  });
+
+  it("prefers explicit node path override", () => {
+    expect(
+      resolveNodeExecPath({
+        currentExecPath: "/Users/home/.bun/bin/bun",
+        platform: "linux",
+        explicitNodePath: "/custom/node",
+      }),
+    ).toBe("/custom/node");
+  });
+
+  it("resolves runtime executable for bun and node", () => {
+    expect(
+      resolveRuntimeExecPath({
+        runtime: "bun",
+        currentExecPath: "/usr/bin/node",
+        platform: "linux",
+      }),
+    ).toBe("bun");
+
+    expect(
+      resolveRuntimeExecPath({
+        runtime: "node",
+        currentExecPath: "/Users/home/.bun/bin/bun",
+        platform: "linux",
+      }),
+    ).toBe("node");
+  });
+});


### PR DESCRIPTION
## Summary
- add a runtime selector helper for scripts/run-node.mjs
- default to node when Bun 1.3.9 is detected on Linux and no explicit runtime override is set
- make MILADY_RUNTIME=node reliably spawn Node even when launcher itself runs under Bun
- add deterministic tests for runtime selection and executable resolution

## Why
- issue #397 reports repeatable Bun 1.3.9 Linux segfaults on pnpm run milady start
- current launcher used process.execPath for node mode, which can still resolve to Bun when invoked via Bun

## Validation
- bunx vitest run scripts/run-node-runtime.test.ts src/runtime/eliza.test.ts src/runtime/trajectory-persistence.test.ts
- bun run lint
- bun run typecheck
- bun run pre-review:local

Fixes #397
