### PR TITLE
fix(ui): settings model dropdowns fall back to env vars for local providers

### DIFF
--- a/apps/app/src/components/ProviderSwitcher.tsx
+++ b/apps/app/src/components/ProviderSwitcher.tsx
@@ -140,15 +140,24 @@ export function ProviderSwitcher({
         const cloudEnabledCfg = cloud?.enabled === true;
         const defaultSmall = "moonshotai/kimi-k2-turbo";
         const defaultLarge = "moonshotai/kimi-k2-0905";
-        setCurrentSmallModel(
-          models?.small || (cloudEnabledCfg ? defaultSmall : ""),
-        );
-        setCurrentLargeModel(
-          models?.large || (cloudEnabledCfg ? defaultLarge : ""),
-        );
 
+        // Environment variables — needed both for model fallback and pi-ai
         const env = cfg.env as Record<string, unknown> | undefined;
         const vars = (env?.vars as Record<string, unknown> | undefined) ?? {};
+
+        // Fall back to SMALL_MODEL / LARGE_MODEL env vars when cfg.models
+        // is empty.  Local providers (e.g. Ollama) store the active model
+        // names as env vars rather than in cfg.models.
+        const envSmall =
+          typeof vars.SMALL_MODEL === "string" ? vars.SMALL_MODEL : "";
+        const envLarge =
+          typeof vars.LARGE_MODEL === "string" ? vars.LARGE_MODEL : "";
+        setCurrentSmallModel(
+          models?.small || envSmall || (cloudEnabledCfg ? defaultSmall : ""),
+        );
+        setCurrentLargeModel(
+          models?.large || envLarge || (cloudEnabledCfg ? defaultLarge : ""),
+        );
         const rawPiAi =
           (typeof vars.MILAIDY_USE_PI_AI === "string"
             ? vars.MILAIDY_USE_PI_AI


### PR DESCRIPTION
## Problem

When using local AI providers (e.g. Ollama), the Settings page model dropdowns show `-- none --` despite models being actively configured and responding to chat. The "Configured" status badge shows green, but the dropdown itself is empty.

## Root Cause

The Settings page reads model names from `cfg.models.small` / `cfg.models.large`, but local providers store their model names as env vars (`SMALL_MODEL` / `LARGE_MODEL` in `cfg.env.vars`). These are two separate config paths that were not connected.

The "Configured" badge reads from the env vars (correct), but the dropdown only reads from `cfg.models` (empty for local setups).

## Fix

Added a fallback chain in `ProviderSwitcher.tsx`:

```
cfg.models.small → env.vars.SMALL_MODEL → cloud default → empty
cfg.models.large → env.vars.LARGE_MODEL → cloud default → empty
```

This is a 14-line change (5 removed, 14 added) in a single file.

## Verification

- Lint: 0 issues (`biome check` + project `npm run lint`)
- No behavioral change for cloud users (cfg.models is populated, env var fallback never reached)
- For local users: dropdowns will now show the configured model name

Fixes #561