### PR TITLE
security(api): DNS rebinding protection via Host header validation

### DIFF
--- a/src/api/dns-rebinding.test.ts
+++ b/src/api/dns-rebinding.test.ts
@@ -1,0 +1,108 @@
+import type http from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { isAllowedHost } from "./server.js";
+
+/* ── Helper ────────────────────────────────────────────────────────── */
+
+function fakeReq(host?: string): http.IncomingMessage {
+  return {
+    headers: host !== undefined ? { host } : {},
+  } as http.IncomingMessage;
+}
+
+/* ── Tests ─────────────────────────────────────────────────────────── */
+
+describe("isAllowedHost — DNS rebinding protection", () => {
+  const savedBind = process.env.MILADY_API_BIND;
+  afterEach(() => {
+    if (savedBind === undefined) {
+      delete process.env.MILADY_API_BIND;
+    } else {
+      process.env.MILADY_API_BIND = savedBind;
+    }
+  });
+
+  /* ── Allowed hosts ────────────────────────────────────────────── */
+
+  it("allows localhost", () => {
+    expect(isAllowedHost(fakeReq("localhost"))).toBe(true);
+  });
+
+  it("allows localhost with port", () => {
+    expect(isAllowedHost(fakeReq("localhost:31337"))).toBe(true);
+  });
+
+  it("allows 127.0.0.1", () => {
+    expect(isAllowedHost(fakeReq("127.0.0.1"))).toBe(true);
+  });
+
+  it("allows 127.0.0.1 with port", () => {
+    expect(isAllowedHost(fakeReq("127.0.0.1:31337"))).toBe(true);
+  });
+
+  it("allows [::1]", () => {
+    expect(isAllowedHost(fakeReq("[::1]"))).toBe(true);
+  });
+
+  it("allows [::1] with port", () => {
+    expect(isAllowedHost(fakeReq("[::1]:31337"))).toBe(true);
+  });
+
+  it("allows ::1 without brackets", () => {
+    expect(isAllowedHost(fakeReq("::1"))).toBe(true);
+  });
+
+  it("allows full IPv6 loopback", () => {
+    expect(isAllowedHost(fakeReq("[0:0:0:0:0:0:0:1]"))).toBe(true);
+  });
+
+  it("allows missing Host header (non-browser client)", () => {
+    expect(isAllowedHost(fakeReq())).toBe(true);
+  });
+
+  it("allows empty Host header", () => {
+    expect(isAllowedHost(fakeReq(""))).toBe(true);
+  });
+
+  /* ── Blocked hosts (DNS rebinding) ────────────────────────────── */
+
+  it("blocks evil.com", () => {
+    expect(isAllowedHost(fakeReq("evil.com"))).toBe(false);
+  });
+
+  it("blocks evil.com:31337", () => {
+    expect(isAllowedHost(fakeReq("evil.com:31337"))).toBe(false);
+  });
+
+  it("blocks attacker.localhost", () => {
+    expect(isAllowedHost(fakeReq("attacker.localhost"))).toBe(false);
+  });
+
+  it("blocks localhost.evil.com", () => {
+    expect(isAllowedHost(fakeReq("localhost.evil.com"))).toBe(false);
+  });
+
+  it("blocks 0.0.0.0 (unspecified)", () => {
+    expect(isAllowedHost(fakeReq("0.0.0.0"))).toBe(false);
+  });
+
+  it("blocks 192.168.1.1 (private IP)", () => {
+    expect(isAllowedHost(fakeReq("192.168.1.1"))).toBe(false);
+  });
+
+  it("blocks 10.0.0.1", () => {
+    expect(isAllowedHost(fakeReq("10.0.0.1"))).toBe(false);
+  });
+
+  /* ── Custom bind host ─────────────────────────────────────────── */
+
+  it("allows custom MILADY_API_BIND host", () => {
+    process.env.MILADY_API_BIND = "myhost.local";
+    expect(isAllowedHost(fakeReq("myhost.local:31337"))).toBe(true);
+  });
+
+  it("still blocks unrelated hosts even with custom bind", () => {
+    process.env.MILADY_API_BIND = "myhost.local";
+    expect(isAllowedHost(fakeReq("evil.com"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

The API server listens on `localhost:31337` with **no auth token by default** (by design for local development). Without Host header validation, the server is vulnerable to [DNS rebinding attacks](https://en.wikipedia.org/wiki/DNS_rebinding):

1. User visits `evil.attacker.com` in browser
2. Attacker rebinds DNS so `evil.attacker.com` resolves to `127.0.0.1`
3. Browser sends request to milady API with `Host: evil.attacker.com`
4. Server accepts it — no Host check, no auth on localhost
5. Attacker reads `/api/config` (model names, base URLs, agent personality) and `/api/logs`

This is a well-documented attack class that motivated Host header validation in VS Code, Jupyter, and Docker.

## Fix

Added `isAllowedHost()` which validates the `Host` header against known loopback hostnames **before** the CORS and auth gates. Requests with foreign Host headers (DNS rebinding) are rejected with `403`.

### Allowed hosts
- `localhost`, `127.0.0.1`, `[::1]` / `::1` (all loopback forms with/without port)
- `::ffff:127.0.0.1` (IPv4-mapped IPv6)
- Custom `MILADY_API_BIND` value (already protected by token gate)
- No `Host` header (non-browser clients like curl)

### IPv6-aware port stripping
Handles bracketed IPv6 (`[::1]:31337`), bare IPv6 (`::1`), and IPv4/hostname correctly.

## Tests (19)

| Category | Tests |
|----------|-------|
| Allowed loopback hosts | 10 |
| Blocked rebinding hosts | 7 |
| Custom bind host | 2 |

## Verification

```
Tests:  19 passed
Lint:    0 issues
```

## Files Changed (158 lines added)

- `src/api/server.ts` — `LOCAL_HOST_RE`, `isAllowedHost()`, Host check in request handler
- `src/api/dns-rebinding.test.ts` — 19-test suite