### PR TITLE
fix: resolve shell command action fallback for issue #559

### DIFF
--- a/src/actions/__tests__/terminal.test.ts
+++ b/src/actions/__tests__/terminal.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { terminalAction } from "../../actions/terminal";
+import { createMiladyPlugin } from "../../runtime/milady-plugin";
 
 function mockResponse(response: { ok: boolean }): Response {
   return {
@@ -30,6 +31,16 @@ describe("terminalAction", () => {
     expect(result.success).toBe(false);
     expect(result.text).toBe("");
     expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+  });
+
+  it("is registered on the Milady plugin", () => {
+    const plugin = createMiladyPlugin();
+    const actionNames = (plugin.actions ?? []).map((action) => action.name);
+    expect(actionNames).toContain("RUN_IN_TERMINAL");
+  });
+
+  it("supports CALL_MCP_TOOL compatibility alias", () => {
+    expect(terminalAction.similes).toContain("CALL_MCP_TOOL");
   });
 
   it("fails when API returns error", async () => {
@@ -69,6 +80,43 @@ describe("terminalAction", () => {
     expect(result.success).toBe(true);
     expect(result.text).toBe("Running in terminal: `bun --version`");
     expect(result.data).toEqual({ command: "bun --version" });
+  });
+
+  it("extracts command from natural language message when params are missing", async () => {
+    vi.mocked(fetch).mockResolvedValue(mockResponse({ ok: true }));
+
+    const result = await terminalAction.handler(
+      undefined,
+      { roomId: "room", content: { text: "Can you run ls -la in the shell?" } },
+      undefined,
+      {},
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({ command: "ls -la" });
+    expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+      "http://localhost:2138/api/terminal/run",
+      expect.objectContaining({
+        body: JSON.stringify({
+          command: "ls -la",
+          clientId: "runtime-terminal-action",
+        }),
+      }),
+    );
+  });
+
+  it("extracts command from MCP-style JSON arguments", async () => {
+    vi.mocked(fetch).mockResolvedValue(mockResponse({ ok: true }));
+
+    const result = await terminalAction.handler(
+      undefined,
+      { roomId: "room", content: { text: "" } },
+      undefined,
+      { parameters: { arguments: '{"command":"ls -la"}' } },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({ command: "ls -la" });
   });
 
   it("handles fetch exceptions", async () => {

--- a/src/actions/terminal.ts
+++ b/src/actions/terminal.ts
@@ -15,6 +15,104 @@ import type { Action, HandlerOptions } from "@elizaos/core";
 /** API port for posting terminal requests. */
 const API_PORT = process.env.API_PORT || process.env.SERVER_PORT || "2138";
 
+type ActionParams = Record<string, unknown>;
+
+function nonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function resolveCommandFromObject(value: unknown): string | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const record = value as ActionParams;
+
+  const direct =
+    nonEmptyString(record.command) ??
+    nonEmptyString(record.cmd) ??
+    nonEmptyString(record.commandLine) ??
+    nonEmptyString(record.shellCommand);
+  if (direct) return direct;
+
+  const args = record.args;
+  if (Array.isArray(args) && args.every((entry) => typeof entry === "string")) {
+    const joined = args.join(" ").trim();
+    if (joined) return joined;
+  }
+
+  const nested =
+    resolveCommandFromObject(record.arguments) ??
+    resolveCommandFromObject(record.input) ??
+    resolveCommandFromObject(record.parameters);
+  if (nested) return nested;
+
+  return undefined;
+}
+
+function resolveCommandFromArguments(
+  argumentsValue: unknown,
+): string | undefined {
+  if (typeof argumentsValue === "string") {
+    const trimmed = argumentsValue.trim();
+    if (!trimmed) return undefined;
+    try {
+      const parsed = JSON.parse(trimmed) as unknown;
+      return resolveCommandFromObject(parsed) ?? trimmed;
+    } catch {
+      return trimmed;
+    }
+  }
+  return resolveCommandFromObject(argumentsValue);
+}
+
+function resolveCommandFromParams(params: unknown): string | undefined {
+  const record = params as ActionParams | undefined;
+  if (!record || typeof record !== "object") return undefined;
+
+  const direct =
+    nonEmptyString(record.command) ??
+    nonEmptyString(record.cmd) ??
+    nonEmptyString(record.commandLine) ??
+    nonEmptyString(record.shellCommand);
+  if (direct) return direct;
+
+  return (
+    resolveCommandFromArguments(record.arguments) ??
+    resolveCommandFromArguments(record.input) ??
+    resolveCommandFromObject(record.parameters)
+  );
+}
+
+function resolveCommandFromText(text: unknown): string | undefined {
+  const source = nonEmptyString(text);
+  if (!source) return undefined;
+
+  const fenced = source.match(/```(?:bash|sh|zsh|shell)?\s*([\s\S]*?)```/i);
+  if (fenced) {
+    const command = nonEmptyString(fenced[1]);
+    if (command) return command;
+  }
+
+  const inline = source.match(/`([^`\n]+)`/);
+  if (inline) {
+    const command = nonEmptyString(inline[1]);
+    if (command) return command;
+  }
+
+  const runMatch = source.match(
+    /\b(?:run|execute|exec)\b\s+(?:(?:the|this)\s+)?(?:(?:command|shell command)\s+)?["'`]?([^"'`\n]+?)["'`]?$/i,
+  );
+  if (runMatch) {
+    const candidate = runMatch[1]
+      .replace(/\s+(?:in|on)\s+(?:the\s+)?(?:terminal|shell)\b.*$/i, "")
+      .replace(/[.?!,:;]+$/g, "")
+      .trim();
+    if (candidate) return candidate;
+  }
+
+  return undefined;
+}
+
 export const terminalAction: Action = {
   name: "RUN_IN_TERMINAL",
 
@@ -25,6 +123,9 @@ export const terminalAction: Action = {
     "SHELL",
     "RUN_SHELL",
     "EXEC",
+    // Compatibility for upstream templates that may still emit CALL_MCP_TOOL.
+    "CALL_MCP_TOOL",
+    "CALL_TOOL",
   ],
 
   description:
@@ -38,7 +139,11 @@ export const terminalAction: Action = {
     try {
       const params = (options as HandlerOptions | undefined)?.parameters;
       const command =
-        typeof params?.command === "string" ? params.command.trim() : undefined;
+        resolveCommandFromParams(params) ??
+        resolveCommandFromText(
+          (_message as { content?: { text?: string } } | undefined)?.content
+            ?.text,
+        );
 
       if (!command) {
         return { text: "", success: false };

--- a/src/runtime/milady-plugin.ts
+++ b/src/runtime/milady-plugin.ts
@@ -17,6 +17,7 @@ import type {
 import { emoteAction } from "../actions/emote";
 import { restartAction } from "../actions/restart";
 import { sendMessageAction } from "../actions/send-message";
+import { terminalAction } from "../actions/terminal";
 import { EMOTE_CATALOG } from "../emotes/catalog";
 import { adminTrustProvider } from "../providers/admin-trust";
 import {
@@ -149,6 +150,7 @@ export function createMiladyPlugin(config?: MiladyPluginConfig): Plugin {
     actions: [
       restartAction,
       sendMessageAction,
+      terminalAction,
       createTriggerTaskAction,
       emoteAction,
       ...loadCustomActions(),


### PR DESCRIPTION
## Summary
- register `RUN_IN_TERMINAL` in the Milady plugin action list
- add compatibility alias handling for `CALL_MCP_TOOL` / `CALL_TOOL`
- improve terminal command extraction from MCP-style arguments and natural-language prompts
- add regression tests covering registration + alias + extraction paths

## Verification
- bunx vitest run src/actions/__tests__/terminal.test.ts
- bunx @biomejs/biome check src/actions/terminal.ts src/actions/__tests__/terminal.test.ts src/runtime/milady-plugin.ts
- bunx tsc --noEmit
- bun run pre-review:local

Fixes #559
