### PR TITLE
security(env): block TLS bypass, proxy hijack, and CA override env vars

### DIFF
--- a/src/api/blocked-env-keys.test.ts
+++ b/src/api/blocked-env-keys.test.ts
@@ -27,6 +27,20 @@ const BLOCKED_ENV_KEYS = new Set([
   "NODE_OPTIONS",
   "NODE_EXTRA_CA_CERTS",
   "ELECTRON_RUN_AS_NODE",
+  // TLS bypass
+  "NODE_TLS_REJECT_UNAUTHORIZED",
+  // Proxy hijack
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "ALL_PROXY",
+  "NO_PROXY",
+  // Module resolution override
+  "NODE_PATH",
+  // CA certificate override
+  "SSL_CERT_FILE",
+  "SSL_CERT_DIR",
+  "CURL_CA_BUNDLE",
+  // Process environment
   "PATH",
   "HOME",
   "SHELL",
@@ -109,6 +123,42 @@ describe("BLOCKED_ENV_KEYS — privilege escalation prevention", () => {
     }
   });
 
+  /* ── TLS bypass ─────────────────────────────────────────────────── */
+
+  describe("TLS bypass must be blocked (MITM prevention)", () => {
+    it("blocks NODE_TLS_REJECT_UNAUTHORIZED", () => {
+      expect(BLOCKED_ENV_KEYS.has("NODE_TLS_REJECT_UNAUTHORIZED")).toBe(true);
+    });
+  });
+
+  /* ── Proxy hijack ───────────────────────────────────────────────── */
+
+  describe("proxy hijack vars must be blocked (traffic interception)", () => {
+    for (const key of ["HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY"]) {
+      it(`blocks ${key}`, () => {
+        expect(BLOCKED_ENV_KEYS.has(key)).toBe(true);
+      });
+    }
+  });
+
+  /* ── Module resolution override ───────────────────────────────── */
+
+  describe("module resolution override must be blocked", () => {
+    it("blocks NODE_PATH", () => {
+      expect(BLOCKED_ENV_KEYS.has("NODE_PATH")).toBe(true);
+    });
+  });
+
+  /* ── CA certificate override ───────────────────────────────────── */
+
+  describe("CA certificate overrides must be blocked (MITM prevention)", () => {
+    for (const key of ["SSL_CERT_FILE", "SSL_CERT_DIR", "CURL_CA_BUNDLE"]) {
+      it(`blocks ${key}`, () => {
+        expect(BLOCKED_ENV_KEYS.has(key)).toBe(true);
+      });
+    }
+  });
+
   /* ── Database connection strings ──────────────────────────────── */
 
   describe("database connection strings must be blocked", () => {
@@ -123,7 +173,7 @@ describe("BLOCKED_ENV_KEYS — privilege escalation prevention", () => {
 
   /* ── Minimum size guard ───────────────────────────────────────── */
 
-  it("has at least 19 entries (guard against accidental truncation)", () => {
-    expect(BLOCKED_ENV_KEYS.size).toBeGreaterThanOrEqual(19);
+  it("has at least 28 entries (guard against accidental truncation)", () => {
+    expect(BLOCKED_ENV_KEYS.size).toBeGreaterThanOrEqual(28);
   });
 });

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -818,6 +818,22 @@ const BLOCKED_ENV_KEYS = new Set([
   "NODE_OPTIONS",
   "NODE_EXTRA_CA_CERTS",
   "ELECTRON_RUN_AS_NODE",
+  // TLS bypass — setting to "0" disables ALL certificate verification,
+  // enabling MITM interception of every outbound HTTPS request (API keys
+  // for OpenAI, Anthropic, ElevenLabs etc. sent in plaintext headers).
+  "NODE_TLS_REJECT_UNAUTHORIZED",
+  // Proxy hijack — routes all HTTP/HTTPS traffic through attacker proxy,
+  // exposing Authorization headers and API keys in transit.
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "ALL_PROXY",
+  "NO_PROXY",
+  // Module resolution override
+  "NODE_PATH",
+  // CA certificate override — trust rogue CAs for MITM
+  "SSL_CERT_FILE",
+  "SSL_CERT_DIR",
+  "CURL_CA_BUNDLE",
   "PATH",
   "HOME",
   "SHELL",
@@ -2976,6 +2992,15 @@ const BLOCKED_MCP_ENV_KEYS = new Set([
   "NODE_OPTIONS",
   "NODE_EXTRA_CA_CERTS",
   "ELECTRON_RUN_AS_NODE",
+  "NODE_TLS_REJECT_UNAUTHORIZED",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "ALL_PROXY",
+  "NO_PROXY",
+  "NODE_PATH",
+  "SSL_CERT_FILE",
+  "SSL_CERT_DIR",
+  "CURL_CA_BUNDLE",
   "PATH",
   "HOME",
   "SHELL",


### PR DESCRIPTION
## Summary

Follow-up env key blocklist hardening. `BLOCKED_ENV_KEYS` and `BLOCKED_MCP_ENV_KEYS` were missing critical network/TLS control vars.

## Vulnerability

### Attack:
```
PUT /api/config
{"env": {"NODE_TLS_REJECT_UNAUTHORIZED": "0"}}
```

This **immediately** disables ALL TLS certificate verification for every outbound HTTPS connection. API keys for OpenAI, Anthropic, ElevenLabs etc. are exposed in `Authorization` headers to any network-level attacker.

### 9 new blocked keys:

| Key | Impact |
|---|---|
| `NODE_TLS_REJECT_UNAUTHORIZED` | Disables ALL TLS cert verification — enables MITM |
| `HTTP_PROXY` | Routes HTTP traffic through attacker proxy |
| `HTTPS_PROXY` | Routes HTTPS traffic through attacker proxy |
| `ALL_PROXY` | Routes all traffic through attacker proxy |
| `NO_PROXY` | Controls proxy bypass list |
| `NODE_PATH` | Overrides module resolution paths |
| `SSL_CERT_FILE` | Trusts rogue CA certificates |
| `SSL_CERT_DIR` | Trusts rogue CA certificate directory |
| `CURL_CA_BUNDLE` | Trusts rogue CAs for curl-based requests |

## Files Changed
- `src/api/server.ts` — 29 insertions, 0 deletions

## Verification
- Clean diff (no biome formatting noise)
- Keys added to both `BLOCKED_ENV_KEYS` (line 812) and `BLOCKED_MCP_ENV_KEYS` (line 2953)