### PR TITLE
security(electron): validate URLs and paths in shell IPC handlers

### DIFF
--- a/apps/app/electron/src/setup.ts
+++ b/apps/app/electron/src/setup.ts
@@ -482,7 +482,7 @@ export class ElectronCapacitorApp {
         menuItems.push(
           {
             label: "Open Link in Browser",
-            click: () => shell.openExternal(params.linkURL),
+            click: () => openExternal(params.linkURL),
           },
           {
             label: "Copy Link Address",

--- a/apps/app/test/electron/desktop-shell.test.ts
+++ b/apps/app/test/electron/desktop-shell.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Regression tests for shell IPC validation in DesktopManager.
+ *
+ * Verifies that openExternal rejects non-http(s) URLs and that
+ * showItemInFolder rejects relative / empty paths.
+ *
+ * See PR #574 — security(electron): validate URLs and paths in shell IPC handlers
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks — we only need shell and path; stub everything else Electron provides
+// ---------------------------------------------------------------------------
+
+vi.mock("electron", () => ({
+  app: {
+    getAppPath: vi.fn(() => "/mock"),
+    getName: vi.fn(() => "milady-test"),
+    getVersion: vi.fn(() => "0.0.0-test"),
+    getPath: vi.fn(() => "/mock"),
+    getLoginItemSettings: vi.fn(() => ({
+      openAtLogin: false,
+      openAsHidden: false,
+    })),
+    setLoginItemSettings: vi.fn(),
+    isPackaged: false,
+    quit: vi.fn(),
+    relaunch: vi.fn(),
+    exit: vi.fn(),
+    on: vi.fn(),
+  },
+  shell: {
+    openExternal: vi.fn().mockResolvedValue(undefined),
+    showItemInFolder: vi.fn(),
+    beep: vi.fn(),
+  },
+  clipboard: {
+    writeText: vi.fn(),
+    readText: vi.fn(() => ""),
+    writeHTML: vi.fn(),
+    readHTML: vi.fn(() => ""),
+    writeRTF: vi.fn(),
+    readRTF: vi.fn(() => ""),
+    readImage: vi.fn(() => ({ isEmpty: () => true })),
+    writeImage: vi.fn(),
+    clear: vi.fn(),
+  },
+  nativeImage: {
+    createFromPath: vi.fn(() => ({
+      resize: vi.fn(() => ({})),
+      isEmpty: () => true,
+    })),
+    createFromDataURL: vi.fn(() => ({})),
+  },
+  BrowserWindow: vi.fn(),
+  Tray: vi.fn(),
+  Menu: { buildFromTemplate: vi.fn(), setApplicationMenu: vi.fn() },
+  MenuItem: vi.fn(),
+  Notification: vi.fn(),
+  globalShortcut: {
+    register: vi.fn(),
+    unregister: vi.fn(),
+    unregisterAll: vi.fn(),
+    isRegistered: vi.fn(),
+  },
+  powerMonitor: {
+    getSystemIdleTime: vi.fn(() => 0),
+    getSystemIdleState: vi.fn(() => "active"),
+    isOnBatteryPower: vi.fn(() => false),
+    on: vi.fn(),
+  },
+  ipcMain: { handle: vi.fn() },
+  session: { defaultSession: { webRequest: { onHeadersReceived: vi.fn() } } },
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test
+// ---------------------------------------------------------------------------
+
+let DesktopManager: typeof import("../../electron/src/native/desktop").DesktopManager;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  // Re-import to reset singleton state
+  const mod = await import("../../electron/src/native/desktop");
+  DesktopManager = mod.DesktopManager;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DesktopManager shell validation", () => {
+  describe("openExternal", () => {
+    it("rejects file:// URLs", async () => {
+      const mgr = new DesktopManager();
+      await expect(
+        mgr.openExternal({ url: "file:///etc/passwd" }),
+      ).rejects.toThrow(/non-http/i);
+    });
+
+    it("rejects smb:// URLs", async () => {
+      const mgr = new DesktopManager();
+      await expect(
+        mgr.openExternal({ url: "smb://evil.com/share" }),
+      ).rejects.toThrow(/non-http/i);
+    });
+
+    it("rejects custom-scheme URLs", async () => {
+      const mgr = new DesktopManager();
+      await expect(
+        mgr.openExternal({ url: "myapp://callback?token=secret" }),
+      ).rejects.toThrow(/non-http/i);
+    });
+
+    it("accepts http:// URLs", async () => {
+      const mgr = new DesktopManager();
+      await expect(
+        mgr.openExternal({ url: "http://example.com" }),
+      ).resolves.toBeUndefined();
+    });
+
+    it("accepts https:// URLs", async () => {
+      const mgr = new DesktopManager();
+      await expect(
+        mgr.openExternal({ url: "https://example.com/page" }),
+      ).resolves.toBeUndefined();
+    });
+
+    it("throws on malformed URLs", async () => {
+      const mgr = new DesktopManager();
+      await expect(mgr.openExternal({ url: "not-a-url" })).rejects.toThrow(
+        /invalid url/i,
+      );
+    });
+  });
+
+  describe("showItemInFolder", () => {
+    it("rejects relative paths", async () => {
+      const mgr = new DesktopManager();
+      await expect(
+        mgr.showItemInFolder({ path: "relative/path/file.txt" }),
+      ).rejects.toThrow(/absolute path/i);
+    });
+
+    it("rejects empty strings", async () => {
+      const mgr = new DesktopManager();
+      await expect(mgr.showItemInFolder({ path: "" })).rejects.toThrow(
+        /absolute path/i,
+      );
+    });
+
+    it("accepts absolute paths", async () => {
+      const mgr = new DesktopManager();
+      await expect(
+        mgr.showItemInFolder({ path: "/Users/test/file.txt" }),
+      ).resolves.toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Three `shell.openExternal` / `showItemInFolder` call sites accepted renderer-supplied input without validation, violating the [Electron Security Checklist](https://www.electronjs.org/docs/latest/tutorial/security#15-do-not-use-shellopenexternal-with-untrusted-content).

## Vulnerability

The `desktop:openExternal` IPC handler passed any URL scheme directly to `shell.openExternal` — including `file://`, `smb://`, and custom protocol handlers that can execute code on macOS/Windows. The `desktop:showItemInFolder` IPC handler accepted any path without validation. The context menu "Open Link in Browser" called `shell.openExternal` directly, bypassing the protocol-validated helper defined 100 lines above it.

## Fix

| File | Location | Change |
|---|---|---|
| `desktop.ts` | `openExternal()` | Restrict to `http:` and `https:` protocols only |
| `desktop.ts` | `showItemInFolder()` | Require absolute path |
| `setup.ts` | Context menu | Use validated `openExternal` helper instead of `shell.openExternal` directly |

## Files Changed

- `apps/app/electron/src/native/desktop.ts` — 25 insertions, 4 deletions
- `apps/app/electron/src/setup.ts` — 1 insertion, 1 deletion

## Verification

- [x] `biome check` clean on both files (base files had 0 errors)
- [x] Diff contains only security changes — zero formatting noise
- [x] Vulnerability confirmed present on current `origin/develop`