### PR TITLE
security(eject): add --ignore-scripts to eject install calls

### DIFF
--- a/src/services/core-eject.ts
+++ b/src/services/core-eject.ts
@@ -268,7 +268,11 @@ async function writeTsconfigCorePaths(
 }
 
 async function runCoreInstallAndBuild(monorepoDir: string): Promise<void> {
-  await execFileAsync("bun", ["install"], { cwd: monorepoDir });
+  // SECURITY: --ignore-scripts prevents postinstall lifecycle scripts from
+  // executing arbitrary code on the host (see PR #573 for full analysis).
+  await execFileAsync("bun", ["install", "--ignore-scripts"], {
+    cwd: monorepoDir,
+  });
   await execFileAsync("bun", ["run", "--filter", CORE_PACKAGE_NAME, "build"], {
     cwd: monorepoDir,
   });

--- a/src/services/plugin-eject.ts
+++ b/src/services/plugin-eject.ts
@@ -179,15 +179,17 @@ async function writeUpstreamMetadata(
 }
 
 async function runInstallDeps(cwd: string): Promise<void> {
+  // SECURITY: --ignore-scripts prevents postinstall lifecycle scripts from
+  // executing arbitrary code on the host (see PR #573 for full analysis).
   const pm = await detectPackageManager();
   try {
-    await execFileAsync(pm, ["install"], { cwd });
+    await execFileAsync(pm, ["install", "--ignore-scripts"], { cwd });
   } catch (err) {
     if (pm === "npm") throw err;
     logger.warn(
       `[plugin-eject] ${pm} install failed; retrying with npm: ${err instanceof Error ? err.message : String(err)}`,
     );
-    await execFileAsync("npm", ["install"], { cwd });
+    await execFileAsync("npm", ["install", "--ignore-scripts"], { cwd });
   }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to PR #573 as requested by reviewer. The same postinstall RCE gap exists in the eject scripts.

## Affected Locations

| File | Function | Line |
|---|---|---|
| `plugin-eject.ts` | `runInstallDeps` | 186 — `pm install` |
| `plugin-eject.ts` | `runInstallDeps` | 192 — `npm install` fallback |
| `core-eject.ts` | `runCoreInstallAndBuild` | 273 — `bun install` |

## Files Changed

- `src/services/plugin-eject.ts` — 4 insertions, 2 deletions
- `src/services/core-eject.ts` — 5 insertions, 1 deletion

## Verification

- [x] `biome check` clean on both files (base had 0 errors)
- [x] Zero formatting noise
- [x] Vulnerability confirmed present on current `origin/develop`