### PR TITLE
feat: wire @elizaos/plugin-blooio for iMessage/SMS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ apps/ui/test-results/
 
 # Vendored repos (clone separately if needed)
 vendor/
+plugins/plugin-blooio/
 
 # Local untracked files
 .local/

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -1266,6 +1266,7 @@ function categorizePlugin(
     "nextcloud-talk",
     "instagram",
     "retake",
+    "blooio",
   ];
   const databases = ["sql", "localdb", "inmemorydb"];
 
@@ -6408,22 +6409,25 @@ async function handleRequest(
       body.blooioApiKey.trim()
     ) {
       if (!config.env) config.env = {};
-      (config.env as Record<string, string>).BLOOIO_API_KEY = (
-        body.blooioApiKey as string
-      ).trim();
-      process.env.BLOOIO_API_KEY = (body.blooioApiKey as string).trim();
+      const trimmedKey = (body.blooioApiKey as string).trim();
+      (config.env as Record<string, string>).BLOOIO_API_KEY = trimmedKey;
+      process.env.BLOOIO_API_KEY = trimmedKey;
+
+      const blooioConnector: Record<string, string> = { apiKey: trimmedKey };
+
       if (
         body.blooioPhoneNumber &&
         typeof body.blooioPhoneNumber === "string" &&
         body.blooioPhoneNumber.trim()
       ) {
-        (config.env as Record<string, string>).BLOOIO_PHONE_NUMBER = (
-          body.blooioPhoneNumber as string
-        ).trim();
-        process.env.BLOOIO_PHONE_NUMBER = (
-          body.blooioPhoneNumber as string
-        ).trim();
+        const trimmedPhone = (body.blooioPhoneNumber as string).trim();
+        (config.env as Record<string, string>).BLOOIO_PHONE_NUMBER =
+          trimmedPhone;
+        process.env.BLOOIO_PHONE_NUMBER = trimmedPhone;
+        blooioConnector.fromNumber = trimmedPhone;
       }
+
+      config.connectors.blooio = blooioConnector;
     }
 
     // ── Inventory / RPC providers ─────────────────────────────────────────

--- a/src/config/connector-parity.test.ts
+++ b/src/config/connector-parity.test.ts
@@ -37,9 +37,9 @@ describe("connector map parity", () => {
   });
 
   it("has identical count across all three maps", () => {
-    expect(CONNECTOR_IDS).toHaveLength(17);
-    expect(Object.keys(CONNECTOR_PLUGINS)).toHaveLength(17);
-    expect(Object.keys(CHANNEL_PLUGIN_MAP)).toHaveLength(17);
+    expect(CONNECTOR_IDS).toHaveLength(18);
+    expect(Object.keys(CONNECTOR_PLUGINS)).toHaveLength(18);
+    expect(Object.keys(CHANNEL_PLUGIN_MAP)).toHaveLength(18);
   });
 
   it("uses valid package name prefixes for all plugin mappings", () => {

--- a/src/config/plugin-auto-enable.test.ts
+++ b/src/config/plugin-auto-enable.test.ts
@@ -606,8 +606,8 @@ describe("CONNECTOR_PLUGINS", () => {
     expect(CONNECTOR_PLUGINS.discord).toBe("@elizaos/plugin-discord");
   });
 
-  it("contains 17 connector mappings", () => {
-    expect(Object.keys(CONNECTOR_PLUGINS)).toHaveLength(17);
+  it("contains 18 connector mappings", () => {
+    expect(Object.keys(CONNECTOR_PLUGINS)).toHaveLength(18);
   });
 
   it("maps retake to @milady/plugin-retake", () => {
@@ -618,6 +618,10 @@ describe("CONNECTOR_PLUGINS", () => {
     expect([...Object.keys(CONNECTOR_PLUGINS)].sort()).toEqual(
       [...CONNECTOR_IDS].sort(),
     );
+  });
+
+  it("maps blooio to @elizaos/plugin-blooio", () => {
+    expect(CONNECTOR_PLUGINS.blooio).toBe("@elizaos/plugin-blooio");
   });
 });
 
@@ -799,5 +803,38 @@ describe("Retake connector auto-enable", () => {
       }),
     );
     expect(config.plugins?.allow ?? []).not.toContain("retake");
+  });
+});
+
+describe("Blooio connector auto-enable", () => {
+  it("auto-enables when apiKey is set", () => {
+    const { config } = applyPluginAutoEnable(
+      makeParams({
+        config: { connectors: { blooio: { apiKey: "blk-test-key" } } },
+      }),
+    );
+    expect(config.plugins?.allow).toContain("blooio");
+  });
+
+  it("does not auto-enable when config is empty", () => {
+    const { config } = applyPluginAutoEnable(
+      makeParams({
+        config: { connectors: { blooio: {} } },
+      }),
+    );
+    expect(config.plugins?.allow ?? []).not.toContain("blooio");
+  });
+
+  it("does not auto-enable when enabled is explicitly false", () => {
+    const { config } = applyPluginAutoEnable(
+      makeParams({
+        config: {
+          connectors: {
+            blooio: { enabled: false, apiKey: "blk-test-key" },
+          },
+        },
+      }),
+    );
+    expect(config.plugins?.allow ?? []).not.toContain("blooio");
   });
 });

--- a/src/config/plugin-auto-enable.ts
+++ b/src/config/plugin-auto-enable.ts
@@ -30,6 +30,7 @@ export const CONNECTOR_PLUGINS: Record<string, string> = {
   matrix: "@elizaos/plugin-matrix",
   nostr: "@elizaos/plugin-nostr",
   retake: "@milady/plugin-retake",
+  blooio: "@elizaos/plugin-blooio",
 };
 
 const PROVIDER_PLUGINS: Record<string, string> = {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -19,6 +19,7 @@ export const CONNECTOR_IDS = [
   "matrix",
   "nostr",
   "retake",
+  "blooio",
 ] as const;
 
 import { MiladySchema } from "./zod-schema";

--- a/src/runtime/eliza.ts
+++ b/src/runtime/eliza.ts
@@ -427,6 +427,13 @@ const CHANNEL_ENV_MAP: Readonly<
   googlechat: {
     serviceAccountKey: "GOOGLE_CHAT_SERVICE_ACCOUNT_KEY",
   },
+  blooio: {
+    apiKey: "BLOOIO_API_KEY",
+    fromNumber: "BLOOIO_PHONE_NUMBER",
+    webhookSecret: "BLOOIO_WEBHOOK_SECRET",
+    webhookUrl: "BLOOIO_WEBHOOK_URL",
+    webhookPort: "BLOOIO_WEBHOOK_PORT",
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -466,6 +473,7 @@ export const CHANNEL_PLUGIN_MAP: Readonly<Record<string, string>> = {
   matrix: "@elizaos/plugin-matrix",
   nostr: "@elizaos/plugin-nostr",
   retake: "@milady/plugin-retake",
+  blooio: "@elizaos/plugin-blooio",
 };
 
 const PI_AI_PLUGIN_PACKAGE = "@elizaos/plugin-pi-ai";


### PR DESCRIPTION
## Summary
- Registers [Blooio](https://blooio.com) as a first-class connector plugin for iMessage/SMS messaging
- Adds `blooio` to `CHANNEL_PLUGIN_MAP`, `CHANNEL_ENV_MAP`, `CONNECTOR_PLUGINS`, `CONNECTOR_IDS`, and `categorizePlugin()` connectors list
- Adds onboarding handler for `blooioApiKey` / `blooioPhoneNumber` in the API server
- Includes the `@elizaos/plugin-blooio` workspace package (source in `plugins/plugin-blooio/typescript`)
- Full test coverage: connector mapping, auto-enable (apiKey set / empty / disabled), and connector-parity alignment

## Files changed
| File | Change |
|---|---|
| `.gitignore` | Exclude cloned `plugins/plugin-blooio/` from git |
| `package.json` | Add workspace entry + `@elizaos/plugin-blooio: workspace:*` dep |
| `src/runtime/eliza.ts` | `CHANNEL_PLUGIN_MAP` + `CHANNEL_ENV_MAP` (apiKey, fromNumber, webhookSecret, webhookUrl, webhookPort) |
| `src/config/plugin-auto-enable.ts` | `CONNECTOR_PLUGINS` entry |
| `src/config/schema.ts` | `CONNECTOR_IDS` entry |
| `src/api/server.ts` | `categorizePlugin()` connector + onboarding handler |
| `src/config/plugin-auto-enable.test.ts` | Count update + blooio mapping + 3 auto-enable tests |
| `src/config/connector-parity.test.ts` | Count update (17 → 18) |

## Setup
1. Get a Blooio API key and phone number from [blooio.com](https://blooio.com)
2. Set env vars: `BLOOIO_API_KEY`, `BLOOIO_PHONE_NUMBER`, `BLOOIO_WEBHOOK_URL`, `BLOOIO_WEBHOOK_SECRET`
3. Expose webhook endpoint publicly (e.g. `npx cloudflared tunnel --url http://localhost:3001`)
4. Plugin auto-enables when `BLOOIO_API_KEY` is configured

## Test plan
- [x] `vitest run src/config/plugin-auto-enable.test.ts` — 72/72 pass
- [x] `vitest run src/config/connector-parity.test.ts` — 6/6 pass
- [x] E2E: signed webhook curl → 200 OK, message processed
- [x] E2E: unsigned webhook curl → 401 rejected
- [x] E2E: Blooio API send → iMessage delivered → webhook events (queued/sent/delivered) received