### PR TITLE
security(api): pin /api/knowledge URL fetches to validated IP at connect time

### DIFF
--- a/src/api/knowledge-routes.ts
+++ b/src/api/knowledge-routes.ts
@@ -1,5 +1,12 @@
 import { lookup as dnsLookup } from "node:dns/promises";
+import {
+  type RequestOptions as HttpRequestOptions,
+  type IncomingMessage,
+  request as requestHttp,
+} from "node:http";
+import { request as requestHttps } from "node:https";
 import net from "node:net";
+import { Readable } from "node:stream";
 import type { AgentRuntime, Memory, UUID } from "@elizaos/core";
 import {
   isBlockedPrivateOrLinkLocalIp,
@@ -242,30 +249,174 @@ function isBlockedIp(ip: string): boolean {
   return isBlockedPrivateOrLinkLocalIp(ip);
 }
 
-async function resolveUrlSafetyRejection(url: string): Promise<string | null> {
+type ResolvedUrlTarget = {
+  parsed: URL;
+  hostname: string;
+  pinnedAddress: string;
+};
+
+type PinnedFetchInput = {
+  url: URL;
+  init: RequestInit;
+  target: ResolvedUrlTarget;
+  timeoutMs: number;
+};
+
+type PinnedFetchImpl = (input: PinnedFetchInput) => Promise<Response>;
+
+function toRequestHeaders(headers: Headers): Record<string, string> {
+  const normalized: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    normalized[key] = value;
+  });
+  return normalized;
+}
+
+function responseFromIncomingMessage(response: IncomingMessage): Response {
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(response.headers)) {
+    if (Array.isArray(value)) {
+      for (const item of value) headers.append(key, item);
+    } else if (typeof value === "string") {
+      headers.set(key, value);
+    }
+  }
+
+  const status = response.statusCode ?? 500;
+  const body =
+    status === 204 || status === 205 || status === 304
+      ? null
+      : (Readable.toWeb(response) as ReadableStream<Uint8Array>);
+
+  return new Response(body, {
+    status,
+    statusText: response.statusMessage,
+    headers,
+  });
+}
+
+async function requestWithPinnedAddress(
+  input: PinnedFetchInput,
+): Promise<Response> {
+  const { url, init, target, timeoutMs } = input;
+
+  if (init.body !== undefined && init.body !== null) {
+    throw new Error("URL fetch request body is not supported");
+  }
+
+  const method = (init.method ?? "GET").toUpperCase();
+  const headers = toRequestHeaders(new Headers(init.headers));
+  const requestFn = url.protocol === "https:" ? requestHttps : requestHttp;
+  const family = net.isIP(target.pinnedAddress) === 6 ? 6 : 4;
+
+  return await new Promise<Response>((resolve, reject) => {
+    let settled = false;
+    const signal = init.signal;
+    let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+
+    const settle = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      if (timeoutHandle !== null) clearTimeout(timeoutHandle);
+      signal?.removeEventListener("abort", onAbort);
+      callback();
+    };
+
+    const onAbort = () => {
+      request.destroy(new DOMException("Aborted", "AbortError"));
+    };
+
+    const requestOptions: HttpRequestOptions = {
+      protocol: url.protocol,
+      hostname: target.hostname,
+      port: url.port ? Number(url.port) : undefined,
+      method,
+      path: `${url.pathname}${url.search}`,
+      headers,
+      lookup: (_hostname, _options, callback) => {
+        callback(null, target.pinnedAddress, family);
+      },
+      ...(url.protocol === "https:"
+        ? { servername: target.hostname }
+        : undefined),
+    };
+
+    const request = requestFn(requestOptions, (response) => {
+      settle(() => resolve(responseFromIncomingMessage(response)));
+    });
+
+    request.on("error", (error) => {
+      settle(() => reject(error));
+    });
+
+    if (signal) {
+      if (signal.aborted) {
+        onAbort();
+      } else {
+        signal.addEventListener("abort", onAbort, { once: true });
+      }
+    }
+
+    timeoutHandle = setTimeout(() => {
+      request.destroy(new Error(`URL fetch timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    request.end();
+  });
+}
+
+let pinnedFetchImpl: PinnedFetchImpl = requestWithPinnedAddress;
+
+// Test hook for deterministic network simulation without sockets.
+export function __setPinnedFetchImplForTests(
+  impl: PinnedFetchImpl | null,
+): void {
+  pinnedFetchImpl = impl ?? requestWithPinnedAddress;
+}
+
+async function resolveSafeUrlTarget(url: string): Promise<{
+  rejection: string | null;
+  target: ResolvedUrlTarget | null;
+}> {
   let parsed: URL;
   try {
     parsed = new URL(url);
   } catch {
-    return "Invalid URL format";
+    return { rejection: "Invalid URL format", target: null };
   }
 
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    return "Only http:// and https:// URLs are allowed";
+    return {
+      rejection: "Only http:// and https:// URLs are allowed",
+      target: null,
+    };
   }
 
   const hostname = normalizeHostLike(parsed.hostname);
-  if (!hostname) return "URL hostname is required";
+  if (!hostname) return { rejection: "URL hostname is required", target: null };
 
   if (BLOCKED_HOST_LITERALS.has(hostname)) {
-    return `URL host "${hostname}" is blocked for security reasons`;
+    return {
+      rejection: `URL host "${hostname}" is blocked for security reasons`,
+      target: null,
+    };
   }
 
   if (net.isIP(hostname)) {
     if (isBlockedIp(hostname)) {
-      return `URL host "${hostname}" is blocked for security reasons`;
+      return {
+        rejection: `URL host "${hostname}" is blocked for security reasons`,
+        target: null,
+      };
     }
-    return null;
+    return {
+      rejection: null,
+      target: {
+        parsed,
+        hostname,
+        pinnedAddress: hostname,
+      },
+    };
   }
 
   let addresses: Array<{ address: string }>;
@@ -273,19 +424,60 @@ async function resolveUrlSafetyRejection(url: string): Promise<string | null> {
     const resolved = await dnsLookup(hostname, { all: true });
     addresses = Array.isArray(resolved) ? resolved : [resolved];
   } catch {
-    return `Could not resolve URL host "${hostname}"`;
+    return {
+      rejection: `Could not resolve URL host "${hostname}"`,
+      target: null,
+    };
   }
 
   if (addresses.length === 0) {
-    return `Could not resolve URL host "${hostname}"`;
+    return {
+      rejection: `Could not resolve URL host "${hostname}"`,
+      target: null,
+    };
   }
   for (const entry of addresses) {
     if (isBlockedIp(entry.address)) {
-      return `URL host "${hostname}" resolves to blocked address ${entry.address}`;
+      return {
+        rejection: `URL host "${hostname}" resolves to blocked address ${entry.address}`,
+        target: null,
+      };
     }
   }
 
-  return null;
+  return {
+    rejection: null,
+    target: {
+      parsed,
+      hostname,
+      pinnedAddress: addresses[0]?.address ?? "",
+    },
+  };
+}
+
+async function fetchWithSafety(
+  url: string,
+  init: RequestInit,
+  timeoutMs = URL_FETCH_TIMEOUT_MS,
+): Promise<Response> {
+  const { rejection, target } = await resolveSafeUrlTarget(url);
+  if (rejection || !target || !target.pinnedAddress) {
+    throw new Error(rejection ?? "URL validation failed");
+  }
+
+  try {
+    return await pinnedFetchImpl({
+      url: target.parsed,
+      init,
+      target,
+      timeoutMs,
+    });
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw new Error(`URL fetch timed out after ${timeoutMs}ms`);
+    }
+    throw error;
+  }
 }
 
 function isYouTubeUrl(url: string): boolean {
@@ -315,7 +507,7 @@ function extractYouTubeVideoId(url: string): string | null {
 async function fetchYouTubeTranscript(videoId: string): Promise<string | null> {
   // Fetch the video page to get transcript data
   const watchUrl = `https://www.youtube.com/watch?v=${videoId}`;
-  const response = await fetchWithTimeout(watchUrl, {
+  const response = await fetchWithSafety(watchUrl, {
     headers: {
       "User-Agent":
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
@@ -357,7 +549,7 @@ async function fetchYouTubeTranscript(videoId: string): Promise<string | null> {
     .replace(/\\\//g, "/");
 
   // Fetch the transcript
-  const transcriptResponse = await fetchWithTimeout(captionUrl, {});
+  const transcriptResponse = await fetchWithSafety(captionUrl, {});
   if (!transcriptResponse.ok) {
     return null;
   }
@@ -408,42 +600,6 @@ function isAbortError(error: unknown): boolean {
   return error instanceof DOMException
     ? error.name === "AbortError"
     : error instanceof Error && error.name === "AbortError";
-}
-
-async function fetchWithTimeout(
-  input: RequestInfo | URL,
-  init: RequestInit,
-  timeoutMs = URL_FETCH_TIMEOUT_MS,
-): Promise<Response> {
-  const controller = new AbortController();
-  const upstreamSignal = init.signal;
-  const onAbort = () => controller.abort();
-
-  if (upstreamSignal) {
-    if (upstreamSignal.aborted) {
-      controller.abort();
-    } else {
-      upstreamSignal.addEventListener("abort", onAbort, { once: true });
-    }
-  }
-
-  const timeoutHandle = setTimeout(() => {
-    controller.abort();
-  }, timeoutMs);
-
-  try {
-    return await fetch(input, { ...init, signal: controller.signal });
-  } catch (error) {
-    if (isAbortError(error)) {
-      throw new Error(`URL fetch timed out after ${timeoutMs}ms`);
-    }
-    throw error;
-  } finally {
-    clearTimeout(timeoutHandle);
-    if (upstreamSignal) {
-      upstreamSignal.removeEventListener("abort", onAbort);
-    }
-  }
 }
 
 async function readResponseBodyWithLimit(
@@ -528,7 +684,7 @@ async function fetchUrlContent(
   }
 
   // Regular URL fetch
-  const response = await fetchWithTimeout(url, {
+  const response = await fetchWithSafety(url, {
     redirect: "manual",
     headers: {
       "User-Agent":
@@ -915,11 +1071,6 @@ export async function handleKnowledgeRoutes(
     }
 
     const urlToFetch = body.url.trim();
-    const safetyRejection = await resolveUrlSafetyRejection(urlToFetch);
-    if (safetyRejection) {
-      error(res, safetyRejection);
-      return true;
-    }
 
     // Fetch and process the URL content
     let content: string;


### PR DESCRIPTION
## Summary
- harden `/api/knowledge` URL import fetches against DNS rebinding by pinning outbound connect-time resolution to the validated IP
- replace pre-fetch TOCTOU checks with pinned transport (`node:http`/`node:https` + custom `lookup`) for URL fetch paths
- add deterministic test hook for pinned transport and regression coverage for destination pinning

## Why
The previous mitigation still performed DNS checks before `fetch(...)`, which can be bypassed by a fast rebind between validation and socket connect.

## Testing
- bunx vitest run src/api/knowledge-routes.test.ts
- bunx biome check src/api/knowledge-routes.ts src/api/knowledge-routes.test.ts

## Residual Risk (tracked separately)
Body-stream timeout is still not enforced end-to-end after headers are received; this is non-blocking for this PR and should be tracked as follow-up hardening.
