### PR TITLE
test: harden x402 and CUA runtime boundaries with explicit tests

### DIFF
--- a/src/benchmark/cua-boundary.test.ts
+++ b/src/benchmark/cua-boundary.test.ts
@@ -1,0 +1,903 @@
+/**
+ * Dedicated boundary tests for CUA (Computer Use Agent) route handlers,
+ * service utilities, and security permissions. Covers hasCuaConfig(),
+ * resolveHost(), resolvePort(), parseBooleanValue(), compactCuaStep/Result(),
+ * handleCuaRoute(), and CUA permission mapping.
+ *
+ * @see https://github.com/milady-ai/milaidy/issues/590
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AUTH_PROVIDER_PLUGINS } from "../config/plugin-auto-enable";
+import {
+  getRequiredPermissions,
+  SYSTEM_PERMISSIONS,
+} from "../permissions/registry";
+import { OPTIONAL_CORE_PLUGINS } from "../runtime/core-plugins";
+import {
+  createEnvSandbox,
+  createMockHttpResponse,
+  createMockIncomingMessage,
+  createMockJsonRequest,
+} from "../test-support/test-helpers";
+import { handleCuaRoute } from "./cua-routes";
+import type { BenchmarkSession, CuaServiceLike } from "./server-utils";
+import {
+  compactCuaResult,
+  compactCuaStep,
+  DEFAULT_HOST,
+  DEFAULT_PORT,
+  hasCuaConfig,
+  parseBooleanValue,
+  resolveHost,
+  resolvePort,
+} from "./server-utils";
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+function createMockCuaService(
+  overrides: Partial<CuaServiceLike> = {},
+): CuaServiceLike {
+  return {
+    runTask: vi.fn().mockResolvedValue({ status: "completed", steps: [] }),
+    approveLatest: vi
+      .fn()
+      .mockResolvedValue({ status: "completed", steps: [] }),
+    cancelLatest: vi.fn().mockResolvedValue(undefined),
+    screenshotBase64: vi.fn().mockResolvedValue("iVBORw0KGgo="),
+    getStatus: vi.fn().mockReturnValue({ running: false }),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Section 1: hasCuaConfig()
+// ---------------------------------------------------------------------------
+
+describe("hasCuaConfig", () => {
+  const envKeys = [
+    "CUA_HOST",
+    "CUA_API_KEY",
+    "CUA_SANDBOX_NAME",
+    "CUA_CONTAINER_NAME",
+  ] as const;
+
+  const sandbox = createEnvSandbox(envKeys);
+
+  beforeEach(() => sandbox.clear());
+  afterEach(() => sandbox.restore());
+
+  it("returns false when no CUA env vars are set", () => {
+    expect(hasCuaConfig()).toBe(false);
+  });
+
+  it("returns true for local mode (CUA_HOST only)", () => {
+    process.env.CUA_HOST = "http://localhost:6080";
+    expect(hasCuaConfig()).toBe(true);
+  });
+
+  it("returns true for cloud mode (CUA_API_KEY + CUA_SANDBOX_NAME)", () => {
+    process.env.CUA_API_KEY = "test-key";
+    process.env.CUA_SANDBOX_NAME = "sandbox-1";
+    expect(hasCuaConfig()).toBe(true);
+  });
+
+  it("returns true for cloud mode (CUA_API_KEY + CUA_CONTAINER_NAME)", () => {
+    process.env.CUA_API_KEY = "test-key";
+    process.env.CUA_CONTAINER_NAME = "container-1";
+    expect(hasCuaConfig()).toBe(true);
+  });
+
+  it("returns false for CUA_API_KEY alone (incomplete cloud config)", () => {
+    process.env.CUA_API_KEY = "test-key";
+    expect(hasCuaConfig()).toBe(false);
+  });
+
+  it("returns false for CUA_SANDBOX_NAME alone (no API key)", () => {
+    process.env.CUA_SANDBOX_NAME = "sandbox-1";
+    expect(hasCuaConfig()).toBe(false);
+  });
+
+  it("returns false when CUA_HOST is whitespace-only", () => {
+    process.env.CUA_HOST = "   ";
+    expect(hasCuaConfig()).toBe(false);
+  });
+
+  it("returns false when CUA_API_KEY is whitespace-only with sandbox set", () => {
+    process.env.CUA_API_KEY = "  ";
+    process.env.CUA_SANDBOX_NAME = "sandbox-1";
+    expect(hasCuaConfig()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Section 2: resolveHost() loopback enforcement
+// ---------------------------------------------------------------------------
+
+describe("resolveHost", () => {
+  const sandbox = createEnvSandbox(["MILADY_BENCH_HOST"]);
+
+  beforeEach(() => sandbox.clear());
+  afterEach(() => sandbox.restore());
+
+  it("defaults to 127.0.0.1 when env is unset", () => {
+    expect(resolveHost()).toBe("127.0.0.1");
+  });
+
+  it("accepts 127.0.0.1", () => {
+    process.env.MILADY_BENCH_HOST = "127.0.0.1";
+    expect(resolveHost()).toBe("127.0.0.1");
+  });
+
+  it("accepts ::1", () => {
+    process.env.MILADY_BENCH_HOST = "::1";
+    expect(resolveHost()).toBe("::1");
+  });
+
+  it("accepts localhost", () => {
+    process.env.MILADY_BENCH_HOST = "localhost";
+    expect(resolveHost()).toBe("localhost");
+  });
+
+  it("rejects 0.0.0.0 and falls back to default", () => {
+    process.env.MILADY_BENCH_HOST = "0.0.0.0";
+    expect(resolveHost()).toBe(DEFAULT_HOST);
+  });
+
+  it("rejects LAN IP and falls back to default", () => {
+    process.env.MILADY_BENCH_HOST = "192.168.1.100";
+    expect(resolveHost()).toBe(DEFAULT_HOST);
+  });
+
+  it("rejects external hostname and falls back to default", () => {
+    process.env.MILADY_BENCH_HOST = "evil.example.com";
+    expect(resolveHost()).toBe(DEFAULT_HOST);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Section 3: resolvePort()
+// ---------------------------------------------------------------------------
+
+describe("resolvePort", () => {
+  const sandbox = createEnvSandbox(["MILADY_BENCH_PORT"]);
+
+  beforeEach(() => sandbox.clear());
+  afterEach(() => sandbox.restore());
+
+  it("defaults to 3939 when env is unset", () => {
+    expect(resolvePort()).toBe(DEFAULT_PORT);
+  });
+
+  it("parses a valid port number", () => {
+    process.env.MILADY_BENCH_PORT = "8080";
+    expect(resolvePort()).toBe(8080);
+  });
+
+  it("falls back to default for non-numeric input", () => {
+    process.env.MILADY_BENCH_PORT = "not-a-port";
+    expect(resolvePort()).toBe(DEFAULT_PORT);
+  });
+
+  it("falls back to default for port 0", () => {
+    process.env.MILADY_BENCH_PORT = "0";
+    expect(resolvePort()).toBe(DEFAULT_PORT);
+  });
+
+  it("falls back to default for port > 65535", () => {
+    process.env.MILADY_BENCH_PORT = "70000";
+    expect(resolvePort()).toBe(DEFAULT_PORT);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Section 4: parseBooleanValue()
+// ---------------------------------------------------------------------------
+
+describe("parseBooleanValue", () => {
+  it("returns boolean value directly", () => {
+    expect(parseBooleanValue(true)).toBe(true);
+    expect(parseBooleanValue(false)).toBe(false);
+  });
+
+  it("returns true for non-zero numbers", () => {
+    expect(parseBooleanValue(1)).toBe(true);
+    expect(parseBooleanValue(-1)).toBe(true);
+  });
+
+  it("returns false for 0", () => {
+    expect(parseBooleanValue(0)).toBe(false);
+  });
+
+  it("parses truthy strings (case-insensitive)", () => {
+    for (const v of [
+      "1",
+      "true",
+      "TRUE",
+      "True",
+      "yes",
+      "YES",
+      "y",
+      "Y",
+      "on",
+      "ON",
+    ]) {
+      expect(parseBooleanValue(v)).toBe(true);
+    }
+  });
+
+  it("parses falsy strings (case-insensitive)", () => {
+    for (const v of [
+      "0",
+      "false",
+      "FALSE",
+      "False",
+      "no",
+      "NO",
+      "n",
+      "N",
+      "off",
+      "OFF",
+    ]) {
+      expect(parseBooleanValue(v)).toBe(false);
+    }
+  });
+
+  it("trims whitespace before parsing", () => {
+    expect(parseBooleanValue("  true  ")).toBe(true);
+    expect(parseBooleanValue("  false  ")).toBe(false);
+  });
+
+  it("returns default for unrecognized values", () => {
+    expect(parseBooleanValue("maybe")).toBe(false);
+    expect(parseBooleanValue("maybe", true)).toBe(true);
+    expect(parseBooleanValue(undefined)).toBe(false);
+    expect(parseBooleanValue(null)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Section 5: compactCuaStep() + compactCuaResult()
+// ---------------------------------------------------------------------------
+
+describe("compactCuaStep", () => {
+  it("strips screenshot when includeScreenshots is false", () => {
+    const step = { action: "click", screenshotAfterBase64: "base64data" };
+    const result = compactCuaStep(step, false);
+    expect(result).not.toHaveProperty("screenshotAfterBase64");
+    expect(result.hasScreenshot).toBe(true);
+  });
+
+  it("keeps screenshot when includeScreenshots is true", () => {
+    const step = { action: "click", screenshotAfterBase64: "base64data" };
+    const result = compactCuaStep(step, true);
+    expect(result.screenshotAfterBase64).toBe("base64data");
+    expect(result.hasScreenshot).toBe(true);
+  });
+
+  it("sets hasScreenshot to false when no screenshot present", () => {
+    const step = { action: "click" };
+    const result = compactCuaStep(step, false);
+    expect(result.hasScreenshot).toBe(false);
+  });
+
+  it("wraps non-record values", () => {
+    const result = compactCuaStep("not-a-record", false);
+    expect(result).toEqual({ step: "not-a-record" });
+  });
+
+  it("wraps null values", () => {
+    const result = compactCuaStep(null, false);
+    expect(result).toEqual({ step: null });
+  });
+});
+
+describe("compactCuaResult", () => {
+  it("compacts completed result with steps", () => {
+    const input = {
+      status: "completed",
+      steps: [{ action: "click", screenshotAfterBase64: "img" }],
+    };
+    const result = compactCuaResult(input, false);
+    expect(result.status).toBe("completed");
+    expect((result.steps as unknown[])[0]).not.toHaveProperty(
+      "screenshotAfterBase64",
+    );
+  });
+
+  it("compacts failed result with steps", () => {
+    const input = {
+      status: "failed",
+      steps: [{ action: "type", screenshotAfterBase64: "img" }],
+      error: "timeout",
+    };
+    const result = compactCuaResult(input, false);
+    expect(result.status).toBe("failed");
+    expect(result.error).toBe("timeout");
+  });
+
+  it("handles paused_for_approval with pending field", () => {
+    const input = {
+      status: "paused_for_approval",
+      pending: {
+        reason: "needs approval",
+        screenshotBeforeBase64: "before-img",
+        stepsSoFar: [{ action: "navigate", screenshotAfterBase64: "ss" }],
+      },
+    };
+    const result = compactCuaResult(input, false);
+    expect(result.status).toBe("paused_for_approval");
+    const pending = result.pending as Record<string, unknown>;
+    expect(pending).not.toHaveProperty("screenshotBeforeBase64");
+    expect(pending.hasScreenshotBefore).toBe(true);
+  });
+
+  it("returns unknown status for non-record input", () => {
+    const result = compactCuaResult("bad-input", false);
+    expect(result.status).toBe("unknown");
+    expect(result.raw).toBe("bad-input");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Section 6: handleCuaRoute() route handlers
+// ---------------------------------------------------------------------------
+
+describe("handleCuaRoute", () => {
+  // -- GET /status -----------------------------------------------------------
+
+  describe("GET /api/benchmark/cua/status", () => {
+    it("returns 503 when service is null", async () => {
+      const req = createMockIncomingMessage({
+        method: "GET",
+        url: "/api/benchmark/cua/status",
+      });
+      const { res, getStatus, getJson } = createMockHttpResponse();
+
+      const handled = await handleCuaRoute({
+        pathname: "/api/benchmark/cua/status",
+        req,
+        res,
+        getCuaService: () => null,
+        activeSession: null,
+      });
+
+      expect(handled).toBe(true);
+      expect(getStatus()).toBe(503);
+      expect(getJson()).toHaveProperty("ok", false);
+    });
+
+    it("returns 200 with status from service", async () => {
+      const service = createMockCuaService({
+        getStatus: vi.fn().mockReturnValue({ running: true, task: "browse" }),
+      });
+      const req = createMockIncomingMessage({
+        method: "GET",
+        url: "/api/benchmark/cua/status",
+      });
+      const { res, getStatus, getJson } = createMockHttpResponse();
+
+      const handled = await handleCuaRoute({
+        pathname: "/api/benchmark/cua/status",
+        req,
+        res,
+        getCuaService: () => service,
+        activeSession: null,
+      });
+
+      expect(handled).toBe(true);
+      expect(getStatus()).toBe(200);
+      expect(getJson()).toMatchObject({ ok: true, status: { running: true } });
+    });
+
+    it("returns 500 on service throw", async () => {
+      const service = createMockCuaService({
+        getStatus: vi.fn().mockImplementation(() => {
+          throw new Error("status boom");
+        }),
+      });
+      const req = createMockIncomingMessage({
+        method: "GET",
+        url: "/api/benchmark/cua/status",
+      });
+      const { res, getStatus, getJson } = createMockHttpResponse();
+
+      await handleCuaRoute({
+        pathname: "/api/benchmark/cua/status",
+        req,
+        res,
+        getCuaService: () => service,
+        activeSession: null,
+      });
+
+      expect(getStatus()).toBe(500);
+      expect(getJson()).toHaveProperty("error", "status boom");
+    });
+  });
+
+  // -- GET /screenshot -------------------------------------------------------
+
+  describe("GET /api/benchmark/cua/screenshot", () => {
+    it("returns 503 when service is null", async () => {
+      const req = createMockIncomingMessage({
+        method: "GET",
+        url: "/api/benchmark/cua/screenshot",
+      });
+      const { res, getStatus } = createMockHttpResponse();
+
+      const handled = await handleCuaRoute({
+        pathname: "/api/benchmark/cua/screenshot",
+        req,
+        res,
+        getCuaService: () => null,
+        activeSession: null,
+      });
+
+      expect(handled).toBe(true);
+      expect(getStatus()).toBe(503);
+    });
+
+    it("returns 200 with base64 screenshot", async () => {
+      const service = createMockCuaService({
+        screenshotBase64: vi.fn().mockResolvedValue("iVBORw0KGgoAAAA=="),
+      });
+      const req = createMockIncomingMessage({
+        method: "GET",
+        url: "/api/benchmark/cua/screenshot",
+      });
+      const { res, getStatus, getJson } = createMockHttpResponse();
+
+      await handleCuaRoute({
+        pathname: "/api/benchmark/cua/screenshot",
+        req,
+        res,
+        getCuaService: () => service,
+        activeSession: null,
+      });
+
+      expect(getStatus()).toBe(200);
+      const body = getJson() as Record<string, unknown>;
+      expect(body.ok).toBe(true);
+      expect(body.screenshot).toBe("iVBORw0KGgoAAAA==");
+      expect(body.mimeType).toBe("image/png");
+    });
+
+    it("returns 500 on service throw", async () => {
+      const service = createMockCuaService({
+        screenshotBase64: vi
+          .fn()
+          .mockRejectedValue(new Error("screenshot boom")),
+      });
+      const req = createMockIncomingMessage({
+        method: "GET",
+        url: "/api/benchmark/cua/screenshot",
+      });
+      const { res, getStatus, getJson } = createMockHttpResponse();
+
+      await handleCuaRoute({
+        pathname: "/api/benchmark/cua/screenshot",
+        req,
+        res,
+        getCuaService: () => service,
+        activeSession: null,
+      });
+
+      expect(getStatus()).toBe(500);
+      expect(getJson()).toHaveProperty("error", "screenshot boom");
+    });
+  });
+
+  // -- POST /run -------------------------------------------------------------
+
+  describe("POST /api/benchmark/cua/run", () => {
+    it("returns 503 when service is null", async () => {
+      const req = createMockJsonRequest(
+        { goal: "test goal" },
+        { method: "POST", url: "/api/benchmark/cua/run" },
+      );
+      const { res, getStatus } = createMockHttpResponse();
+
+      const handled = await handleCuaRoute({
+        pathname: "/api/benchmark/cua/run",
+        req,
+        res,
+        getCuaService: () => null,
+        activeSession: null,
+      });
+
+      expect(handled).toBe(true);
+      expect(getStatus()).toBe(503);
+    });
+
+    it("returns 400 for missing goal", async () => {
+      const service = createMockCuaService();
+      const req = createMockJsonRequest(
+        {},
+        { method: "POST", url: "/api/benchmark/cua/run" },
+      );
+      const { res, getStatus, getJson } = createMockHttpResponse();
+
+      await handleCuaRoute({
+        pathname: "/api/benchmark/cua/run",
+        req,
+        res,
+        getCuaService: () => service,
+        activeSession: null,
+      });
+
+      expect(getStatus()).toBe(400);
+      expect(getJson()).toHaveProperty("error");
+    });
+
+    it("returns 400 for empty goal string", async () => {
+      const service = createMockCuaService();
+      const req = createMockJsonRequest(
+        { goal: "   " },
+        { method: "POST", url: "/api/benchmark/cua/run" },
+      );
+      const { res, getStatus } = createMockHttpResponse();
+
+      await handleCuaRoute({
+        pathname: "/api/benchmark/cua/run",
+        req,
+        res,
+        getCuaService: () => service,
+        activeSession: null,
+      });
+
+      expect(getStatus()).toBe(400);
+    });
+
+    it("uses roomId from body when provided", async () => {
+      const service = createMockCuaService();
+      const req = createMockJsonRequest(
+        { goal: "browse web", roomId: "custom-room-123" },
+        { method: "POST", url: "/api/benchmark/cua/run" },
+      );
+      const { res } = createMockHttpResponse();
+
+      await handleCuaRoute({
+        pathname: "/api/benchmark/cua/run",
+        req,
+        res,
+        getCuaService: () => service,
+        activeSession: null,
+      });
+
+      expect(service.runTask).toHaveBeenCalledWith(
+        "custom-room-123",
+        "browse web",
+      );
+    });
+
+    it("uses session roomId as fallback", async () => {
+      const service = createMockCuaService();
+      const session = { roomId: "session-room" } as BenchmarkSession;
+      const req = createMockJsonRequest(
+        { goal: "browse web" },
+        { method: "POST", url: "/api/benchmark/cua/run" },
+      );
+      const { res } = createMockHttpResponse();
+
+      await handleCuaRoute({
+        pathname: "/api/benchmark/cua/run",
+        req,
+        res,
+        getCuaService: () => service,
+        activeSession: session,
+      });
+
+      expect(service.runTask).toHaveBeenCalledWith(
+        "session-room",
+        "browse web",
+      );
+    });
+
+    it("accepts snake_case params (room_id, auto_approve)", async () => {
+      const service = createMockCuaService();
+      const req = createMockJsonRequest(
+        { goal: "test", room_id: "snake-room", auto_approve: false },
+        { method: "POST", url: "/api/benchmark/cua/run" },
+      );
+      const { res, getJson } = createMockHttpResponse();
+
+      await handleCuaRoute({
+        pathname: "/api/benchmark/cua/run",
+        req,
+        res,
+        getCuaService: () => service,
+        activeSession: null,
+      });
+
+      const body = getJson() as Record<string, unknown>;
+      expect(body.room_id).toBe("snake-room");
+      expect(body.auto_approve).toBe(false);
+    });
+
+    it("runs auto-approve loop when enabled", async () => {
+      const service = createMockCuaService({
+        runTask: vi.fn().mockResolvedValue({ status: "paused_for_approval" }),
+        approveLatest: vi
+          .fn()
+          .mockResolvedValueOnce({ status: "paused_for_approval" })
+          .mockResolvedValueOnce({ status: "completed", steps: [] }),
+      });
+      const req = createMockJsonRequest(
+        { goal: "auto task", autoApprove: true },
+        { method: "POST", url: "/api/benchmark/cua/run" },
+      );
+      const { res, getJson } = createMockHttpResponse();
+
+      await handleCuaRoute({
+        pathname: "/api/benchmark/cua/run",
+        req,
+        res,
+        getCuaService: () => service,
+        activeSession: null,
+      });
+
+      const body = getJson() as Record<string, unknown>;
+      expect(body.approvals).toBe(2);
+      expect(service.approveLatest).toHaveBeenCalledTimes(2);
+    });
+
+    it("caps auto-approve loop at maxApprovals", async () => {
+      const service = createMockCuaService({
+        runTask: vi.fn().mockResolvedValue({ status: "paused_for_approval" }),
+        approveLatest: vi
+          .fn()
+          .mockResolvedValue({ status: "paused_for_approval" }),
+      });
+      const req = createMockJsonRequest(
+        { goal: "capped task", autoApprove: true, maxApprovals: 2 },
+        { method: "POST", url: "/api/benchmark/cua/run" },
+      );
+      const { res, getJson } = createMockHttpResponse();
+
+      await handleCuaRoute({
+        pathname: "/api/benchmark/cua/run",
+        req,
+        res,
+        getCuaService: () => service,
+        activeSession: null,
+      });
+
+      const body = getJson() as Record<string, unknown>;
+      expect(body.approvals).toBe(2);
+      expect(service.approveLatest).toHaveBeenCalledTimes(2);
+    });
+
+    it("returns 500 on service throw", async () => {
+      const service = createMockCuaService({
+        runTask: vi.fn().mockRejectedValue(new Error("run boom")),
+      });
+      const req = createMockJsonRequest(
+        { goal: "test" },
+        { method: "POST", url: "/api/benchmark/cua/run" },
+      );
+      const { res, getStatus, getJson } = createMockHttpResponse();
+
+      await handleCuaRoute({
+        pathname: "/api/benchmark/cua/run",
+        req,
+        res,
+        getCuaService: () => service,
+        activeSession: null,
+      });
+
+      expect(getStatus()).toBe(500);
+      expect(getJson()).toHaveProperty("error", "run boom");
+    });
+  });
+
+  // -- POST /approve ---------------------------------------------------------
+
+  describe("POST /api/benchmark/cua/approve", () => {
+    it("returns 503 when service is null", async () => {
+      const req = createMockJsonRequest(
+        {},
+        { method: "POST", url: "/api/benchmark/cua/approve" },
+      );
+      const { res, getStatus } = createMockHttpResponse();
+
+      await handleCuaRoute({
+        pathname: "/api/benchmark/cua/approve",
+        req,
+        res,
+        getCuaService: () => null,
+        activeSession: null,
+      });
+
+      expect(getStatus()).toBe(503);
+    });
+
+    it("returns 200 with result on success", async () => {
+      const service = createMockCuaService({
+        approveLatest: vi
+          .fn()
+          .mockResolvedValue({ status: "completed", steps: [] }),
+      });
+      const req = createMockJsonRequest(
+        { roomId: "room-1" },
+        { method: "POST", url: "/api/benchmark/cua/approve" },
+      );
+      const { res, getStatus, getJson } = createMockHttpResponse();
+
+      await handleCuaRoute({
+        pathname: "/api/benchmark/cua/approve",
+        req,
+        res,
+        getCuaService: () => service,
+        activeSession: null,
+      });
+
+      expect(getStatus()).toBe(200);
+      const body = getJson() as Record<string, unknown>;
+      expect(body.ok).toBe(true);
+      expect(body.room_id).toBe("room-1");
+    });
+
+    it("returns 500 on service throw", async () => {
+      const service = createMockCuaService({
+        approveLatest: vi.fn().mockRejectedValue(new Error("approve boom")),
+      });
+      const req = createMockJsonRequest(
+        {},
+        { method: "POST", url: "/api/benchmark/cua/approve" },
+      );
+      const { res, getStatus, getJson } = createMockHttpResponse();
+
+      await handleCuaRoute({
+        pathname: "/api/benchmark/cua/approve",
+        req,
+        res,
+        getCuaService: () => service,
+        activeSession: null,
+      });
+
+      expect(getStatus()).toBe(500);
+      expect(getJson()).toHaveProperty("error", "approve boom");
+    });
+  });
+
+  // -- POST /cancel ----------------------------------------------------------
+
+  describe("POST /api/benchmark/cua/cancel", () => {
+    it("returns 503 when service is null", async () => {
+      const req = createMockJsonRequest(
+        {},
+        { method: "POST", url: "/api/benchmark/cua/cancel" },
+      );
+      const { res, getStatus } = createMockHttpResponse();
+
+      await handleCuaRoute({
+        pathname: "/api/benchmark/cua/cancel",
+        req,
+        res,
+        getCuaService: () => null,
+        activeSession: null,
+      });
+
+      expect(getStatus()).toBe(503);
+    });
+
+    it("returns 200 with cancelled status", async () => {
+      const service = createMockCuaService();
+      const req = createMockJsonRequest(
+        { room_id: "cancel-room" },
+        { method: "POST", url: "/api/benchmark/cua/cancel" },
+      );
+      const { res, getStatus, getJson } = createMockHttpResponse();
+
+      await handleCuaRoute({
+        pathname: "/api/benchmark/cua/cancel",
+        req,
+        res,
+        getCuaService: () => service,
+        activeSession: null,
+      });
+
+      expect(getStatus()).toBe(200);
+      const body = getJson() as Record<string, unknown>;
+      expect(body.ok).toBe(true);
+      expect(body.status).toBe("cancelled");
+      expect(body.room_id).toBe("cancel-room");
+    });
+
+    it("returns 500 on service throw", async () => {
+      const service = createMockCuaService({
+        cancelLatest: vi.fn().mockRejectedValue(new Error("cancel boom")),
+      });
+      const req = createMockJsonRequest(
+        {},
+        { method: "POST", url: "/api/benchmark/cua/cancel" },
+      );
+      const { res, getStatus, getJson } = createMockHttpResponse();
+
+      await handleCuaRoute({
+        pathname: "/api/benchmark/cua/cancel",
+        req,
+        res,
+        getCuaService: () => service,
+        activeSession: null,
+      });
+
+      expect(getStatus()).toBe(500);
+      expect(getJson()).toHaveProperty("error", "cancel boom");
+    });
+  });
+
+  // -- Route matching --------------------------------------------------------
+
+  describe("route matching", () => {
+    it("returns false for unknown path", async () => {
+      const req = createMockIncomingMessage({
+        method: "GET",
+        url: "/api/benchmark/cua/unknown",
+      });
+      const { res } = createMockHttpResponse();
+
+      const handled = await handleCuaRoute({
+        pathname: "/api/benchmark/cua/unknown",
+        req,
+        res,
+        getCuaService: () => createMockCuaService(),
+        activeSession: null,
+      });
+
+      expect(handled).toBe(false);
+    });
+
+    it("returns false for wrong HTTP method", async () => {
+      const req = createMockIncomingMessage({
+        method: "POST",
+        url: "/api/benchmark/cua/status",
+      });
+      const { res } = createMockHttpResponse();
+
+      const handled = await handleCuaRoute({
+        pathname: "/api/benchmark/cua/status",
+        req,
+        res,
+        getCuaService: () => createMockCuaService(),
+        activeSession: null,
+      });
+
+      expect(handled).toBe(false);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Section 7: CUA permission + mapping
+// ---------------------------------------------------------------------------
+
+describe("CUA permission and plugin mapping", () => {
+  it("CUA requires accessibility and screen-recording permissions", () => {
+    const perms = getRequiredPermissions("cua");
+    expect(perms).toContain("accessibility");
+    expect(perms).toContain("screen-recording");
+    expect(perms).toHaveLength(2);
+  });
+
+  it("accessibility permission is darwin-only", () => {
+    const perm = SYSTEM_PERMISSIONS.find((p) => p.id === "accessibility");
+    expect(perm?.platforms).toEqual(["darwin"]);
+  });
+
+  it("screen-recording permission is darwin-only", () => {
+    const perm = SYSTEM_PERMISSIONS.find((p) => p.id === "screen-recording");
+    expect(perm?.platforms).toEqual(["darwin"]);
+  });
+
+  it("@elizaos/plugin-cua is in OPTIONAL_CORE_PLUGINS", () => {
+    expect(OPTIONAL_CORE_PLUGINS).toContain("@elizaos/plugin-cua");
+  });
+
+  it("AUTH_PROVIDER_PLUGINS maps both CUA_API_KEY and CUA_HOST to CUA plugin", () => {
+    expect(AUTH_PROVIDER_PLUGINS.CUA_API_KEY).toBe("@elizaos/plugin-cua");
+    expect(AUTH_PROVIDER_PLUGINS.CUA_HOST).toBe("@elizaos/plugin-cua");
+  });
+});

--- a/src/runtime/x402-boundary.test.ts
+++ b/src/runtime/x402-boundary.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Dedicated boundary tests for x402 (payment protocol) security and runtime
+ * integration. Covers env-forwarding denylist, config-to-env propagation,
+ * plugin mapping, and character secrets — all without starting a runtime.
+ *
+ * @see https://github.com/milady-ai/milaidy/issues/590
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { MiladyConfig } from "../config/config";
+import { AUTH_PROVIDER_PLUGINS } from "../config/plugin-auto-enable";
+import {
+  applyX402ConfigToEnv,
+  buildCharacterFromConfig,
+  collectPluginNames,
+  isEnvKeyAllowedForForwarding,
+} from "./eliza";
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+function envSnapshot(keys: string[]): {
+  save: () => void;
+  restore: () => void;
+} {
+  const saved = new Map<string, string | undefined>();
+  return {
+    save() {
+      for (const k of keys) saved.set(k, process.env[k]);
+    },
+    restore() {
+      for (const [k, v] of saved) {
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+    },
+  };
+}
+
+const EMPTY_CONFIG: MiladyConfig = {} as MiladyConfig;
+
+// ---------------------------------------------------------------------------
+// Section 1: Env forwarding denylist (security)
+// ---------------------------------------------------------------------------
+
+describe("isEnvKeyAllowedForForwarding – x402 boundaries", () => {
+  it("blocks X402_SELLER_PRIVATE_KEY (pattern match, not exact)", () => {
+    expect(isEnvKeyAllowedForForwarding("X402_SELLER_PRIVATE_KEY")).toBe(false);
+  });
+
+  it("blocks lowercase private_key variants", () => {
+    expect(isEnvKeyAllowedForForwarding("x402_private_key")).toBe(false);
+  });
+
+  it("blocks PRIVATE_KEY embedded anywhere in key name", () => {
+    expect(isEnvKeyAllowedForForwarding("MY_PRIVATE_KEY_BACKUP")).toBe(false);
+  });
+
+  it("allows non-secret x402 operational vars", () => {
+    const allowed = [
+      "X402_ENABLED",
+      "X402_NETWORK",
+      "X402_PAY_TO",
+      "X402_FACILITATOR_URL",
+      "X402_MAX_PAYMENT_USD",
+      "X402_MAX_TOTAL_USD",
+      "X402_DB_PATH",
+    ];
+    for (const key of allowed) {
+      expect(isEnvKeyAllowedForForwarding(key)).toBe(true);
+    }
+  });
+
+  it("blocks EVM_PRIVATE_KEY even in x402 context", () => {
+    expect(isEnvKeyAllowedForForwarding("EVM_PRIVATE_KEY")).toBe(false);
+  });
+
+  it("blocks SOLANA_PRIVATE_KEY even in x402 context", () => {
+    expect(isEnvKeyAllowedForForwarding("SOLANA_PRIVATE_KEY")).toBe(false);
+  });
+
+  it("blocks EVM_ prefix vars (wallet keys)", () => {
+    expect(isEnvKeyAllowedForForwarding("EVM_MNEMONIC_PHRASE")).toBe(false);
+  });
+
+  it("blocks SOLANA_ prefix vars (wallet keys)", () => {
+    expect(isEnvKeyAllowedForForwarding("SOLANA_SECRET_SEED")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Section 2: Config type boundary – applyX402ConfigToEnv
+// ---------------------------------------------------------------------------
+
+describe("applyX402ConfigToEnv – propagation boundaries", () => {
+  const ENV_KEYS = [
+    "X402_ENABLED",
+    "X402_API_KEY",
+    "X402_BASE_URL",
+    "X402_NETWORK",
+    "X402_PAY_TO",
+    "X402_FACILITATOR_URL",
+    "X402_MAX_PAYMENT_USD",
+    "X402_MAX_TOTAL_USD",
+    "X402_DB_PATH",
+    "X402_PRIVATE_KEY",
+  ];
+
+  const snap = envSnapshot(ENV_KEYS);
+
+  beforeEach(() => snap.save());
+  afterEach(() => snap.restore());
+
+  it("propagates only ENABLED, API_KEY, BASE_URL from full config", () => {
+    // Clear all x402 env vars
+    for (const k of ENV_KEYS) delete process.env[k];
+
+    const config = {
+      x402: {
+        enabled: true,
+        apiKey: "test-key-123",
+        baseUrl: "https://x402.example.com",
+        privateKey: "0xDEADBEEF",
+        network: "base-sepolia",
+        payTo: "0x1234",
+        facilitatorUrl: "https://facilitator.example.com",
+        maxPaymentUsd: 10,
+        maxTotalUsd: 100,
+        dbPath: "/tmp/x402.db",
+      },
+    } as unknown as MiladyConfig;
+
+    applyX402ConfigToEnv(config);
+
+    // These 3 should be set
+    expect(process.env.X402_ENABLED).toBe("true");
+    expect(process.env.X402_API_KEY).toBe("test-key-123");
+    expect(process.env.X402_BASE_URL).toBe("https://x402.example.com");
+
+    // These should NOT be propagated
+    expect(process.env.X402_NETWORK).toBeUndefined();
+    expect(process.env.X402_PAY_TO).toBeUndefined();
+    expect(process.env.X402_FACILITATOR_URL).toBeUndefined();
+    expect(process.env.X402_MAX_PAYMENT_USD).toBeUndefined();
+    expect(process.env.X402_MAX_TOTAL_USD).toBeUndefined();
+    expect(process.env.X402_DB_PATH).toBeUndefined();
+    expect(process.env.X402_PRIVATE_KEY).toBeUndefined();
+  });
+
+  it("never leaks privateKey to any process.env entry", () => {
+    for (const k of ENV_KEYS) delete process.env[k];
+
+    const marker = `SUPER_SECRET_MARKER_${Date.now()}`;
+    const config = {
+      x402: {
+        enabled: true,
+        privateKey: marker,
+        apiKey: "safe-key",
+        baseUrl: "https://safe.example.com",
+      },
+    } as unknown as MiladyConfig;
+
+    applyX402ConfigToEnv(config);
+
+    // Scan ALL env vars for the marker
+    for (const [_key, value] of Object.entries(process.env)) {
+      expect(value).not.toBe(marker);
+    }
+  });
+
+  it("does nothing when x402.enabled is false", () => {
+    for (const k of ENV_KEYS) delete process.env[k];
+
+    const config = {
+      x402: { enabled: false, apiKey: "should-not-appear" },
+    } as unknown as MiladyConfig;
+
+    applyX402ConfigToEnv(config);
+
+    expect(process.env.X402_ENABLED).toBeUndefined();
+    expect(process.env.X402_API_KEY).toBeUndefined();
+  });
+
+  it("does nothing when x402 section is absent", () => {
+    for (const k of ENV_KEYS) delete process.env[k];
+
+    applyX402ConfigToEnv(EMPTY_CONFIG);
+
+    expect(process.env.X402_ENABLED).toBeUndefined();
+  });
+
+  it("does not set API_KEY when apiKey is empty string", () => {
+    for (const k of ENV_KEYS) delete process.env[k];
+
+    const config = {
+      x402: { enabled: true, apiKey: "", baseUrl: "" },
+    } as unknown as MiladyConfig;
+
+    applyX402ConfigToEnv(config);
+
+    expect(process.env.X402_ENABLED).toBe("true");
+    expect(process.env.X402_API_KEY).toBeUndefined();
+    expect(process.env.X402_BASE_URL).toBeUndefined();
+  });
+
+  it("does not overwrite pre-existing env vars", () => {
+    process.env.X402_ENABLED = "already-set";
+    process.env.X402_API_KEY = "original-key";
+
+    const config = {
+      x402: { enabled: true, apiKey: "new-key" },
+    } as unknown as MiladyConfig;
+
+    applyX402ConfigToEnv(config);
+
+    expect(process.env.X402_ENABLED).toBe("already-set");
+    expect(process.env.X402_API_KEY).toBe("original-key");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Section 3: Runtime plugin mapping
+// ---------------------------------------------------------------------------
+
+describe("x402 plugin mapping", () => {
+  const snap = envSnapshot([
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "X402_ENABLED",
+  ]);
+
+  beforeEach(() => {
+    snap.save();
+    // Provide a model provider so collectPluginNames doesn't complain
+    process.env.ANTHROPIC_API_KEY = "test";
+  });
+  afterEach(() => snap.restore());
+
+  it("collectPluginNames includes @elizaos/plugin-x402 when config.x402.enabled", () => {
+    const config = { x402: { enabled: true } } as unknown as MiladyConfig;
+    const names = collectPluginNames(config);
+    expect(names.has("@elizaos/plugin-x402")).toBe(true);
+  });
+
+  it("collectPluginNames excludes @elizaos/plugin-x402 when x402 not enabled", () => {
+    const names = collectPluginNames(EMPTY_CONFIG);
+    expect(names.has("@elizaos/plugin-x402")).toBe(false);
+  });
+
+  it("x402 is NOT in AUTH_PROVIDER_PLUGINS values", () => {
+    const authPluginValues = Object.values(AUTH_PROVIDER_PLUGINS);
+    expect(authPluginValues).not.toContain("@elizaos/plugin-x402");
+  });
+
+  it("both config path and features path produce exactly one entry", () => {
+    const config = {
+      x402: { enabled: true },
+      features: { x402: true },
+    } as unknown as MiladyConfig;
+
+    const names = collectPluginNames(config);
+    const x402Entries = [...names].filter((n) => n === "@elizaos/plugin-x402");
+    expect(x402Entries).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Section 4: Character secrets propagation
+// ---------------------------------------------------------------------------
+
+describe("buildCharacterFromConfig – x402 secrets", () => {
+  const X402_SECRET_KEYS = [
+    "X402_PRIVATE_KEY",
+    "X402_NETWORK",
+    "X402_PAY_TO",
+    "X402_FACILITATOR_URL",
+    "X402_MAX_PAYMENT_USD",
+    "X402_MAX_TOTAL_USD",
+    "X402_ENABLED",
+    "X402_DB_PATH",
+  ];
+
+  const ALL_SECRET_ENV_KEYS = [
+    ...X402_SECRET_KEYS,
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+  ];
+
+  const snap = envSnapshot(ALL_SECRET_ENV_KEYS);
+
+  beforeEach(() => {
+    snap.save();
+    // Clear all x402 env vars
+    for (const k of ALL_SECRET_ENV_KEYS) delete process.env[k];
+  });
+  afterEach(() => snap.restore());
+
+  it("includes all 8 X402_* keys in character secrets when set", () => {
+    for (const key of X402_SECRET_KEYS) {
+      process.env[key] = `test-value-${key}`;
+    }
+
+    const character = buildCharacterFromConfig(EMPTY_CONFIG);
+
+    for (const key of X402_SECRET_KEYS) {
+      expect(character.secrets).toHaveProperty(key, `test-value-${key}`);
+    }
+  });
+
+  it("omits x402 secrets when env vars are not set", () => {
+    const character = buildCharacterFromConfig(EMPTY_CONFIG);
+
+    for (const key of X402_SECRET_KEYS) {
+      expect(character.secrets).not.toHaveProperty(key);
+    }
+  });
+
+  it("omits x402 secrets when env vars are whitespace-only", () => {
+    for (const key of X402_SECRET_KEYS) {
+      process.env[key] = "   ";
+    }
+
+    const character = buildCharacterFromConfig(EMPTY_CONFIG);
+
+    for (const key of X402_SECRET_KEYS) {
+      expect(character.secrets).not.toHaveProperty(key);
+    }
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -132,6 +132,12 @@ export default defineConfig({
         replacement: path.join(repoRoot, "test", "stubs", "empty-module.mjs"),
       },
       {
+        // @elizaos/plugin-repoprompt has a broken package.json entry; redirect
+        // to an empty stub so Vite import analysis doesn't fail.
+        find: "@elizaos/plugin-repoprompt",
+        replacement: path.join(repoRoot, "test", "stubs", "empty-module.mjs"),
+      },
+      {
         find: "electron",
         replacement: path.join(repoRoot, "test", "stubs", "electron-module.ts"),
       },


### PR DESCRIPTION
## Summary
- Add **85 dedicated boundary tests** across 2 new test files covering x402 payment protocol and CUA runtime integration — areas previously with **zero** dedicated test coverage
- Fix pre-existing broken `@elizaos/plugin-repoprompt` Vite alias that was causing all `eliza.ts` test imports to fail

## New Test Files

### `src/runtime/x402-boundary.test.ts` (21 tests)
- **Env forwarding denylist security**: validates `isEnvKeyAllowedForForwarding()` blocks `PRIVATE_KEY` variants, `EVM_*`, `SOLANA_*` keys while allowing operational x402 config vars
- **Config-to-env propagation**: validates `applyX402ConfigToEnv()` only propagates `ENABLED`/`API_KEY`/`BASE_URL`, never leaks `privateKey`, handles disabled/missing/empty configs
- **Plugin mapping**: validates `collectPluginNames()` x402 inclusion, deduplication, and absence from `AUTH_PROVIDER_PLUGINS`
- **Character secrets**: validates `buildCharacterFromConfig()` includes all 8 `X402_*` keys in secrets

### `src/benchmark/cua-boundary.test.ts` (64 tests)
- **`hasCuaConfig()`**: local mode, cloud mode (sandbox/container), incomplete configs, whitespace edge cases
- **`resolveHost()` loopback enforcement**: accepts only `127.0.0.1`/`::1`/`localhost`, rejects `0.0.0.0`/LAN IPs/external hostnames
- **`resolvePort()`**: default 3939, valid parse, non-numeric/zero/overflow fallback
- **`parseBooleanValue()`**: boolean/number/string coercion, case-insensitive, whitespace trimming, defaults
- **`compactCuaStep()`/`compactCuaResult()`**: screenshot stripping, hasScreenshot flag, all result states
- **`handleCuaRoute()`**: all 5 routes (status/screenshot/run/approve/cancel) with 503/200/400/500 responses, roomId resolution, snake_case+camelCase params, auto-approve loop with maxApprovals cap, route matching
- **CUA permissions + mapping**: required permissions, darwin-only platform, `OPTIONAL_CORE_PLUGINS` membership

## Test plan
- [x] `bunx vitest run src/runtime/x402-boundary.test.ts src/benchmark/cua-boundary.test.ts` — 85/85 pass
- [x] `bun run test:once` — full suite regression (4204 tests pass, 0 failures)
- [x] `bun run check` — lint/format clean

Closes #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)