### PR TITLE
test: close auth test gaps on sensitive ingress paths

### DIFF
--- a/src/api/server.wallet-export-auth.test.ts
+++ b/src/api/server.wallet-export-auth.test.ts
@@ -116,4 +116,40 @@ describe("resolveWalletExportRejection", () => {
         "Wallet export is disabled. Set MILADY_WALLET_EXPORT_TOKEN to enable secure exports.",
     });
   });
+
+  it("rejects confirm: false explicitly", () => {
+    process.env.MILADY_WALLET_EXPORT_TOKEN = "secret-token";
+    const rejection = resolveWalletExportRejection(
+      req() as http.IncomingMessage,
+      { confirm: false },
+    );
+    expect(rejection?.status).toBe(403);
+    expect(rejection?.reason).toContain("confirm");
+  });
+
+  it("treats whitespace-only body exportToken as missing", () => {
+    process.env.MILADY_WALLET_EXPORT_TOKEN = "secret-token";
+    const rejection = resolveWalletExportRejection(
+      req() as http.IncomingMessage,
+      { confirm: true, exportToken: "   " },
+    );
+    expect(rejection).toEqual({
+      status: 401,
+      reason:
+        "Missing export token. Provide X-Milady-Export-Token header or exportToken in request body.",
+    });
+  });
+
+  it("treats whitespace-only header X-Milady-Export-Token as missing", () => {
+    process.env.MILADY_WALLET_EXPORT_TOKEN = "secret-token";
+    const rejection = resolveWalletExportRejection(
+      req({ "x-milady-export-token": "   " }) as http.IncomingMessage,
+      { confirm: true },
+    );
+    expect(rejection).toEqual({
+      status: 401,
+      reason:
+        "Missing export token. Provide X-Milady-Export-Token header or exportToken in request body.",
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes #591 (MW-04, P0)

- **+16 security edge-case tests** across 3 existing test files — no new files created
- Covers previously untested code paths for WebSocket auth, MCP config validation, and wallet export auth

### WebSocket auth (`server.websocket-auth.test.ts`, +4 tests)
- Rejects whitespace-only bearer token (`"Bearer   "` → 401)
- Accepts `apiKey` and `api_key` query token variants when enabled
- Accepts `null` origin when `MILADY_ALLOW_NULL_ORIGIN=1`

### MCP config validation (`server.mcp-config-validation.test.ts`, +9 tests)
- V8 inspector flag blocking: `--inspect` / `--inspect-brk` for node and bun
- Prototype pollution guards: `__proto__` and `$include` as server names
- Deep nested blocked key detection via `hasBlockedObjectKeyDeep`
- `$include` as env key injection
- Non-object env rejection (array, null)

### Wallet export auth (`server.wallet-export-auth.test.ts`, +3 tests)
- Explicit `confirm: false` rejection
- Whitespace-only body `exportToken` treated as missing → 401
- Whitespace-only header `X-Milady-Export-Token` treated as missing → 401

## Test plan

- [x] `bunx vitest run src/api/server.websocket-auth.test.ts src/api/server.mcp-config-validation.test.ts src/api/server.wallet-export-auth.test.ts` — 65/65 pass
- [x] `bun run test:once` — 3769 tests pass, no regressions (sole failure is pre-existing `@elizaos/plugin-repoprompt` package resolution)
- [x] `bun run check` — no lint errors in modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)