### PR TITLE
docs: expand media-generation runbook for MW-11 completeness

### DIFF
--- a/INTEGRATION_DOD_MAP.md
+++ b/INTEGRATION_DOD_MAP.md
@@ -614,7 +614,7 @@ Prioritization order applied: correctness/security first, then reliability/obser
   - `docs/plugins/skills.md` — added Skill Operations Runbook covering catalog, marketplace, and skill loading failure modes with recovery procedures.
   - `docs/guides/connectors.md` — added platform-specific failure modes for Discord, Telegram, Slack, and WhatsApp with recovery procedures.
   - `docs/plugin-registry/computeruse.md` — added vision model selection, action failure taxonomy, sandbox configuration, cross-platform guidance, and recovery procedures.
-  - `docs/guides/media-generation.md` — already comprehensive (no changes needed).
+  - `docs/guides/media-generation.md` — expanded runbook with provider-specific failure modes (auth, empty responses, Ollama, Google Veo polling), recovery procedures (credential rotation, fallback debugging, Ollama model corruption), and a 5-item setup checklist.
 - Acceptance criteria:
   - Registry/drop, skill catalog, media provider, connector specifics, and CUA operations have setup, failure, and verify guidance.
 - Verification commands:


### PR DESCRIPTION
## Summary
- Expanded `docs/guides/media-generation.md` runbook to close the last MW-11 gap — it was missing recovery procedures and had minimal setup/failure coverage compared to the other four runbook files
- Updated `INTEGRATION_DOD_MAP.md` MW-11 resolution note to reflect the expansion

### Changes to `docs/guides/media-generation.md`
- **Setup Checklist**: 3 items → 5 items (added Ollama prereqs, Cloud fallback awareness, network connectivity)
- **Failure Modes**: 3 brief bullets → 3 categorized subsections with real error strings from `src/providers/media-provider.ts` (provider auth/selection, generation failures, Ollama-specific)
- **Recovery Procedures**: Added 3 procedures (credential rotation, fallback debugging, Ollama model corruption) — this section was entirely missing
- **Verification Commands**: Added comments for clarity

## Test plan
- [x] Verified all 5 MW-11 doc files now have complete runbook sections (setup, failure modes, recovery, verification)
- [x] Confirmed error messages in failure modes match actual strings in `src/providers/media-provider.ts`
- [x] Ran `bun run check` — no new lint errors introduced (pre-existing `tsconfig.json` format issues only)

Closes milady-ai/milady#598

🤖 Generated with [Claude Code](https://claude.com/claude-code)