### PR TITLE
ci: enforce db:check in CI and agent review for MW-12

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -173,6 +173,7 @@ jobs:
             - Bug fixes MUST include a regression test
             - New features MUST include unit tests
             - Coverage thresholds: 25% lines/functions/statements, 15% branches (enforced in vitest.config.ts)
+            - Database changes (routes, adapters, query logic): `bun run db:check` must pass (verifies security hardening and read-only query guards)
 
             ### 5. Dark Forest Awareness
             Assume adversarial intent until proven otherwise. Ask yourself:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,27 @@ jobs:
           path: coverage/
           retention-days: 14
 
+  db-check:
+    name: Database Security Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run repository postinstall patches
+        run: bun run postinstall
+
+      - name: Run database security and query-guard tests
+        run: bun run db:check
+
   e2e-tests:
     name: E2E Tests (Vitest)
     runs-on: ubuntu-latest
@@ -237,13 +258,14 @@ jobs:
   test-status:
     name: All Tests Passed
     if: always()
-    needs: [unit-tests, e2e-tests, app-startup-e2e, electron-ui-e2e, electron-packaged-dmg-e2e, cloud-live-e2e, validation-e2e]
+    needs: [unit-tests, db-check, e2e-tests, app-startup-e2e, electron-ui-e2e, electron-packaged-dmg-e2e, cloud-live-e2e, validation-e2e]
     runs-on: ubuntu-latest
     steps:
       - name: Check test results
         run: |
           # Note: electron jobs are optional (macOS packaging can have flaky deps)
           if [[ "${{ needs.unit-tests.result }}" == "failure" || \
+                "${{ needs.db-check.result }}" == "failure" || \
                 "${{ needs.e2e-tests.result }}" == "failure" || \
                 "${{ needs.app-startup-e2e.result }}" == "failure" || \
                 "${{ needs.cloud-live-e2e.result }}" == "failure" || \

--- a/INTEGRATION_DOD_MAP.md
+++ b/INTEGRATION_DOD_MAP.md
@@ -632,7 +632,7 @@ Prioritization order applied: correctness/security first, then reliability/obser
 - Acceptance criteria:
   - `db:check` (or documented explicit N/A policy) exists and is enforced in docs/workflow.
 - Resolution:
-  - `bun run db:check` exists in `package.json` — runs database security and read-only query-guard tests (20 tests).
+  - `bun run db:check` exists in `package.json` — runs database security and read-only query-guard tests (30 tests).
   - **Explicit N/A policy for manual migrations:** `@elizaos/plugin-sql` auto-applies schema migrations on startup. There are no user-managed migration files. Schema versioning is embedded in the plugin package. See `docs/plugin-registry/sql.md` §Migrations.
 - Verification commands:
   - `bun run db:check`
@@ -719,7 +719,7 @@ bunx vitest run --config vitest.e2e.config.ts test/e2e-validation.e2e.test.ts
 bun run db:check
 ```
 
-- Runs database security tests and read-only query-guard tests (20 tests).
+- Runs database security tests and read-only query-guard tests (30 tests).
 - **Migration policy (N/A):** `@elizaos/plugin-sql` auto-applies schema migrations on startup — there are no user-managed migration files and no manual migration step is required. Schema versions are embedded in the plugin package.
 
 ---


### PR DESCRIPTION
## Summary
- Added `db-check` job to `.github/workflows/test.yml` — runs `bun run db:check` (30 database security + query-guard tests) on every push/PR to main/develop
- Wired `db-check` into the `test-status` gate job so failures block merge
- Added db:check requirement to `.github/workflows/agent-review.yml` prompt so the agent reviewer enforces it for database-related PRs
- Fixed test count in `INTEGRATION_DOD_MAP.md` (was "20 tests", actual is 30)

## Context
MW-12 acceptance criteria: "`db:check` (or documented explicit N/A policy) exists and is **enforced** in docs/workflow."

The command existed and was documented in 4 places (CONTRIBUTING.md, contribution-guide.md, sql.md, INTEGRATION_DOD_MAP.md), but was **not enforced by any automation** — a PR touching database code could merge without db:check ever running.

## Test plan
- [x] `bun run db:check` passes locally (30/30 tests green)
- [x] New CI job follows existing test.yml patterns (checkout → setup bun → install → postinstall → run)
- [x] `db-check` added to `test-status` needs array and failure check
- [x] Agent review prompt addition is minimal and scoped to database changes

Closes milady-ai/milady#599

🤖 Generated with [Claude Code](https://claude.com/claude-code)