### PR TITLE
feat(coding-agent): add dynamic agent selection strategy

### DIFF
--- a/apps/app/src/components/CodingAgentSettingsSection.tsx
+++ b/apps/app/src/components/CodingAgentSettingsSection.tsx
@@ -6,6 +6,7 @@ type AgentTab = "claude" | "gemini" | "codex" | "aider" | "pi";
 type ConfigurableAgentTab = Exclude<AgentTab, "pi">;
 type AiderProvider = "anthropic" | "openai" | "google";
 type ApprovalPreset = "readonly" | "standard" | "permissive" | "autonomous";
+type AgentSelectionStrategy = "fixed" | "ranked";
 
 const APPROVAL_PRESETS: {
   value: ApprovalPreset;
@@ -121,6 +122,11 @@ export function CodingAgentSettingsSection() {
         if (env.PARALLAX_DEFAULT_APPROVAL_PRESET)
           loaded.PARALLAX_DEFAULT_APPROVAL_PRESET =
             env.PARALLAX_DEFAULT_APPROVAL_PRESET;
+        if (env.PARALLAX_AGENT_SELECTION_STRATEGY)
+          loaded.PARALLAX_AGENT_SELECTION_STRATEGY =
+            env.PARALLAX_AGENT_SELECTION_STRATEGY;
+        if (env.PARALLAX_DEFAULT_AGENT_TYPE)
+          loaded.PARALLAX_DEFAULT_AGENT_TYPE = env.PARALLAX_DEFAULT_AGENT_TYPE;
         setPrefs(loaded);
 
         // Process fetched models — filter to "chat" category only
@@ -219,9 +225,55 @@ export function CodingAgentSettingsSection() {
 
   const approvalPreset = (prefs.PARALLAX_DEFAULT_APPROVAL_PRESET ||
     "permissive") as ApprovalPreset;
+  const selectionStrategy = (prefs.PARALLAX_AGENT_SELECTION_STRATEGY ||
+    "fixed") as AgentSelectionStrategy;
+  const defaultAgentType = (prefs.PARALLAX_DEFAULT_AGENT_TYPE ||
+    "claude") as ConfigurableAgentTab;
 
   return (
     <div className="flex flex-col gap-4">
+      {/* Agent selection strategy */}
+      <div className="flex flex-col gap-1.5">
+        <span className="text-xs font-semibold">Agent Selection Strategy</span>
+        <select
+          className="px-2.5 py-1.5 border border-[var(--border)] bg-[var(--card)] text-xs focus:border-[var(--accent)] focus:outline-none"
+          value={selectionStrategy}
+          onChange={(e) =>
+            setPref("PARALLAX_AGENT_SELECTION_STRATEGY", e.target.value)
+          }
+        >
+          <option value="fixed">Fixed</option>
+          <option value="ranked">Ranked (auto-select best performer)</option>
+        </select>
+        <div className="text-[11px] text-[var(--muted)]">
+          {selectionStrategy === "fixed"
+            ? "Always use the selected default agent type when none is specified."
+            : "Automatically select the best-performing installed agent based on success rate and stall metrics."}
+        </div>
+      </div>
+
+      {/* Default agent type — only shown when strategy is "fixed" */}
+      {selectionStrategy === "fixed" && (
+        <div className="flex flex-col gap-1.5">
+          <span className="text-xs font-semibold">Default Agent Type</span>
+          <select
+            className="px-2.5 py-1.5 border border-[var(--border)] bg-[var(--card)] text-xs focus:border-[var(--accent)] focus:outline-none"
+            value={defaultAgentType}
+            onChange={(e) =>
+              setPref("PARALLAX_DEFAULT_AGENT_TYPE", e.target.value)
+            }
+          >
+            <option value="claude">Claude</option>
+            <option value="gemini">Gemini</option>
+            <option value="codex">Codex</option>
+            <option value="aider">Aider</option>
+          </select>
+          <div className="text-[11px] text-[var(--muted)]">
+            Agent used when no explicit type is specified in a spawn request.
+          </div>
+        </div>
+      )}
+
       {/* Default approval preset — global, not per-agent */}
       <div className="flex flex-col gap-1.5">
         <span className="text-xs font-semibold">Default Permission Level</span>

--- a/packages/plugin-coding-agent/src/__tests__/agent-selection.test.ts
+++ b/packages/plugin-coding-agent/src/__tests__/agent-selection.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Agent selection algorithm tests
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  computeAgentScore,
+  selectAgentType,
+} from "../services/agent-selection.js";
+
+describe("computeAgentScore", () => {
+  it("returns 0.5 for undefined metrics (cold start)", () => {
+    expect(computeAgentScore(undefined)).toBe(0.5);
+  });
+
+  it("returns 0.5 when spawned is 0", () => {
+    expect(
+      computeAgentScore({
+        spawned: 0,
+        completed: 0,
+        stallCount: 0,
+        avgCompletionMs: 0,
+      }),
+    ).toBe(0.5);
+  });
+
+  it("scores higher for agents with better success rate", () => {
+    const good = computeAgentScore({
+      spawned: 10,
+      completed: 9,
+      stallCount: 0,
+      avgCompletionMs: 30_000,
+    });
+    const bad = computeAgentScore({
+      spawned: 10,
+      completed: 3,
+      stallCount: 0,
+      avgCompletionMs: 30_000,
+    });
+    expect(good).toBeGreaterThan(bad);
+  });
+
+  it("penalizes stalls", () => {
+    const noStalls = computeAgentScore({
+      spawned: 10,
+      completed: 8,
+      stallCount: 0,
+      avgCompletionMs: 30_000,
+    });
+    const manyStalls = computeAgentScore({
+      spawned: 10,
+      completed: 8,
+      stallCount: 8,
+      avgCompletionMs: 30_000,
+    });
+    expect(noStalls).toBeGreaterThan(manyStalls);
+  });
+
+  it("blends toward neutral with low sample count", () => {
+    // With only 1 spawn, volume weight is 0.2, so 80% comes from neutral 0.5
+    const oneSpawn = computeAgentScore({
+      spawned: 1,
+      completed: 1,
+      stallCount: 0,
+      avgCompletionMs: 10_000,
+    });
+    // Should be close to 0.5, not close to 1.0
+    expect(oneSpawn).toBeGreaterThan(0.45);
+    expect(oneSpawn).toBeLessThan(0.65);
+  });
+
+  it("applies weak speed penalty for slow agents", () => {
+    const fast = computeAgentScore({
+      spawned: 10,
+      completed: 10,
+      stallCount: 0,
+      avgCompletionMs: 10_000,
+    });
+    const slow = computeAgentScore({
+      spawned: 10,
+      completed: 10,
+      stallCount: 0,
+      avgCompletionMs: 300_000,
+    });
+    expect(fast).toBeGreaterThan(slow);
+    // Speed penalty is capped at 0.1
+    expect(fast - slow).toBeLessThanOrEqual(0.1);
+  });
+
+  it("never returns negative", () => {
+    const worst = computeAgentScore({
+      spawned: 10,
+      completed: 0,
+      stallCount: 10,
+      avgCompletionMs: 600_000,
+    });
+    expect(worst).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe("selectAgentType", () => {
+  it("returns fixedAgentType in fixed mode", () => {
+    const result = selectAgentType({
+      config: { strategy: "fixed", fixedAgentType: "gemini" },
+      metrics: {},
+      installedAgents: [],
+    });
+    expect(result).toBe("gemini");
+  });
+
+  it("falls back to fixedAgentType in ranked mode when nothing is installed", () => {
+    const result = selectAgentType({
+      config: { strategy: "ranked", fixedAgentType: "codex" },
+      metrics: {},
+      installedAgents: [
+        {
+          adapter: "claude",
+          installed: false,
+          installCommand: "",
+          docsUrl: "",
+        },
+      ],
+    });
+    expect(result).toBe("codex");
+  });
+
+  it("returns the best-scoring installed agent in ranked mode", () => {
+    const result = selectAgentType({
+      config: { strategy: "ranked", fixedAgentType: "claude" },
+      metrics: {
+        claude: {
+          spawned: 10,
+          completed: 3,
+          stallCount: 5,
+          avgCompletionMs: 200_000,
+        },
+        gemini: {
+          spawned: 10,
+          completed: 9,
+          stallCount: 1,
+          avgCompletionMs: 30_000,
+        },
+      },
+      installedAgents: [
+        {
+          adapter: "claude",
+          installed: true,
+          installCommand: "",
+          docsUrl: "",
+        },
+        {
+          adapter: "gemini",
+          installed: true,
+          installCommand: "",
+          docsUrl: "",
+        },
+      ],
+    });
+    expect(result).toBe("gemini");
+  });
+
+  it("skips agents that are not installed", () => {
+    const result = selectAgentType({
+      config: { strategy: "ranked", fixedAgentType: "claude" },
+      metrics: {
+        gemini: {
+          spawned: 10,
+          completed: 10,
+          stallCount: 0,
+          avgCompletionMs: 1_000,
+        },
+      },
+      installedAgents: [
+        {
+          adapter: "claude",
+          installed: true,
+          installCommand: "",
+          docsUrl: "",
+        },
+        {
+          adapter: "gemini",
+          installed: false,
+          installCommand: "",
+          docsUrl: "",
+        },
+      ],
+    });
+    // Gemini has better metrics but isn't installed
+    expect(result).toBe("claude");
+  });
+
+  it("returns claude by default order when all scores are tied", () => {
+    const result = selectAgentType({
+      config: { strategy: "ranked", fixedAgentType: "aider" },
+      metrics: {},
+      installedAgents: [
+        {
+          adapter: "claude",
+          installed: true,
+          installCommand: "",
+          docsUrl: "",
+        },
+        {
+          adapter: "gemini",
+          installed: true,
+          installCommand: "",
+          docsUrl: "",
+        },
+        {
+          adapter: "codex",
+          installed: true,
+          installCommand: "",
+          docsUrl: "",
+        },
+      ],
+    });
+    // All have score 0.5 — claude is first in DEFAULT_ORDER
+    expect(result).toBe("claude");
+  });
+});

--- a/packages/plugin-coding-agent/src/actions/start-coding-task.ts
+++ b/packages/plugin-coding-agent/src/actions/start-coding-task.ts
@@ -118,10 +118,10 @@ export const startCodingTaskAction: Action = {
     const params = options?.parameters;
     const content = message.content as Record<string, unknown>;
 
+    const explicitRawType =
+      (params?.agentType as string) ?? (content.agentType as string);
     const rawAgentType =
-      (params?.agentType as string) ??
-      (content.agentType as string) ??
-      "claude";
+      explicitRawType ?? (await ptyService.resolveAgentType());
     const defaultAgentType = normalizeAgentType(rawAgentType);
     const memoryContent =
       (params?.memoryContent as string) ?? (content.memoryContent as string);

--- a/packages/plugin-coding-agent/src/api/agent-routes.ts
+++ b/packages/plugin-coding-agent/src/api/agent-routes.ts
@@ -149,6 +149,8 @@ export async function handleAgentRoutes(
     }
     sendJson(res, {
       defaultApprovalPreset: ctx.ptyService.defaultApprovalPreset,
+      agentSelectionStrategy: ctx.ptyService.agentSelectionStrategy,
+      defaultAgentType: ctx.ptyService.defaultAgentType,
     } as unknown as JsonValue);
     return true;
   }
@@ -282,7 +284,9 @@ export async function handleAgentRoutes(
       };
 
       // Read model preferences from runtime settings
-      const agentStr = ((agentType as string) || "claude").toLowerCase();
+      const agentStr = agentType
+        ? (agentType as string).toLowerCase()
+        : await ctx.ptyService.resolveAgentType();
       const piRequested = isPiAgentType(agentStr);
       const normalizedType = normalizeAgentType(agentStr);
       const prefixMap: Record<string, string> = {

--- a/packages/plugin-coding-agent/src/services/agent-selection.ts
+++ b/packages/plugin-coding-agent/src/services/agent-selection.ts
@@ -1,0 +1,112 @@
+/**
+ * Dynamic agent selection strategy.
+ *
+ * Chooses which coding-agent CLI to spawn when the caller does not
+ * specify an explicit `agentType`.
+ *
+ *   - **fixed**  — always returns `config.fixedAgentType`
+ *   - **ranked** — scores each installed agent on success rate,
+ *                  stall frequency, and completion speed, then
+ *                  returns the highest-scoring one
+ *
+ * @module services/agent-selection
+ */
+
+import type { AdapterType, PreflightResult } from "coding-agent-adapters";
+// ── Types ────────────────────────────────────────────────────────────
+
+export type AgentSelectionStrategy = "fixed" | "ranked";
+
+/** Subset of AgentMetrics fields used for scoring. */
+export interface AgentScoreInput {
+  spawned: number;
+  completed: number;
+  stallCount: number;
+  avgCompletionMs: number;
+}
+
+export interface AgentSelectionConfig {
+  strategy: AgentSelectionStrategy;
+  fixedAgentType: AdapterType;
+}
+
+export interface AgentSelectionContext {
+  config: AgentSelectionConfig;
+  /** Per-agent-type metrics snapshot (may be empty). */
+  metrics: Record<string, AgentScoreInput>;
+  /** Preflight results — only the `installed` ones are candidates. */
+  installedAgents: PreflightResult[];
+}
+
+// ── Scoring ──────────────────────────────────────────────────────────
+
+/**
+ * Compute a 0–1 score for a single agent based on its metrics.
+ *
+ * - `successRate`  = completed / spawned  (0.5 neutral prior when no data)
+ * - `volumeWeight` = min(1, spawned / 5)  — blends toward neutral at low N
+ * - `stallPenalty`  = (stallCount / spawned) * 0.3
+ * - `speedPenalty`  = min(avgCompletionMs / 300_000, 1) * 0.1  — weak tiebreaker
+ *
+ * Cold-start (no spawns): returns 0.5 so all agents are equal.
+ */
+export function computeAgentScore(
+  metrics: AgentScoreInput | undefined,
+): number {
+  if (!metrics || metrics.spawned === 0) return 0.5;
+
+  const { spawned, completed, stallCount, avgCompletionMs } = metrics;
+
+  const rawSuccess = completed / spawned;
+  const volumeWeight = Math.min(1, spawned / 5);
+  const successRate = rawSuccess * volumeWeight + 0.5 * (1 - volumeWeight);
+
+  const stallPenalty = (stallCount / spawned) * 0.3;
+  const speedPenalty = Math.min(avgCompletionMs / 300_000, 1) * 0.1;
+
+  return Math.max(0, successRate - stallPenalty - speedPenalty);
+}
+
+// ── Selection ────────────────────────────────────────────────────────
+
+/** Default ordering when scores are tied — first entry wins. */
+const DEFAULT_ORDER: AdapterType[] = ["claude", "gemini", "codex", "aider"];
+
+/**
+ * Select the best agent type given the current strategy, metrics, and
+ * installed agents.
+ *
+ * Explicit user choice (`params.agentType`) should be resolved by the
+ * caller *before* reaching this function.
+ */
+export function selectAgentType(ctx: AgentSelectionContext): AdapterType {
+  if (ctx.config.strategy === "fixed") {
+    return ctx.config.fixedAgentType;
+  }
+
+  // ── ranked mode ──
+  const installed = new Set(
+    ctx.installedAgents
+      .filter((r) => r.installed)
+      .map((r) => r.adapter as AdapterType),
+  );
+
+  // If nothing is installed, fall back to config default
+  if (installed.size === 0) {
+    return ctx.config.fixedAgentType;
+  }
+
+  let bestAgent: AdapterType = ctx.config.fixedAgentType;
+  let bestScore = -1;
+
+  for (const agent of DEFAULT_ORDER) {
+    if (!installed.has(agent)) continue;
+    const score = computeAgentScore(ctx.metrics[agent]);
+    if (score > bestScore) {
+      bestScore = score;
+      bestAgent = agent;
+    }
+  }
+
+  return bestAgent;
+}


### PR DESCRIPTION
## Summary
- Adds `AgentSelectionStrategy` (`fixed` | `ranked`) with env vars `PARALLAX_AGENT_SELECTION_STRATEGY` and `PARALLAX_DEFAULT_AGENT_TYPE`
- Ranked mode auto-selects the best-performing installed agent based on success rate, stall count, and completion speed
- Settings UI for strategy and default agent type in CodingAgentSettingsSection
- Explicit `agentType` in params always overrides the strategy

## Test plan
- [x] Unit tests for `computeAgentScore()` and `selectAgentType()` (12 tests in agent-selection.test.ts)
- [x] Fixed mode returns configured `defaultAgentType` from env var
- [x] Ranked mode with no metrics falls back to claude (neutral 0.5 scores, claude wins by array order)
- [x] Explicit `agentType` in params always overrides strategy (checked start-coding-task.ts and agent-routes.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)