### PR TITLE
feat(coding-agent): add tool_running agent status

### DIFF
--- a/apps/app/src/AppContext.tsx
+++ b/apps/app/src/AppContext.tsx
@@ -4940,6 +4940,23 @@ export function AppProvider({ children }: { children: ReactNode }) {
                 : s,
             ),
           );
+        } else if (eventType === "tool_running") {
+          const d = data.data as Record<string, unknown> | undefined;
+          const toolDesc =
+            (d?.description as string) ??
+            (d?.toolName as string) ??
+            "external tool";
+          setPtySessions((prev) =>
+            prev.map((s) =>
+              s.sessionId === sessionId
+                ? {
+                    ...s,
+                    status: "tool_running" as const,
+                    toolDescription: toolDesc,
+                  }
+                : s,
+            ),
+          );
         } else if (
           eventType === "coordination_decision" ||
           eventType === "blocked_auto_resolved" ||
@@ -4948,7 +4965,11 @@ export function AppProvider({ children }: { children: ReactNode }) {
           setPtySessions((prev) =>
             prev.map((s) =>
               s.sessionId === sessionId
-                ? { ...s, status: "active" as const }
+                ? {
+                    ...s,
+                    status: "active" as const,
+                    toolDescription: undefined,
+                  }
                 : s,
             ),
           );

--- a/apps/app/src/api-client.ts
+++ b/apps/app/src/api-client.ts
@@ -1100,9 +1100,17 @@ export interface CodingAgentSession {
   label: string;
   originalTask: string;
   workdir: string;
-  status: "active" | "blocked" | "completed" | "stopped" | "error";
+  status:
+    | "active"
+    | "blocked"
+    | "completed"
+    | "stopped"
+    | "error"
+    | "tool_running";
   decisionCount: number;
   autoResolvedCount: number;
+  /** Description of the active tool when status is "tool_running". */
+  toolDescription?: string;
 }
 
 export interface CodingAgentStatus {

--- a/apps/app/src/components/CodingAgentsSection.tsx
+++ b/apps/app/src/components/CodingAgentsSection.tsx
@@ -14,6 +14,7 @@ const AGENT_LABELS: Record<string, string> = {
 /** Status dot color classes. */
 const STATUS_DOT: Record<string, string> = {
   active: "bg-ok",
+  tool_running: "bg-accent",
   blocked: "bg-warn",
   error: "bg-danger",
   completed: "bg-ok opacity-50",
@@ -71,7 +72,7 @@ export function CodingAgentsSection({ sessions }: CodingAgentsSectionProps) {
                     <span
                       className={`inline-block w-2 h-2 rounded-full shrink-0 ${
                         STATUS_DOT[session.status] ?? "bg-muted"
-                      }${session.status === "active" ? " animate-pulse" : ""}`}
+                      }${session.status === "active" || session.status === "tool_running" ? " animate-pulse" : ""}`}
                     />
                     <span className="text-[11px] font-medium text-accent uppercase">
                       {AGENT_LABELS[session.agentType] ?? session.agentType}
@@ -89,13 +90,16 @@ export function CodingAgentsSection({ sessions }: CodingAgentsSectionProps) {
                   )}
                   <div className="flex items-center justify-between mt-1.5">
                     <span className="text-[10px] text-muted">
-                      {session.status === "blocked"
-                        ? "Waiting for input"
-                        : session.status === "error"
-                          ? "Error"
-                          : "Running"}
+                      {session.status === "tool_running"
+                        ? `Using ${session.toolDescription ?? "external tool"}`
+                        : session.status === "blocked"
+                          ? "Waiting for input"
+                          : session.status === "error"
+                            ? "Error"
+                            : "Running"}
                     </span>
                     {(session.status === "active" ||
+                      session.status === "tool_running" ||
                       session.status === "blocked") && (
                       <button
                         type="button"

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "chalk": "^5.4.1",
     "chokidar": "~3.5.3",
     "cli-highlight": "^2.1.11",
-    "coding-agent-adapters": "0.7.5",
+    "coding-agent-adapters": "0.8.0",
     "commander": "^14.0.0",
     "cross-spawn": "^7.0.6",
     "crypto-browserify": "^3.12.0",
@@ -166,7 +166,7 @@
     "pdfjs-dist": "^5.4.530",
     "pg": "^8.16.3",
     "pino": "^10.3.1",
-    "pty-manager": "1.8.0",
+    "pty-manager": "1.9.0",
     "puppeteer-core": "^24.37.5",
     "qrcode": "^1.5.4",
     "telegraf": "^4.16.3",
@@ -197,6 +197,6 @@
     "@elizaos/core": "next",
     "@elizaos/prompts": "next",
     "libsignal": "git+https://github.com/whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67",
-    "pty-manager": "1.8.0"
+    "pty-manager": "1.9.0"
   }
 }

--- a/packages/plugin-coding-agent/package.json
+++ b/packages/plugin-coding-agent/package.json
@@ -38,7 +38,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "coding-agent-adapters": "0.7.5",
-    "pty-console": "0.2.0"
+    "coding-agent-adapters": "0.8.0",
+    "pty-console": "0.3.0"
   }
 }

--- a/packages/plugin-coding-agent/src/__tests__/ansi-utils.test.ts
+++ b/packages/plugin-coding-agent/src/__tests__/ansi-utils.test.ts
@@ -4,9 +4,8 @@
 
 import { describe, expect, it } from "bun:test";
 
-const { captureTaskResponse, cleanForChat, stripAnsi } = await import(
-  "../services/ansi-utils.js"
-);
+const { captureTaskResponse, cleanForChat, extractDevServerUrl, stripAnsi } =
+  await import("../services/ansi-utils.js");
 
 describe("stripAnsi", () => {
   it("should replace cursor movement codes with spaces", () => {
@@ -137,5 +136,51 @@ describe("captureTaskResponse", () => {
     const markers = new Map([["s1", 1]]);
 
     expect(captureTaskResponse("s1", buffers, markers)).toBe("");
+  });
+});
+
+describe("extractDevServerUrl", () => {
+  it("extracts http://localhost with port", () => {
+    expect(extractDevServerUrl("Server running at http://localhost:3000")).toBe(
+      "http://localhost:3000",
+    );
+  });
+
+  it("extracts https://localhost with port", () => {
+    expect(extractDevServerUrl("  https://localhost:4200/")).toBe(
+      "https://localhost:4200/",
+    );
+  });
+
+  it("extracts 127.0.0.1 URLs", () => {
+    expect(extractDevServerUrl("Listening on http://127.0.0.1:8080")).toBe(
+      "http://127.0.0.1:8080",
+    );
+  });
+
+  it("extracts 0.0.0.0 URLs", () => {
+    expect(extractDevServerUrl("Local: http://0.0.0.0:5173/app")).toBe(
+      "http://0.0.0.0:5173/app",
+    );
+  });
+
+  it("returns null when no dev server URL is present", () => {
+    expect(extractDevServerUrl("Just some terminal output")).toBeNull();
+  });
+
+  it("returns null for non-local URLs", () => {
+    expect(extractDevServerUrl("Visit https://example.com:3000")).toBeNull();
+  });
+
+  it("handles ANSI codes in output", () => {
+    expect(extractDevServerUrl("\x1b[32m  http://localhost:3000\x1b[0m")).toBe(
+      "http://localhost:3000",
+    );
+  });
+
+  it("extracts the first URL when multiple are present", () => {
+    const input =
+      "Local: http://localhost:3000\nNetwork: http://192.168.1.5:3000";
+    expect(extractDevServerUrl(input)).toBe("http://localhost:3000");
   });
 });

--- a/packages/plugin-coding-agent/src/services/ansi-utils.ts
+++ b/packages/plugin-coding-agent/src/services/ansi-utils.ts
@@ -140,6 +140,26 @@ export function extractCompletionSummary(raw: string): string {
 }
 
 /**
+ * Extract a dev server URL from recent terminal output, if present.
+ *
+ * Looks for common patterns like:
+ *   - http://localhost:3000
+ *   - http://127.0.0.1:8080
+ *   - http://0.0.0.0:5173
+ *   - https://localhost:4200
+ *
+ * Returns the first match, or null if no dev server URL is found.
+ */
+export function extractDevServerUrl(raw: string): string | null {
+  const stripped = applyAnsiStrip(raw);
+  // Match local dev server URLs with a port number
+  const match = stripped.match(
+    /https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0):\d{1,5}[^\s)}\]'"`,]*/,
+  );
+  return match ? match[0] : null;
+}
+
+/**
  * Capture the agent's output since the last task was sent, cleaned for chat display.
  * Returns readable text with TUI noise removed, or empty string if no marker exists.
  *

--- a/packages/plugin-coding-agent/src/services/pty-init.ts
+++ b/packages/plugin-coding-agent/src/services/pty-init.ts
@@ -18,6 +18,7 @@ import {
   type SessionMessage,
   ShellAdapter,
   type StallClassification,
+  type ToolRunningInfo,
   type WorkerSessionHandle,
 } from "pty-manager";
 import { captureTaskResponse } from "./ansi-utils.js";
@@ -157,6 +158,16 @@ export async function initializePTYManager(
       ctx.emitEvent(session.id, "task_complete", { session, response });
     });
 
+    bunManager.on(
+      "tool_running",
+      (session: WorkerSessionHandle, info: ToolRunningInfo) => {
+        ctx.log(
+          `tool_running for ${session.id}: ${info.toolName}${info.description ? ` — ${info.description}` : ""}`,
+        );
+        ctx.emitEvent(session.id, "tool_running", { session, ...info });
+      },
+    );
+
     bunManager.on("message", (message: SessionMessage) => {
       ctx.emitEvent(message.sessionId, "message", message);
     });
@@ -276,6 +287,16 @@ export async function initializePTYManager(
     );
     ctx.emitEvent(session.id, "task_complete", { session, response });
   });
+
+  nodeManager.on(
+    "tool_running",
+    (session: SessionHandle, info: ToolRunningInfo) => {
+      ctx.log(
+        `tool_running for ${session.id}: ${info.toolName}${info.description ? ` — ${info.description}` : ""}`,
+      );
+      ctx.emitEvent(session.id, "tool_running", { session, ...info });
+    },
+  );
 
   nodeManager.on(
     "session_stopped",

--- a/packages/plugin-coding-agent/src/services/pty-types.ts
+++ b/packages/plugin-coding-agent/src/services/pty-types.ts
@@ -128,6 +128,7 @@ export type SessionEventName =
   | "blocked"
   | "login_required"
   | "task_complete"
+  | "tool_running"
   | "stopped"
   | "error"
   | "message";

--- a/packages/plugin-coding-agent/src/services/swarm-coordinator.ts
+++ b/packages/plugin-coding-agent/src/services/swarm-coordinator.ts
@@ -22,6 +22,7 @@
 import type { ServerResponse } from "node:http";
 import type { IAgentRuntime } from "@elizaos/core";
 import { logger } from "@elizaos/core";
+import { extractDevServerUrl } from "./ansi-utils.js";
 import type { PTYService } from "./pty-service.js";
 import type { CodingAgentType } from "./pty-types.js";
 import type { CoordinationLLMResponse } from "./swarm-coordinator-prompts.js";
@@ -98,6 +99,8 @@ export interface SwarmCoordinatorContext {
   readonly pendingDecisions: Map<string, PendingDecision>;
   /** Last-seen output snapshot per session — used by idle watchdog. */
   readonly lastSeenOutput: Map<string, string>;
+  /** Timestamp of last tool_running chat notification per session — for throttling. */
+  readonly lastToolNotification: Map<string, number>;
 
   broadcast(event: SwarmEvent): void;
   sendChatMessage(text: string, source?: string): void;
@@ -154,6 +157,9 @@ export class SwarmCoordinator implements SwarmCoordinatorContext {
 
   /** Last-seen output snapshot per session — used by idle watchdog to detect data flow. */
   readonly lastSeenOutput: Map<string, string> = new Map();
+
+  /** Timestamp of last tool_running chat notification per session — for throttling. */
+  readonly lastToolNotification: Map<string, number> = new Map();
 
   constructor(runtime: IAgentRuntime) {
     this.runtime = runtime;
@@ -228,6 +234,7 @@ export class SwarmCoordinator implements SwarmCoordinatorContext {
     this.inFlightDecisions.clear();
     this.unregisteredBuffer.clear();
     this.lastSeenOutput.clear();
+    this.lastToolNotification.clear();
     this.log("SwarmCoordinator stopped");
   }
 
@@ -458,6 +465,55 @@ export class SwarmCoordinator implements SwarmCoordinatorContext {
           data,
         });
         break;
+
+      case "tool_running": {
+        // Agent is actively working via an external tool — keep watchdog happy
+        taskCtx.lastActivityAt = Date.now();
+        taskCtx.idleCheckCount = 0;
+
+        this.broadcast({
+          type: "tool_running",
+          sessionId,
+          timestamp: Date.now(),
+          data,
+        });
+
+        // Throttle chat notifications: at most one per 30s per session
+        const toolData = data as {
+          toolName?: string;
+          description?: string;
+        };
+        const now = Date.now();
+        const lastNotif = this.lastToolNotification.get(sessionId) ?? 0;
+        if (now - lastNotif > 30_000) {
+          this.lastToolNotification.set(sessionId, now);
+          const toolDesc =
+            toolData.description ?? toolData.toolName ?? "an external tool";
+
+          // Try to extract a dev server URL from recent output
+          let urlSuffix = "";
+          if (this.ptyService) {
+            try {
+              const recentOutput = await this.ptyService.getSessionOutput(
+                sessionId,
+                50,
+              );
+              const devUrl = extractDevServerUrl(recentOutput);
+              if (devUrl) {
+                urlSuffix = ` Dev server running at ${devUrl}`;
+              }
+            } catch {
+              // Best-effort — don't block on failure
+            }
+          }
+
+          this.sendChatMessage(
+            `[${taskCtx.label}] Running ${toolDesc}.${urlSuffix} The agent is working outside the terminal — I'll let it finish.`,
+            "coding-agent",
+          );
+        }
+        break;
+      }
 
       default:
         // Broadcast unknown events for observability


### PR DESCRIPTION
## Summary
- Surfaces `tool_running` as a new agent status when CLIs use external tools (browser, MCP, etc.)
- Adds stall classifier awareness so tool-running sessions aren't flagged as stalled
- Throttled coordinator chat notifications (max 1 per 30s) with dev-server URL extraction
- UI status dot animation and "Using {tool}" indicator in CodingAgentsSection
- Bumps pty-manager 1.8.0→1.9.0, coding-agent-adapters 0.7.5→0.8.0, pty-console 0.2.0→0.3.0

## Test plan
- [x] All 279 tests pass (including 8 new extractDevServerUrl tests)
- [x] extractDevServerUrl correctly extracts localhost/127.0.0.1/0.0.0.0 URLs
- [x] tool_running event forwarded from pty-init to session event handler
- [x] Stall classifier recognizes tool_running as valid state
- [x] SwarmCoordinator broadcasts tool_running SSE events and throttles chat notifications
- [x] UI shows animate-pulse dot and tool description for tool_running sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)