### PR TITLE
feat: wire UiSpec actions to chat API for server-round-trip (#35)

### DIFF
--- a/apps/app/src/components/MessageContent.tsx
+++ b/apps/app/src/components/MessageContent.tsx
@@ -405,12 +405,14 @@ function InlinePluginConfig({ pluginId }: { pluginId: string }) {
 
 function UiSpecBlock({ spec, raw }: { spec: UiSpec; raw: string }) {
   const [showRaw, setShowRaw] = useState(false);
+  const { sendActionMessage } = useApp();
 
-  // Actions from UiSpec elements — currently a no-op.
-  // TODO(#35): Wire to chat API for server-round-trip actions.
   const handleAction = useCallback(
-    (_action: string, _params?: Record<string, unknown>) => {},
-    [],
+    (action: string, params?: Record<string, unknown>) => {
+      const paramsStr = params ? ` ${JSON.stringify(params)}` : "";
+      void sendActionMessage(`[action:${action}]${paramsStr}`);
+    },
+    [sendActionMessage],
   );
 
   return (


### PR DESCRIPTION
Add sendActionMessage to AppContext so UiSpec interactive elements can
send actions as chat messages without touching the chatInput state.
When a UiSpec button fires an action, it is formatted as
[action:<name>] <params> and streamed through the conversation API,
with the agent's response appearing in real-time in the chat.

https://claude.ai/code/session_01SqVUMUURNoRMAocB273tQZ