### PR TITLE
docs: restructure navigation to mirror dashboard + close 43 endpoint gaps

### DIFF
--- a/docs/advanced/database.md
+++ b/docs/advanced/database.md
@@ -1,0 +1,125 @@
+---
+title: Database
+sidebarTitle: Database
+description: Browse your Milady agent's database — inspect tables, media files, and vector stores directly from the dashboard.
+---
+
+The Database tab provides a built-in browser for your agent's data stores. Access it from the **Advanced** section of the dashboard at `/database`.
+
+## Overview
+
+The database browser has three sub-tabs for different data types:
+
+| Tab | Description |
+|-----|-------------|
+| **Tables** | Browse relational database tables — view rows, columns, and record counts |
+| **Media** | Browse uploaded and generated media files (images, audio, video) |
+| **Vectors** | Inspect vector store entries used for semantic search and RAG |
+
+## Tables
+
+The Tables view lists all database tables used by the agent runtime. Select a table to browse its contents in a paginated data grid.
+
+Common tables include:
+
+| Table | Contents |
+|-------|----------|
+| `memories` | Agent memories and conversation state |
+| `messages` | Conversation history |
+| `knowledge` / `documents` | Knowledge base documents and fragments |
+| `entities` | People, agents, and other entities the agent knows about |
+| `rooms` | Conversation rooms and channels |
+| `tasks` | Scheduled and active tasks |
+| `triggers` | Event triggers and their run history |
+
+Select any table to view its rows in a paginated grid. Each row displays all columns with their values.
+
+## Media Gallery
+
+The Media view scans database tables for embedded media URLs (images, videos, audio) and presents them in a filterable, searchable grid with a lightbox viewer.
+
+### How Media Is Discovered
+
+The gallery scans up to 10 database tables, prioritizing tables whose names contain `memor`, `message`, `media`, `attach`, `file`, `asset`, or `document`. For each row, it extracts HTTP URLs and `data:` URIs from all string-valued columns, including JSON content blobs.
+
+### Supported Media Types
+
+| Type | Extensions | Badge Color |
+|------|-----------|-------------|
+| **Image** | `.png` `.jpg` `.jpeg` `.gif` `.webp` `.svg` `.bmp` `.ico` `.avif` | Blue |
+| **Video** | `.mp4` `.webm` `.mov` `.avi` `.mkv` `.ogv` | Purple |
+| **Audio** | `.mp3` `.wav` `.ogg` `.flac` `.aac` `.m4a` `.opus` | Green |
+
+### Filtering
+
+- **Text search** — filter by filename or URL (case-insensitive)
+- **Type filter chips** — All / Images / Video / Audio (mutually exclusive)
+- Results are deduplicated by URL and sorted by creation date (newest first)
+
+### Lightbox
+
+Click any media item to open the lightbox:
+
+- **Images** display at up to 70% viewport height
+- **Video** plays with native controls
+- **Audio** plays with native controls
+- Footer shows type, source table, and creation date
+- Close with click outside, Escape, or Enter
+
+## Vector Browser
+
+The Vectors view browses agent memories and vector embeddings with three visualization modes. It auto-discovers vector-relevant tables (`memories`, `embeddings`, `knowledge`, `vector`) and joins embedding data when available.
+
+### Toolbar
+
+- **Table selector** — choose which vector table to browse
+- **Stats bar** — total count, embedding dimensions, unique memory count
+- **Search** — filter by content text (SQL `LIKE` query)
+- **View mode toggle** — List, Graph (2D), or 3D
+- **Refresh** — reload data
+
+### Embedding Support
+
+The viewer detects ElizaOS embedding tables with dimension columns (`dim_384`, `dim_512`, `dim_768`, `dim_1024`, `dim_1536`, `dim_3072`). When the `memories` table is selected and an `embeddings` table exists, the viewer performs a LEFT JOIN to attach embedding vectors to memory records.
+
+### List View
+
+Paginated cards (25 per page). Each card shows:
+
+- Content preview (first ~200 characters)
+- Type badge and Unique badge
+- Room ID, Entity ID, Created At
+- Embedding dimension count (e.g., "384 dims")
+
+Click any card to open the **Memory Detail Modal** with full content, metadata grid, embedding values, and raw JSON record.
+
+### Graph View (2D Scatter Plot)
+
+Projects high-dimensional embeddings to 2D using PCA (power iteration, 2 principal components). Renders to an HTML canvas.
+
+- Axes labeled PC1 (horizontal) and PC2 (vertical)
+- Points colored by memory `type` with a legend
+- **Hover** — nearest point highlights with a tooltip showing content preview (60 chars)
+- **Click** — opens the Memory Detail Modal
+- Requires at least 2 records with embeddings (fetches up to 500)
+
+### 3D View (Three.js)
+
+Projects embeddings to 3 principal components and renders in an interactive Three.js scene.
+
+- Each memory is a colored sphere positioned in 3D space
+- **Mouse drag** — orbit camera around the scene (with damping)
+- **Scroll wheel** — zoom in/out (radius clamped 2–15)
+- **Hover** — highlighted sphere scales up with content tooltip (150 chars)
+- **Click** — opens the Memory Detail Modal
+- Scene includes a grid floor and 3-axis lines for spatial reference
+- Points colored by memory type with a legend below the canvas
+
+### Memory Detail Modal
+
+Full-screen overlay showing:
+
+- **Content** — full text in a scrollable panel
+- **Metadata** — ID, Type, Room, Entity, Created At, Unique flag
+- **Embedding preview** — all dimension values to 6 decimal places
+- **Raw Record** — expandable JSON dump of the complete database row

--- a/docs/advanced/logs.md
+++ b/docs/advanced/logs.md
@@ -1,0 +1,37 @@
+---
+title: Logs
+sidebarTitle: Logs
+description: View runtime and service logs for your Milady agent directly in the dashboard.
+---
+
+The Logs tab provides a real-time log viewer for your agent's runtime output. Access it from the **Advanced** section of the dashboard at `/logs`.
+
+## Overview
+
+The log viewer streams runtime logs directly in the browser, giving you visibility into agent operations without needing terminal access.
+
+## Log Levels
+
+Logs are color-coded by severity level:
+
+| Level | Color | Description |
+|-------|-------|-------------|
+| **ERROR** | Red | Runtime errors and exceptions |
+| **WARN** | Yellow | Warnings and potential issues |
+| **INFO** | Default | General informational messages |
+| **DEBUG** | Gray | Detailed debugging output |
+
+## Filtering
+
+Use the filter controls to narrow down log output:
+
+- **Level filter** — show only logs at or above a specific severity level
+- **Text search** — filter logs by keyword or pattern
+- **Service filter** — narrow down to logs from a specific service or plugin
+
+## Features
+
+- **Auto-scroll** — the viewer automatically scrolls to show the latest log entries
+- **Pause** — temporarily pause auto-scroll to inspect a specific log section
+- **Copy** — copy individual log entries or selections to clipboard
+- **Timestamp display** — each log entry includes a precise timestamp

--- a/docs/advanced/trajectories.md
+++ b/docs/advanced/trajectories.md
@@ -1,0 +1,56 @@
+---
+title: Trajectories
+sidebarTitle: Trajectories
+description: View and analyze LLM call history for your Milady agent — inspect prompts, responses, token usage, and latency.
+---
+
+The Trajectories tab provides a detailed viewer for your agent's LLM call history. Every call the agent makes to a language model is recorded as a trajectory, giving you full visibility into prompts, responses, token usage, and performance.
+
+## Overview
+
+Access Trajectories from the **Advanced** section of the dashboard at `/trajectories`. The viewer displays a reverse-chronological list of all LLM interactions.
+
+## What's Recorded
+
+Each trajectory entry captures:
+
+| Field | Description |
+|-------|-------------|
+| **Timestamp** | When the LLM call was made |
+| **Model** | Which model was used (e.g., GPT-4o, Claude 3.5 Sonnet) |
+| **Prompt** | The full prompt sent to the model, including system message and conversation history |
+| **Response** | The model's complete response |
+| **Token usage** | Input tokens, output tokens, and total |
+| **Latency** | Time taken for the call to complete |
+| **Status** | Success or error state |
+
+## Using the Viewer
+
+The trajectory list shows a summary card for each call. Click any entry to open the detail view, which displays the full prompt and response in a readable format.
+
+### Filtering
+
+Filter trajectories by:
+
+- **Model** — narrow down to calls made to a specific model
+- **Time range** — view calls from a specific period
+- **Status** — filter by success or error
+
+### Detail View
+
+The detail view for an individual trajectory shows:
+
+- Full prompt with system message, conversation history, and any tool calls
+- Complete model response
+- Token breakdown (input/output/total)
+- Latency and timing information
+- Error details if the call failed
+
+## API Reference
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/trajectories` | List trajectory entries |
+| GET | `/api/trajectories/:id` | Get a specific trajectory detail |
+
+See the [REST API Reference](/rest/trajectories) for full endpoint documentation.

--- a/docs/apps/dashboard.md
+++ b/docs/apps/dashboard.md
@@ -70,91 +70,11 @@ Legacy paths are redirected automatically: `/game` maps to Apps, `/agent` to Cha
 
 ### Chat
 
-The default landing tab. The `ChatView` component provides the core messaging interface.
+The default landing tab — a full messaging interface with voice chat, 3D avatar, conversation management, and autonomous monitoring.
 
-**Message Area**
-
-Messages render through the `MessageContent` component, which supports:
-
-- **Plain text** -- standard chat messages with line breaks preserved.
-- **Inline plugin config** -- `[CONFIG:pluginId]` markers in agent responses render as interactive plugin configuration forms using `ConfigRenderer`.
-- **UI Spec rendering** -- fenced JSON code blocks containing UiSpec objects render as interactive UI elements via `UiRenderer`.
-- **Code blocks** -- syntax-highlighted fenced code blocks.
-- **Streaming** -- agent responses stream in token-by-token with a visible typing indicator. The `chatFirstTokenReceived` flag tracks when the first token arrives.
-
-**Input Area**
-
-The chat input area sits at the bottom of the view:
-
-- **Auto-resizing textarea** -- grows from 38 px to a maximum of 200 px as you type.
-- **Image attachments** -- attach images via the file picker button, drag-and-drop onto the chat area, or paste from clipboard. Pending images display as thumbnails above the input.
-- **File drops** -- drag and drop files into the chat area to share them with the agent. A visual drop zone indicator appears during drag.
-- **Send / Stop** -- the send button submits the message; while the agent is responding, a stop button appears to cancel generation.
-
-**Voice Chat**
-
-Built-in voice chat powered by ElevenLabs or browser TTS/STT:
-
-- Voice configuration loads automatically from the agent's config on mount.
-- The `useVoiceChat` hook manages the microphone toggle, agent voice playback, and the speaking state that drives avatar lip-sync.
-- Voice config changes in Settings or Character views are synchronized in real-time via a `milady:voice-config-updated` custom DOM event.
-
-**VRM 3D Avatar**
-
-A live 3D avatar rendered with Three.js and `@pixiv/three-vrm`:
-
-- The avatar responds to conversation with idle animations and emotes.
-- Select from 8 built-in VRM models via the `selectedVrmIndex` state.
-- Toggle avatar visibility and agent voice mute via the two control buttons in the Autonomous Panel's Chat Controls section.
-
-**Conversations Sidebar**
-
-The `ConversationsSidebar` component manages multiple conversations:
-
-- **Conversation list** -- sorted by most recently updated. Each entry shows the title, a relative timestamp (e.g., "5m ago", "2d ago"), and an unread indicator for conversations with new messages.
-- **Create new** -- a "New Chat" button at the top creates a fresh conversation thread.
-- **Rename** -- double-click a conversation title to enter inline edit mode. Press Enter to save or Escape to cancel.
-- **Delete** -- each conversation has a delete button that removes the thread permanently.
-- **Unread tracking** -- the `unreadConversations` set tracks which conversations have new messages the user has not yet viewed.
-
-**Autonomous Panel**
-
-Displayed on the right side of the Chat tab, the `AutonomousPanel` component provides real-time visibility into autonomous operations:
-
-- **Current state** -- shows the latest "Thought" (from assistant/evaluator streams) and latest "Action" (from action/tool/provider streams).
-- **Event Stream** -- a collapsible, reverse-chronological feed of the last 120 events, color-coded by type:
-
-| Event Type | Color |
-|------------|-------|
-| Heartbeat events | Accent |
-| Error events | Red (danger) |
-| Action, tool, provider events | Green (success) |
-| Assistant thoughts | Accent |
-| Other events | Muted gray |
-
-- **Workbench Tasks** -- active tasks the agent is working on, displayed as a checklist.
-- **Triggers** -- scheduled triggers (interval, cron, one-time) with their type, enabled status, and run count.
-- **Todos** -- task items tracked by the agent, displayed as a checklist.
-- **Chat Controls** -- at the bottom, avatar visibility toggle and agent voice mute toggle, plus a VRM avatar preview window (260-420 px tall depending on viewport).
-
-**Emote Picker**
-
-Trigger VRM avatar emotes with the keyboard shortcut **Cmd+E** (macOS) or **Ctrl+E** (Windows/Linux). The picker provides 29 emotes across 6 categories:
-
-| Category | Emotes |
-|----------|--------|
-| **Greeting** | Wave, Kiss |
-| **Emotion** | Crying, Sorrow, Rude Gesture, Looking Around |
-| **Dance** | Dance Happy, Dance Breaking, Dance Hip Hop, Dance Popping |
-| **Combat** | Hook Punch, Punching, Firing Gun, Sword Swing, Chopping, Spell Cast, Range, Death |
-| **Idle** | Idle, Talk, Squat, Fishing |
-| **Movement** | Float, Jump, Flip, Run, Walk, Crawling, Fall |
-
-Each emote is represented by a clickable icon button. Categories are displayed as filterable tabs within the picker.
-
-**Context Menu**
-
-Right-click messages to access a context menu for saving commands or performing custom actions.
+<Card title="Chat Documentation" icon="message" href="/dashboard/chat">
+  Full Chat tab documentation — message area, voice chat, VRM avatar, conversations sidebar, autonomous panel, emote picker, and context menu.
+</Card>
 
 ### Character
 

--- a/docs/apps/dashboard/settings.md
+++ b/docs/apps/dashboard/settings.md
@@ -262,4 +262,4 @@ On iOS and Android the dashboard's storage bridge mirrors every write to Capacit
 - [Desktop App](/apps/desktop) — global keyboard shortcuts and native permission management
 - [Mobile App](/apps/mobile) — storage bridge that syncs settings to Capacitor Preferences on iOS/Android
 - [Talk Mode](/apps/dashboard/talk-mode) — voice conversation setup and Talk Mode configuration
-- [Plugins](/plugins) — how plugins register additional AI providers and capability toggles
+- [Plugins](/plugins/overview) — how plugins register additional AI providers and capability toggles

--- a/docs/apps/dashboard/talk-mode.md
+++ b/docs/apps/dashboard/talk-mode.md
@@ -1,0 +1,105 @@
+---
+title: Talk Mode
+sidebarTitle: Talk Mode
+description: Full voice conversation with your Milady agent using offline speech recognition, text-to-speech, and voice activity detection.
+---
+
+Talk Mode provides a full voice conversation pipeline for the Milady desktop app. It combines offline speech-to-text (Whisper.cpp), streaming text-to-speech (ElevenLabs), and voice activity detection into a seamless hands-free experience.
+
+<Info>
+Talk Mode is a native desktop feature. It requires the Electron desktop app — it is not available in the web dashboard or mobile app.
+</Info>
+
+## How It Works
+
+1. **You speak** — the microphone captures audio and streams PCM samples to the main process
+2. **Speech recognition** — Whisper.cpp transcribes your speech to text offline
+3. **Agent processes** — the transcript is sent to the agent as a message
+4. **Agent speaks** — the response is converted to speech via ElevenLabs and played back
+
+### State Machine
+
+Talk Mode cycles through four states:
+
+| State | Description |
+|-------|-------------|
+| `idle` | Talk Mode is off |
+| `listening` | Microphone is active, waiting for speech |
+| `processing` | Transcription complete, agent is generating a response |
+| `speaking` | Agent response is being played back as audio |
+
+After `speaking` completes, Talk Mode returns to `listening` for the next turn.
+
+## Configuration
+
+Talk Mode is configured through the `TalkModeConfig` interface:
+
+### Speech-to-Text (STT)
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `engine` | string | `"whisper"` | `"whisper"` for offline Whisper.cpp, `"web"` for browser Web Speech API |
+| `modelSize` | string | `"base"` | Whisper model size: `"tiny"`, `"base"`, `"small"`, `"medium"`, `"large"` |
+| `language` | string | — | Optional language code for transcription |
+
+Larger Whisper models are more accurate but require more memory and processing time. If Whisper is unavailable, Talk Mode falls back to the Web Speech API automatically.
+
+### Text-to-Speech (TTS)
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `engine` | string | `"elevenlabs"` | `"elevenlabs"` for ElevenLabs API, `"system"` for native OS TTS |
+| `apiKey` | string | — | ElevenLabs API key (configured in Settings > Secrets) |
+| `voiceId` | string | — | ElevenLabs voice ID |
+| `modelId` | string | `"eleven_v3"` | ElevenLabs model |
+
+Falls back to system TTS if no ElevenLabs API key is configured.
+
+### Voice Activity Detection (VAD)
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `enabled` | boolean | `true` | Enable/disable voice activity detection |
+| `silenceThreshold` | number | — | Audio level below which silence is detected |
+| `silenceDuration` | number | — | Duration of silence (ms) before stopping capture |
+
+## Permissions
+
+Talk Mode requires the **microphone** permission. In the desktop app, you can grant this from **Settings > Permissions**.
+
+## IPC Events
+
+Talk Mode communicates between the renderer and main process via IPC:
+
+### Commands (Renderer → Main)
+
+| Channel | Description |
+|---------|-------------|
+| `talkmode:start` | Start Talk Mode |
+| `talkmode:stop` | Stop Talk Mode |
+| `talkmode:speak` | Trigger TTS for text |
+| `talkmode:stopSpeaking` | Interrupt current playback |
+| `talkmode:isSpeaking` | Query speaking state |
+| `talkmode:getState` | Query current state |
+| `talkmode:isEnabled` | Check if Talk Mode is available |
+| `talkmode:updateConfig` | Update configuration |
+| `talkmode:isWhisperAvailable` | Check Whisper.cpp availability |
+| `talkmode:getWhisperInfo` | Get Whisper model info |
+
+### Events (Main → Renderer)
+
+| Channel | Description |
+|---------|-------------|
+| `talkmode:transcript` | Transcription result with `isFinal` flag |
+| `talkmode:speaking` | Speaking state changed |
+| `talkmode:speakComplete` | Playback finished |
+| `talkmode:audioChunk` | Base64-encoded audio chunk for playback |
+| `talkmode:audioComplete` | All audio chunks sent |
+| `talkmode:stateChange` | State machine transition |
+| `talkmode:error` | Error with diagnostic `code` |
+
+## Related
+
+- [Desktop App](/apps/desktop) — desktop-specific features and keyboard shortcuts
+- [Native Modules](/apps/desktop/native-modules) — IPC reference for Talk Mode and other native features
+- [Settings](/apps/dashboard/settings) — TTS/STT provider configuration

--- a/docs/dashboard/apps.md
+++ b/docs/dashboard/apps.md
@@ -1,0 +1,75 @@
+---
+title: Apps
+sidebarTitle: Apps
+description: Browse, launch, and manage apps and games that integrate with your Milady agent from the in-dashboard app browser.
+---
+
+The Apps tab provides a built-in app browser for discovering, launching, and managing applications that integrate with your agent. Access it from the main dashboard navigation at `/apps`.
+
+## App Browser
+
+The browser displays apps from the registry as a searchable, filterable grid of cards. Each card shows the app's display name, category badge, active/inactive status, description, and a launch button.
+
+### Search and Filter
+
+- **Search** — filter apps by name, display name, or description
+- **Active Only toggle** — show only currently running apps
+- **Active count badge** — shows how many apps are currently running
+
+### App Categories
+
+| Category | Description |
+|----------|-------------|
+| `game` | Interactive games the agent can play |
+| `social` | Social platform integrations |
+| `platform` | Platform and infrastructure apps |
+| `world` | Virtual world environments |
+
+## Launching Apps
+
+Click **Launch** on any app card to start it. The launch behavior depends on the app's configuration:
+
+1. **Viewer URL available** — the app opens in full-screen Game View within the dashboard
+2. **Launch URL only** — the app opens in a new browser tab
+3. **Neither** — an error notice is displayed
+
+If an app is already running, an **Active Session** banner appears above the app list with options to resume full-screen or open in a new tab.
+
+## App Detail Page
+
+Click the arrow on any app card to open the detail view:
+
+- **Metadata** — launch type, latest version, launch URL, repository link
+- **Capabilities** — tags describing what the app can do
+- **Viewer config** — URL, postMessage auth status, sandbox policy
+- **Hyperscape Controls** — for `@elizaos/app-hyperscape` apps, an expandable panel with embedded agent management, messaging, commands, and goal tracking
+
+## Game View
+
+When an app with a viewer URL is launched, it opens in the **Game View** — a full-screen iframe that fills the entire Apps tab area.
+
+### Game View Header
+
+| Control | Description |
+|---------|-------------|
+| **App name** | Display name of the running app |
+| **Connection status** | `Connecting` (yellow), `Connected` (green), or `Disconnected` (red) |
+| **Show/Hide Logs** | Toggle the agent logs panel |
+| **Retake Capture** | Stream iframe frames to retake.tv (when retake plugin is enabled) |
+| **Keep on Top** | Pin app as a floating overlay when navigating other tabs |
+| **Open in New Tab** | Open the app viewer URL in a separate browser tab |
+| **Stop** | Stop the app and return to the browser |
+| **Back to Apps** | Return to browser without stopping the app |
+
+### Agent Logs Panel
+
+Toggle the logs panel to see a split-screen view with the last 50 agent log entries filtered for the current app. The panel includes a chat input for sending commands directly to the agent (e.g., "go chop wood", "attack the goblin").
+
+### Floating Overlay
+
+When **Keep on Top** is enabled, the game renders as a 480x360 draggable, resizable overlay window pinned to the bottom-right corner. The overlay persists across tab navigation, letting you monitor the game while working in other parts of the dashboard.
+
+- **Drag** the title bar to reposition
+- **Resize** using the CSS resize handle
+- **Expand** to return to full-screen Game View
+- **Close** to dismiss the overlay (does not stop the game)

--- a/docs/dashboard/chat.md
+++ b/docs/dashboard/chat.md
@@ -1,0 +1,91 @@
+---
+title: Chat
+sidebarTitle: Chat
+description: The core messaging interface for interacting with your Milady agent — voice chat, 3D avatar, conversations, and autonomous monitoring.
+---
+
+The Chat tab is the default landing view of the dashboard. It provides the core messaging interface through the `ChatView` component, with a three-column layout: Conversations Sidebar on the left, the Chat View in the center, and the Autonomous Panel on the right.
+
+## Message Area
+
+Messages render through the `MessageContent` component, which supports:
+
+- **Plain text** — standard chat messages with line breaks preserved.
+- **Inline plugin config** — `[CONFIG:pluginId]` markers in agent responses render as interactive plugin configuration forms using `ConfigRenderer`.
+- **UI Spec rendering** — fenced JSON code blocks containing UiSpec objects render as interactive UI elements via `UiRenderer`.
+- **Code blocks** — syntax-highlighted fenced code blocks.
+- **Streaming** — agent responses stream in token-by-token with a visible typing indicator. The `chatFirstTokenReceived` flag tracks when the first token arrives.
+
+## Input Area
+
+The chat input area sits at the bottom of the view:
+
+- **Auto-resizing textarea** — grows from 38 px to a maximum of 200 px as you type.
+- **Image attachments** — attach images via the file picker button, drag-and-drop onto the chat area, or paste from clipboard. Pending images display as thumbnails above the input.
+- **File drops** — drag and drop files into the chat area to share them with the agent. A visual drop zone indicator appears during drag.
+- **Send / Stop** — the send button submits the message; while the agent is responding, a stop button appears to cancel generation.
+
+## Voice Chat
+
+Built-in voice chat powered by ElevenLabs or browser TTS/STT:
+
+- Voice configuration loads automatically from the agent's config on mount.
+- The `useVoiceChat` hook manages the microphone toggle, agent voice playback, and the speaking state that drives avatar lip-sync.
+- Voice config changes in Settings or Character views are synchronized in real-time via a `milady:voice-config-updated` custom DOM event.
+
+## VRM 3D Avatar
+
+A live 3D avatar rendered with Three.js and `@pixiv/three-vrm`:
+
+- The avatar responds to conversation with idle animations and emotes.
+- Select from 8 built-in VRM models via the `selectedVrmIndex` state.
+- Toggle avatar visibility and agent voice mute via the two control buttons in the Autonomous Panel's Chat Controls section.
+
+## Conversations Sidebar
+
+The `ConversationsSidebar` component manages multiple conversations:
+
+- **Conversation list** — sorted by most recently updated. Each entry shows the title, a relative timestamp (e.g., "5m ago", "2d ago"), and an unread indicator for conversations with new messages.
+- **Create new** — a "New Chat" button at the top creates a fresh conversation thread.
+- **Rename** — double-click a conversation title to enter inline edit mode. Press Enter to save or Escape to cancel.
+- **Delete** — each conversation has a delete button that removes the thread permanently.
+- **Unread tracking** — the `unreadConversations` set tracks which conversations have new messages the user has not yet viewed.
+
+## Autonomous Panel
+
+Displayed on the right side of the Chat tab, the `AutonomousPanel` component provides real-time visibility into autonomous operations:
+
+- **Current state** — shows the latest "Thought" (from assistant/evaluator streams) and latest "Action" (from action/tool/provider streams).
+- **Event Stream** — a collapsible, reverse-chronological feed of the last 120 events, color-coded by type:
+
+| Event Type | Color |
+|------------|-------|
+| Heartbeat events | Accent |
+| Error events | Red (danger) |
+| Action, tool, provider events | Green (success) |
+| Assistant thoughts | Accent |
+| Other events | Muted gray |
+
+- **Workbench Tasks** — active tasks the agent is working on, displayed as a checklist.
+- **Triggers** — scheduled triggers (interval, cron, one-time) with their type, enabled status, and run count.
+- **Todos** — task items tracked by the agent, displayed as a checklist.
+- **Chat Controls** — at the bottom, avatar visibility toggle and agent voice mute toggle, plus a VRM avatar preview window (260-420 px tall depending on viewport).
+
+## Emote Picker
+
+Trigger VRM avatar emotes with the keyboard shortcut **Cmd+E** (macOS) or **Ctrl+E** (Windows/Linux). The picker provides 29 emotes across 6 categories:
+
+| Category | Emotes |
+|----------|--------|
+| **Greeting** | Wave, Kiss |
+| **Emotion** | Crying, Sorrow, Rude Gesture, Looking Around |
+| **Dance** | Dance Happy, Dance Breaking, Dance Hip Hop, Dance Popping |
+| **Combat** | Hook Punch, Punching, Firing Gun, Sword Swing, Chopping, Spell Cast, Range, Death |
+| **Idle** | Idle, Talk, Squat, Fishing |
+| **Movement** | Float, Jump, Flip, Run, Walk, Crawling, Fall |
+
+Each emote is represented by a clickable icon button. Categories are displayed as filterable tabs within the picker.
+
+## Context Menu
+
+Right-click messages to access a context menu for saving commands or performing custom actions.

--- a/docs/dashboard/pairing.md
+++ b/docs/dashboard/pairing.md
@@ -1,0 +1,42 @@
+---
+title: Pairing
+sidebarTitle: Pairing
+description: Authenticate with the Milady dashboard by entering a pairing code from the server logs.
+---
+
+The Pairing View is the authentication screen shown when the dashboard cannot connect with an authenticated session. You must provide a pairing code to establish a secure connection between the dashboard and the agent runtime.
+
+## How Pairing Works
+
+1. Start the Milady agent — a one-time pairing code is printed to the server logs
+2. Open the dashboard — the Pairing View appears if no valid session exists
+3. Enter the pairing code from the server logs
+4. The dashboard exchanges the code for an API token and stores it for future sessions
+
+## Pairing Screen
+
+The screen displays a centered card with:
+
+- **Title** — "Pairing Required"
+- **Pairing code input** — a text field for entering the code from server logs
+- **Submit button** — disabled when the input is empty or submission is in progress
+- **Expiry countdown** — shows remaining time before the code expires (format: `M:SS`), or "Expired" if the code has timed out
+- **Error display** — shows pairing errors (e.g., invalid code, expired code)
+
+## When Pairing Is Not Enabled
+
+If the server does not have pairing enabled, the screen shows:
+
+1. "Pairing is not enabled on this server."
+2. Instructions to either:
+   - Ask the server owner for an API token
+   - Enable pairing on the server and restart Milady
+
+## After Pairing
+
+Once pairing succeeds, the dashboard stores the API token and redirects to the main dashboard. The token persists across browser sessions — you won't need to pair again unless the token is revoked or expires.
+
+## Related
+
+- [Authentication API](/rest/auth) — REST API endpoints for auth status and pairing
+- [API Reference](/api-reference) — full API authentication documentation

--- a/docs/dashboard/stream.md
+++ b/docs/dashboard/stream.md
@@ -1,0 +1,180 @@
+---
+title: Stream
+sidebarTitle: Stream
+description: Go live with your Milady agent — stream to Twitch, YouTube, or any RTMP destination with overlays, voice, and real-time widgets.
+---
+
+The Stream tab lets you broadcast your agent live to streaming platforms. The `StreamView` component renders the stream canvas (1280x720), manages overlays, and provides controls for going live, adjusting volume, and switching destinations.
+
+## Going Live
+
+To start streaming, select a destination from the status bar and click the stream toggle button.
+
+### Supported Destinations
+
+| Destination | Plugin | Notes |
+|-------------|--------|-------|
+| **Twitch** | `@milady/plugin-twitch-streaming` | Standard Twitch RTMP ingest |
+| **YouTube** | `@milady/plugin-youtube-streaming` | Supports custom RTMP URL |
+| **Custom RTMP** | Any RTMP-compatible plugin | Any platform using standard RTMP protocol |
+
+Each destination provides RTMP URL and stream key credentials, optional lifecycle hooks (`onStreamStart`, `onStreamStop`), and per-destination default overlay layouts.
+
+<Info>
+Streaming destinations are provided by plugins. Install the appropriate streaming plugin for your target platform, then configure your stream key in the plugin settings.
+</Info>
+
+### FFmpeg Requirement
+
+Streaming requires FFmpeg to be installed on the host system. FFmpeg handles encoding and RTMP output.
+
+| Platform | Install Command |
+|----------|----------------|
+| **macOS** | `brew install ffmpeg` |
+| **Linux (Debian/Ubuntu)** | `sudo apt install ffmpeg` |
+| **Windows** | Download from [ffmpeg.org](https://ffmpeg.org/download.html) and add to PATH |
+
+The runtime auto-detects the capture mode based on environment:
+
+| Mode | Environment | Method |
+|------|-------------|--------|
+| **pipe** | Electron | UI frames captured via `capturePage()` and piped to FFmpeg stdin |
+| **x11grab** | Linux | Xvfb virtual display capture |
+| **avfoundation** | macOS | Native screen capture |
+| **file** | Headless | Puppeteer CDP screenshots piped to FFmpeg |
+
+All modes output 1280x720 at 15-30 fps with 1500k bitrate.
+
+## Overlay System
+
+The stream canvas renders a configurable set of overlay widgets on top of the stream content. Overlays are managed through the widget editor accessible from the Stream tab.
+
+### Built-in Widgets
+
+| Widget | Description |
+|--------|-------------|
+| **Thought Bubble** | Displays the agent's latest thought or reasoning, auto-fades after a configurable delay (2-30s) |
+| **Action Ticker** | Scrolling horizontal strip of recent actions and tool calls (configurable 3-20 visible items) |
+| **Alert Popup** | Animated fade-in/out alerts for new viewers and chat messages |
+| **Viewer Count** | Live viewer count badge with pulsing green dot |
+| **Branding** | Agent name/logo watermark with configurable opacity |
+| **Custom HTML** | User-defined HTML overlay for full extensibility |
+
+Each widget supports position (x, y, width, height), z-index, and an enable/disable toggle.
+
+### Custom HTML Widgets
+
+The Custom HTML widget lets you inject arbitrary HTML into the overlay layer. Use it for custom branding, animated graphics, or third-party widget embeds. The widget can subscribe to configurable event streams for dynamic content.
+
+### Overlay Layouts
+
+Overlay layouts are JSON-serializable and versioned. Each streaming destination can have its own layout, and layouts are persisted to `data/stream/stream-settings.json`.
+
+## Voice on Stream
+
+The TTS-to-RTMP bridge generates speech server-side and pipes audio directly into the FFmpeg stream.
+
+### How It Works
+
+1. Agent generates a response
+2. TTS provider converts text to PCM audio (s16le, 24 kHz, mono)
+3. Audio chunks are piped to FFmpeg via pipe:3 (4th stdio fd) every 50ms
+4. Silence is written when the agent is not speaking
+
+### Supported TTS Providers
+
+- **ElevenLabs** — high-quality neural voices
+- **OpenAI** — OpenAI TTS voices
+- **Edge (Microsoft)** — browser-native Microsoft Edge TTS
+
+### Voice Settings
+
+| Setting | Description |
+|---------|-------------|
+| **Enabled** | Toggle voice on/off for the stream |
+| **Auto-Speak** | Automatically speak agent responses when enabled |
+| **Provider** | Select TTS provider (auto-detected if not set) |
+
+The `StreamVoiceConfig` component displays a compact control panel with toggle, provider status, and a test button. The test button only appears when the stream is live and the TTS bridge is attached.
+
+<Warning>
+Voice requires valid TTS API keys configured in Settings > Secrets. Maximum text length per speak request is 2000 characters. The agent cannot speak again until the current speech finishes.
+</Warning>
+
+## Stream Settings
+
+| Setting | Description |
+|---------|-------------|
+| **Theme** | Visual theme applied to the stream canvas |
+| **Avatar** | VRM avatar index displayed on stream |
+| **Volume** | Stream audio volume (0-100) |
+| **Mute** | Mute/unmute stream audio |
+
+### Agent Mode Detection
+
+The StreamView automatically detects the agent's current activity mode and renders appropriate content:
+
+| Mode | Content |
+|------|---------|
+| **Gaming** | Game iframe |
+| **Terminal** | Stream terminal |
+| **Chatting** | Chat content overlay |
+| **Idle** | Idle content with avatar |
+
+## Stream Components
+
+The StreamView is composed of several sub-components:
+
+- **StatusBar** — top bar with mode indicator, viewer count, stream toggle, volume slider, and destination selector.
+- **StreamVoiceConfig** — compact voice control panel.
+- **OverlayLayer** — renders all enabled widgets at their configured positions.
+- **AvatarPip** — VRM avatar picture-in-picture window.
+- **ActivityFeed** — right sidebar event stream.
+- **ChatTicker** — bottom scrolling chat message ticker.
+
+## API Reference
+
+### Stream Control
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/api/stream/live` | Start streaming using destination credentials |
+| POST | `/api/stream/offline` | Stop streaming |
+| GET | `/api/stream/status` | Stream health (running, FFmpeg alive, uptime, frames, volume, muted) |
+
+### Audio
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/api/stream/volume` | Set volume (0-100) |
+| POST | `/api/stream/mute` | Mute stream |
+| POST | `/api/stream/unmute` | Unmute stream |
+
+### Voice (TTS)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/stream/voice` | Get voice config and status |
+| POST | `/api/stream/voice` | Save voice settings |
+| POST | `/api/stream/voice/speak` | Trigger TTS with custom text (max 2000 chars) |
+
+### Destinations
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/streaming/destinations` | List available streaming destinations |
+| POST | `/api/streaming/destination` | Set active destination |
+
+### Overlays
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/stream/overlay-layout` | Read overlay layout (supports `?destination=<id>`) |
+| POST | `/api/stream/overlay-layout` | Save overlay layout |
+
+### Visual Settings
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/stream/settings` | Read theme/avatar settings |
+| POST | `/api/stream/settings` | Save theme/avatar settings |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -27,7 +27,7 @@
   "navigation": {
     "tabs": [
       {
-        "tab": "Docs",
+        "tab": "Getting Started",
         "groups": [
           {
             "group": "Getting Started",
@@ -40,15 +40,6 @@
             ]
           },
           {
-            "group": "Agent",
-            "pages": [
-              "agents/character-interface",
-              "agents/personality-and-behavior",
-              "agents/memory-and-state",
-              "agents/runtime-and-lifecycle"
-            ]
-          },
-          {
             "group": "Configuration",
             "pages": ["configuration", "config-schema", "model-providers"]
           },
@@ -56,23 +47,74 @@
             "group": "Guides",
             "pages": [
               "guides/autonomous-mode",
-              "guides/custom-actions",
-              "guides/triggers",
               "guides/hooks",
-              "guides/knowledge",
-              "guides/media-generation",
-              "guides/training",
-              "guides/agent-export",
-              "guides/themes",
               "guides/config-includes",
               "guides/emotes",
               "guides/local-models",
               "guides/mcp-marketplace",
-              "chat-commands"
+              "chat-commands",
+              "guides/media-generation",
+              "guides/themes",
+              "guides/agent-export"
             ]
           },
           {
-            "group": "Connectors",
+            "group": "Apps & Platforms",
+            "pages": [
+              "apps/overview",
+              "apps/desktop",
+              "apps/desktop/native-modules",
+              "apps/desktop/deep-linking",
+              "apps/mobile",
+              "apps/mobile/capacitor-plugins",
+              "apps/mobile/build-guide",
+              "apps/chrome-extension",
+              "apps/tui"
+            ]
+          },
+          {
+            "group": "Infrastructure",
+            "pages": ["deployment", "self-updates", "guides/cloud"]
+          },
+          {
+            "group": "Contributing",
+            "pages": ["guides/contribution-guide"]
+          }
+        ]
+      },
+      {
+        "tab": "Dashboard",
+        "groups": [
+          {
+            "group": "Overview",
+            "pages": ["apps/dashboard", "dashboard/pairing"]
+          },
+          {
+            "group": "Chat",
+            "pages": ["dashboard/chat"]
+          },
+          {
+            "group": "Stream",
+            "pages": ["dashboard/stream"]
+          },
+          {
+            "group": "Character",
+            "pages": [
+              "agents/character-interface",
+              "agents/personality-and-behavior",
+              "agents/memory-and-state"
+            ]
+          },
+          {
+            "group": "Wallets",
+            "pages": ["guides/wallet"]
+          },
+          {
+            "group": "Knowledge",
+            "pages": ["guides/knowledge"]
+          },
+          {
+            "group": "Social",
             "pages": [
               "guides/connectors",
               "guides/whatsapp",
@@ -83,72 +125,27 @@
             ]
           },
           {
-            "group": "Infrastructure",
-            "pages": [
-              "guides/wallet",
-              "guides/sandbox",
-              "guides/cloud",
-              "deployment",
-              "self-updates"
-            ]
+            "group": "Apps",
+            "pages": ["dashboard/apps"]
           },
           {
-            "group": "Contributing",
-            "pages": ["guides/contribution-guide"]
+            "group": "Settings",
+            "pages": [
+              "apps/dashboard/settings",
+              "apps/dashboard/talk-mode"
+            ]
           }
         ]
       },
       {
-        "tab": "Apps",
+        "tab": "Advanced",
         "groups": [
           {
-            "group": "Overview",
-            "pages": ["apps/overview"]
-          },
-          {
-            "group": "Desktop App",
-            "pages": [
-              "apps/desktop",
-              "apps/desktop/native-modules",
-              "apps/desktop/deep-linking"
-            ]
-          },
-          {
-            "group": "Mobile App",
-            "pages": [
-              "apps/mobile",
-              "apps/mobile/capacitor-plugins",
-              "apps/mobile/build-guide"
-            ]
-          },
-          {
-            "group": "Chrome Extension",
-            "pages": ["apps/chrome-extension"]
-          },
-          {
-            "group": "Dashboard",
-            "pages": ["apps/dashboard", "apps/dashboard/settings"]
-          },
-          {
-            "group": "TUI",
-            "pages": ["apps/tui"]
-          }
-        ]
-      },
-      {
-        "tab": "Plugins",
-        "groups": [
-          {
-            "group": "Overview",
+            "group": "Plugins",
             "pages": [
               "plugins/overview",
               "plugins/architecture",
-              "plugins/registry"
-            ]
-          },
-          {
-            "group": "Development",
-            "pages": [
+              "plugins/registry",
               "plugins/create-a-plugin",
               "plugins/development",
               "plugins/local-plugins",
@@ -162,6 +159,43 @@
             "group": "Skills",
             "pages": ["plugins/skills"]
           },
+          {
+            "group": "Actions",
+            "pages": ["guides/custom-actions"]
+          },
+          {
+            "group": "Triggers",
+            "pages": ["guides/triggers"]
+          },
+          {
+            "group": "Fine-Tuning",
+            "pages": ["guides/training"]
+          },
+          {
+            "group": "Trajectories",
+            "pages": ["advanced/trajectories"]
+          },
+          {
+            "group": "Runtime",
+            "pages": ["agents/runtime-and-lifecycle"]
+          },
+          {
+            "group": "Database",
+            "pages": ["advanced/database"]
+          },
+          {
+            "group": "Logs",
+            "pages": ["advanced/logs"]
+          },
+          {
+            "group": "Security",
+            "pages": ["guides/sandbox"]
+          }
+        ]
+      },
+      {
+        "tab": "Plugin Registry",
+        "groups": [
           {
             "group": "Core Plugins",
             "pages": [
@@ -202,7 +236,10 @@
           },
           {
             "group": "DeFi & Blockchain",
-            "pages": ["plugin-registry/defi/evm", "plugin-registry/defi/solana"]
+            "pages": [
+              "plugin-registry/defi/evm",
+              "plugin-registry/defi/solana"
+            ]
           },
           {
             "group": "Feature Plugins",
@@ -252,7 +289,15 @@
               "rest/diagnostics",
               "rest/subscriptions",
               "rest/trajectories",
-              "rest/v1-compat"
+              "rest/v1-compat",
+              "rest/stream",
+              "rest/memory",
+              "rest/avatar",
+              "rest/whatsapp-pairing",
+              "rest/bug-report",
+              "rest/ltcg",
+              "rest/coding-agents",
+              "rest/whitelist"
             ]
           },
           {

--- a/docs/guides/contributing.md
+++ b/docs/guides/contributing.md
@@ -1,3 +1,8 @@
+---
+title: Contributing Guide
+description: How to set up a development environment, follow code conventions, and submit pull requests to the Milady project.
+---
+
 # Contributing Guide
 
 Welcome to Milaidy! This guide will help you set up your development environment and contribute effectively.
@@ -468,7 +473,7 @@ What should happen
 
 ## Next Steps
 
-- [Plugin Development Guide](./plugin-development.md) — Build plugins
-- [Skills Documentation](./skills.md) — Create skills
-- [Local Plugin Development](./local-plugins.md) — Develop locally
+- [Plugin Development Guide](/plugins/development) — Build plugins
+- [Skills Documentation](/plugins/skills) — Create skills
+- [Local Plugin Development](/plugins/local-plugins) — Develop locally
 - Browse the codebase: start with `src/runtime/milaidy-plugin.ts`

--- a/docs/guides/registry.md
+++ b/docs/guides/registry.md
@@ -1,3 +1,8 @@
+---
+title: Plugin Registry Guide
+description: How to discover, configure, submit, and maintain plugins in the Milady/ElizaOS plugin registry.
+---
+
 # Plugin Registry Guide
 
 The plugin registry is the central index of available ElizaOS plugins. This guide covers discovering, using, and submitting plugins to the registry.
@@ -460,8 +465,8 @@ pnpm add elizaos-plugin-custom-feature
 
 ## Next Steps
 
-- [Plugin Development Guide](./plugin-development.md) — Create your own plugins
-- [Local Plugin Development](./local-plugins.md) — Develop without publishing
+- [Plugin Development Guide](/plugins/development) — Create your own plugins
+- [Local Plugin Development](/plugins/local-plugins) — Develop without publishing
 - [Contributing Guide](./contributing.md) — Submit plugins upstream
 
 ---

--- a/docs/rest/avatar.md
+++ b/docs/rest/avatar.md
@@ -1,0 +1,47 @@
+---
+title: Avatar API
+sidebarTitle: Avatar
+description: REST API endpoints for uploading and serving custom VRM avatars.
+---
+
+## Upload Custom VRM Avatar
+
+```
+POST /api/avatar/vrm
+```
+
+Uploads a custom VRM avatar file and saves it to `~/.milady/avatars/custom.vrm`, replacing any previous upload.
+
+**Request:** Raw binary body containing a `.vrm` (glTF-binary) file.
+
+| Constraint | Value |
+|------------|-------|
+| Max file size | 50 MB |
+| Format | glTF-binary (must begin with `glTF` magic bytes) |
+
+**Response:**
+```json
+{ "ok": true, "size": 1048576 }
+```
+
+`size` is the file size in bytes.
+
+**Errors:** `400` if body is empty, exceeds 50 MB, or fails the glTF magic-byte check.
+
+## Get Custom VRM Avatar
+
+```
+GET /api/avatar/vrm
+```
+
+Serves the currently uploaded custom VRM avatar file. Also supports `HEAD` requests for existence checks.
+
+**Response:** Binary VRM/GLB file body.
+
+| Header | Value |
+|--------|-------|
+| `Content-Type` | `model/gltf-binary` |
+| `Content-Length` | File size in bytes |
+| `Cache-Control` | `no-cache` |
+
+**Errors:** `404` if no custom avatar has been uploaded.

--- a/docs/rest/bug-report.md
+++ b/docs/rest/bug-report.md
@@ -1,0 +1,55 @@
+---
+title: Bug Report API
+sidebarTitle: Bug Report
+description: REST API endpoints for submitting bug reports from the dashboard.
+---
+
+## Get Environment Info
+
+```
+GET /api/bug-report/info
+```
+
+Returns the server's Node.js version and OS platform, used by the frontend to pre-fill environment fields in the bug report form.
+
+**Response:**
+```json
+{ "nodeVersion": "v20.11.0", "platform": "linux" }
+```
+
+## Submit Bug Report
+
+```
+POST /api/bug-report
+```
+
+Submits a bug report. If `GITHUB_TOKEN` is set in the environment, creates a GitHub issue on the project repository with labels `bug`, `triage`, `user-reported`. Without the token, returns a pre-filled GitHub issue URL as a fallback.
+
+Rate-limited to **5 submissions per IP per 10-minute window**.
+
+**Request body:**
+
+| Field | Type | Required | Max Length |
+|-------|------|----------|-----------|
+| `description` | string | yes | 80 chars (used as issue title) |
+| `stepsToReproduce` | string | yes | — |
+| `expectedBehavior` | string | no | — |
+| `actualBehavior` | string | no | — |
+| `environment` | string | no | 200 chars |
+| `nodeVersion` | string | no | 200 chars |
+| `modelProvider` | string | no | 200 chars |
+| `logs` | string | no | 50,000 chars |
+
+All fields are HTML-stripped before use.
+
+**Response — with GitHub token:**
+```json
+{ "url": "https://github.com/milady-ai/milady/issues/42" }
+```
+
+**Response — without GitHub token:**
+```json
+{ "fallback": "https://github.com/milady-ai/milady/issues/new?template=bug_report.yml" }
+```
+
+**Errors:** `400` missing required fields; `429` rate limit exceeded; `502` GitHub API error.

--- a/docs/rest/coding-agents.md
+++ b/docs/rest/coding-agents.md
@@ -1,0 +1,69 @@
+---
+title: Coding Agents API
+sidebarTitle: Coding Agents
+description: REST API endpoints for managing autonomous coding agent tasks and sessions.
+---
+
+These endpoints manage coding agent tasks orchestrated by the `AgentOrchestratorService`. They serve as fallback handlers when the coding agent plugin does not export its own route handler.
+
+## Coordinator Status
+
+```
+GET /api/coding-agents/coordinator/status
+```
+
+Returns the supervision level and list of all active/completed coding agent tasks.
+
+**Response:**
+```json
+{
+  "supervisionLevel": "autonomous",
+  "taskCount": 2,
+  "pendingConfirmations": 0,
+  "tasks": [
+    {
+      "sessionId": "550e8400-e29b-41d4-a716-446655440000",
+      "agentType": "eliza",
+      "label": "Refactor auth module",
+      "originalTask": "Refactor the auth module to use JWT",
+      "workdir": "/home/user/project",
+      "status": "active",
+      "decisionCount": 5,
+      "autoResolvedCount": 3
+    }
+  ]
+}
+```
+
+Returns an empty task list (not an error) if the orchestrator service is unavailable.
+
+**Task status mapping:**
+
+| Orchestrator State | API Status |
+|-------------------|------------|
+| `running`, `pending` | `active` |
+| `completed` | `completed` |
+| `failed`, `error` | `error` |
+| `cancelled` | `stopped` |
+| `paused` | `blocked` |
+
+## Stop Task
+
+```
+POST /api/coding-agents/:sessionId/stop
+```
+
+Cancels a specific coding agent task by its session ID.
+
+**Path params:**
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `sessionId` | string | The task UUID |
+
+**Response:**
+```json
+{ "ok": true }
+```
+
+**Errors:** `503` if the orchestrator service is unavailable; `500` on cancellation failure.

--- a/docs/rest/knowledge.md
+++ b/docs/rest/knowledge.md
@@ -241,3 +241,60 @@ List all text fragments for a specific document, ordered by position.
   "count": 48
 }
 ```
+
+## Bulk Upload
+
+```
+POST /api/knowledge/documents/bulk
+```
+
+Uploads up to 100 knowledge documents in a single request. Each document is processed independently — partial failures do not abort the batch.
+
+**Request body:**
+```json
+{
+  "documents": [
+    {
+      "content": "Document text or base64 content",
+      "filename": "notes.pdf",
+      "contentType": "application/pdf",
+      "metadata": {}
+    }
+  ]
+}
+```
+
+| Constraint | Value |
+|------------|-------|
+| Max body size | 32 MB |
+| Max documents per request | 100 |
+
+**Response:**
+```json
+{
+  "ok": true,
+  "total": 3,
+  "successCount": 2,
+  "failureCount": 1,
+  "results": [
+    {
+      "index": 0,
+      "ok": true,
+      "filename": "notes.pdf",
+      "documentId": "550e8400-e29b-41d4-a716-446655440000",
+      "fragmentCount": 14,
+      "warnings": []
+    },
+    {
+      "index": 1,
+      "ok": false,
+      "filename": "broken.txt",
+      "error": "content and filename must be non-empty strings"
+    }
+  ]
+}
+```
+
+Top-level `ok` is `true` only when `failureCount === 0`. `warnings` is present only on successful items when the ingestion emitted warnings.
+
+**Errors:** `400` if `documents` is missing, empty, or exceeds 100 items.

--- a/docs/rest/ltcg.md
+++ b/docs/rest/ltcg.md
@@ -1,0 +1,85 @@
+---
+title: LTCG Autonomy API
+sidebarTitle: LTCG
+description: REST API endpoints for controlling the LTCG (Lunch Table Card Game) autonomy loop.
+---
+
+These endpoints control the autonomy loop provided by the `@lunchtable/plugin-ltcg` plugin. All endpoints return `500` if the plugin is not installed.
+
+## Get Status
+
+```
+GET /api/ltcg/autonomy/status
+```
+
+Returns the current autonomy controller state.
+
+**Response:**
+```json
+{
+  "state": "running",
+  "mode": "story",
+  "continuous": true
+}
+```
+
+## Start
+
+```
+POST /api/ltcg/autonomy/start
+```
+
+Starts the LTCG autonomy loop in the specified mode.
+
+**Request body:**
+
+| Field | Type | Required | Default |
+|-------|------|----------|---------|
+| `mode` | string | no | `"story"` |
+| `continuous` | boolean | no | `true` |
+
+Valid modes: `"story"`, `"pvp"`.
+
+**Response:**
+```json
+{ "ok": true, "mode": "story", "continuous": true }
+```
+
+## Pause
+
+```
+POST /api/ltcg/autonomy/pause
+```
+
+Pauses the running autonomy loop without stopping it.
+
+**Response:**
+```json
+{ "ok": true, "state": "paused" }
+```
+
+## Resume
+
+```
+POST /api/ltcg/autonomy/resume
+```
+
+Resumes a paused autonomy loop.
+
+**Response:**
+```json
+{ "ok": true, "state": "running" }
+```
+
+## Stop
+
+```
+POST /api/ltcg/autonomy/stop
+```
+
+Stops the autonomy loop entirely and resets to idle.
+
+**Response:**
+```json
+{ "ok": true, "state": "idle" }
+```

--- a/docs/rest/memory.md
+++ b/docs/rest/memory.md
@@ -1,0 +1,111 @@
+---
+title: Memory & Context API
+sidebarTitle: Memory
+description: REST API endpoints for storing, searching, and retrieving agent memory and context.
+---
+
+## Remember
+
+```
+POST /api/memory/remember
+```
+
+Saves a free-text note into the agent's persistent hash-memory room.
+
+**Request body:**
+```json
+{ "text": "The user prefers dark mode themes." }
+```
+
+| Field | Type | Required |
+|-------|------|----------|
+| `text` | string | yes |
+
+**Response:**
+```json
+{
+  "ok": true,
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "text": "The user prefers dark mode themes.",
+  "createdAt": 1700000000000
+}
+```
+
+**Errors:** `400` if `text` is missing or empty; `503` if agent runtime is unavailable.
+
+## Search Memory
+
+```
+GET /api/memory/search
+```
+
+Full-text keyword search over saved memory notes. Scans up to 500 most recent entries and returns top matches by term-overlap score.
+
+**Query params:**
+
+| Param | Type | Required | Default | Max |
+|-------|------|----------|---------|-----|
+| `q` | string | yes | — | — |
+| `limit` | integer | no | `10` | `50` |
+
+**Response:**
+```json
+{
+  "query": "dark mode",
+  "results": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "text": "The user prefers dark mode themes.",
+      "createdAt": 1700000000000,
+      "score": 1.5
+    }
+  ],
+  "count": 1,
+  "limit": 10
+}
+```
+
+**Errors:** `400` if `q` is absent.
+
+## Quick Context
+
+```
+GET /api/context/quick
+```
+
+Searches both memory notes and the knowledge base simultaneously, then synthesizes a concise answer (max 120 words) via the agent's text model.
+
+**Query params:**
+
+| Param | Type | Required | Default | Max |
+|-------|------|----------|---------|-----|
+| `q` | string | yes | — | — |
+| `limit` | integer | no | `8` | `20` |
+
+**Response:**
+```json
+{
+  "query": "What theme does the user prefer?",
+  "answer": "The user prefers dark mode themes.",
+  "memories": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "text": "The user prefers dark mode themes.",
+      "createdAt": 1700000000000,
+      "score": 1.5
+    }
+  ],
+  "knowledge": [
+    {
+      "id": "uuid",
+      "text": "Theme configuration documentation...",
+      "similarity": 0.87,
+      "documentId": "uuid",
+      "documentTitle": "themes.pdf",
+      "position": 3
+    }
+  ]
+}
+```
+
+Knowledge results are filtered to `similarity >= 0.2`. The `documentId`, `documentTitle`, and `position` fields are present only when available in the fragment metadata.

--- a/docs/rest/skills.md
+++ b/docs/rest/skills.md
@@ -513,6 +513,53 @@ Arbitrary configuration object — varies by marketplace backend.
 
 ### Verification Commands
 
+## Acknowledge Skill Findings
+
+```
+POST /api/skills/:id/acknowledge
+```
+
+Acknowledges the security scan findings for a skill. Required before the skill can be enabled. Optionally enables the skill in the same request.
+
+**Path params:**
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `id` | string | Skill slug |
+
+**Request body:**
+```json
+{ "enable": true }
+```
+
+`enable` is optional — omit or set to `false` to acknowledge without enabling.
+
+**Response — findings present:**
+```json
+{
+  "ok": true,
+  "skillId": "my-skill",
+  "acknowledged": true,
+  "enabled": true,
+  "findingCount": 3
+}
+```
+
+**Response — no findings (clean scan):**
+```json
+{
+  "ok": true,
+  "message": "No findings to acknowledge.",
+  "acknowledged": true
+}
+```
+
+**Errors:** `404` no scan report found; `403` skill status is `"blocked"` (cannot be acknowledged).
+
+---
+
+## Testing
+
 ```bash
 # Skill catalog and marketplace unit tests
 bunx vitest run src/services/plugin-installer.test.ts src/services/skill-marketplace.test.ts src/services/skill-catalog-client.test.ts

--- a/docs/rest/stream.md
+++ b/docs/rest/stream.md
@@ -1,0 +1,360 @@
+---
+title: Stream API
+sidebarTitle: Stream
+description: REST API endpoints for controlling live streaming, overlays, voice TTS, and stream settings.
+---
+
+## Stream Control
+
+### Start Stream (Destination-Managed)
+
+```
+POST /api/stream/live
+```
+
+Starts streaming using the configured destination adapter. Fetches RTMP credentials automatically from the active destination plugin.
+
+**Response:**
+```json
+{
+  "ok": true,
+  "live": true,
+  "rtmpUrl": "rtmp://live.twitch.tv/app",
+  "inputMode": "pipe",
+  "audioSource": "tts",
+  "destination": "twitch"
+}
+```
+
+### Stop Stream
+
+```
+POST /api/stream/offline
+```
+
+Stops the active stream and notifies the destination plugin.
+
+**Response:**
+```json
+{ "ok": true, "live": false }
+```
+
+### Stream Status
+
+```
+GET /api/stream/status
+```
+
+Returns current stream health and configuration.
+
+**Response:**
+```json
+{
+  "ok": true,
+  "running": true,
+  "ffmpegAlive": true,
+  "uptime": 3742,
+  "frameCount": 112260,
+  "volume": 80,
+  "muted": false,
+  "audioSource": "tts",
+  "inputMode": "pipe",
+  "destination": "twitch"
+}
+```
+
+### Start Stream (Direct RTMP)
+
+```
+POST /api/stream/start
+```
+
+Backward-compatible explicit RTMP start with full parameter control. Prefer `POST /api/stream/live` for destination-managed starts.
+
+**Request body:**
+```json
+{
+  "rtmpUrl": "rtmp://live.twitch.tv/app",
+  "rtmpKey": "live_abc123",
+  "inputMode": "testsrc",
+  "resolution": "1280x720",
+  "bitrate": "2500k",
+  "framerate": 30
+}
+```
+
+| Field | Type | Required | Default | Notes |
+|-------|------|----------|---------|-------|
+| `rtmpUrl` | string | yes | — | Must start with `rtmp://` or `rtmps://` |
+| `rtmpKey` | string | yes | — | Stream key |
+| `inputMode` | string | no | `"testsrc"` | `"testsrc"`, `"avfoundation"`, or `"pipe"` |
+| `resolution` | string | no | `"1280x720"` | Must match `/^\d{3,4}x\d{3,4}$/` |
+| `bitrate` | string | no | `"2500k"` | Must match `/^\d+k$/` |
+| `framerate` | number | no | `30` | Integer 1–60 |
+
+**Response:**
+```json
+{ "ok": true, "message": "Stream started" }
+```
+
+### Stop Stream (Direct)
+
+```
+POST /api/stream/stop
+```
+
+Stops the active FFmpeg process and returns session uptime.
+
+**Response:**
+```json
+{ "ok": true, "uptime": 3742 }
+```
+
+`uptime` is in seconds.
+
+### Send Frame
+
+```
+POST /api/stream/frame
+```
+
+Pipes a raw JPEG/image frame buffer to FFmpeg. Used in `pipe` capture mode (Electron `capturePage()`).
+
+**Request:** Raw binary body (max 2 MB).
+
+**Response:** `200` with empty body.
+
+**Errors:** `400` empty body; `503` stream not running.
+
+## Audio
+
+### Set Volume
+
+```
+POST /api/stream/volume
+```
+
+**Request body:**
+```json
+{ "volume": 80 }
+```
+
+`volume` is an integer 0–100.
+
+**Response:**
+```json
+{ "ok": true, "volume": 80, "muted": false }
+```
+
+### Mute
+
+```
+POST /api/stream/mute
+```
+
+**Response:**
+```json
+{ "ok": true, "muted": true, "volume": 80 }
+```
+
+### Unmute
+
+```
+POST /api/stream/unmute
+```
+
+**Response:**
+```json
+{ "ok": true, "muted": false, "volume": 80 }
+```
+
+## Destinations
+
+### List Destinations
+
+```
+GET /api/streaming/destinations
+```
+
+Returns all available streaming destinations from installed plugins.
+
+**Response:**
+```json
+{
+  "ok": true,
+  "destinations": [
+    { "id": "twitch", "name": "Twitch" },
+    { "id": "youtube", "name": "YouTube" }
+  ]
+}
+```
+
+### Set Active Destination
+
+```
+POST /api/streaming/destination
+```
+
+**Request body:**
+```json
+{ "destinationId": "twitch" }
+```
+
+**Response:**
+```json
+{ "ok": true }
+```
+
+## Overlays
+
+### Get Overlay Layout
+
+```
+GET /api/stream/overlay-layout
+```
+
+**Query params:**
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `destination` | string | no | Destination ID for per-destination layouts |
+
+**Response:**
+```json
+{
+  "ok": true,
+  "layout": {
+    "version": 1,
+    "widgets": [...]
+  },
+  "destinationId": "twitch"
+}
+```
+
+### Save Overlay Layout
+
+```
+POST /api/stream/overlay-layout
+```
+
+**Request body:**
+```json
+{
+  "layout": {
+    "version": 1,
+    "widgets": [...]
+  }
+}
+```
+
+**Response:**
+```json
+{ "ok": true }
+```
+
+## Voice (TTS-to-RTMP)
+
+### Get Voice Config
+
+```
+GET /api/stream/voice
+```
+
+Returns voice configuration and current speaking status.
+
+**Response:**
+```json
+{
+  "enabled": true,
+  "autoSpeak": true,
+  "provider": "elevenlabs",
+  "speaking": false,
+  "bridgeAttached": true,
+  "apiKeyConfigured": true
+}
+```
+
+### Save Voice Settings
+
+```
+POST /api/stream/voice
+```
+
+**Request body:**
+```json
+{
+  "enabled": true,
+  "autoSpeak": true,
+  "provider": "elevenlabs"
+}
+```
+
+**Response:**
+```json
+{ "ok": true }
+```
+
+### Speak Text
+
+```
+POST /api/stream/voice/speak
+```
+
+Manually trigger TTS on the live stream.
+
+**Request body:**
+```json
+{ "text": "Hello, stream!" }
+```
+
+| Constraint | Value |
+|------------|-------|
+| Max text length | 2000 characters |
+| Rate limit | One at a time (429 if speaking) |
+| Requires | Stream must be live, TTS bridge attached |
+
+**Response:**
+```json
+{ "ok": true }
+```
+
+**Errors:** `400` text missing/too long; `429` already speaking; `503` bridge not attached.
+
+## Visual Settings
+
+### Get Stream Settings
+
+```
+GET /api/stream/settings
+```
+
+**Response:**
+```json
+{
+  "ok": true,
+  "settings": {
+    "theme": "milady",
+    "avatarIndex": 0
+  }
+}
+```
+
+### Save Stream Settings
+
+```
+POST /api/stream/settings
+```
+
+**Request body:**
+```json
+{
+  "settings": {
+    "theme": "milady",
+    "avatarIndex": 2
+  }
+}
+```
+
+**Response:**
+```json
+{ "ok": true }
+```

--- a/docs/rest/whatsapp-pairing.md
+++ b/docs/rest/whatsapp-pairing.md
@@ -1,0 +1,105 @@
+---
+title: WhatsApp Pairing API
+sidebarTitle: WhatsApp
+description: REST API endpoints for WhatsApp QR-code pairing, connection status, and disconnection.
+---
+
+## Start Pairing
+
+```
+POST /api/whatsapp/pair
+```
+
+Initiates a WhatsApp QR-code pairing session. Replaces any existing session for the given account. Maximum 10 concurrent sessions.
+
+**Request body:**
+```json
+{ "accountId": "default" }
+```
+
+| Field | Type | Required | Default |
+|-------|------|----------|---------|
+| `accountId` | string | no | `"default"` |
+
+`accountId` is sanitized — only alphanumeric characters, hyphens, and underscores are accepted.
+
+**Response:**
+```json
+{ "ok": true, "accountId": "default", "status": "pending" }
+```
+
+**Errors:** `400` invalid `accountId`; `429` too many concurrent sessions; `500` session start failure.
+
+## Connection Status
+
+```
+GET /api/whatsapp/status
+```
+
+Returns the current pairing status, whether auth credentials exist on disk, and whether the live WhatsApp service is connected.
+
+**Query params:**
+
+| Param | Type | Required | Default |
+|-------|------|----------|---------|
+| `accountId` | string | no | `"default"` |
+
+**Response:**
+```json
+{
+  "accountId": "default",
+  "status": "idle",
+  "authExists": true,
+  "serviceConnected": false,
+  "servicePhone": null
+}
+```
+
+| Status | Meaning |
+|--------|---------|
+| `idle` | No pairing session active |
+| `pending` | Pairing in progress, waiting for QR scan |
+| `connected` | Successfully paired and connected |
+| `error` | Pairing failed |
+
+`servicePhone` is `null` when not connected.
+
+## Stop Pairing
+
+```
+POST /api/whatsapp/pair/stop
+```
+
+Stops an in-progress pairing session without removing stored auth credentials.
+
+**Request body:**
+```json
+{ "accountId": "default" }
+```
+
+**Response:**
+```json
+{ "ok": true, "accountId": "default", "status": "idle" }
+```
+
+Always returns `ok: true` even if no session was active.
+
+## Disconnect
+
+```
+POST /api/whatsapp/disconnect
+```
+
+Stops any active pairing session, performs a Baileys logout, deletes auth files from disk, and removes the WhatsApp connector from the saved config.
+
+**Request body:**
+```json
+{ "accountId": "default" }
+```
+
+**Response:**
+```json
+{ "ok": true, "accountId": "default" }
+```
+
+Logout and file-deletion failures are logged but suppressed — the response is always `ok: true` on success.

--- a/docs/rest/whitelist.md
+++ b/docs/rest/whitelist.md
@@ -1,0 +1,97 @@
+---
+title: Whitelist API
+sidebarTitle: Whitelist
+description: REST API endpoints for NFT ownership verification and Merkle proof generation for whitelisted minting.
+---
+
+## NFT Verification
+
+### Verify NFT Ownership
+
+```
+POST /api/whitelist/nft/verify
+```
+
+Verifies Milady NFT ownership for the agent's own EVM wallet and, if verified, adds it to the in-memory whitelist. The wallet address is resolved server-side from the agent's onboarded wallet — no address is accepted in the request body.
+
+**Request body:** none.
+
+**Response:**
+```json
+{
+  "verified": true,
+  "balance": 2,
+  "contractAddress": "0x5Af0D9827E0c53E4799BB226655A1de152A425a5",
+  "error": null,
+  "walletAddress": "0xabc..."
+}
+```
+
+**Errors:** `400` if no wallet address is onboarded; `500` on chain verification failure.
+
+### NFT Whitelist Status
+
+```
+GET /api/whitelist/nft/status
+```
+
+Returns the agent's current NFT whitelist eligibility without triggering a blockchain call.
+
+**Response:**
+```json
+{
+  "walletAddress": "0xabc...",
+  "whitelisted": false,
+  "contractAddress": "0x5Af0D9827E0c53E4799BB226655A1de152A425a5",
+  "message": "Address is not whitelisted. Use POST /api/whitelist/nft/verify to verify NFT ownership."
+}
+```
+
+`walletAddress` is an empty string if no wallet is onboarded.
+
+## Merkle Proofs
+
+### Get Merkle Root
+
+```
+GET /api/whitelist/merkle/root
+```
+
+Returns the Merkle root hash and address count for the current in-memory whitelist tree.
+
+**Response:**
+```json
+{
+  "root": "0xdeadbeef...",
+  "addressCount": 1847,
+  "proofReady": true
+}
+```
+
+### Get Merkle Proof
+
+```
+GET /api/whitelist/merkle/proof
+```
+
+Generates the Merkle inclusion proof for a given wallet address. The proof can be passed directly to the `mintWhitelist()` on-chain function.
+
+**Query params:**
+
+| Param | Type | Required |
+|-------|------|----------|
+| `address` | string | yes |
+
+**Response:**
+```json
+{
+  "proof": ["0xabc...", "0xdef..."],
+  "leaf": "0x123...",
+  "root": "0xdeadbeef...",
+  "isWhitelisted": true
+}
+```
+
+`proof` is an empty array and `isWhitelisted` is `false` if the address is not in the tree.
+
+**Errors:** `400` if `address` query param is missing.


### PR DESCRIPTION
## Summary

- Restructures Mintlify docs from 5 tabs to 6, mirroring the dashboard/Electron app navigation so users can find docs for the features they see in the app
- Closes **43 undocumented API endpoint gaps** with 8 new REST reference pages
- Fixes **7 broken internal links** and **2 missing frontmatter** blocks
- Adds **16 new documentation pages** covering previously undocumented features (Talk Mode, Stream, Apps browser, Pairing, Database/Vector/Media viewers, and more)

### New Tab Structure (was 5, now 6)

| Tab | What It Maps To |
|-----|-----------------|
| Getting Started | Onboarding, config, guides, platform apps, infrastructure |
| **Dashboard** | Mirrors app tabs: Chat, Stream, Character, Wallets, Knowledge, Social, Apps, Settings |
| **Advanced** | Mirrors app's Advanced sub-tabs: Plugins, Skills, Actions, Triggers, Fine-Tuning, Trajectories, Runtime, Database, Logs, Security |
| Plugin Registry | Catalog of all plugins (unchanged content, own tab) |
| API Reference | REST API + 8 new endpoint pages (stream, memory, avatar, whatsapp, bug-report, ltcg, coding-agents, whitelist) |
| CLI Reference | Unchanged |

### New Pages (16)

**Dashboard:** `dashboard/chat`, `dashboard/stream`, `dashboard/apps`, `dashboard/pairing`, `apps/dashboard/talk-mode`

**Advanced:** `advanced/trajectories`, `advanced/database` (expanded with 3-mode vector viz docs), `advanced/logs`

**REST API:** `rest/stream` (18 endpoints), `rest/memory` (3), `rest/avatar` (2), `rest/whatsapp-pairing` (4), `rest/bug-report` (2), `rest/ltcg` (5), `rest/coding-agents` (2), `rest/whitelist` (4)

### Fixes

- 7 broken internal links in `settings.md`, `contributing.md`, `registry.md`
- Missing frontmatter on `guides/contributing.md` and `guides/registry.md`
- Added `POST /api/skills/:id/acknowledge` to `rest/skills.md`
- Added `POST /api/knowledge/documents/bulk` to `rest/knowledge.md`

### Verification

- 157 total pages, all paths verified against filesystem
- Zero broken links in new/modified files
- Valid JSON structure
- All new files have proper frontmatter (title + description)
- Docs-only change — no source code modified

## Test plan

- [ ] Verify `docs.json` is valid JSON and Mintlify renders all 6 tabs
- [ ] Spot-check new pages render correctly (dashboard/stream, rest/stream, advanced/database)
- [ ] Verify no 404s when navigating between docs tabs
- [ ] Confirm internal links from new pages resolve (e.g., Talk Mode → Desktop App, Stream → REST API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)