### PR TITLE
fix: close MW-01 coverage drift gaps in 3 unguarded doc files

### DIFF
--- a/INTEGRATION_DOD_MAP.md
+++ b/INTEGRATION_DOD_MAP.md
@@ -18,7 +18,7 @@ Repository: `milady-ai/milady`
 - External registry/marketplace boundaries include plugin registry, skill marketplace, and MCP registry (`src/services/registry-client.ts`, `src/services/skill-marketplace.ts`, `src/services/mcp-marketplace.ts`).
 - Connector ecosystem is plugin-driven with env/config auto-enable maps (`src/config/plugin-auto-enable.ts`, `src/config/schema.ts`).
 - Security hardening exists for wallet export token, MCP config validation, websocket auth, DB host pinning, and URL safety checks (`src/api/server.wallet-export-auth.test.ts`, `src/api/server.mcp-config-validation.test.ts`, `src/api/server.websocket-auth.test.ts`, `src/api/database.ts`, `src/cloud/validate-url.ts`, `src/api/knowledge-routes.ts`).
-- Coverage policy is aligned: 25% lines/functions/statements, 15% branches — enforced in `vitest.config.ts` and documented in `AGENTS.md`, `CONTRIBUTING.md`, `docs/guides/contribution-guide.md`, and `.github/workflows/agent-review.yml`.
+- Coverage policy is aligned: 25% lines/functions/statements, 15% branches — enforced in `vitest.config.ts` and documented in `AGENTS.md`, `CONTRIBUTING.md`, `docs/guides/contribution-guide.md`, `docs/guides/contributing.md`, `docs/plugins/publish.md`, `docs/INTEGRATION_DEFINITION_OF_DONE_GRAPH.md`, and `.github/workflows/agent-review.yml`. Drift is guarded by `scripts/coverage-policy-drift.test.ts`.
 
 ---
 

--- a/scripts/coverage-policy-drift.test.ts
+++ b/scripts/coverage-policy-drift.test.ts
@@ -35,6 +35,9 @@ const DOCS_THAT_REFERENCE_THRESHOLDS = [
   "AGENTS.md",
   "docs/guides/contribution-guide.md",
   "docs/guides/contributing.md",
+  "docs/plugins/publish.md",
+  "docs/INTEGRATION_DEFINITION_OF_DONE_GRAPH.md",
+  "INTEGRATION_DOD_MAP.md",
   ".github/workflows/agent-review.yml",
 ];
 


### PR DESCRIPTION
## Summary
- The `scripts/coverage-policy-drift.test.ts` drift-detection test only guarded **5 of 8** files that reference the `25/25/25/15` coverage thresholds
- `docs/plugins/publish.md`, `docs/INTEGRATION_DEFINITION_OF_DONE_GRAPH.md`, and `INTEGRATION_DOD_MAP.md` were unguarded — a threshold change in `vitest.config.ts` would silently leave them stale
- Added all three files to `DOCS_THAT_REFERENCE_THRESHOLDS` (7→10 test assertions)
- Updated `INTEGRATION_DOD_MAP.md` line 21 to list every doc location and reference the drift guard

## Acceptance Criteria (from #749)
- [x] Coverage threshold policy is singular across docs and `vitest.config.ts`
- [x] CI fails when coverage falls below the chosen floor (`bun run test:coverage` in `test.yml`)
- [x] All 8 doc/config files referencing thresholds are now guarded by the drift test

## Verification
```bash
bunx vitest run scripts/coverage-policy-drift.test.ts   # 10/10 pass
bun run check                                            # lint + typecheck clean
```

## Test plan
- [x] `bunx vitest run scripts/coverage-policy-drift.test.ts` — 10/10 pass (was 7/7)
- [x] `bun run check` — lint/typecheck clean
- [ ] CI passes on this PR

Closes #749

🤖 Generated with [Claude Code](https://claude.com/claude-code)