### PR TITLE
fix: close MW-02 route->service error gaps for shiny mint and whitelist mint

### DIFF
--- a/src/api/onchain-routes-error.test.ts
+++ b/src/api/onchain-routes-error.test.ts
@@ -203,4 +203,24 @@ describe("on-chain route error propagation (MW-02)", () => {
     expect(status).toBe(500);
     expect(data.error).toMatch(/insufficient funds/i);
   });
+
+  it("POST /api/drop/mint with shiny returns 500 on service failure", async () => {
+    const { status, data } = await req(port, "POST", "/api/drop/mint", {
+      name: "TestAgent",
+      shiny: true,
+    });
+    expect(status).toBe(500);
+    expect(data.error).toMatch(/insufficient funds for shiny/i);
+  });
+
+  it("POST /api/drop/mint-whitelist returns 500 on invalid proof", async () => {
+    const { status, data } = await req(
+      port,
+      "POST",
+      "/api/drop/mint-whitelist",
+      { name: "TestAgent", proof: ["0xabc"] },
+    );
+    expect(status).toBe(500);
+    expect(data.error).toMatch(/invalid proof/i);
+  });
 });


### PR DESCRIPTION
## Summary
- The `onchain-routes-error.test.ts` route-level error propagation test covered **6 of 8** drop/registry error paths
- Two drop routes lacked error-path coverage:
  - `POST /api/drop/mint` with `shiny: true` — exercises `dropService.mintShiny()` error path
  - `POST /api/drop/mint-whitelist` — exercises `dropService.mintWithWhitelist()` error path
- Added both tests (6→8 route-level error assertions)
- Total on-chain test count: **82** (66 service-level + 16 route-level)

## Acceptance Criteria (from #750)
- [x] Deterministic tests cover timeout for tx/registry/drop services
- [x] Deterministic tests cover nonce/retry for tx/registry/drop services
- [x] Deterministic tests cover route->service failure mapping for ALL routes (now 8/8 error paths)

## Verification
```bash
bunx vitest run src/api/tx-service.test.ts src/api/registry-service.test.ts src/api/drop-service.test.ts  # 66 pass
bunx vitest run src/api/onchain-routes-error.test.ts src/api/onchain-routes.test.ts  # 16 pass
```

## Test plan
- [x] `bunx vitest run` on all 5 on-chain test files — 82/82 pass
- [x] `bun run check` — lint/typecheck clean
- [ ] CI passes on this PR

Closes #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)