### PR TITLE
fix: unblock MW-03 x402/CUA boundary tests broken by plugin-ollama ESM import

### DIFF
--- a/src/runtime/cua-boundary.test.ts
+++ b/src/runtime/cua-boundary.test.ts
@@ -7,12 +7,50 @@
  * with runtime-focused mapping and security tests (MW-03).
  */
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { MiladyConfig } from "../config/config";
 import {
   AUTH_PROVIDER_PLUGINS,
   applyPluginAutoEnable,
 } from "../config/plugin-auto-enable";
+
+// Mock all static plugin star-imports in eliza.ts to isolate boundary tests
+// from heavy transitive dependencies (e.g. plugin-ollama → @elizaos/core ESM
+// named-export issue with MAX_EMBEDDING_TOKENS).
+vi.mock("@elizaos/plugin-agent-orchestrator", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-agent-skills", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-anthropic", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-browser", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-cli", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-coding-agent", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-computeruse", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-cron", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-discord", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-edge-tts", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-elevenlabs", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-elizacloud", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-experience", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-form", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-google-genai", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-groq", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-knowledge", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-local-embedding", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-ollama", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-openai", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-openrouter", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-pdf", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-personality", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-plugin-manager", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-rolodex", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-secrets-manager", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-shell", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-sql", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-telegram", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-todo", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-trajectory-logger", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-trust", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-twitch", () => ({ default: {} }));
+
 import { collectPluginNames } from "./eliza";
 
 // ---------------------------------------------------------------------------

--- a/src/runtime/x402-boundary.test.ts
+++ b/src/runtime/x402-boundary.test.ts
@@ -6,9 +6,47 @@
  * @see https://github.com/milady-ai/milaidy/issues/590
  */
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { MiladyConfig } from "../config/config";
 import { AUTH_PROVIDER_PLUGINS } from "../config/plugin-auto-enable";
+
+// Mock all static plugin star-imports in eliza.ts to isolate boundary tests
+// from heavy transitive dependencies (e.g. plugin-ollama → @elizaos/core ESM
+// named-export issue with MAX_EMBEDDING_TOKENS).
+vi.mock("@elizaos/plugin-agent-orchestrator", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-agent-skills", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-anthropic", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-browser", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-cli", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-coding-agent", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-computeruse", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-cron", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-discord", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-edge-tts", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-elevenlabs", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-elizacloud", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-experience", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-form", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-google-genai", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-groq", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-knowledge", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-local-embedding", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-ollama", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-openai", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-openrouter", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-pdf", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-personality", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-plugin-manager", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-rolodex", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-secrets-manager", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-shell", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-sql", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-telegram", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-todo", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-trajectory-logger", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-trust", () => ({ default: {} }));
+vi.mock("@elizaos/plugin-twitch", () => ({ default: {} }));
+
 import {
   applyX402ConfigToEnv,
   buildCharacterFromConfig,


### PR DESCRIPTION
## Summary
- The 44 x402/CUA boundary tests (24 + 20) were **completely dead** — they couldn't even load
- Root cause: `./eliza.ts` star-imports all plugins, and `@elizaos/plugin-ollama` fails at Vitest load time (`MAX_EMBEDDING_TOKENS` ESM named-import resolution from `@elizaos/core`)
- Added explicit `vi.mock()` stubs for all 33 static plugin imports in both test files
- The boundary tests only exercise utility functions (`collectPluginNames`, `applyX402ConfigToEnv`, `isEnvKeyAllowedForForwarding`, `buildCharacterFromConfig`) — no plugin code is needed

## Acceptance Criteria (from #751)
- [x] x402 and CUA runtime mappings are covered by dedicated tests (44 tests, now actually runnable)
- [x] Security assumptions (key handling/auth behavior) are explicitly validated

## Verification
```bash
bunx vitest run src/runtime/x402-boundary.test.ts src/runtime/cua-boundary.test.ts  # 44/44 pass
bun run check                                                                        # clean
```

## Test plan
- [x] `bunx vitest run src/runtime/x402-boundary.test.ts` — 24/24 pass (was 0 — SyntaxError)
- [x] `bunx vitest run src/runtime/cua-boundary.test.ts` — 20/20 pass (was 0 — SyntaxError)
- [x] `bun run check` — lint/typecheck clean
- [ ] CI passes on this PR

Closes #751

🤖 Generated with [Claude Code](https://claude.com/claude-code)