### PR TITLE
fix: add orphaned registry runbook to Mintlify nav [MW-11]

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -146,6 +146,7 @@
               "plugins/overview",
               "plugins/architecture",
               "plugins/registry",
+              "guides/registry",
               "plugins/create-a-plugin",
               "plugins/development",
               "plugins/local-plugins",


### PR DESCRIPTION
## Summary
- `docs/guides/registry.md` has the full operational runbook for registry/drop operations (setup checklist, failure modes, recovery procedures, verification commands) but was **completely orphaned from the Mintlify navigation** — unreachable by users browsing the docs site.
- `docs/plugins/registry.md` (which IS in the nav) only covers technical architecture — no runbook.
- Added `"guides/registry"` to the Advanced > Plugins nav group right after `"plugins/registry"` so users can find both the architecture reference and the operational runbook.
- All other acceptance criteria topics (skill catalog, media providers, connector specifics, CUA operations) already have their runbooks wired into the nav correctly.

## Test plan
- [x] Verify `docs/guides/registry.md` now appears in `docs.json` nav
- [x] Verify all 5 acceptance criteria topics have setup/failure/verify guidance in their respective docs
- [x] Verify all test files referenced in verification commands exist on disk

Closes #759

🤖 Generated with [Claude Code](https://claude.com/claude-code)