### PR TITLE
feat: auto-clone avatar assets on install for new devs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ test-output/
 elizaos-plugins/
 e2e-screenshots/
 data/
+.avatar-clone-tmp

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "scripts/patch-deps.mjs",
     "scripts/init-submodules.mjs",
     "scripts/ensure-skills.mjs",
+    "scripts/ensure-avatars.mjs",
     "scripts/link-browser-server.mjs"
   ],
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "scripts": {
     "benchmark:server": "node --import tsx src/benchmark/server.ts",
     "build": "tsdown && echo '{\"type\":\"module\"}' > dist/package.json && scripts/rt.sh scripts/write-build-info.ts && cd apps/app && ../../scripts/rt.sh run build",
-    "install:build": "bun install --ignore-scripts && node scripts/init-submodules.mjs && node scripts/ensure-skills.mjs && node scripts/link-browser-server.mjs && node scripts/patch-deps.mjs",
+    "install:build": "bun install --ignore-scripts && node scripts/init-submodules.mjs && node scripts/ensure-skills.mjs && node scripts/ensure-avatars.mjs && node scripts/link-browser-server.mjs && node scripts/patch-deps.mjs",
     "build:node": "tsdown && echo '{\"type\":\"module\"}' > dist/package.json && node --import tsx scripts/write-build-info.ts && cd apps/app && npm run build",
     "build:android": "cd apps/app && ../../scripts/rt.sh run build:android",
     "build:desktop": "cd apps/app && ../../scripts/rt.sh run build:electron",
@@ -76,7 +76,7 @@
     "learn:loop": "echo 'Knowledge loop not yet implemented'",
     "learn:snapshot": "echo 'Knowledge snapshot not yet implemented'",
     "milady": "scripts/rt.sh scripts/run-node.mjs",
-    "postinstall": "node ./scripts/init-submodules.mjs && node ./scripts/ensure-skills.mjs && node ./scripts/link-browser-server.mjs && node ./scripts/patch-deps.mjs",
+    "postinstall": "node ./scripts/init-submodules.mjs && node ./scripts/ensure-skills.mjs && node ./scripts/ensure-avatars.mjs && node ./scripts/link-browser-server.mjs && node ./scripts/patch-deps.mjs",
     "pre-review:local": "node scripts/pre-review-local.mjs",
     "prepack": "scripts/rt.sh run build",
     "prepare": "node -e \"try{require('child_process').execSync('git config core.hooksPath git-hooks',{stdio:'ignore'})}catch{}\"",

--- a/scripts/ensure-avatars.mjs
+++ b/scripts/ensure-avatars.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+/**
+ * Ensure avatar assets (VRMs, animations, backgrounds) are present in the app.
+ *
+ * On a fresh clone, apps/app/public/vrms/ and animations/ may be empty or
+ * contain only Git LFS pointers.  This script clones the milady-ai/avatars
+ * repository into a temp directory and copies the assets into the correct
+ * locations under apps/app/public/.
+ *
+ * Run automatically via the `postinstall` hook, or manually:
+ *   node scripts/ensure-avatars.mjs
+ *   node scripts/ensure-avatars.mjs --force   # re-download even if present
+ */
+import { execSync } from "node:child_process";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const ROOT = resolve(__dirname, "..");
+const PUBLIC = join(ROOT, "apps", "app", "public");
+const VRMS_DIR = join(PUBLIC, "vrms");
+const ANIMATIONS_DIR = join(PUBLIC, "animations");
+
+const AVATARS_REPO = "https://github.com/milady-ai/avatars.git";
+const TAG = "[ensure-avatars]";
+
+/** A VRM file is valid if it is > 1 KB (rules out LFS pointers & stubs). */
+function hasValidVrm(dir) {
+  if (!existsSync(dir)) return false;
+  try {
+    const files = readdirSync(dir).filter((f) => f.endsWith(".vrm"));
+    if (files.length === 0) return false;
+    // Check the first VRM is a real binary, not an LFS pointer (~130 bytes)
+    const stat = statSync(join(dir, files[0]));
+    return stat.size > 1024;
+  } catch {
+    return false;
+  }
+}
+
+function hasValidAnimations(dir) {
+  if (!existsSync(dir)) return false;
+  const emotesDir = join(dir, "emotes");
+  if (!existsSync(emotesDir)) return false;
+  try {
+    const files = readdirSync(emotesDir).filter((f) => f.endsWith(".glb"));
+    if (files.length === 0) return false;
+    const stat = statSync(join(emotesDir, files[0]));
+    return stat.size > 1024;
+  } catch {
+    return false;
+  }
+}
+
+function gitAvailable() {
+  try {
+    execSync("git --version", { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function runEnsureAvatars({ force = false, log = console.log, logError = console.error } = {}) {
+  if (!force && hasValidVrm(VRMS_DIR) && hasValidAnimations(ANIMATIONS_DIR)) {
+    log(`${TAG} Avatar assets already present — skipping`);
+    return { cloned: false, reason: "already-present" };
+  }
+
+  if (!gitAvailable()) {
+    logError(`${TAG} git not found — cannot clone avatar assets`);
+    return { cloned: false, reason: "no-git" };
+  }
+
+  log(`${TAG} Avatar assets missing or incomplete — cloning from ${AVATARS_REPO}...`);
+
+  const tmpDir = join(ROOT, ".avatar-clone-tmp");
+
+  try {
+    // Clean up any previous failed attempt
+    if (existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+
+    // Shallow clone for speed (assets only, no history)
+    execSync(`git clone --depth 1 ${AVATARS_REPO} "${tmpDir}"`, {
+      cwd: ROOT,
+      stdio: "inherit",
+    });
+
+    // Copy VRM files and directories
+    const avatarVrms = join(tmpDir, "vrms");
+    if (existsSync(avatarVrms)) {
+      mkdirSync(VRMS_DIR, { recursive: true });
+      cpSync(avatarVrms, VRMS_DIR, { recursive: true, force: true });
+      log(`${TAG} Copied VRMs, previews, and backgrounds`);
+    }
+
+    // Copy animation files and directories
+    const avatarAnims = join(tmpDir, "animations");
+    if (existsSync(avatarAnims)) {
+      mkdirSync(ANIMATIONS_DIR, { recursive: true });
+      cpSync(avatarAnims, ANIMATIONS_DIR, { recursive: true, force: true });
+      log(`${TAG} Copied animations and emotes`);
+    }
+
+    // Verify the copy worked
+    const vrmsOk = hasValidVrm(VRMS_DIR);
+    const animsOk = hasValidAnimations(ANIMATIONS_DIR);
+
+    if (vrmsOk && animsOk) {
+      log(`${TAG} Avatar assets installed successfully`);
+    } else {
+      logError(
+        `${TAG} Warning: copy completed but verification failed (vrms=${vrmsOk}, animations=${animsOk})`
+      );
+    }
+
+    return { cloned: true, vrmsOk, animsOk };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logError(`${TAG} Failed to clone avatar assets: ${message}`);
+    logError(
+      `${TAG} You can manually clone: git clone ${AVATARS_REPO} /tmp/avatars && cp -r /tmp/avatars/vrms/ apps/app/public/vrms/ && cp -r /tmp/avatars/animations/ apps/app/public/animations/`
+    );
+    return { cloned: false, reason: "clone-failed", error: message };
+  } finally {
+    // Always clean up temp directory
+    try {
+      if (existsSync(tmpDir)) {
+        rmSync(tmpDir, { recursive: true, force: true });
+      }
+    } catch {
+      // Ignore cleanup errors
+    }
+  }
+}
+
+// Run directly if invoked from CLI
+const isDirectRun =
+  process.argv[1] && resolve(process.argv[1]) === resolve(__filename);
+
+if (isDirectRun) {
+  const force = process.argv.includes("--force");
+  runEnsureAvatars({ force });
+}

--- a/scripts/ensure-avatars.mjs
+++ b/scripts/ensure-avatars.mjs
@@ -96,6 +96,10 @@ export function runEnsureAvatars({
     return { cloned: false, reason: "already-present" };
   }
 
+  // SKIP_AVATAR_CLONE is a hard circuit-breaker for CI and restricted
+  // environments (e.g. sandboxed postinstall, air-gapped machines).
+  // It intentionally overrides --force so that automated pipelines can
+  // always prevent network I/O during install, regardless of invocation flags.
   const skipEnv = process.env.SKIP_AVATAR_CLONE;
   if (skipEnv === "1" || skipEnv === "true") {
     log(`${TAG} SKIP_AVATAR_CLONE set — skipping clone`);

--- a/scripts/ensure-avatars.mjs
+++ b/scripts/ensure-avatars.mjs
@@ -88,6 +88,7 @@ export function runEnsureAvatars({
   logError = console.error,
   _hasValidVrm = hasValidVrm,
   _hasValidAnimations = hasValidAnimations,
+  _gitAvailable = gitAvailable,
 } = {}) {
   if (!force && _hasValidVrm(VRMS_DIR) && _hasValidAnimations(ANIMATIONS_DIR)) {
     log(`${TAG} Avatar assets already present — skipping`);
@@ -100,7 +101,7 @@ export function runEnsureAvatars({
     return { cloned: false, reason: "skipped-by-env" };
   }
 
-  if (!gitAvailable()) {
+  if (!_gitAvailable()) {
     logError(`${TAG} git not found — cannot clone avatar assets`);
     return { cloned: false, reason: "no-git" };
   }

--- a/scripts/ensure-avatars.mjs
+++ b/scripts/ensure-avatars.mjs
@@ -16,7 +16,6 @@ import {
   cpSync,
   existsSync,
   mkdirSync,
-  readFileSync,
   readdirSync,
   rmSync,
   statSync,
@@ -71,7 +70,11 @@ function gitAvailable() {
   }
 }
 
-export function runEnsureAvatars({ force = false, log = console.log, logError = console.error } = {}) {
+export function runEnsureAvatars({
+  force = false,
+  log = console.log,
+  logError = console.error,
+} = {}) {
   if (!force && hasValidVrm(VRMS_DIR) && hasValidAnimations(ANIMATIONS_DIR)) {
     log(`${TAG} Avatar assets already present — skipping`);
     return { cloned: false, reason: "already-present" };
@@ -82,7 +85,9 @@ export function runEnsureAvatars({ force = false, log = console.log, logError = 
     return { cloned: false, reason: "no-git" };
   }
 
-  log(`${TAG} Avatar assets missing or incomplete — cloning from ${AVATARS_REPO}...`);
+  log(
+    `${TAG} Avatar assets missing or incomplete — cloning from ${AVATARS_REPO}...`,
+  );
 
   const tmpDir = join(ROOT, ".avatar-clone-tmp");
 
@@ -122,7 +127,7 @@ export function runEnsureAvatars({ force = false, log = console.log, logError = 
       log(`${TAG} Avatar assets installed successfully`);
     } else {
       logError(
-        `${TAG} Warning: copy completed but verification failed (vrms=${vrmsOk}, animations=${animsOk})`
+        `${TAG} Warning: copy completed but verification failed (vrms=${vrmsOk}, animations=${animsOk})`,
       );
     }
 
@@ -131,7 +136,7 @@ export function runEnsureAvatars({ force = false, log = console.log, logError = 
     const message = err instanceof Error ? err.message : String(err);
     logError(`${TAG} Failed to clone avatar assets: ${message}`);
     logError(
-      `${TAG} You can manually clone: git clone ${AVATARS_REPO} /tmp/avatars && cp -r /tmp/avatars/vrms/ apps/app/public/vrms/ && cp -r /tmp/avatars/animations/ apps/app/public/animations/`
+      `${TAG} You can manually clone: git clone ${AVATARS_REPO} /tmp/avatars && cp -r /tmp/avatars/vrms/ apps/app/public/vrms/ && cp -r /tmp/avatars/animations/ apps/app/public/animations/`,
     );
     return { cloned: false, reason: "clone-failed", error: message };
   } finally {

--- a/scripts/ensure-avatars.mjs
+++ b/scripts/ensure-avatars.mjs
@@ -4,8 +4,8 @@
  *
  * On a fresh clone, apps/app/public/vrms/ and animations/ may be empty or
  * contain only Git LFS pointers.  This script clones the milady-ai/avatars
- * repository into a temp directory and copies the assets into the correct
- * locations under apps/app/public/.
+ * repository (org-owned) into a temp directory and copies the assets into
+ * the correct locations under apps/app/public/.
  *
  * Run automatically via the `postinstall` hook, or manually:
  *   node scripts/ensure-avatars.mjs
@@ -30,16 +30,18 @@ const PUBLIC = join(ROOT, "apps", "app", "public");
 const VRMS_DIR = join(PUBLIC, "vrms");
 const ANIMATIONS_DIR = join(PUBLIC, "animations");
 
+// milady-ai/avatars is an org-owned repo in the milady-ai GitHub organization.
+// Pinned to a specific commit for reproducible installs (supply-chain safety).
 const AVATARS_REPO = "https://github.com/milady-ai/avatars.git";
+const AVATARS_COMMIT = "23e9bfc02e55e70acb8c8f0d4786829ecccbb5b6";
 const TAG = "[ensure-avatars]";
 
 /** A VRM file is valid if it is > 1 KB (rules out LFS pointers & stubs). */
-function hasValidVrm(dir) {
+export function hasValidVrm(dir) {
   if (!existsSync(dir)) return false;
   try {
     const files = readdirSync(dir).filter((f) => f.endsWith(".vrm"));
     if (files.length === 0) return false;
-    // Check the first VRM is a real binary, not an LFS pointer (~130 bytes)
     const stat = statSync(join(dir, files[0]));
     return stat.size > 1024;
   } catch {
@@ -47,7 +49,7 @@ function hasValidVrm(dir) {
   }
 }
 
-function hasValidAnimations(dir) {
+export function hasValidAnimations(dir) {
   if (!existsSync(dir)) return false;
   const emotesDir = join(dir, "emotes");
   if (!existsSync(emotesDir)) return false;
@@ -70,6 +72,16 @@ function gitAvailable() {
   }
 }
 
+/** Count files matching an extension in a directory (non-recursive). */
+function countFiles(dir, ext) {
+  if (!existsSync(dir)) return 0;
+  try {
+    return readdirSync(dir).filter((f) => f.endsWith(ext)).length;
+  } catch {
+    return 0;
+  }
+}
+
 export function runEnsureAvatars({
   force = false,
   log = console.log,
@@ -86,7 +98,7 @@ export function runEnsureAvatars({
   }
 
   log(
-    `${TAG} Avatar assets missing or incomplete — cloning from ${AVATARS_REPO}...`,
+    `${TAG} Avatar assets missing or incomplete — cloning from ${AVATARS_REPO} @ ${AVATARS_COMMIT.slice(0, 8)}...`,
   );
 
   const tmpDir = join(ROOT, ".avatar-clone-tmp");
@@ -97,40 +109,54 @@ export function runEnsureAvatars({
       rmSync(tmpDir, { recursive: true, force: true });
     }
 
-    // Shallow clone for speed (assets only, no history)
+    // Clone and checkout pinned commit for reproducibility.
+    // Uses --depth 1 + fetch for speed (avoids full history).
     execSync(`git clone --depth 1 ${AVATARS_REPO} "${tmpDir}"`, {
       cwd: ROOT,
       stdio: "inherit",
     });
+    execSync(`git -C "${tmpDir}" fetch --depth 1 origin ${AVATARS_COMMIT}`, {
+      cwd: ROOT,
+      stdio: "inherit",
+    });
+    execSync(`git -C "${tmpDir}" checkout ${AVATARS_COMMIT}`, {
+      cwd: ROOT,
+      stdio: "inherit",
+    });
 
-    // Copy VRM files and directories
+    // cpSync(src, dest, { recursive: true }) merges src contents INTO dest
+    // (like rsync -a src/ dest/), it does NOT create dest/basename(src).
+    // So vrms/milady-1.vrm → apps/app/public/vrms/milady-1.vrm (correct).
+
     const avatarVrms = join(tmpDir, "vrms");
     if (existsSync(avatarVrms)) {
       mkdirSync(VRMS_DIR, { recursive: true });
       cpSync(avatarVrms, VRMS_DIR, { recursive: true, force: true });
-      log(`${TAG} Copied VRMs, previews, and backgrounds`);
+      const vrmCount = countFiles(VRMS_DIR, ".vrm");
+      log(`${TAG} Copied ${vrmCount} VRMs + previews and backgrounds`);
     }
 
-    // Copy animation files and directories
     const avatarAnims = join(tmpDir, "animations");
     if (existsSync(avatarAnims)) {
       mkdirSync(ANIMATIONS_DIR, { recursive: true });
       cpSync(avatarAnims, ANIMATIONS_DIR, { recursive: true, force: true });
-      log(`${TAG} Copied animations and emotes`);
+      const glbCount = countFiles(join(ANIMATIONS_DIR, "emotes"), ".glb");
+      const fbxCount = countFiles(join(ANIMATIONS_DIR, "mixamo"), ".fbx");
+      log(`${TAG} Copied ${glbCount} emotes + ${fbxCount} mixamo animations`);
     }
 
-    // Verify the copy worked
+    // Verify the copy produced valid assets
     const vrmsOk = hasValidVrm(VRMS_DIR);
     const animsOk = hasValidAnimations(ANIMATIONS_DIR);
 
-    if (vrmsOk && animsOk) {
-      log(`${TAG} Avatar assets installed successfully`);
-    } else {
+    if (!vrmsOk || !animsOk) {
       logError(
-        `${TAG} Warning: copy completed but verification failed (vrms=${vrmsOk}, animations=${animsOk})`,
+        `${TAG} ERROR: copy completed but verification failed (vrms=${vrmsOk}, animations=${animsOk})`,
       );
+      return { cloned: true, vrmsOk, animsOk, reason: "verify-failed" };
     }
 
+    log(`${TAG} Avatar assets installed successfully`);
     return { cloned: true, vrmsOk, animsOk };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -140,7 +166,6 @@ export function runEnsureAvatars({
     );
     return { cloned: false, reason: "clone-failed", error: message };
   } finally {
-    // Always clean up temp directory
     try {
       if (existsSync(tmpDir)) {
         rmSync(tmpDir, { recursive: true, force: true });

--- a/scripts/ensure-avatars.mjs
+++ b/scripts/ensure-avatars.mjs
@@ -119,6 +119,10 @@ export function runEnsureAvatars({
 
     // Clone and checkout pinned commit for reproducibility.
     // Uses --depth 1 + fetch for speed (avoids full history).
+    // TODO: Pin the initial clone to a tag (e.g. --branch v1.0) so the
+    //       shallow clone fetches a known ref instead of the current default
+    //       branch HEAD.  The checkout below still locks to AVATARS_COMMIT,
+    //       so correctness is unaffected — a tag would just save one fetch.
     execSync(`git clone --depth 1 ${AVATARS_REPO} "${tmpDir}"`, {
       cwd: ROOT,
       stdio: "inherit",

--- a/scripts/ensure-avatars.mjs
+++ b/scripts/ensure-avatars.mjs
@@ -86,10 +86,18 @@ export function runEnsureAvatars({
   force = false,
   log = console.log,
   logError = console.error,
+  _hasValidVrm = hasValidVrm,
+  _hasValidAnimations = hasValidAnimations,
 } = {}) {
-  if (!force && hasValidVrm(VRMS_DIR) && hasValidAnimations(ANIMATIONS_DIR)) {
+  if (!force && _hasValidVrm(VRMS_DIR) && _hasValidAnimations(ANIMATIONS_DIR)) {
     log(`${TAG} Avatar assets already present — skipping`);
     return { cloned: false, reason: "already-present" };
+  }
+
+  const skipEnv = process.env.SKIP_AVATAR_CLONE;
+  if (skipEnv === "1" || skipEnv === "true") {
+    log(`${TAG} SKIP_AVATAR_CLONE set — skipping clone`);
+    return { cloned: false, reason: "skipped-by-env" };
   }
 
   if (!gitAvailable()) {

--- a/scripts/ensure-avatars.mjs
+++ b/scripts/ensure-avatars.mjs
@@ -89,6 +89,7 @@ export function runEnsureAvatars({
   _hasValidVrm = hasValidVrm,
   _hasValidAnimations = hasValidAnimations,
   _gitAvailable = gitAvailable,
+  _exec = execSync,
 } = {}) {
   if (!force && _hasValidVrm(VRMS_DIR) && _hasValidAnimations(ANIMATIONS_DIR)) {
     log(`${TAG} Avatar assets already present — skipping`);
@@ -124,15 +125,15 @@ export function runEnsureAvatars({
     //       shallow clone fetches a known ref instead of the current default
     //       branch HEAD.  The checkout below still locks to AVATARS_COMMIT,
     //       so correctness is unaffected — a tag would just save one fetch.
-    execSync(`git clone --depth 1 ${AVATARS_REPO} "${tmpDir}"`, {
+    _exec(`git clone --depth 1 ${AVATARS_REPO} "${tmpDir}"`, {
       cwd: ROOT,
       stdio: "inherit",
     });
-    execSync(`git -C "${tmpDir}" fetch --depth 1 origin ${AVATARS_COMMIT}`, {
+    _exec(`git -C "${tmpDir}" fetch --depth 1 origin ${AVATARS_COMMIT}`, {
       cwd: ROOT,
       stdio: "inherit",
     });
-    execSync(`git -C "${tmpDir}" checkout ${AVATARS_COMMIT}`, {
+    _exec(`git -C "${tmpDir}" checkout ${AVATARS_COMMIT}`, {
       cwd: ROOT,
       stdio: "inherit",
     });
@@ -158,9 +159,9 @@ export function runEnsureAvatars({
       log(`${TAG} Copied ${glbCount} emotes + ${fbxCount} mixamo animations`);
     }
 
-    // Verify the copy produced valid assets
-    const vrmsOk = hasValidVrm(VRMS_DIR);
-    const animsOk = hasValidAnimations(ANIMATIONS_DIR);
+    // Verify the copy produced valid assets (use injected validators for testability)
+    const vrmsOk = _hasValidVrm(VRMS_DIR);
+    const animsOk = _hasValidAnimations(ANIMATIONS_DIR);
 
     if (!vrmsOk || !animsOk) {
       logError(

--- a/src/runtime/ensure-avatars-script.test.ts
+++ b/src/runtime/ensure-avatars-script.test.ts
@@ -147,8 +147,8 @@ describe("runEnsureAvatars", () => {
 
   it("bypasses already-present check when force=true", () => {
     // Even though validators report assets present, force should skip
-    // the early return and attempt to clone (which will fail in CI
-    // without git — that's fine, we're testing the branch logic).
+    // the early return and reach the git-available check.
+    // Stub _gitAvailable to false so we never hit the network.
     const logs: string[] = [];
     const result = runEnsureAvatars({
       force: true,
@@ -156,10 +156,12 @@ describe("runEnsureAvatars", () => {
       logError: (msg: string) => logs.push(msg),
       _hasValidVrm: presentVrm,
       _hasValidAnimations: presentAnims,
+      _gitAvailable: () => false,
     });
-    // With force=true and assets "present", the function should NOT
-    // return "already-present" — it proceeds to the clone path.
+    // With force=true the function skips "already-present" and reaches
+    // the no-git path (because we stubbed git as unavailable).
     expect(result.reason).not.toBe("already-present");
+    expect(result.reason).toBe("no-git");
   });
 
   it("does not skip when SKIP_AVATAR_CLONE is an unrelated value", () => {
@@ -171,9 +173,27 @@ describe("runEnsureAvatars", () => {
       logError: (msg: string) => logs.push(msg),
       _hasValidVrm: absentVrm,
       _hasValidAnimations: absentAnims,
+      _gitAvailable: () => false,
     });
-    // "no" is not "1" or "true", so the env guard should not trigger
+    // "no" is not "1" or "true", so the env guard should not trigger.
+    // Falls through to no-git (stubbed) instead.
     expect(result.reason).not.toBe("skipped-by-env");
+    expect(result.reason).toBe("no-git");
+  });
+
+  it("returns no-git when git is unavailable", () => {
+    const logs: string[] = [];
+    const result = runEnsureAvatars({
+      force: false,
+      log: (msg: string) => logs.push(msg),
+      logError: (msg: string) => logs.push(msg),
+      _hasValidVrm: absentVrm,
+      _hasValidAnimations: absentAnims,
+      _gitAvailable: () => false,
+    });
+    expect(result.cloned).toBe(false);
+    expect(result.reason).toBe("no-git");
+    expect(logs.some((m: string) => m.includes("git not found"))).toBe(true);
   });
 
   it("returns skipped-by-env when SKIP_AVATAR_CLONE=1", () => {

--- a/src/runtime/ensure-avatars-script.test.ts
+++ b/src/runtime/ensure-avatars-script.test.ts
@@ -95,13 +95,36 @@ describe("hasValidAnimations", () => {
 
 // ── runEnsureAvatars ──────────────────────────────────────────────────
 
+// Stub checkers that simulate "assets already present" without touching disk.
+const presentVrm = () => true;
+const presentAnims = () => true;
+const absentVrm = () => false;
+const absentAnims = () => false;
+
 describe("runEnsureAvatars", () => {
+  let savedSkipEnv: string | undefined;
+
+  beforeEach(() => {
+    savedSkipEnv = process.env.SKIP_AVATAR_CLONE;
+    delete process.env.SKIP_AVATAR_CLONE;
+  });
+
+  afterEach(() => {
+    if (savedSkipEnv === undefined) {
+      delete process.env.SKIP_AVATAR_CLONE;
+    } else {
+      process.env.SKIP_AVATAR_CLONE = savedSkipEnv;
+    }
+  });
+
   it("skips when avatar assets are already present", () => {
     const logs: string[] = [];
     const result = runEnsureAvatars({
       force: false,
       log: (msg: string) => logs.push(msg),
       logError: (msg: string) => logs.push(msg),
+      _hasValidVrm: presentVrm,
+      _hasValidAnimations: presentAnims,
     });
 
     expect(result.cloned).toBe(false);
@@ -114,6 +137,8 @@ describe("runEnsureAvatars", () => {
       force: false,
       log: () => {},
       logError: () => {},
+      _hasValidVrm: presentVrm,
+      _hasValidAnimations: presentAnims,
     });
     expect(result.cloned).toBe(false);
     expect(result.reason).toBe("already-present");
@@ -127,7 +152,39 @@ describe("runEnsureAvatars", () => {
       force: false,
       log: () => {},
       logError: () => {},
+      _hasValidVrm: presentVrm,
+      _hasValidAnimations: presentAnims,
     });
     expect(result).toHaveProperty("cloned");
+  });
+
+  it("returns skipped-by-env when SKIP_AVATAR_CLONE=1", () => {
+    process.env.SKIP_AVATAR_CLONE = "1";
+    const logs: string[] = [];
+    const result = runEnsureAvatars({
+      force: false,
+      log: (msg: string) => logs.push(msg),
+      logError: (msg: string) => logs.push(msg),
+      _hasValidVrm: absentVrm,
+      _hasValidAnimations: absentAnims,
+    });
+    expect(result.cloned).toBe(false);
+    expect(result.reason).toBe("skipped-by-env");
+    expect(logs.some((m: string) => m.includes("SKIP_AVATAR_CLONE"))).toBe(
+      true,
+    );
+  });
+
+  it("returns skipped-by-env when SKIP_AVATAR_CLONE=true", () => {
+    process.env.SKIP_AVATAR_CLONE = "true";
+    const result = runEnsureAvatars({
+      force: false,
+      log: () => {},
+      logError: () => {},
+      _hasValidVrm: absentVrm,
+      _hasValidAnimations: absentAnims,
+    });
+    expect(result.cloned).toBe(false);
+    expect(result.reason).toBe("skipped-by-env");
   });
 });

--- a/src/runtime/ensure-avatars-script.test.ts
+++ b/src/runtime/ensure-avatars-script.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { runEnsureAvatars } from "../../scripts/ensure-avatars.mjs";
+
+describe("ensure-avatars script", () => {
+  it("skips when avatar assets are already present", () => {
+    const logs: string[] = [];
+    // Running against the real repo — assets should already exist
+    const result = runEnsureAvatars({
+      force: false,
+      log: (msg: string) => logs.push(msg),
+      logError: (msg: string) => logs.push(msg),
+    });
+
+    expect(result.cloned).toBe(false);
+    expect(result.reason).toBe("already-present");
+    expect(logs.some((m) => m.includes("already present"))).toBe(true);
+  });
+
+  it("does not skip when force flag is set (but we don't actually clone in CI)", () => {
+    // We just verify the function signature accepts force — actual clone
+    // is too slow for unit tests. The postinstall integration test covers it.
+    expect(typeof runEnsureAvatars).toBe("function");
+  });
+});

--- a/src/runtime/ensure-avatars-script.test.ts
+++ b/src/runtime/ensure-avatars-script.test.ts
@@ -1,10 +1,103 @@
-import { describe, expect, it } from "vitest";
-import { runEnsureAvatars } from "../../scripts/ensure-avatars.mjs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  hasValidVrm,
+  hasValidAnimations,
+  runEnsureAvatars,
+} from "../../scripts/ensure-avatars.mjs";
 
-describe("ensure-avatars script", () => {
+// ── Deterministic helpers ─────────────────────────────────────────────
+
+function makeTmpDir(prefix: string): string {
+  const dir = join(tmpdir(), `ensure-avatars-test-${prefix}-${Date.now()}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeFakeFile(filePath: string, sizeBytes: number): void {
+  mkdirSync(join(filePath, ".."), { recursive: true });
+  writeFileSync(filePath, Buffer.alloc(sizeBytes, 0x42));
+}
+
+// ── hasValidVrm ───────────────────────────────────────────────────────
+
+describe("hasValidVrm", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = makeTmpDir("vrm");
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns false for non-existent directory", () => {
+    expect(hasValidVrm("/tmp/does-not-exist-xyz-99999")).toBe(false);
+  });
+
+  it("returns false for empty directory", () => {
+    expect(hasValidVrm(dir)).toBe(false);
+  });
+
+  it("returns false when VRM is an LFS pointer (< 1 KB)", () => {
+    writeFakeFile(join(dir, "milady-1.vrm"), 130);
+    expect(hasValidVrm(dir)).toBe(false);
+  });
+
+  it("returns true when VRM is a real binary (> 1 KB)", () => {
+    writeFakeFile(join(dir, "milady-1.vrm"), 2048);
+    expect(hasValidVrm(dir)).toBe(true);
+  });
+
+  it("ignores non-VRM files", () => {
+    writeFakeFile(join(dir, "readme.txt"), 5000);
+    expect(hasValidVrm(dir)).toBe(false);
+  });
+});
+
+// ── hasValidAnimations ────────────────────────────────────────────────
+
+describe("hasValidAnimations", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = makeTmpDir("anim");
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns false for non-existent directory", () => {
+    expect(hasValidAnimations("/tmp/does-not-exist-xyz-99999")).toBe(false);
+  });
+
+  it("returns false when emotes subdirectory is missing", () => {
+    expect(hasValidAnimations(dir)).toBe(false);
+  });
+
+  it("returns false when emotes has no .glb files", () => {
+    mkdirSync(join(dir, "emotes"), { recursive: true });
+    expect(hasValidAnimations(dir)).toBe(false);
+  });
+
+  it("returns false when .glb is an LFS pointer (< 1 KB)", () => {
+    writeFakeFile(join(dir, "emotes", "idle.glb"), 100);
+    expect(hasValidAnimations(dir)).toBe(false);
+  });
+
+  it("returns true when .glb is a real binary (> 1 KB)", () => {
+    writeFakeFile(join(dir, "emotes", "idle.glb"), 4096);
+    expect(hasValidAnimations(dir)).toBe(true);
+  });
+});
+
+// ── runEnsureAvatars ──────────────────────────────────────────────────
+
+describe("runEnsureAvatars", () => {
   it("skips when avatar assets are already present", () => {
     const logs: string[] = [];
-    // Running against the real repo — assets should already exist
     const result = runEnsureAvatars({
       force: false,
       log: (msg: string) => logs.push(msg),
@@ -13,12 +106,28 @@ describe("ensure-avatars script", () => {
 
     expect(result.cloned).toBe(false);
     expect(result.reason).toBe("already-present");
-    expect(logs.some((m) => m.includes("already present"))).toBe(true);
+    expect(logs.some((m: string) => m.includes("already present"))).toBe(true);
   });
 
-  it("does not skip when force flag is set (but we don't actually clone in CI)", () => {
-    // We just verify the function signature accepts force — actual clone
-    // is too slow for unit tests. The postinstall integration test covers it.
+  it("returns expected shape for already-present path", () => {
+    const result = runEnsureAvatars({
+      force: false,
+      log: () => {},
+      logError: () => {},
+    });
+    expect(result.cloned).toBe(false);
+    expect(result.reason).toBe("already-present");
+    expect(result).not.toHaveProperty("error");
+  });
+
+  it("accepts all option parameters", () => {
+    // Verify the function signature accepts force, log, logError
     expect(typeof runEnsureAvatars).toBe("function");
+    const result = runEnsureAvatars({
+      force: false,
+      log: () => {},
+      logError: () => {},
+    });
+    expect(result).toHaveProperty("cloned");
   });
 });

--- a/src/runtime/ensure-avatars-script.test.ts
+++ b/src/runtime/ensure-avatars-script.test.ts
@@ -1,10 +1,10 @@
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
-  hasValidVrm,
   hasValidAnimations,
+  hasValidVrm,
   runEnsureAvatars,
 } from "../../scripts/ensure-avatars.mjs";
 

--- a/src/runtime/ensure-avatars-script.test.ts
+++ b/src/runtime/ensure-avatars-script.test.ts
@@ -225,6 +225,74 @@ describe("runEnsureAvatars", () => {
     expect(result.cloned).toBe(false);
     expect(result.reason).toBe("skipped-by-env");
   });
+
+  it("returns clone-failed when exec throws", () => {
+    const errors: string[] = [];
+    const result = runEnsureAvatars({
+      force: true,
+      log: () => {},
+      logError: (msg: string) => errors.push(msg),
+      _hasValidVrm: presentVrm,
+      _hasValidAnimations: presentAnims,
+      _gitAvailable: () => true,
+      _exec: () => {
+        throw new Error("git clone failed: connection refused");
+      },
+    });
+    expect(result.cloned).toBe(false);
+    expect(result.reason).toBe("clone-failed");
+    expect((result as { error?: string }).error).toContain(
+      "git clone failed: connection refused",
+    );
+    expect(errors.some((m: string) => m.includes("Failed to clone"))).toBe(
+      true,
+    );
+  });
+
+  it("returns verify-failed when copy succeeds but validators return false", () => {
+    // _exec is a no-op (clone never creates files) so existsSync(tmpDir/vrms)
+    // returns false — no cpSync is called.  With _hasValidVrm returning false,
+    // the post-clone verification fails with "verify-failed".
+    const errors: string[] = [];
+    const result = runEnsureAvatars({
+      force: true,
+      log: () => {},
+      logError: (msg: string) => errors.push(msg),
+      _hasValidVrm: absentVrm,
+      _hasValidAnimations: absentAnims,
+      _gitAvailable: () => true,
+      _exec: () => {},
+    });
+    expect(result.cloned).toBe(true);
+    expect((result as { reason?: string }).reason).toBe("verify-failed");
+    expect(errors.some((m: string) => m.includes("verification failed"))).toBe(
+      true,
+    );
+  });
+
+  it("returns success when clone and verification succeed", () => {
+    const logs: string[] = [];
+    const result = runEnsureAvatars({
+      force: true,
+      log: (msg: string) => logs.push(msg),
+      logError: () => {},
+      _hasValidVrm: presentVrm,
+      _hasValidAnimations: presentAnims,
+      _gitAvailable: () => true,
+      _exec: () => {},
+    });
+    expect(result.cloned).toBe(true);
+    expect((result as { reason?: string }).reason).toBeUndefined();
+    expect(
+      (result as { vrmsOk?: boolean; animsOk?: boolean }).vrmsOk,
+    ).toBe(true);
+    expect(
+      (result as { vrmsOk?: boolean; animsOk?: boolean }).animsOk,
+    ).toBe(true);
+    expect(
+      logs.some((m: string) => m.includes("installed successfully")),
+    ).toBe(true);
+  });
 });
 
 // ── Module exports ───────────────────────────────────────────────────

--- a/src/runtime/ensure-avatars-script.test.ts
+++ b/src/runtime/ensure-avatars-script.test.ts
@@ -145,17 +145,35 @@ describe("runEnsureAvatars", () => {
     expect(result).not.toHaveProperty("error");
   });
 
-  it("accepts all option parameters", () => {
-    // Verify the function signature accepts force, log, logError
-    expect(typeof runEnsureAvatars).toBe("function");
+  it("bypasses already-present check when force=true", () => {
+    // Even though validators report assets present, force should skip
+    // the early return and attempt to clone (which will fail in CI
+    // without git — that's fine, we're testing the branch logic).
+    const logs: string[] = [];
     const result = runEnsureAvatars({
-      force: false,
-      log: () => {},
-      logError: () => {},
+      force: true,
+      log: (msg: string) => logs.push(msg),
+      logError: (msg: string) => logs.push(msg),
       _hasValidVrm: presentVrm,
       _hasValidAnimations: presentAnims,
     });
-    expect(result).toHaveProperty("cloned");
+    // With force=true and assets "present", the function should NOT
+    // return "already-present" — it proceeds to the clone path.
+    expect(result.reason).not.toBe("already-present");
+  });
+
+  it("does not skip when SKIP_AVATAR_CLONE is an unrelated value", () => {
+    process.env.SKIP_AVATAR_CLONE = "no";
+    const logs: string[] = [];
+    const result = runEnsureAvatars({
+      force: false,
+      log: (msg: string) => logs.push(msg),
+      logError: (msg: string) => logs.push(msg),
+      _hasValidVrm: absentVrm,
+      _hasValidAnimations: absentAnims,
+    });
+    // "no" is not "1" or "true", so the env guard should not trigger
+    expect(result.reason).not.toBe("skipped-by-env");
   });
 
   it("returns skipped-by-env when SKIP_AVATAR_CLONE=1", () => {
@@ -186,5 +204,15 @@ describe("runEnsureAvatars", () => {
     });
     expect(result.cloned).toBe(false);
     expect(result.reason).toBe("skipped-by-env");
+  });
+});
+
+// ── Module exports ───────────────────────────────────────────────────
+
+describe("module exports", () => {
+  it("exports expected functions", () => {
+    expect(typeof hasValidVrm).toBe("function");
+    expect(typeof hasValidAnimations).toBe("function");
+    expect(typeof runEnsureAvatars).toBe("function");
   });
 });


### PR DESCRIPTION
## Summary
- Adds `scripts/ensure-avatars.mjs` postinstall script that detects missing VRM/animation assets and shallow-clones them from [milady-ai/avatars](https://github.com/milady-ai/avatars)
- Validates real binaries vs LFS pointers (file size > 1KB)
- Supports `--force` flag and prints manual clone fallback on failure
- Wired into both `postinstall` and `install:build` package.json hooks

## Test plan
- [x] `node scripts/ensure-avatars.mjs` — skips when assets present
- [x] `node scripts/ensure-avatars.mjs --force` — re-downloads
- [x] Unit test passes: `bunx vitest run src/runtime/ensure-avatars-script.test.ts`
- [ ] Fresh clone: `rm -rf apps/app/public/vrms && bun install` — assets auto-restored

Co-Authored-By: Milady-BSC <262491033+miladybsc@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)