### PR TITLE
fix(ci): fix review bot crash and false aesthetic classification

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Run Claude Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1.0.60
+        uses: anthropics/claude-code-action@v1.0.66
         env:
           NPM_CONFIG_REGISTRY: 'https://registry.npmjs.org'
         with:
@@ -130,7 +130,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_non_write_users: '*'
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-sonnet-4-6
             --allowedTools "Read,Glob,Grep,LS,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(cat:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(wc:*),Bash(head:*),Bash(tail:*)"
           prompt: |
             You are the sole code reviewer for the Milady project (milady-ai/milady).
@@ -756,7 +756,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Triage Issue
-        uses: anthropics/claude-code-action@v1.0.60
+        uses: anthropics/claude-code-action@v1.0.66
         env:
           NPM_CONFIG_REGISTRY: 'https://registry.npmjs.org'
         with:
@@ -764,7 +764,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_non_write_users: '*'
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-sonnet-4-6
             --allowedTools "Bash(gh issue comment:*),Bash(gh issue edit:*),Bash(gh issue close:*),Bash(gh issue view:*),Bash(cat:*),Read,Glob,Grep,LS"
           prompt: |
             You are the issue triager for the Milady project. This is an agents-only codebase where humans serve as QA testers.


### PR DESCRIPTION
## Summary

The `review-pr` job in `agent-review.yml` has been crashing on **ALL PRs** since ~05:53 UTC March 3 with `Claude Code process exited with code 1` (SDK crash in ~250ms, $0 cost — never reaches the API).

### Investigation

Compared the last successful run (22601641232, PR #746, 00:04 UTC) against the first failed run (22610336795, PR #762, 05:53 UTC):

| | Successful | Failed |
|---|---|---|
| Action | v1.0.60 | v1.0.60 |
| SDK | @anthropic-ai/claude-agent-sdk@0.2.56 | @0.2.56 |
| CLI | Claude Code v2.1.56 | v2.1.56 |
| Node.js | v20.20.0 | v20.20.0 |
| Bun | 1.3.6 | 1.3.6 |
| SDK options | identical | identical |
| Init | ✅ "Claude Code initialized" | ✅ "Claude Code initialized" |
| Result | 13 turns, $0.78, 155s | 1 turn, $0, 250ms, crash |

**Same exact configuration, same versions, same init — but one works and one doesn't.** The CLI starts up, prints "Claude Code initialized", then immediately exits with code 1. The error output shows AJV schema validation code from the CLI's internals.

This pattern (everything identical but failure after a timestamp cutoff) strongly suggests an **API-side or model compatibility change** that broke `claude-opus-4-6` with Claude Code v2.1.56.

### Fixes (2 commits)

**Commit 1: Fix classifier and tool names**
- Removed `'animation'` from aesthetic patterns (too broad — catches animation *files*)
- Added `technicalPatterns` override: PRs mentioning both aesthetic and technical keywords (`install`, `build`, `script`, `deploy`, etc.) are classified as `'feature'` not `'aesthetic'`
- Switched to multiline `claude_args` format per action docs
- Replaced invalid `GitHub` tool name with scoped Bash commands the reviewer actually needs
- Added missing `Grep` tool

**Commit 2: Upgrade action and model**
- Upgraded `anthropics/claude-code-action` from `v1.0.60` → `v1.0.66` (latest, may bundle newer compatible SDK)
- Switched model from `claude-opus-4-6` → `claude-sonnet-4-6` (faster for reviews, better compatibility)

### Impact

All review-pr runs have been failing since 05:53 UTC. This blocks auto-merge for all open PRs (#775, #776, #777, #778 + ~15 others).

## Test plan

- [ ] Merge this PR to develop (requires manual merge — see note below)
- [ ] Re-run review on any open PR → verify `review-pr` step succeeds
- [ ] Verify classifier correctly labels infrastructure PRs as `feature` (not `aesthetic`)

> **Note:** Since `pull_request_target` runs the workflow from the BASE branch (develop), this PR's fixes won't take effect until merged. The CI on this PR will show the same old failure. This needs **manual merge**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)