### PR TITLE
fix(ci): workaround upstream AJV crash in claude-code-action

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -122,15 +122,15 @@ jobs:
 
       - name: Run Claude Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1.0.66
+        uses: anthropics/claude-code-action@v1
         env:
           NPM_CONFIG_REGISTRY: 'https://registry.npmjs.org'
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_non_write_users: '*'
+          show_full_output: true
           claude_args: |
-            --model claude-sonnet-4-6
             --allowedTools "Read,Glob,Grep,LS,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(cat:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(wc:*),Bash(head:*),Bash(tail:*)"
           prompt: |
             You are the sole code reviewer for the Milady project (milady-ai/milady).
@@ -756,15 +756,15 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Triage Issue
-        uses: anthropics/claude-code-action@v1.0.66
+        uses: anthropics/claude-code-action@v1
         env:
           NPM_CONFIG_REGISTRY: 'https://registry.npmjs.org'
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_non_write_users: '*'
+          show_full_output: true
           claude_args: |
-            --model claude-sonnet-4-6
             --allowedTools "Bash(gh issue comment:*),Bash(gh issue edit:*),Bash(gh issue close:*),Bash(gh issue view:*),Bash(cat:*),Read,Glob,Grep,LS"
           prompt: |
             You are the issue triager for the Milady project. This is an agents-only codebase where humans serve as QA testers.


### PR DESCRIPTION
## Summary

Workaround for known upstream bug in `anthropics/claude-code-action` where the Claude Code CLI crashes with an AJV JSON schema validation error during initialization, before making any API calls (`$0 cost`, `~300ms duration`).

**Root cause:** Known issue affecting many users since Feb 2026:
- [anthropics/claude-code-action#947](https://github.com/anthropics/claude-code-action/issues/947) — CLI crashes on startup with AJV error
- [anthropics/claude-code-action#965](https://github.com/anthropics/claude-code-action/issues/965) — Crash persists across all versions, pinning doesn't help
- Same exact config works intermittently: succeeded at 00:04 UTC Mar 3, failed at 05:53+ UTC with identical versions

**Changes:**
- Remove explicit `--model` flag from `claude_args` — let CLI use its default model (avoids model validation path that may trigger AJV crash)
- Switch from pinned `v1.0.66` to floating `v1` tag to pick up upstream fixes automatically
- Enable `show_full_output: true` temporarily for debugging if crash persists

## Test plan
- [ ] Merge to develop and observe next PR review run
- [ ] Check CI logs for successful review or detailed error output
- [ ] If still failing: file upstream issue with full debug output, consider disabling bot until fixed
- [ ] Once stable: remove `show_full_output: true` (it exposes tool execution details in public logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)