### PR TITLE
fix(ci): use correct Codex effort value (xhigh)

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -239,7 +239,7 @@ jobs:
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           model: gpt-5.3-codex
-          effort: extra-high
+          effort: xhigh
           safety-strategy: read-only
           prompt: |
             You are the sole code reviewer for the Milady project (milady-ai/milady).


### PR DESCRIPTION
## Summary

Fix Codex fallback crash: `extra-high` is not a valid effort value. Codex CLI expects `xhigh`.

**Error from CI:**
```
Error loading config.toml: unknown variant `extra-high`, expected one of `none`, `minimal`, `low`, `medium`, `high`, `xhigh`
```

## Test plan
- [ ] Merge and trigger a PR review
- [ ] Verify Codex runs successfully with `xhigh` effort

🤖 Generated with [Claude Code](https://claude.com/claude-code)