### PR TITLE
fix(deps): add missing @elizaos/plugin-pi-ai dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -39,7 +39,7 @@
         "@elizaos/plugin-openrouter": "next",
         "@elizaos/plugin-pdf": "next",
         "@elizaos/plugin-personality": "next",
-        "@elizaos/plugin-pi-ai": "next",
+        "@elizaos/plugin-pi-ai": "^1.7.3-alpha.3",
         "@elizaos/plugin-plugin-manager": "next",
         "@elizaos/plugin-rolodex": "next",
         "@elizaos/plugin-secrets-manager": "next",
@@ -2715,7 +2715,7 @@
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
-    "libsignal": ["@whiskeysockets/libsignal-node@github:whiskeysockets/libsignal-node#1c30d7d", { "dependencies": { "curve25519-js": "^0.0.4", "protobufjs": "6.8.8" } }, "WhiskeySockets-libsignal-node-1c30d7d", "sha512-5q4/OuDQaMYx3RpDqMqS3WYyqjrsSMpU8ipQZtpYnm5l6DwNoLV9oIYMDK0NILKW+tyk3tVCIA11BMYQ+A1+GA=="],
+    "libsignal": ["@whiskeysockets/libsignal-node@github:whiskeysockets/libsignal-node#1c30d7d", { "dependencies": { "curve25519-js": "^0.0.4", "protobufjs": "6.8.8" } }, "WhiskeySockets-libsignal-node-1c30d7d"],
 
     "libsodium": ["libsodium@0.7.16", "", {}, "sha512-3HrzSPuzm6Yt9aTYCDxYEG8x8/6C0+ag655Y7rhhWZM9PT4NpdnbqlzXhGZlDnkgR6MeSTnOt/VIyHLs9aSf+Q=="],
 

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "@elizaos/plugin-openrouter": "next",
     "@elizaos/plugin-pdf": "next",
     "@elizaos/plugin-personality": "next",
-    "@elizaos/plugin-pi-ai": "next",
+    "@elizaos/plugin-pi-ai": "^1.7.3-alpha.3",
     "@elizaos/plugin-plugin-manager": "next",
     "@elizaos/plugin-rolodex": "next",
     "@elizaos/plugin-secrets-manager": "next",


### PR DESCRIPTION
## Description
Fixes a silent 500/crash during \startApiServer\ caused by \@elizaos/plugin-pi-ai\ not resolving.

Without this dependency, \server.js\ fails to bind to port 2138 because the module-level import throws an \ERR_MODULE_NOT_FOUND\ before the server is initialized.

## Testing
- Tested in local environment.
- Verified \milady start\ boots the API server correctly after applying this patch.