### PR TITLE
fix(CD): deb can't publish

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -32,9 +32,6 @@ on:
         type: boolean
         default: true
 
-permissions:
-  contents: write
-
 concurrency:
   group: publish-packages-${{ github.ref }}
   cancel-in-progress: false
@@ -243,6 +240,8 @@ jobs:
       (github.event_name == 'release') ||
       (github.event_name == 'workflow_dispatch' && inputs.apt)
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # gh release upload
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -331,6 +330,8 @@ jobs:
       (github.event_name == 'release' && needs.prepare.outputs.is_prerelease == 'false') ||
       (github.event_name == 'workflow_dispatch' && inputs.flatpak)
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # gh release upload
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This gives the GITHUB_TOKEN permission to upload release assets, which is required when workflows attach files to releases.

This PR will be reviewed by an AI agent. Provide clear context to help it assess your changes.

Aesthetic/UI changes that don't improve agent capability are out of scope and will be rejected.

## Category
- [x] Bug fix
- [ ] Security fix
- [ ] Performance improvement
- [ ] New feature
- [ ] Documentation
- [ ] Test coverage
- [ ] Other

## What
This gives the GITHUB_TOKEN permission to upload release assets, which is required when workflows attach files to releases.

## Why
Fix deb publishing

## How
Change workflow perms

## Testing
Move fast and break things
