### PR TITLE
test: hooks discovery + loader test coverage (F-17)

### DIFF
--- a/src/hooks/discovery.test.ts
+++ b/src/hooks/discovery.test.ts
@@ -1,0 +1,357 @@
+/**
+ * Hook Discovery — Unit Tests
+ *
+ * Tests for:
+ * - Frontmatter parsing (valid, metadata JSON, missing delimiters, empty name, invalid JSON)
+ * - Handler resolution (handler.ts, fallback chain, no handler)
+ * - Discovery precedence (workspace > managed > bundled > extra)
+ */
+
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { discoverHooks } from "./discovery";
+
+// ---------------------------------------------------------------------------
+// mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@elizaos/core", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+
+// Stub the managed dir (~/.milady/hooks) to avoid picking up real hooks
+vi.mock("node:os", async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import("node:os");
+  return {
+    ...actual,
+    // Point homedir to a temp location so ~/.milady/hooks doesn't exist
+    homedir: () => join(tmpdir(), "__discovery_test_fake_home__"),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+let tempRoot: string;
+
+async function createHookDir(
+  base: string,
+  name: string,
+  opts: {
+    hookMd?: string;
+    handlerFile?: string; // which handler filename to create
+    handlerContent?: string;
+  } = {},
+): Promise<string> {
+  const dir = join(base, name);
+  await mkdir(dir, { recursive: true });
+
+  if (opts.hookMd !== undefined) {
+    await writeFile(join(dir, "HOOK.md"), opts.hookMd, "utf-8");
+  }
+
+  const handlerFile = opts.handlerFile ?? "handler.ts";
+  const handlerContent = opts.handlerContent ?? "export default () => {};";
+  await writeFile(join(dir, handlerFile), handlerContent, "utf-8");
+
+  return dir;
+}
+
+// ---------------------------------------------------------------------------
+// lifecycle
+// ---------------------------------------------------------------------------
+
+beforeEach(async () => {
+  tempRoot = join(
+    tmpdir(),
+    `hooks-discovery-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  await mkdir(tempRoot, { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(tempRoot, { recursive: true, force: true });
+});
+
+// ============================================================================
+//  1. Frontmatter parsing (tested via discoverHooks)
+// ============================================================================
+
+describe("frontmatter parsing", () => {
+  it("parses valid frontmatter with name and description", async () => {
+    const bundled = join(tempRoot, "bundled");
+    await createHookDir(bundled, "my-hook", {
+      hookMd: [
+        "---",
+        "name: my-hook",
+        "description: A test hook",
+        "---",
+        "",
+        "# My Hook",
+      ].join("\n"),
+    });
+
+    const entries = await discoverHooks({ bundledDir: bundled });
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].hook.name).toBe("my-hook");
+    expect(entries[0].frontmatter.description).toBe("A test hook");
+    expect(entries[0].hook.source).toBe("milady-bundled");
+  });
+
+  it("extracts milady metadata from frontmatter JSON", async () => {
+    const bundled = join(tempRoot, "bundled");
+    await createHookDir(bundled, "meta-hook", {
+      hookMd: [
+        "---",
+        "name: meta-hook",
+        "description: Hook with metadata",
+        'metadata: { "milady": { "emoji": "🔥", "events": ["command:new"], "hookKey": "custom-key" } }',
+        "---",
+      ].join("\n"),
+    });
+
+    const entries = await discoverHooks({ bundledDir: bundled });
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].metadata).toBeDefined();
+    expect(entries[0].metadata?.emoji).toBe("🔥");
+    expect(entries[0].metadata?.events).toEqual(["command:new"]);
+    expect(entries[0].metadata?.hookKey).toBe("custom-key");
+  });
+
+  it("skips hook when frontmatter delimiters are missing", async () => {
+    const bundled = join(tempRoot, "bundled");
+    await createHookDir(bundled, "bad-fm", {
+      hookMd: "name: no-delimiters\ndescription: missing ---\n",
+    });
+
+    const entries = await discoverHooks({ bundledDir: bundled });
+
+    expect(entries).toHaveLength(0);
+  });
+
+  it("skips hook when name is empty", async () => {
+    const bundled = join(tempRoot, "bundled");
+    await createHookDir(bundled, "empty-name", {
+      hookMd: [
+        "---",
+        "name: ",
+        "description: Has description but no name",
+        "---",
+      ].join("\n"),
+    });
+
+    const entries = await discoverHooks({ bundledDir: bundled });
+
+    expect(entries).toHaveLength(0);
+  });
+
+  it("warns but still parses name/description when metadata JSON is invalid", async () => {
+    const { logger } = await import("@elizaos/core");
+    const bundled = join(tempRoot, "bundled");
+    await createHookDir(bundled, "bad-meta", {
+      hookMd: [
+        "---",
+        "name: bad-meta",
+        "description: Invalid metadata JSON",
+        "metadata: {not valid json!!!}",
+        "---",
+      ].join("\n"),
+    });
+
+    const entries = await discoverHooks({ bundledDir: bundled });
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].hook.name).toBe("bad-meta");
+    expect(entries[0].frontmatter.description).toBe("Invalid metadata JSON");
+    expect(entries[0].metadata).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to parse metadata"),
+    );
+  });
+
+  it("parses homepage from frontmatter", async () => {
+    const bundled = join(tempRoot, "bundled");
+    await createHookDir(bundled, "hp-hook", {
+      hookMd: [
+        "---",
+        "name: hp-hook",
+        "description: Hook with homepage",
+        "homepage: https://example.com",
+        "---",
+      ].join("\n"),
+    });
+
+    const entries = await discoverHooks({ bundledDir: bundled });
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].frontmatter.homepage).toBe("https://example.com");
+  });
+});
+
+// ============================================================================
+//  2. Handler resolution
+// ============================================================================
+
+describe("handler resolution", () => {
+  it("uses handler.ts when found", async () => {
+    const bundled = join(tempRoot, "bundled");
+    await createHookDir(bundled, "ts-handler", {
+      hookMd: "---\nname: ts-handler\ndescription: uses handler.ts\n---",
+      handlerFile: "handler.ts",
+    });
+
+    const entries = await discoverHooks({ bundledDir: bundled });
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].hook.handlerPath).toContain("handler.ts");
+  });
+
+  it("falls back to index.ts when handler.ts is missing", async () => {
+    const bundled = join(tempRoot, "bundled");
+    const dir = join(bundled, "idx-hook");
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, "HOOK.md"),
+      "---\nname: idx-hook\ndescription: uses index.ts\n---",
+      "utf-8",
+    );
+    // Only create index.ts, no handler.ts or handler
+    await writeFile(join(dir, "index.ts"), "export default () => {};", "utf-8");
+
+    const entries = await discoverHooks({ bundledDir: bundled });
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].hook.handlerPath).toContain("index.ts");
+  });
+
+  it("falls back to handler (no ext) when handler.ts is missing", async () => {
+    const bundled = join(tempRoot, "bundled");
+    const dir = join(bundled, "noext-hook");
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, "HOOK.md"),
+      "---\nname: noext-hook\ndescription: uses handler (no ext)\n---",
+      "utf-8",
+    );
+    await writeFile(join(dir, "handler"), "export default () => {};", "utf-8");
+
+    const entries = await discoverHooks({ bundledDir: bundled });
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].hook.handlerPath.endsWith("/handler")).toBe(true);
+  });
+
+  it("skips hook when no handler file exists", async () => {
+    const { logger } = await import("@elizaos/core");
+    const bundled = join(tempRoot, "bundled");
+    const dir = join(bundled, "no-handler");
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, "HOOK.md"),
+      "---\nname: no-handler\ndescription: missing handler\n---",
+      "utf-8",
+    );
+    // No handler file at all
+
+    const entries = await discoverHooks({ bundledDir: bundled });
+
+    expect(entries).toHaveLength(0);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("no handler"),
+    );
+  });
+});
+
+// ============================================================================
+//  3. Discovery precedence
+// ============================================================================
+
+describe("discovery precedence", () => {
+  it("workspace hook overrides bundled hook with the same name", async () => {
+    const bundled = join(tempRoot, "bundled");
+    const workspace = join(tempRoot, "workspace");
+
+    await createHookDir(bundled, "shared-hook", {
+      hookMd: "---\nname: shared-hook\ndescription: bundled version\n---",
+    });
+    // workspace hooks live under <workspacePath>/hooks/
+    const wsHooks = join(workspace, "hooks");
+    await createHookDir(wsHooks, "shared-hook", {
+      hookMd: "---\nname: shared-hook\ndescription: workspace version\n---",
+    });
+
+    const entries = await discoverHooks({
+      bundledDir: bundled,
+      workspacePath: workspace,
+    });
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].frontmatter.description).toBe("workspace version");
+    expect(entries[0].hook.source).toBe("milady-workspace");
+  });
+
+  it("collects hooks from all sources when names are unique", async () => {
+    const bundled = join(tempRoot, "bundled");
+    const extra = join(tempRoot, "extra");
+
+    await createHookDir(bundled, "hook-a", {
+      hookMd: "---\nname: hook-a\ndescription: bundled\n---",
+    });
+    await createHookDir(extra, "hook-b", {
+      hookMd: "---\nname: hook-b\ndescription: extra\n---",
+    });
+
+    const entries = await discoverHooks({
+      bundledDir: bundled,
+      extraDirs: [extra],
+    });
+
+    const names = entries.map((e) => e.hook.name).sort();
+    expect(names).toEqual(["hook-a", "hook-b"]);
+  });
+
+  it("returns empty array for nonexistent directory", async () => {
+    const entries = await discoverHooks({
+      bundledDir: join(tempRoot, "does-not-exist"),
+    });
+
+    expect(entries).toEqual([]);
+  });
+
+  it("skips non-directory entries inside hooks dir", async () => {
+    const bundled = join(tempRoot, "bundled");
+    await mkdir(bundled, { recursive: true });
+    // Create a file (not directory) inside the hooks dir
+    await writeFile(join(bundled, "not-a-dir.txt"), "just a file", "utf-8");
+
+    await createHookDir(bundled, "real-hook", {
+      hookMd: "---\nname: real-hook\ndescription: a real hook\n---",
+    });
+
+    const entries = await discoverHooks({ bundledDir: bundled });
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].hook.name).toBe("real-hook");
+  });
+
+  it("skips directories without HOOK.md", async () => {
+    const bundled = join(tempRoot, "bundled");
+    const dir = join(bundled, "no-hookmd");
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, "handler.ts"),
+      "export default () => {};",
+      "utf-8",
+    );
+    // No HOOK.md
+
+    const entries = await discoverHooks({ bundledDir: bundled });
+
+    expect(entries).toEqual([]);
+  });
+});

--- a/src/hooks/loader.test.ts
+++ b/src/hooks/loader.test.ts
@@ -1,0 +1,418 @@
+/**
+ * Hook Loader — Unit Tests
+ *
+ * Tests for:
+ * - loadHooks orchestration (disabled, clears hooks, skips ineligible/disabled/no-events, registers)
+ * - Path safety (legacy handlers under/outside allowed roots)
+ * - Config extraDirs safety (must be under ~/.milady/)
+ */
+
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import type { InternalHooksConfig } from "../config/types.hooks";
+import type { HookEntry, MiladyHookMetadata } from "./types";
+
+// ---------------------------------------------------------------------------
+// mocks
+// ---------------------------------------------------------------------------
+
+// Use a deterministic fake homedir so loader.ts and test code agree on paths
+const FAKE_HOME = join(tmpdir(), "__loader_test_home__");
+vi.mock("node:os", async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import("node:os");
+  return { ...actual, homedir: () => FAKE_HOME };
+});
+
+vi.mock("@elizaos/core", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+
+// Mock discoverHooks to return controlled entries
+const mockDiscoverHooks = vi.fn<() => Promise<HookEntry[]>>();
+vi.mock("./discovery", () => ({
+  discoverHooks: (...args: unknown[]) => mockDiscoverHooks(...(args as [])),
+}));
+
+// Mock eligibility — default to eligible
+const mockCheckEligibility = vi.fn();
+const mockResolveHookConfig = vi.fn();
+vi.mock("./eligibility", () => ({
+  checkEligibility: (...args: unknown[]) =>
+    mockCheckEligibility(...(args as [])),
+  resolveHookConfig: (...args: unknown[]) =>
+    mockResolveHookConfig(...(args as [])),
+}));
+
+// Track calls to registerHook and clearHooks
+const mockRegisterHook = vi.fn();
+const mockClearHooks = vi.fn();
+vi.mock("./registry", () => ({
+  registerHook: (...args: unknown[]) => mockRegisterHook(...(args as [])),
+  clearHooks: () => mockClearHooks(),
+}));
+
+// ---------------------------------------------------------------------------
+// shared temp dir for handler files
+// ---------------------------------------------------------------------------
+
+let tempRoot: string;
+let dummyHandlerPath: string;
+
+beforeAll(async () => {
+  tempRoot = join(
+    tmpdir(),
+    `loader-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  await mkdir(tempRoot, { recursive: true });
+
+  // Create a reusable dummy handler module
+  dummyHandlerPath = join(tempRoot, "handler.mjs");
+  await writeFile(
+    dummyHandlerPath,
+    "export default function handler(event) {}",
+    "utf-8",
+  );
+});
+
+afterAll(async () => {
+  await rm(tempRoot, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+function makeEntry(
+  name: string,
+  opts: {
+    events?: string[];
+    hookKey?: string;
+    emoji?: string;
+    export?: string;
+    handlerPath?: string;
+    source?: HookEntry["hook"]["source"];
+  } = {},
+): HookEntry {
+  const metadata: MiladyHookMetadata | undefined =
+    opts.events !== undefined
+      ? {
+          events: opts.events,
+          hookKey: opts.hookKey,
+          emoji: opts.emoji,
+          export: opts.export,
+        }
+      : undefined;
+
+  return {
+    hook: {
+      name,
+      description: `${name} description`,
+      source: opts.source ?? "milady-bundled",
+      filePath: `/fake/hooks/${name}/HOOK.md`,
+      baseDir: `/fake/hooks/${name}`,
+      handlerPath: opts.handlerPath ?? `/fake/hooks/${name}/handler.ts`,
+    },
+    frontmatter: { name, description: `${name} description` },
+    metadata,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// lifecycle
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDiscoverHooks.mockResolvedValue([]);
+  mockCheckEligibility.mockReturnValue({ eligible: true, missing: [] });
+  mockResolveHookConfig.mockReturnValue(undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// import loadHooks lazily so mocks are set up first
+// ---------------------------------------------------------------------------
+
+async function getLoadHooks() {
+  const mod = await import("./loader");
+  return mod.loadHooks;
+}
+
+// ============================================================================
+//  1. loadHooks orchestration
+// ============================================================================
+
+describe("loadHooks orchestration", () => {
+  it("returns zeros and does nothing when internalConfig.enabled === false", async () => {
+    const loadHooks = await getLoadHooks();
+
+    const result = await loadHooks({
+      internalConfig: { enabled: false },
+    });
+
+    expect(result).toEqual({
+      discovered: 0,
+      eligible: 0,
+      registered: 0,
+      skipped: [],
+      failed: [],
+    });
+    expect(mockDiscoverHooks).not.toHaveBeenCalled();
+    expect(mockClearHooks).not.toHaveBeenCalled();
+  });
+
+  it("clears existing hooks before loading", async () => {
+    const loadHooks = await getLoadHooks();
+    mockDiscoverHooks.mockResolvedValue([]);
+
+    await loadHooks({});
+
+    expect(mockClearHooks).toHaveBeenCalledOnce();
+  });
+
+  it("skips ineligible hooks into result.skipped", async () => {
+    const loadHooks = await getLoadHooks();
+    const entry = makeEntry("ineligible-hook", {
+      events: ["command:new"],
+    });
+    mockDiscoverHooks.mockResolvedValue([entry]);
+    mockCheckEligibility.mockReturnValue({
+      eligible: false,
+      missing: ["Binary missing: ffmpeg"],
+    });
+
+    const result = await loadHooks({});
+
+    expect(result.discovered).toBe(1);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]).toContain("ineligible-hook");
+    expect(result.skipped[0]).toContain("Binary missing: ffmpeg");
+    expect(result.registered).toBe(0);
+  });
+
+  it("skips hooks when hookConfig.enabled === false", async () => {
+    const loadHooks = await getLoadHooks();
+    const entry = makeEntry("disabled-hook", {
+      events: ["command:new"],
+    });
+    mockDiscoverHooks.mockResolvedValue([entry]);
+    mockCheckEligibility.mockReturnValue({ eligible: true, missing: [] });
+    mockResolveHookConfig.mockReturnValue({ enabled: false });
+
+    const result = await loadHooks({});
+
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]).toContain("disabled in config");
+    expect(result.registered).toBe(0);
+  });
+
+  it("skips hooks with no events configured", async () => {
+    const loadHooks = await getLoadHooks();
+    // Handler import must succeed for the no-events check to be reached
+    const entry = makeEntry("no-events-hook", {
+      events: [],
+      handlerPath: dummyHandlerPath,
+    });
+    mockDiscoverHooks.mockResolvedValue([entry]);
+
+    const result = await loadHooks({});
+
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]).toContain("no events");
+    expect(result.registered).toBe(0);
+  });
+
+  it("counts failed handler imports in result.failed", async () => {
+    const loadHooks = await getLoadHooks();
+    const entry = makeEntry("bad-import-hook", {
+      events: ["command:new"],
+      handlerPath: "/nonexistent/path/handler.ts",
+    });
+    mockDiscoverHooks.mockResolvedValue([entry]);
+
+    const result = await loadHooks({});
+
+    expect(result.failed).toContain("bad-import-hook");
+    expect(result.registered).toBe(0);
+  });
+
+  it("registers successful hooks for all event keys", async () => {
+    const loadHooks = await getLoadHooks();
+    const entry = makeEntry("good-hook", {
+      events: ["command:new", "session:start"],
+      handlerPath: dummyHandlerPath,
+    });
+    mockDiscoverHooks.mockResolvedValue([entry]);
+
+    const result = await loadHooks({});
+
+    expect(result.registered).toBe(1);
+    expect(mockRegisterHook).toHaveBeenCalledTimes(2);
+    expect(mockRegisterHook).toHaveBeenCalledWith(
+      "command:new",
+      expect.any(Function),
+    );
+    expect(mockRegisterHook).toHaveBeenCalledWith(
+      "session:start",
+      expect.any(Function),
+    );
+  });
+
+  it("uses hookKey from metadata when available", async () => {
+    const loadHooks = await getLoadHooks();
+    const entry = makeEntry("display-name", {
+      events: ["command:new"],
+      hookKey: "custom-config-key",
+    });
+    mockDiscoverHooks.mockResolvedValue([entry]);
+
+    await loadHooks({
+      internalConfig: {
+        entries: { "custom-config-key": { enabled: false } },
+      },
+    });
+
+    expect(mockResolveHookConfig).toHaveBeenCalledWith(
+      expect.anything(),
+      "custom-config-key",
+    );
+  });
+});
+
+// ============================================================================
+//  2. Path safety (legacy handlers)
+// ============================================================================
+
+describe("path safety — legacy handlers", () => {
+  it("rejects legacy handler with module path outside allowed roots", async () => {
+    const { logger } = await import("@elizaos/core");
+    const loadHooks = await getLoadHooks();
+    mockDiscoverHooks.mockResolvedValue([]);
+
+    const config: InternalHooksConfig = {
+      handlers: [
+        {
+          event: "command:new",
+          module: "/etc/malicious/handler.ts",
+        },
+      ],
+    };
+
+    const result = await loadHooks({ internalConfig: config });
+
+    expect(result.failed).toContain("/etc/malicious/handler.ts");
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("outside allowed hook directories"),
+    );
+  });
+
+  it("accepts legacy handler with module path under allowed root", async () => {
+    const loadHooks = await getLoadHooks();
+    mockDiscoverHooks.mockResolvedValue([]);
+
+    // FAKE_HOME is the mocked homedir — managed hooks dir = FAKE_HOME/.milady/hooks
+    const managedPath = resolve(
+      FAKE_HOME,
+      ".milady",
+      "hooks",
+      "my-hook",
+      "handler.ts",
+    );
+    const config: InternalHooksConfig = {
+      handlers: [
+        {
+          event: "command:new",
+          module: managedPath,
+        },
+      ],
+    };
+
+    // The handler import will fail (file doesn't exist), but path validation passes
+    const result = await loadHooks({ internalConfig: config });
+
+    // Should fail on import, not on path validation
+    expect(result.failed).toContain(managedPath);
+    // The warning should NOT mention "outside allowed"
+    const { logger } = await import("@elizaos/core");
+    const outsideCalls = (
+      logger.warn as ReturnType<typeof vi.fn>
+    ).mock.calls.filter(
+      (call: unknown[]) =>
+        typeof call[0] === "string" && call[0].includes("outside allowed"),
+    );
+    expect(outsideCalls).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+//  3. Config extraDirs safety
+// ============================================================================
+
+describe("config extraDirs safety", () => {
+  it("rejects config extraDirs outside ~/.milady/", async () => {
+    const { logger } = await import("@elizaos/core");
+    const loadHooks = await getLoadHooks();
+    mockDiscoverHooks.mockResolvedValue([]);
+
+    const config: InternalHooksConfig = {
+      load: {
+        extraDirs: ["/tmp/attacker-controlled"],
+      },
+    };
+
+    await loadHooks({ internalConfig: config });
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Rejected config extraDir "/tmp/attacker-controlled"',
+      ),
+    );
+  });
+
+  it("accepts config extraDirs under ~/.milady/", async () => {
+    const { logger } = await import("@elizaos/core");
+    const loadHooks = await getLoadHooks();
+    mockDiscoverHooks.mockResolvedValue([]);
+
+    // Use absolute path under the mocked homedir's .milady
+    const safePath = resolve(FAKE_HOME, ".milady", "custom-hooks");
+    const config: InternalHooksConfig = {
+      load: {
+        extraDirs: [safePath],
+      },
+    };
+
+    await loadHooks({ internalConfig: config });
+
+    // Should NOT warn about rejection
+    const rejectCalls = (
+      logger.warn as ReturnType<typeof vi.fn>
+    ).mock.calls.filter(
+      (call: unknown[]) =>
+        typeof call[0] === "string" &&
+        call[0].includes("Rejected config extraDir"),
+    );
+    expect(rejectCalls).toHaveLength(0);
+
+    // The safe dir should be passed to discoverHooks
+    expect(mockDiscoverHooks).toHaveBeenCalledWith(
+      expect.objectContaining({
+        extraDirs: expect.arrayContaining([safePath]),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `discovery.test.ts` (15 tests): frontmatter parsing, handler resolution fallback chain, discovery precedence (workspace > managed > bundled > extra)
- Adds `loader.test.ts` (12 tests): orchestration flow (disabled/ineligible/no-events/success), legacy handler path safety, config extraDirs validation

No production code changes.

## Test plan
- [x] `npx vitest run src/hooks/` — all 60 tests pass (27 new + 33 existing)
- [x] `npx biome check` clean
- [x] `bun run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)