### PR TITLE
fix: human-readable error for document uploads exceeding 32 MB (F-08)

### DIFF
--- a/src/api/knowledge-routes.test.ts
+++ b/src/api/knowledge-routes.test.ts
@@ -1,10 +1,15 @@
 import * as dns from "node:dns/promises";
+import { EventEmitter } from "node:events";
+import type http from "node:http";
 import type { AgentRuntime, Memory, UUID } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { createRouteInvoker } from "../test-support/route-test-helpers.js";
+import { createMockHttpResponse } from "../test-support/test-helpers.js";
+import { readJsonBody } from "./http-helpers.js";
 import {
   __setPinnedFetchImplForTests,
   handleKnowledgeRoutes,
+  type KnowledgeRouteContext,
 } from "./knowledge-routes.js";
 
 vi.mock("node:dns/promises", () => ({
@@ -885,5 +890,111 @@ describe("knowledge routes", () => {
     expect((result.payload as { error?: string }).error).toContain("timed out");
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(addKnowledgeMock).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Create a mock request that defers data/end emission until a "data"
+   * listener is attached. This avoids a race where queueMicrotask fires
+   * before the consumer (readRequestBodyBuffer) sets up handlers — which
+   * happens when an async call (getKnowledgeService) sits between request
+   * creation and readJsonBody.
+   */
+  function createDeferredMockRequest(opts: {
+    method: string;
+    url: string;
+    bodyChunks: Buffer[];
+  }): http.IncomingMessage {
+    const req = new EventEmitter() as http.IncomingMessage &
+      EventEmitter & { destroy: () => void };
+    req.method = opts.method;
+    req.url = opts.url;
+    req.headers = {};
+    req.destroy = vi.fn();
+
+    let emitted = false;
+    const originalOn = req.on.bind(req);
+    req.on = ((event: string, listener: (...args: unknown[]) => void) => {
+      originalOn(event, listener);
+      if (event === "data" && !emitted) {
+        emitted = true;
+        queueMicrotask(() => {
+          for (const chunk of opts.bodyChunks) {
+            req.emit("data", chunk);
+          }
+          req.emit("end");
+        });
+      }
+      return req;
+    }) as typeof req.on;
+
+    return req;
+  }
+
+  test("returns 413 with human-readable message when single document upload exceeds 32 MB", async () => {
+    // Use a small buffer with a lowered maxBytes to verify the tooLargeMessage
+    // plumbing without allocating 32 MB in tests.
+    const req = createDeferredMockRequest({
+      method: "POST",
+      url: "/api/knowledge/documents",
+      bodyChunks: [Buffer.alloc(1024, "a")],
+    });
+    const { res, getStatus, getJson } = createMockHttpResponse();
+
+    const readJsonBodySmallLimit: KnowledgeRouteContext["readJsonBody"] = (
+      req,
+      res,
+      opts,
+    ) => readJsonBody(req, res, { ...opts, maxBytes: 512 });
+
+    await handleKnowledgeRoutes({
+      req,
+      res,
+      method: "POST",
+      pathname: "/api/knowledge/documents",
+      url: new URL("/api/knowledge/documents", "http://localhost:2138"),
+      runtime,
+      readJsonBody: readJsonBodySmallLimit,
+      json: () => {},
+      error: () => {},
+    } as unknown as KnowledgeRouteContext);
+
+    expect(getStatus()).toBe(413);
+    expect(getJson()).toEqual({
+      error:
+        "Document upload exceeds the 32 MB limit. Split large files into smaller parts before uploading.",
+    });
+  });
+
+  test("returns 413 with human-readable message when bulk document upload exceeds 32 MB", async () => {
+    const req = createDeferredMockRequest({
+      method: "POST",
+      url: "/api/knowledge/documents/bulk",
+      bodyChunks: [Buffer.alloc(1024, "a")],
+    });
+    const { res, getStatus, getJson } = createMockHttpResponse();
+
+    const readJsonBodySmallLimit: KnowledgeRouteContext["readJsonBody"] = (
+      req,
+      res,
+      opts,
+    ) => readJsonBody(req, res, { ...opts, maxBytes: 512 });
+
+    await handleKnowledgeRoutes({
+      req,
+      res,
+      method: "POST",
+      pathname: "/api/knowledge/documents/bulk",
+      url: new URL("/api/knowledge/documents/bulk", "http://localhost:2138"),
+      runtime,
+      readJsonBody: readJsonBodySmallLimit,
+      json: () => {},
+      error: () => {},
+    } as unknown as KnowledgeRouteContext);
+
+    expect(getStatus()).toBe(413);
+    expect(getJson()).toEqual({
+      error:
+        "Document upload exceeds the 32 MB limit. Split large files into smaller parts before uploading.",
+    });
   });
 });

--- a/src/api/knowledge-routes.ts
+++ b/src/api/knowledge-routes.ts
@@ -887,6 +887,8 @@ export async function handleKnowledgeRoutes(
   if (method === "POST" && pathname === "/api/knowledge/documents") {
     const body = await readJsonBody<KnowledgeUploadDocumentBody>(req, res, {
       maxBytes: KNOWLEDGE_UPLOAD_MAX_BODY_BYTES,
+      tooLargeMessage:
+        "Document upload exceeds the 32 MB limit. Split large files into smaller parts before uploading.",
     });
     if (!body) return true;
 
@@ -912,6 +914,8 @@ export async function handleKnowledgeRoutes(
       documents?: KnowledgeUploadDocumentBody[];
     }>(req, res, {
       maxBytes: KNOWLEDGE_UPLOAD_MAX_BODY_BYTES,
+      tooLargeMessage:
+        "Document upload exceeds the 32 MB limit. Split large files into smaller parts before uploading.",
     });
     if (!body) return true;
 


### PR DESCRIPTION
## Summary
- Add clear `tooLargeMessage` for document upload endpoints exceeding 32 MB
- 413 regression tests for upload size validation

Extracted from #812 to keep the companion UI PR focused.

## Test plan
- [ ] Upload limit tests pass
- [ ] Manual test: upload >32MB doc shows clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)