### PR TITLE
fix(CD): remove node-gyp build artifacts before Electron packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -375,7 +375,7 @@ jobs:
             find "$nm" -type d \( -name 'build-tmp*' -o -name 'node_gyp_bins' \) 2>/dev/null | while read -r d; do
               echo "Removing build artifact: $d"
               rm -rf "$d"
-            done
+            done || true
           done
         working-directory: apps/app/electron
 


### PR DESCRIPTION
@tensorflow/tfjs-node leaves build-tmp*/node_gyp_bins (symlink to system Python). electron-builder refuses to pack symlinks outside the app (denied access to system or unsafe path). Delete these dirs from electron node_modules and milady-dist/node_modules before pack.

Made-with: Cursor

This PR will be reviewed by an AI agent. Provide clear context to help it assess your changes.

Aesthetic/UI changes that don't improve agent capability are out of scope and will be rejected.

## Category
- [X] Bug fix
- [ ] Security fix
- [ ] Performance improvement
- [ ] New feature
- [ ] Documentation
- [ ] Test coverage
- [ ] Other

## What
(brief description)

## Why
(motivation)

## How
(implementation approach)

## Testing
(what was tested, how to verify)
