### PR TITLE
Add BAP-578 NFA plugin with on-chain learning provenance

### DIFF
--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -19,6 +19,7 @@ import { CustomActionsPanel } from "./components/CustomActionsPanel";
 import { EmotePicker } from "./components/EmotePicker";
 import { GameViewOverlay } from "./components/GameViewOverlay";
 import { Header } from "./components/Header";
+import { IdentityView } from "./components/IdentityView";
 import { InventoryView } from "./components/InventoryView";
 import { KnowledgeView } from "./components/KnowledgeView";
 import { LifoSandboxView } from "./components/LifoSandboxView";
@@ -73,6 +74,8 @@ function ViewRouter() {
     case "character":
     case "character-select":
       return <CharacterView />;
+    case "identity":
+      return <IdentityView />;
     case "wallets":
       return <InventoryView />;
     case "knowledge":

--- a/apps/app/src/api-client.ts
+++ b/apps/app/src/api-client.ts
@@ -1815,6 +1815,39 @@ export interface RegistryConfig {
   explorerUrl: string;
 }
 
+export interface NfaStatusResponse {
+  nfa: {
+    tokenId: string;
+    contractAddress: string;
+    network: string;
+    ownerAddress: string;
+    merkleRoot: string;
+    mintTxHash: string;
+    mintedAt: string;
+    lastUpdatedAt: string;
+    bscscanUrl: string;
+  } | null;
+  identity: {
+    agentId: string;
+    network: string;
+    ownerAddress: string;
+    agentURI: string;
+    registeredAt: string;
+    scanUrl: string;
+  } | null;
+  configured: boolean;
+}
+
+export interface NfaLearningsResponse {
+  entries: Array<{
+    date: string;
+    content: string;
+    hash: string;
+  }>;
+  merkleRoot: string;
+  totalEntries: number;
+}
+
 export interface WhitelistStatus {
   eligible: boolean;
   twitterVerified: boolean;
@@ -4497,6 +4530,18 @@ export class MiladyClient {
     this.disconnectedAt = null;
     this.connectionState = "disconnected";
     this.emitConnectionStateChange();
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════
+  //  BAP-578 NFA
+  // ═══════════════════════════════════════════════════════════════════════
+
+  async getNfaStatus(): Promise<NfaStatusResponse> {
+    return this.fetch("/api/nfa/status");
+  }
+
+  async getNfaLearnings(): Promise<NfaLearningsResponse> {
+    return this.fetch("/api/nfa/learnings");
   }
 
   // ═══════════════════════════════════════════════════════════════════════

--- a/apps/app/src/components/Header.tsx
+++ b/apps/app/src/components/Header.tsx
@@ -3,13 +3,15 @@ import {
   Bug,
   Check,
   CircleDollarSign,
+  Fingerprint,
   Loader2,
   Pause,
   Play,
   RotateCcw,
   Wallet,
 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { client, type NfaStatusResponse } from "../api-client";
 import { useApp } from "../AppContext";
 import { useBugReport } from "../hooks/useBugReport";
 import { createTranslator } from "../i18n";
@@ -120,6 +122,21 @@ export function Header() {
   useEffect(() => {
     void loadDropStatus();
   }, [loadDropStatus]);
+
+  // Identity status for the popover
+  const [identityStatus, setIdentityStatus] =
+    useState<NfaStatusResponse | null>(null);
+  const loadIdentityStatus = useCallback(async () => {
+    try {
+      const data = await client.getNfaStatus();
+      setIdentityStatus(data);
+    } catch {
+      // non-critical — silently ignore
+    }
+  }, []);
+  useEffect(() => {
+    void loadIdentityStatus();
+  }, [loadIdentityStatus]);
 
   // Clear copied state after 2 seconds
   useEffect(() => {
@@ -357,6 +374,89 @@ export function Header() {
                 <Bug className="w-5 h-5" />
               </button>
             </IconButtonTooltip>
+
+            {/* Identity Popover */}
+            {identityStatus?.configured && (
+              <div className="identity-wrapper relative inline-flex shrink-0 group">
+                <IconButtonTooltip label="Agent Identity">
+                  <button
+                    type="button"
+                    onClick={() => setTab("identity")}
+                    aria-label="View agent identity"
+                    className={`${iconBtnBase} ${identityStatus.nfa ? "border-[#d4af37] text-[#d4af37]" : ""}`}
+                  >
+                    <Fingerprint className="w-5 h-5" />
+                  </button>
+                </IconButtonTooltip>
+
+                {/* Identity Popover */}
+                <div className="identity-tooltip hidden group-hover:block group-focus-within:block absolute top-full right-0 mt-2 p-3 border border-border bg-bg-elevated z-50 min-w-[280px] shadow-xl rounded-lg">
+                  <div className="text-[11px] text-muted uppercase tracking-wide mb-2 px-1">
+                    On-Chain Identity
+                  </div>
+
+                  {identityStatus.identity && (
+                    <div className="py-1.5 px-1">
+                      <div className="flex items-center gap-2 text-xs mb-1">
+                        <span className="font-bold text-muted min-w-[60px]">
+                          ERC-8004
+                        </span>
+                        <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[9px] bg-ok/15 text-ok border border-ok/30">
+                          <span className="w-1 h-1 rounded-full bg-ok" />
+                          Active
+                        </span>
+                      </div>
+                      <div className="text-[10px] font-mono text-txt-strong truncate">
+                        Agent #{identityStatus.identity.agentId}
+                      </div>
+                      <div className="text-[10px] text-muted">
+                        {identityStatus.identity.network}
+                      </div>
+                      <a
+                        href={identityStatus.identity.scanUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-[10px] text-accent hover:underline"
+                      >
+                        View on 8004Scan
+                      </a>
+                    </div>
+                  )}
+
+                  {identityStatus.nfa && (
+                    <div className="py-1.5 px-1 border-t border-border mt-1">
+                      <div className="flex items-center gap-2 text-xs mb-1">
+                        <span className="font-bold text-muted min-w-[60px]">
+                          NFA
+                        </span>
+                        <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[9px] bg-[#d4af37]/15 text-[#d4af37] border border-[#d4af37]/30">
+                          <span className="w-1 h-1 rounded-full bg-[#d4af37]" />
+                          Token #{identityStatus.nfa.tokenId}
+                        </span>
+                      </div>
+                      <div className="text-[10px] font-mono text-txt-strong truncate">
+                        Root: {identityStatus.nfa.merkleRoot.slice(0, 16)}...
+                      </div>
+                      <div className="text-[10px] text-muted">
+                        {identityStatus.nfa.network}
+                      </div>
+                      <a
+                        href={identityStatus.nfa.bscscanUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-[10px] text-accent hover:underline"
+                      >
+                        View on BscScan
+                      </a>
+                    </div>
+                  )}
+
+                  <div className="mt-2 pt-2 border-t border-border text-[10px] text-muted text-center">
+                    Click to view full identity details
+                  </div>
+                </div>
+              </div>
+            )}
 
             {/* Wallet Dropdown */}
             {(evmShort || solShort) && (

--- a/apps/app/src/components/IdentityView.tsx
+++ b/apps/app/src/components/IdentityView.tsx
@@ -1,0 +1,310 @@
+/**
+ * Identity view — unified ERC-8004 + BAP-578 NFA on-chain identity.
+ *
+ * Displays the agent's on-chain identity state, NFA token info,
+ * and learning history with Merkle root verification.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { useApp } from "../AppContext";
+import {
+  client,
+  type NfaLearningsResponse,
+  type NfaStatusResponse,
+} from "../api-client";
+import { createTranslator } from "../i18n";
+
+type SectionStatus = "loading" | "loaded" | "error";
+
+function SectionCard({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="border border-border rounded-lg bg-bg-elevated">
+      <div className="px-4 py-3 border-b border-border">
+        <h3 className="text-sm font-semibold text-txt-strong">{title}</h3>
+      </div>
+      <div className="p-4">{children}</div>
+    </div>
+  );
+}
+
+function InfoRow({
+  label,
+  value,
+  mono,
+  href,
+}: {
+  label: string;
+  value: string | null | undefined;
+  mono?: boolean;
+  href?: string;
+}) {
+  if (!value) return null;
+  return (
+    <div className="flex items-start gap-3 py-1.5 text-xs">
+      <span className="text-muted min-w-[100px] shrink-0">{label}</span>
+      {href ? (
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={`text-accent hover:underline break-all ${mono ? "font-mono" : ""}`}
+        >
+          {value}
+        </a>
+      ) : (
+        <span
+          className={`text-txt-strong break-all ${mono ? "font-mono" : ""}`}
+        >
+          {value}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function StatusBadge({ active }: { active: boolean }) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium ${
+        active
+          ? "bg-ok/15 text-ok border border-ok/30"
+          : "bg-muted/15 text-muted border border-muted/30"
+      }`}
+    >
+      <span
+        className={`w-1.5 h-1.5 rounded-full ${active ? "bg-ok" : "bg-muted"}`}
+      />
+      {active ? "Active" : "Not configured"}
+    </span>
+  );
+}
+
+export function IdentityView() {
+  const { uiLanguage, setTab } = useApp();
+  const t = createTranslator(uiLanguage);
+
+  const [nfaStatus, setNfaStatus] = useState<NfaStatusResponse | null>(null);
+  const [learnings, setLearnings] = useState<NfaLearningsResponse | null>(null);
+  const [statusState, setStatusState] = useState<SectionStatus>("loading");
+  const [learningsState, setLearningsState] =
+    useState<SectionStatus>("loading");
+
+  const loadStatus = useCallback(async () => {
+    try {
+      setStatusState("loading");
+      const data = await client.getNfaStatus();
+      setNfaStatus(data);
+      setStatusState("loaded");
+    } catch {
+      setStatusState("error");
+    }
+  }, []);
+
+  const loadLearnings = useCallback(async () => {
+    try {
+      setLearningsState("loading");
+      const data = await client.getNfaLearnings();
+      setLearnings(data);
+      setLearningsState("loaded");
+    } catch {
+      setLearningsState("error");
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadStatus();
+    void loadLearnings();
+  }, [loadStatus, loadLearnings]);
+
+  const identity = nfaStatus?.identity;
+  const nfa = nfaStatus?.nfa;
+
+  return (
+    <div className="flex-1 overflow-y-auto p-4 sm:p-6 max-w-4xl mx-auto w-full">
+      <div className="mb-6">
+        <h2 className="text-lg font-bold text-txt-strong mb-1">
+          On-Chain Identity
+        </h2>
+        <p className="text-xs text-muted">
+          ERC-8004 agent identity and BAP-578 NFA learning provenance on BNB
+          Chain.
+        </p>
+      </div>
+
+      <div className="space-y-4">
+        {/* ERC-8004 Identity Section */}
+        <SectionCard title="ERC-8004 Agent Identity">
+          {statusState === "loading" ? (
+            <div className="text-xs text-muted animate-pulse">Loading...</div>
+          ) : statusState === "error" ? (
+            <div className="text-xs text-danger">
+              Failed to load identity status.{" "}
+              <button
+                type="button"
+                onClick={loadStatus}
+                className="text-accent hover:underline"
+              >
+                Retry
+              </button>
+            </div>
+          ) : identity ? (
+            <div>
+              <div className="mb-3">
+                <StatusBadge active />
+              </div>
+              <InfoRow label="Agent ID" value={identity.agentId} mono />
+              <InfoRow label="Network" value={identity.network} />
+              <InfoRow label="Owner" value={identity.ownerAddress} mono />
+              <InfoRow label="Registered" value={identity.registeredAt} />
+              <InfoRow
+                label="8004Scan"
+                value="View on 8004Scan"
+                href={identity.scanUrl}
+              />
+            </div>
+          ) : (
+            <div>
+              <div className="mb-3">
+                <StatusBadge active={false} />
+              </div>
+              <p className="text-xs text-muted">
+                No ERC-8004 identity registered. Use the{" "}
+                <button
+                  type="button"
+                  onClick={() => setTab("character")}
+                  className="text-accent hover:underline"
+                >
+                  Character
+                </button>{" "}
+                tab or say &quot;register milady on bnb chain&quot; in chat.
+              </p>
+            </div>
+          )}
+        </SectionCard>
+
+        {/* BAP-578 NFA Section */}
+        <SectionCard title="BAP-578 Non-Fungible Agent">
+          {statusState === "loading" ? (
+            <div className="text-xs text-muted animate-pulse">Loading...</div>
+          ) : statusState === "error" ? (
+            <div className="text-xs text-danger">
+              Failed to load NFA status.{" "}
+              <button
+                type="button"
+                onClick={loadStatus}
+                className="text-accent hover:underline"
+              >
+                Retry
+              </button>
+            </div>
+          ) : nfa ? (
+            <div>
+              <div className="mb-3">
+                <StatusBadge active />
+              </div>
+              <InfoRow label="Token ID" value={nfa.tokenId} mono />
+              <InfoRow label="Contract" value={nfa.contractAddress} mono />
+              <InfoRow label="Network" value={nfa.network} />
+              <InfoRow label="Owner" value={nfa.ownerAddress} mono />
+              <InfoRow
+                label="Merkle Root"
+                value={nfa.merkleRoot}
+                mono
+              />
+              <InfoRow label="Minted" value={nfa.mintedAt} />
+              <InfoRow label="Last Updated" value={nfa.lastUpdatedAt} />
+              <InfoRow
+                label="BscScan"
+                value="View transaction"
+                href={nfa.bscscanUrl}
+              />
+            </div>
+          ) : (
+            <div>
+              <div className="mb-3">
+                <StatusBadge active={false} />
+              </div>
+              <p className="text-xs text-muted">
+                No NFA token minted. Say &quot;mint nfa&quot; in chat to create
+                one. Requires BAP578_CONTRACT_ADDRESS in environment and
+                BNB_PRIVATE_KEY.
+              </p>
+            </div>
+          )}
+        </SectionCard>
+
+        {/* Learning History Section */}
+        <SectionCard title="Learning History">
+          {learningsState === "loading" ? (
+            <div className="text-xs text-muted animate-pulse">Loading...</div>
+          ) : learningsState === "error" ? (
+            <div className="text-xs text-danger">
+              Failed to load learnings.{" "}
+              <button
+                type="button"
+                onClick={loadLearnings}
+                className="text-accent hover:underline"
+              >
+                Retry
+              </button>
+            </div>
+          ) : learnings && learnings.totalEntries > 0 ? (
+            <div>
+              <div className="flex items-center gap-3 mb-3">
+                <span className="text-xs text-muted">
+                  {learnings.totalEntries} entries
+                </span>
+                <span className="text-[10px] text-muted font-mono">
+                  Root: {learnings.merkleRoot.slice(0, 16)}...
+                </span>
+                {nfa && learnings.merkleRoot === nfa.merkleRoot ? (
+                  <span className="text-[10px] text-ok">
+                    In sync with on-chain root
+                  </span>
+                ) : nfa ? (
+                  <span className="text-[10px] text-warn">
+                    Out of sync — say &quot;update nfa learning root&quot; to
+                    sync
+                  </span>
+                ) : null}
+              </div>
+
+              <div className="space-y-2 max-h-[400px] overflow-y-auto">
+                {learnings.entries.map((entry, i) => (
+                  <div
+                    key={`${entry.date}-${i}`}
+                    className="border border-border/50 rounded p-3 bg-bg"
+                  >
+                    <div className="flex items-center gap-2 mb-1">
+                      <span className="text-[10px] font-mono text-accent">
+                        {entry.date}
+                      </span>
+                      <span className="text-[9px] font-mono text-muted">
+                        {entry.hash.slice(0, 12)}...
+                      </span>
+                    </div>
+                    <p className="text-xs text-txt whitespace-pre-wrap line-clamp-3">
+                      {entry.content}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <p className="text-xs text-muted">
+              No LEARNINGS.md found. Create one at ~/.milady/LEARNINGS.md to
+              track agent learning history. Entries should use ## YYYY-MM-DD
+              headings.
+            </p>
+          )}
+        </SectionCard>
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/navigation.ts
+++ b/apps/app/src/navigation.ts
@@ -6,6 +6,7 @@ import type { LucideIcon } from "lucide-react";
 import {
   Bot,
   Brain,
+  Fingerprint,
   Gamepad2,
   Heart,
   MessageSquare,
@@ -33,6 +34,7 @@ export type Tab =
   | "apps"
   | "character"
   | "character-select"
+  | "identity"
   | "wallets"
   | "knowledge"
   | "connectors"
@@ -82,6 +84,12 @@ export const ALL_TAB_GROUPS: TabGroup[] = [
     tabs: ["character", "character-select"],
     icon: Bot,
     description: "AI personality and behavior",
+  },
+  {
+    label: "Identity",
+    tabs: ["identity"],
+    icon: Fingerprint,
+    description: "On-chain agent identity and NFA",
   },
   {
     label: "Wallets",
@@ -152,6 +160,7 @@ const TAB_PATHS: Record<Tab, string> = {
   character: "/character",
   "character-select": "/character-select",
   triggers: "/triggers",
+  identity: "/identity",
   wallets: "/wallets",
   knowledge: "/knowledge",
   connectors: "/connectors",
@@ -250,6 +259,8 @@ export function titleForTab(tab: Tab): string {
       return "Character Select";
     case "triggers":
       return "Triggers";
+    case "identity":
+      return "Identity";
     case "wallets":
       return "Wallets";
     case "knowledge":

--- a/packages/plugin-bap578-nfa/build.ts
+++ b/packages/plugin-bap578-nfa/build.ts
@@ -1,0 +1,16 @@
+import { build } from "bun";
+import { rmSync } from "node:fs";
+
+rmSync("dist", { recursive: true, force: true });
+
+await build({
+  entrypoints: ["./src/index.ts"],
+  outdir: "./dist",
+  target: "node",
+  format: "esm",
+  splitting: false,
+  sourcemap: "external",
+  external: ["@elizaos/core"],
+});
+
+console.log("@milady/plugin-bap578-nfa built successfully.");

--- a/packages/plugin-bap578-nfa/package.json
+++ b/packages/plugin-bap578-nfa/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "@milady/plugin-bap578-nfa",
+  "description": "BAP-578 Non-Fungible Agent (NFA) plugin for Milady — on-chain agent identity with Merkle-rooted learning provenance",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "packageType": "plugin",
+  "platform": "node",
+  "license": "VPL-1.0",
+  "keywords": [
+    "elizaos",
+    "elizaos-plugin",
+    "bnb-chain",
+    "bsc",
+    "bap578",
+    "nfa",
+    "non-fungible-agent",
+    "merkle-tree"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/milady-ai/milady.git",
+    "directory": "packages/plugin-bap578-nfa"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "bun": "./src/index.ts",
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "files": ["dist", "package.json"],
+  "dependencies": {
+    "@elizaos/core": "next"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  },
+  "scripts": {
+    "build": "bun run build.ts",
+    "test": "bun test"
+  },
+  "agentConfig": {
+    "pluginType": "elizaos:plugin:1.0.0",
+    "pluginParameters": {
+      "BAP578_CONTRACT_ADDRESS": {
+        "type": "string",
+        "description": "Address of the BAP-578 NFA contract. Must be set via environment — never hardcode.",
+        "required": true,
+        "sensitive": false
+      },
+      "BNB_PRIVATE_KEY": {
+        "type": "string",
+        "description": "Hex private key for the wallet that owns the NFA token. Required for write operations (mint, transfer, pause). Read-only actions work without it.",
+        "required": false,
+        "sensitive": true
+      },
+      "BNB_NETWORK": {
+        "type": "string",
+        "description": "Target network: 'bsc' (mainnet) or 'bsc-testnet'. Defaults to bsc-testnet for safety.",
+        "required": false,
+        "default": "bsc-testnet"
+      }
+    }
+  }
+}

--- a/packages/plugin-bap578-nfa/src/actions.ts
+++ b/packages/plugin-bap578-nfa/src/actions.ts
@@ -1,0 +1,465 @@
+/**
+ * ElizaOS Actions for @milady/plugin-bap578-nfa.
+ *
+ * Actions:
+ *   NFA_GET_INFO   — read-only: display current NFA status
+ *   NFA_MINT       — write: mint a new NFA token (requires confirmation)
+ *   NFA_UPDATE_ROOT — write: update learning Merkle root (requires confirmation)
+ */
+
+import type {
+  Action,
+  ActionExample,
+  HandlerCallback,
+  IAgentRuntime,
+  Memory,
+  State,
+} from "@elizaos/core";
+
+import { Bap578NfaService } from "./service.js";
+import { readNfaRecord, writeNfaRecord, patchNfaRecord } from "./store.js";
+import { computeLearningsData } from "./merkle.js";
+import type { Bap578NfaConfig } from "./types.js";
+
+function loadConfig(runtime: IAgentRuntime): Bap578NfaConfig {
+  const contractAddress = runtime.getSetting("BAP578_CONTRACT_ADDRESS");
+  if (!contractAddress) {
+    throw new Error(
+      "BAP578_CONTRACT_ADDRESS is required. Set it in your environment or milady.json plugin parameters."
+    );
+  }
+
+  const rawNetwork = (
+    runtime.getSetting("BNB_NETWORK") ?? "bsc-testnet"
+  )
+    .trim()
+    .toLowerCase();
+
+  const network =
+    rawNetwork === "bsc" || rawNetwork === "mainnet" ? "bsc" : "bsc-testnet";
+
+  return {
+    contractAddress,
+    privateKey: runtime.getSetting("BNB_PRIVATE_KEY") ?? undefined,
+    network,
+  };
+}
+
+function networkLabel(network: string): string {
+  return network === "bsc" ? "BSC Mainnet" : `${network} (testnet)`;
+}
+
+function bscscanUrl(network: string, txHash: string): string {
+  const base =
+    network === "bsc" ? "https://bscscan.com" : "https://testnet.bscscan.com";
+  return `${base}/tx/${txHash}`;
+}
+
+function userConfirmed(message: Memory): boolean {
+  const text = message.content?.text?.toLowerCase() ?? "";
+  return text.includes("confirm") || text.includes("yes");
+}
+
+async function loadLearningsMarkdown(): Promise<string | null> {
+  try {
+    const { readFile } = await import("node:fs/promises");
+    const { join } = await import("node:path");
+    const { homedir } = await import("node:os");
+    // Check common locations for LEARNINGS.md
+    const paths = [
+      join(homedir(), ".milady", "LEARNINGS.md"),
+      join(process.cwd(), "LEARNINGS.md"),
+    ];
+    for (const p of paths) {
+      try {
+        return await readFile(p, "utf8");
+      } catch {
+        continue;
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// ── Action: NFA_GET_INFO ──────────────────────────────────────────────────
+
+export const getNfaInfoAction: Action = {
+  name: "NFA_GET_INFO",
+  similes: [
+    "nfa status",
+    "nfa info",
+    "show nfa",
+    "my nfa",
+    "check nfa",
+    "nfa details",
+  ],
+  description:
+    "Displays the current BAP-578 NFA status — token ID, owner, Merkle root, and contract details. Read-only, no private key needed.",
+
+  validate: async (
+    _runtime: IAgentRuntime,
+    _message: Memory
+  ): Promise<boolean> => true,
+
+  handler: async (
+    runtime: IAgentRuntime,
+    _message: Memory,
+    _state: State | undefined,
+    _options: Record<string, unknown>,
+    callback: HandlerCallback
+  ): Promise<void> => {
+    const record = await readNfaRecord();
+    if (!record) {
+      await callback({
+        text:
+          "No NFA record found. Mint one with: **mint nfa**\n\n" +
+          "This will create a BAP-578 Non-Fungible Agent token representing Milady's on-chain identity and learning history.",
+      });
+      return;
+    }
+
+    let config: Bap578NfaConfig;
+    try {
+      config = loadConfig(runtime);
+    } catch (err) {
+      // Show local record even if config is missing
+      await callback({
+        text:
+          `**NFA Token ID:** \`${record.tokenId}\`\n` +
+          `**Network:** ${record.network}\n` +
+          `**Contract:** \`${record.contractAddress}\`\n` +
+          `**Owner:** \`${record.ownerAddress}\`\n` +
+          `**Merkle Root:** \`${record.merkleRoot}\`\n` +
+          `**Minted:** ${record.mintedAt}\n\n` +
+          `_Could not verify on-chain: ${(err as Error).message}_`,
+      });
+      return;
+    }
+
+    // Try to fetch fresh on-chain data
+    const svc = new Bap578NfaService(runtime, config);
+    try {
+      const info = await svc.getNfaInfo(record.tokenId);
+      await callback({
+        text:
+          `**NFA Token ID:** \`${info.tokenId}\`\n` +
+          `**Network:** ${networkLabel(info.network)}\n` +
+          `**Contract:** \`${config.contractAddress}\`\n` +
+          `**Owner:** \`${info.owner}\`\n` +
+          `**Merkle Root:** \`${info.merkleRoot}\`\n` +
+          `**Paused:** ${info.paused ? "Yes" : "No"}\n` +
+          `**Minted:** ${record.mintedAt}\n` +
+          `**BscScan:** ${bscscanUrl(info.network, record.mintTxHash)}`,
+      });
+    } catch {
+      // Fall back to local record
+      await callback({
+        text:
+          `**NFA Token ID:** \`${record.tokenId}\`\n` +
+          `**Network:** ${record.network}\n` +
+          `**Contract:** \`${record.contractAddress}\`\n` +
+          `**Owner:** \`${record.ownerAddress}\`\n` +
+          `**Merkle Root:** \`${record.merkleRoot}\`\n` +
+          `**Minted:** ${record.mintedAt}\n\n` +
+          `_Showing cached data — could not reach the contract._`,
+      });
+    }
+  },
+
+  examples: [
+    [
+      {
+        user: "{{user1}}",
+        content: { text: "show my nfa status" },
+      },
+      {
+        user: "{{agentName}}",
+        content: {
+          text: "NFA Token ID: `1` on bsc-testnet. Merkle Root: `0xabc...`",
+          action: "NFA_GET_INFO",
+        },
+      },
+    ],
+  ] as ActionExample[][],
+};
+
+// ── Action: NFA_MINT ──────────────────────────────────────────────────────
+
+export const mintNfaAction: Action = {
+  name: "NFA_MINT",
+  similes: [
+    "mint nfa",
+    "create nfa",
+    "mint agent token",
+    "create non-fungible agent",
+  ],
+  description:
+    "Mints a new BAP-578 Non-Fungible Agent token on BNB Chain. The Merkle root of Milady's LEARNINGS.md is embedded on-chain. Requires BNB_PRIVATE_KEY and explicit user confirmation.",
+
+  validate: async (
+    _runtime: IAgentRuntime,
+    _message: Memory
+  ): Promise<boolean> => true,
+
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    state: State | undefined,
+    _options: Record<string, unknown>,
+    callback: HandlerCallback
+  ): Promise<void> => {
+    let config: Bap578NfaConfig;
+    try {
+      config = loadConfig(runtime);
+    } catch (err) {
+      await callback({ text: `Configuration error: ${(err as Error).message}` });
+      return;
+    }
+
+    // Check for existing NFA
+    const existing = await readNfaRecord();
+    if (existing) {
+      await callback({
+        text:
+          `Milady already has an NFA token (ID: \`${existing.tokenId}\`) on ${existing.network}.\n\n` +
+          `To update the learning root instead, say: **update nfa learning root**`,
+      });
+      return;
+    }
+
+    if (!config.privateKey) {
+      await callback({
+        text:
+          "BNB_PRIVATE_KEY is not set. Add it to `~/.milady/.env`:\n\n" +
+          "```\nBNB_PRIVATE_KEY=0x...\n```\n\n" +
+          "This key will own the NFA token. Keep it safe.",
+      });
+      return;
+    }
+
+    // Compute Merkle root from LEARNINGS.md
+    const markdown = await loadLearningsMarkdown();
+    const learnings = computeLearningsData(markdown ?? "");
+
+    const pendingKey = "nfa_mint_pending";
+    if (!state?.[pendingKey]) {
+      await callback({
+        text:
+          `Ready to mint NFA on **${networkLabel(config.network)}**.\n\n` +
+          `**Contract:** \`${config.contractAddress}\`\n` +
+          `**Learning entries:** ${learnings.totalEntries}\n` +
+          `**Merkle root:** \`${learnings.merkleRoot.slice(0, 16)}...\`\n\n` +
+          `This will send a transaction from your wallet. Reply **confirm** to proceed.`,
+      });
+      if (state) state[pendingKey] = { merkleRoot: learnings.merkleRoot };
+      return;
+    }
+
+    if (!userConfirmed(message)) {
+      await callback({ text: "Minting cancelled." });
+      if (state) delete state[pendingKey];
+      return;
+    }
+
+    await callback({ text: "Sending mint transaction..." });
+
+    const svc = new Bap578NfaService(runtime, config);
+    try {
+      const result = await svc.mintNfa(learnings.merkleRoot);
+
+      const record = {
+        tokenId: result.tokenId,
+        contractAddress: config.contractAddress,
+        network: result.network,
+        ownerAddress: "", // populated on next getNfaInfo call
+        mintTxHash: result.txHash,
+        merkleRoot: learnings.merkleRoot,
+        mintedAt: new Date().toISOString(),
+        lastUpdatedAt: new Date().toISOString(),
+      };
+
+      // Try to get owner address
+      try {
+        const info = await svc.getNfaInfo(result.tokenId);
+        record.ownerAddress = info.owner;
+      } catch {
+        // non-fatal
+      }
+
+      await writeNfaRecord(record);
+
+      await callback({
+        text:
+          `NFA minted successfully!\n\n` +
+          `**Token ID:** \`${result.tokenId}\`\n` +
+          `**Network:** ${networkLabel(result.network)}\n` +
+          `**Tx:** ${bscscanUrl(result.network, result.txHash)}\n` +
+          `**Merkle Root:** \`${learnings.merkleRoot.slice(0, 16)}...\`\n\n` +
+          `Milady's learning history is now provably anchored on-chain.`,
+      });
+    } catch (err) {
+      await callback({
+        text: `Minting failed: ${(err as Error).message}`,
+      });
+    }
+
+    if (state) delete state[pendingKey];
+  },
+
+  examples: [
+    [
+      {
+        user: "{{user1}}",
+        content: { text: "mint nfa" },
+      },
+      {
+        user: "{{agentName}}",
+        content: {
+          text: "Ready to mint NFA on bsc-testnet. Reply confirm to proceed.",
+          action: "NFA_MINT",
+        },
+      },
+    ],
+  ] as ActionExample[][],
+};
+
+// ── Action: NFA_UPDATE_ROOT ───────────────────────────────────────────────
+
+export const updateLearningRootAction: Action = {
+  name: "NFA_UPDATE_ROOT",
+  similes: [
+    "update nfa",
+    "update learning root",
+    "sync nfa learnings",
+    "update merkle root",
+    "refresh nfa",
+  ],
+  description:
+    "Updates the on-chain Merkle root for Milady's NFA token to reflect her latest LEARNINGS.md. Requires BNB_PRIVATE_KEY and explicit user confirmation.",
+
+  validate: async (
+    _runtime: IAgentRuntime,
+    _message: Memory
+  ): Promise<boolean> => {
+    const record = await readNfaRecord();
+    return record !== null;
+  },
+
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    state: State | undefined,
+    _options: Record<string, unknown>,
+    callback: HandlerCallback
+  ): Promise<void> => {
+    let config: Bap578NfaConfig;
+    try {
+      config = loadConfig(runtime);
+    } catch (err) {
+      await callback({ text: `Configuration error: ${(err as Error).message}` });
+      return;
+    }
+
+    const existing = await readNfaRecord();
+    if (!existing) {
+      await callback({
+        text: "No NFA found. Mint one first with: **mint nfa**",
+      });
+      return;
+    }
+
+    if (!config.privateKey) {
+      await callback({
+        text: "BNB_PRIVATE_KEY is required to update the learning root. Set it in `~/.milady/.env`.",
+      });
+      return;
+    }
+
+    const markdown = await loadLearningsMarkdown();
+    if (!markdown) {
+      await callback({
+        text:
+          "No LEARNINGS.md found. Expected at `~/.milady/LEARNINGS.md` or in the current directory.",
+      });
+      return;
+    }
+
+    const learnings = computeLearningsData(markdown);
+
+    if (learnings.merkleRoot === existing.merkleRoot) {
+      await callback({
+        text:
+          `Learning root is already up to date.\n\n` +
+          `**Current root:** \`${existing.merkleRoot.slice(0, 16)}...\`\n` +
+          `**Entries:** ${learnings.totalEntries}`,
+      });
+      return;
+    }
+
+    const pendingKey = "nfa_update_root_pending";
+    if (!state?.[pendingKey]) {
+      await callback({
+        text:
+          `Ready to update NFA learning root on **${networkLabel(existing.network)}**.\n\n` +
+          `**Token ID:** \`${existing.tokenId}\`\n` +
+          `**Old root:** \`${existing.merkleRoot.slice(0, 16)}...\`\n` +
+          `**New root:** \`${learnings.merkleRoot.slice(0, 16)}...\`\n` +
+          `**Entries:** ${learnings.totalEntries}\n\n` +
+          `This will send a transaction. Reply **confirm** to proceed.`,
+      });
+      if (state) state[pendingKey] = { merkleRoot: learnings.merkleRoot };
+      return;
+    }
+
+    if (!userConfirmed(message)) {
+      await callback({ text: "Update cancelled." });
+      if (state) delete state[pendingKey];
+      return;
+    }
+
+    await callback({ text: "Sending update transaction..." });
+
+    const svc = new Bap578NfaService(runtime, config);
+    try {
+      const result = await svc.updateLearningRoot(
+        existing.tokenId,
+        learnings.merkleRoot
+      );
+
+      await patchNfaRecord({ merkleRoot: learnings.merkleRoot });
+
+      await callback({
+        text:
+          `Learning root updated!\n\n` +
+          `**Token ID:** \`${existing.tokenId}\`\n` +
+          `**Tx:** ${bscscanUrl(existing.network, result.txHash)}\n` +
+          `**New root:** \`${learnings.merkleRoot.slice(0, 16)}...\`\n` +
+          `**Entries:** ${learnings.totalEntries}`,
+      });
+    } catch (err) {
+      await callback({
+        text: `Update failed: ${(err as Error).message}`,
+      });
+    }
+
+    if (state) delete state[pendingKey];
+  },
+
+  examples: [
+    [
+      {
+        user: "{{user1}}",
+        content: { text: "update nfa learning root" },
+      },
+      {
+        user: "{{agentName}}",
+        content: {
+          text: "Ready to update learning root. Reply confirm to proceed.",
+          action: "NFA_UPDATE_ROOT",
+        },
+      },
+    ],
+  ] as ActionExample[][],
+};

--- a/packages/plugin-bap578-nfa/src/index.ts
+++ b/packages/plugin-bap578-nfa/src/index.ts
@@ -1,0 +1,49 @@
+/**
+ * @milady/plugin-bap578-nfa
+ *
+ * BAP-578 Non-Fungible Agent (NFA) plugin for Milady.
+ *
+ * Creates an on-chain NFA token on BNB Chain that anchors a Merkle root
+ * of Milady's learning history (LEARNINGS.md). Other agents can verify
+ * her provenance and learning trajectory on-chain.
+ *
+ * Actions exposed in chat:
+ *   - "nfa status"              → NFA_GET_INFO
+ *   - "mint nfa"                → NFA_MINT       (requires confirmation)
+ *   - "update nfa learning root" → NFA_UPDATE_ROOT (requires confirmation)
+ */
+
+import type { Plugin } from "@elizaos/core";
+import {
+  getNfaInfoAction,
+  mintNfaAction,
+  updateLearningRootAction,
+} from "./actions.js";
+
+export { Bap578NfaService } from "./service.js";
+export {
+  sha256,
+  buildMerkleRoot,
+  parseLearnings,
+  computeLearningsData,
+} from "./merkle.js";
+export { readNfaRecord, writeNfaRecord, patchNfaRecord } from "./store.js";
+export type {
+  NfaRecord,
+  Bap578NfaConfig,
+  MintNfaResult,
+  NfaInfoResult,
+  LearningEntry,
+  LearningsData,
+} from "./types.js";
+
+export const bap578NfaPlugin: Plugin = {
+  name: "@milady/plugin-bap578-nfa",
+  description:
+    "BAP-578 Non-Fungible Agent (NFA) for Milady — on-chain agent identity with Merkle-rooted learning provenance on BNB Chain.",
+  actions: [getNfaInfoAction, mintNfaAction, updateLearningRootAction],
+  evaluators: [],
+  providers: [],
+};
+
+export default bap578NfaPlugin;

--- a/packages/plugin-bap578-nfa/src/merkle.ts
+++ b/packages/plugin-bap578-nfa/src/merkle.ts
@@ -1,0 +1,106 @@
+/**
+ * Merkle tree utilities for BAP-578 NFA learning provenance.
+ *
+ * Hashes LEARNINGS.md content into a Merkle tree so the root can be
+ * stored on-chain as proof of the agent's learning history.
+ */
+
+import { createHash } from "node:crypto";
+import type { LearningEntry, LearningsData } from "./types.js";
+
+/** SHA-256 hash of a string, returned as hex. */
+export function sha256(data: string): string {
+  return createHash("sha256").update(data, "utf8").digest("hex");
+}
+
+/** Hash two sibling hashes together for the Merkle tree. */
+function hashPair(left: string, right: string): string {
+  // Sort to ensure deterministic ordering regardless of insertion order
+  const [a, b] = left < right ? [left, right] : [right, left];
+  return sha256(a + b);
+}
+
+/**
+ * Builds a Merkle root from a list of leaf hashes.
+ * Returns the zero hash for an empty list.
+ */
+export function buildMerkleRoot(leafHashes: string[]): string {
+  if (leafHashes.length === 0) {
+    return sha256("");
+  }
+  if (leafHashes.length === 1) {
+    return leafHashes[0];
+  }
+
+  let level = [...leafHashes];
+  while (level.length > 1) {
+    const next: string[] = [];
+    for (let i = 0; i < level.length; i += 2) {
+      if (i + 1 < level.length) {
+        next.push(hashPair(level[i], level[i + 1]));
+      } else {
+        // Odd leaf: promote to next level
+        next.push(level[i]);
+      }
+    }
+    level = next;
+  }
+
+  return level[0];
+}
+
+/**
+ * Parses LEARNINGS.md content into structured entries.
+ *
+ * Expected format — each entry starts with a date heading:
+ *   ## 2025-01-15
+ *   Content of the learning entry...
+ *
+ * Entries without a date heading are grouped under "undated".
+ */
+export function parseLearnings(markdown: string): LearningEntry[] {
+  const lines = markdown.split("\n");
+  const entries: LearningEntry[] = [];
+  let currentDate = "undated";
+  let currentContent: string[] = [];
+
+  const flushEntry = () => {
+    const content = currentContent.join("\n").trim();
+    if (content) {
+      entries.push({
+        date: currentDate,
+        content,
+        hash: sha256(content),
+      });
+    }
+    currentContent = [];
+  };
+
+  for (const line of lines) {
+    const dateMatch = line.match(/^##\s+(\d{4}-\d{2}-\d{2})/);
+    if (dateMatch) {
+      flushEntry();
+      currentDate = dateMatch[1];
+    } else {
+      currentContent.push(line);
+    }
+  }
+  flushEntry();
+
+  return entries;
+}
+
+/**
+ * Parses LEARNINGS.md and computes the Merkle root of all entries.
+ */
+export function computeLearningsData(markdown: string): LearningsData {
+  const entries = parseLearnings(markdown);
+  const leafHashes = entries.map((e) => e.hash);
+  const merkleRoot = buildMerkleRoot(leafHashes);
+
+  return {
+    entries,
+    merkleRoot,
+    totalEntries: entries.length,
+  };
+}

--- a/packages/plugin-bap578-nfa/src/service.ts
+++ b/packages/plugin-bap578-nfa/src/service.ts
@@ -1,0 +1,120 @@
+/**
+ * Bap578NfaService — wraps NFA contract interactions.
+ *
+ * Read-only operations (getNfaInfo) work without a private key.
+ * Write operations (mintNfa, updateLearningRoot) require a private key
+ * and explicit user confirmation at the action layer.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import type {
+  Bap578NfaConfig,
+  MintNfaResult,
+  NfaInfoResult,
+} from "./types.js";
+import {
+  type McpToolResponse,
+  assertMcpToolSuccess,
+  parseMcpResult,
+} from "@milady/plugin-bnb-identity";
+
+export class Bap578NfaService {
+  private runtime: IAgentRuntime;
+  private config: Bap578NfaConfig;
+
+  constructor(runtime: IAgentRuntime, config: Bap578NfaConfig) {
+    this.runtime = runtime;
+    this.config = config;
+  }
+
+  /**
+   * Reads NFA info from the contract. Read-only — no key needed.
+   */
+  async getNfaInfo(tokenId: string): Promise<NfaInfoResult> {
+    return this.callMcpTool<NfaInfoResult>("get_bap578_nfa_info", {
+      contractAddress: this.config.contractAddress,
+      tokenId,
+      network: this.config.network,
+    });
+  }
+
+  /**
+   * Mints a new NFA token. Requires private key.
+   * Caller (action handler) must obtain user confirmation first.
+   */
+  async mintNfa(merkleRoot: string): Promise<MintNfaResult> {
+    this.assertPrivateKey();
+    return this.callMcpTool<MintNfaResult>("mint_bap578_nfa", {
+      privateKey: this.config.privateKey,
+      contractAddress: this.config.contractAddress,
+      merkleRoot,
+      network: this.config.network,
+    });
+  }
+
+  /**
+   * Updates the on-chain Merkle root for an existing NFA token.
+   * Caller must own the token. Requires private key + user confirmation.
+   */
+  async updateLearningRoot(
+    tokenId: string,
+    merkleRoot: string
+  ): Promise<{ txHash: string }> {
+    this.assertPrivateKey();
+    return this.callMcpTool<{ txHash: string }>("update_bap578_learning_root", {
+      privateKey: this.config.privateKey,
+      contractAddress: this.config.contractAddress,
+      tokenId,
+      merkleRoot,
+      network: this.config.network,
+    });
+  }
+
+  private assertPrivateKey(): void {
+    if (!this.config.privateKey) {
+      throw new Error(
+        "BNB_PRIVATE_KEY is required for write operations. " +
+          "Add it to ~/.milady/.env or milady.json plugin parameters."
+      );
+    }
+  }
+
+  private async callMcpTool<T>(
+    toolName: string,
+    params: Record<string, unknown>
+  ): Promise<T> {
+    const mcpClient = (this.runtime as any).mcpClient;
+    if (mcpClient?.callTool) {
+      const result = (await mcpClient.callTool({
+        name: toolName,
+        arguments: params,
+      })) as McpToolResponse;
+      assertMcpToolSuccess(toolName, result);
+      return parseMcpResult<T>(result, toolName);
+    }
+
+    // Fallback: direct HTTP call to local MCP dev server
+    const baseUrl = process.env.BNB_MCP_URL ?? "http://localhost:3001";
+    const res = await fetch(`${baseUrl}/tools/${toolName}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(params),
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`bap578-mcp HTTP ${res.status}: ${body}`);
+    }
+
+    let raw: unknown;
+    try {
+      raw = await res.json();
+    } catch {
+      raw = { content: await res.text() } as McpToolResponse;
+    }
+
+    const httpResult = raw as McpToolResponse;
+    assertMcpToolSuccess(toolName, httpResult);
+    return parseMcpResult<T>(httpResult, toolName);
+  }
+}

--- a/packages/plugin-bap578-nfa/src/store.ts
+++ b/packages/plugin-bap578-nfa/src/store.ts
@@ -1,0 +1,59 @@
+/**
+ * Lightweight file-based persistence for BAP-578 NFA state.
+ *
+ * Writes to ~/.milady/bap578-nfa.json so NFA state survives restarts
+ * and can be read by other plugins and API routes.
+ */
+
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import type { NfaRecord } from "./types.js";
+
+const MILADY_DIR = join(homedir(), ".milady");
+const NFA_FILE = join(MILADY_DIR, "bap578-nfa.json");
+
+/** Reads the persisted NFA record, or null if none exists. */
+export async function readNfaRecord(): Promise<NfaRecord | null> {
+  try {
+    const raw = await readFile(NFA_FILE, "utf8");
+    return JSON.parse(raw) as NfaRecord;
+  } catch {
+    return null;
+  }
+}
+
+/** Writes an NFA record to disk, creating ~/.milady/ if needed. */
+export async function writeNfaRecord(record: NfaRecord): Promise<void> {
+  await mkdir(MILADY_DIR, { recursive: true });
+  await writeFile(NFA_FILE, JSON.stringify(record, null, 2), "utf8");
+}
+
+/** Updates specific fields on the existing record, or throws if none exists. */
+export async function patchNfaRecord(
+  patch: Partial<NfaRecord>
+): Promise<NfaRecord> {
+  const existing = await readNfaRecord();
+  if (!existing) {
+    throw new Error(
+      "No NFA record found. Mint first with: mint nfa"
+    );
+  }
+  const updated: NfaRecord = {
+    ...existing,
+    ...patch,
+    lastUpdatedAt: new Date().toISOString(),
+  };
+  await writeNfaRecord(updated);
+  return updated;
+}
+
+/** Deletes the NFA file. Used in tests. */
+export async function clearNfaRecord(): Promise<void> {
+  try {
+    const { unlink } = await import("node:fs/promises");
+    await unlink(NFA_FILE);
+  } catch {
+    // already gone
+  }
+}

--- a/packages/plugin-bap578-nfa/src/types.ts
+++ b/packages/plugin-bap578-nfa/src/types.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared types for @milady/plugin-bap578-nfa.
+ */
+
+/** Persisted NFA state written to ~/.milady/bap578-nfa.json. */
+export interface NfaRecord {
+  tokenId: string;
+  contractAddress: string;
+  network: string;
+  ownerAddress: string;
+  mintTxHash: string;
+  merkleRoot: string;
+  mintedAt: string; // ISO 8601
+  lastUpdatedAt: string; // ISO 8601
+}
+
+/** Runtime config derived from env + pluginParameters. */
+export interface Bap578NfaConfig {
+  contractAddress: string;
+  privateKey?: string; // undefined = read-only mode
+  network: string;
+}
+
+/** Result from minting an NFA token. */
+export interface MintNfaResult {
+  tokenId: string;
+  txHash: string;
+  network: string;
+}
+
+/** Result from querying NFA on-chain state. */
+export interface NfaInfoResult {
+  tokenId: string;
+  owner: string;
+  merkleRoot: string;
+  paused: boolean;
+  network: string;
+}
+
+/** A parsed learning entry from LEARNINGS.md. */
+export interface LearningEntry {
+  date: string;
+  content: string;
+  hash: string;
+}
+
+/** Aggregated learnings response. */
+export interface LearningsData {
+  entries: LearningEntry[];
+  merkleRoot: string;
+  totalEntries: number;
+}
+
+export const SUPPORTED_BNB_NETWORKS = ["bsc", "bsc-testnet"] as const;
+export type SupportedBnbNetwork = (typeof SUPPORTED_BNB_NETWORKS)[number];

--- a/packages/plugin-bap578-nfa/test/merkle.test.ts
+++ b/packages/plugin-bap578-nfa/test/merkle.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "bun:test";
+import {
+  sha256,
+  buildMerkleRoot,
+  parseLearnings,
+  computeLearningsData,
+} from "../src/merkle";
+
+describe("sha256", () => {
+  it("hashes empty string deterministically", () => {
+    const hash = sha256("");
+    expect(hash).toBe(
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    );
+  });
+
+  it("hashes content deterministically", () => {
+    const a = sha256("hello");
+    const b = sha256("hello");
+    expect(a).toBe(b);
+  });
+
+  it("produces different hashes for different inputs", () => {
+    expect(sha256("a")).not.toBe(sha256("b"));
+  });
+});
+
+describe("buildMerkleRoot", () => {
+  it("returns zero hash for empty array", () => {
+    const root = buildMerkleRoot([]);
+    expect(root).toBe(sha256(""));
+  });
+
+  it("returns the leaf itself for single element", () => {
+    const leaf = sha256("hello");
+    expect(buildMerkleRoot([leaf])).toBe(leaf);
+  });
+
+  it("produces deterministic root for multiple leaves", () => {
+    const leaves = ["a", "b", "c"].map(sha256);
+    const root1 = buildMerkleRoot(leaves);
+    const root2 = buildMerkleRoot(leaves);
+    expect(root1).toBe(root2);
+  });
+
+  it("produces different root for different leaves", () => {
+    const root1 = buildMerkleRoot(["a", "b"].map(sha256));
+    const root2 = buildMerkleRoot(["a", "c"].map(sha256));
+    expect(root1).not.toBe(root2);
+  });
+
+  it("handles odd number of leaves", () => {
+    const leaves = ["a", "b", "c", "d", "e"].map(sha256);
+    const root = buildMerkleRoot(leaves);
+    expect(root).toBeTruthy();
+    expect(root.length).toBe(64); // hex sha256
+  });
+});
+
+describe("parseLearnings", () => {
+  it("parses dated entries", () => {
+    const md = `## 2025-01-15
+Learned about Merkle trees.
+
+## 2025-01-16
+Explored ERC-8004 identity.
+`;
+    const entries = parseLearnings(md);
+    expect(entries).toHaveLength(2);
+    expect(entries[0].date).toBe("2025-01-15");
+    expect(entries[0].content).toContain("Merkle trees");
+    expect(entries[1].date).toBe("2025-01-16");
+  });
+
+  it("hashes each entry", () => {
+    const md = `## 2025-01-15
+Content A
+`;
+    const entries = parseLearnings(md);
+    expect(entries[0].hash).toBe(sha256("Content A"));
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(parseLearnings("")).toHaveLength(0);
+  });
+
+  it("handles undated content", () => {
+    const md = "Some content without date headers";
+    const entries = parseLearnings(md);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].date).toBe("undated");
+  });
+});
+
+describe("computeLearningsData", () => {
+  it("returns aggregated data with merkle root", () => {
+    const md = `## 2025-01-15
+Entry one
+
+## 2025-01-16
+Entry two
+`;
+    const data = computeLearningsData(md);
+    expect(data.totalEntries).toBe(2);
+    expect(data.merkleRoot).toBeTruthy();
+    expect(data.merkleRoot.length).toBe(64);
+    expect(data.entries).toHaveLength(2);
+  });
+
+  it("handles empty content", () => {
+    const data = computeLearningsData("");
+    expect(data.totalEntries).toBe(0);
+    expect(data.merkleRoot).toBe(sha256(""));
+  });
+});

--- a/packages/plugin-bap578-nfa/test/store.test.ts
+++ b/packages/plugin-bap578-nfa/test/store.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+  readNfaRecord,
+  writeNfaRecord,
+  patchNfaRecord,
+  clearNfaRecord,
+} from "../src/store";
+import type { NfaRecord } from "../src/types";
+
+const SAMPLE_RECORD: NfaRecord = {
+  tokenId: "42",
+  contractAddress: "0x1234567890abcdef1234567890abcdef12345678",
+  network: "bsc-testnet",
+  ownerAddress: "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+  mintTxHash: "0xdeadbeef",
+  merkleRoot: "abc123",
+  mintedAt: "2025-01-15T00:00:00.000Z",
+  lastUpdatedAt: "2025-01-15T00:00:00.000Z",
+};
+
+afterEach(async () => {
+  await clearNfaRecord();
+});
+
+describe("store", () => {
+  it("returns null when no record exists", async () => {
+    expect(await readNfaRecord()).toBeNull();
+  });
+
+  it("writes and reads a record", async () => {
+    await writeNfaRecord(SAMPLE_RECORD);
+    const read = await readNfaRecord();
+    expect(read).toEqual(SAMPLE_RECORD);
+  });
+
+  it("patches an existing record", async () => {
+    await writeNfaRecord(SAMPLE_RECORD);
+    const patched = await patchNfaRecord({ merkleRoot: "newroot" });
+    expect(patched.merkleRoot).toBe("newroot");
+    expect(patched.tokenId).toBe("42");
+    // lastUpdatedAt should change
+    expect(patched.lastUpdatedAt).not.toBe(SAMPLE_RECORD.lastUpdatedAt);
+  });
+
+  it("throws when patching without existing record", async () => {
+    await expect(patchNfaRecord({ merkleRoot: "x" })).rejects.toThrow(
+      "No NFA record found"
+    );
+  });
+
+  it("clears the record", async () => {
+    await writeNfaRecord(SAMPLE_RECORD);
+    await clearNfaRecord();
+    expect(await readNfaRecord()).toBeNull();
+  });
+});

--- a/packages/plugin-bap578-nfa/tsconfig.json
+++ b/packages/plugin-bap578-nfa/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src"]
+}

--- a/src/api/nfa-routes.ts
+++ b/src/api/nfa-routes.ts
@@ -1,0 +1,198 @@
+/**
+ * API routes for BAP-578 NFA (Non-Fungible Agent) status and learnings.
+ *
+ *   GET /api/nfa/status    — NFA state composed with ERC-8004 identity
+ *   GET /api/nfa/learnings — Parsed LEARNINGS.md with Merkle root
+ */
+
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import type { RouteHelpers, RouteRequestMeta } from "./route-helpers";
+
+export interface NfaRouteContext
+  extends RouteRequestMeta,
+    Pick<RouteHelpers, "json" | "error"> {}
+
+interface NfaRecord {
+  tokenId: string;
+  contractAddress: string;
+  network: string;
+  ownerAddress: string;
+  mintTxHash: string;
+  merkleRoot: string;
+  mintedAt: string;
+  lastUpdatedAt: string;
+}
+
+interface IdentityRecord {
+  agentId: string;
+  network: string;
+  txHash: string;
+  ownerAddress: string;
+  agentURI: string;
+  registeredAt: string;
+  lastUpdatedAt: string;
+}
+
+async function readJsonFile<T>(filePath: string): Promise<T | null> {
+  try {
+    const raw = await readFile(filePath, "utf8");
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Inline Merkle utilities — avoids importing from plugin package which
+ * may not be installed. Mirrors the plugin's merkle.ts logic.
+ */
+function sha256Hex(data: string): string {
+  const { createHash } = require("node:crypto");
+  return createHash("sha256").update(data, "utf8").digest("hex");
+}
+
+function buildMerkleRoot(leafHashes: string[]): string {
+  if (leafHashes.length === 0) return sha256Hex("");
+  if (leafHashes.length === 1) return leafHashes[0];
+  let level = [...leafHashes];
+  while (level.length > 1) {
+    const next: string[] = [];
+    for (let i = 0; i < level.length; i += 2) {
+      if (i + 1 < level.length) {
+        const [a, b] =
+          level[i] < level[i + 1]
+            ? [level[i], level[i + 1]]
+            : [level[i + 1], level[i]];
+        next.push(sha256Hex(a + b));
+      } else {
+        next.push(level[i]);
+      }
+    }
+    level = next;
+  }
+  return level[0];
+}
+
+interface LearningEntry {
+  date: string;
+  content: string;
+  hash: string;
+}
+
+function parseLearnings(markdown: string): LearningEntry[] {
+  const lines = markdown.split("\n");
+  const entries: LearningEntry[] = [];
+  let currentDate = "undated";
+  let currentContent: string[] = [];
+
+  const flush = () => {
+    const content = currentContent.join("\n").trim();
+    if (content) {
+      entries.push({ date: currentDate, content, hash: sha256Hex(content) });
+    }
+    currentContent = [];
+  };
+
+  for (const line of lines) {
+    const m = line.match(/^##\s+(\d{4}-\d{2}-\d{2})/);
+    if (m) {
+      flush();
+      currentDate = m[1];
+    } else {
+      currentContent.push(line);
+    }
+  }
+  flush();
+  return entries;
+}
+
+export async function handleNfaRoutes(
+  ctx: NfaRouteContext
+): Promise<boolean> {
+  const { res, method, pathname, json, error } = ctx;
+
+  // ── GET /api/nfa/status ──────────────────────────────────────────────
+  if (method === "GET" && pathname === "/api/nfa/status") {
+    const miladyDir = join(homedir(), ".milady");
+    const [nfaRecord, identityRecord] = await Promise.all([
+      readJsonFile<NfaRecord>(join(miladyDir, "bap578-nfa.json")),
+      readJsonFile<IdentityRecord>(join(miladyDir, "bnb-identity.json")),
+    ]);
+
+    const bscscanBase =
+      (nfaRecord?.network ?? identityRecord?.network ?? "bsc-testnet") === "bsc"
+        ? "https://bscscan.com"
+        : "https://testnet.bscscan.com";
+
+    json(res, {
+      nfa: nfaRecord
+        ? {
+            tokenId: nfaRecord.tokenId,
+            contractAddress: nfaRecord.contractAddress,
+            network: nfaRecord.network,
+            ownerAddress: nfaRecord.ownerAddress,
+            merkleRoot: nfaRecord.merkleRoot,
+            mintTxHash: nfaRecord.mintTxHash,
+            mintedAt: nfaRecord.mintedAt,
+            lastUpdatedAt: nfaRecord.lastUpdatedAt,
+            bscscanUrl: `${bscscanBase}/tx/${nfaRecord.mintTxHash}`,
+          }
+        : null,
+      identity: identityRecord
+        ? {
+            agentId: identityRecord.agentId,
+            network: identityRecord.network,
+            ownerAddress: identityRecord.ownerAddress,
+            agentURI: identityRecord.agentURI,
+            registeredAt: identityRecord.registeredAt,
+            scanUrl: `https://${identityRecord.network === "bsc" ? "www" : "testnet"}.8004scan.io/agent/${identityRecord.agentId}`,
+          }
+        : null,
+      configured: !!(nfaRecord || identityRecord),
+    });
+    return true;
+  }
+
+  // ── GET /api/nfa/learnings ───────────────────────────────────────────
+  if (method === "GET" && pathname === "/api/nfa/learnings") {
+    const learningsPaths = [
+      join(homedir(), ".milady", "LEARNINGS.md"),
+      join(process.cwd(), "LEARNINGS.md"),
+    ];
+
+    let markdown: string | null = null;
+    for (const p of learningsPaths) {
+      try {
+        markdown = await readFile(p, "utf8");
+        break;
+      } catch {
+        continue;
+      }
+    }
+
+    if (!markdown) {
+      json(res, {
+        entries: [],
+        merkleRoot: sha256Hex(""),
+        totalEntries: 0,
+        source: null,
+      });
+      return true;
+    }
+
+    const entries = parseLearnings(markdown);
+    const leafHashes = entries.map((e) => e.hash);
+    const merkleRoot = buildMerkleRoot(leafHashes);
+
+    json(res, {
+      entries,
+      merkleRoot,
+      totalEntries: entries.length,
+    });
+    return true;
+  }
+
+  return false;
+}

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -149,6 +149,7 @@ import {
   applySubscriptionProviderConfig,
   clearSubscriptionProviderConfig,
 } from "./provider-switch-config";
+import { handleNfaRoutes } from "./nfa-routes";
 import { handleRegistryRoutes } from "./registry-routes";
 import { RegistryService } from "./registry-service";
 import { handleSandboxRoute } from "./sandbox-routes";
@@ -9393,6 +9394,22 @@ async function handleRequest(
       resolveWalletExportRejection,
       scheduleRuntimeRestart,
       readJsonBody,
+      json,
+      error,
+    })
+  ) {
+    return;
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // BAP-578 NFA Routes
+  // ═══════════════════════════════════════════════════════════════════════
+  if (
+    await handleNfaRoutes({
+      req,
+      res,
+      method,
+      pathname,
       json,
       error,
     })


### PR DESCRIPTION
## Category
- [x] New feature

## What
Introduces the `@milady/plugin-bap578-nfa` plugin that enables Milady to mint and manage BAP-578 Non-Fungible Agent (NFA) tokens on BNB Chain. The plugin anchors a Merkle root of her learning history (LEARNINGS.md) on-chain, creating cryptographic proof of her learning trajectory.

Key additions:
- **NFA Actions**: Three chat-driven actions for NFA management
  - `NFA_GET_INFO`: Read-only display of NFA status and on-chain state
  - `NFA_MINT`: Mint a new NFA token with learning Merkle root (requires confirmation)
  - `NFA_UPDATE_ROOT`: Update the on-chain Merkle root when learnings change (requires confirmation)
- **Merkle Tree Utilities**: SHA-256 based Merkle tree implementation for hashing LEARNINGS.md entries
- **Persistent Storage**: File-based NFA state in `~/.milady/bap578-nfa.json`
- **API Routes**: Two new endpoints for querying NFA status and learning history
- **UI Components**: Identity view tab displaying ERC-8004 identity and NFA token info with learning history
- **Header Integration**: Identity status indicator with popover showing on-chain identity state

## Why
Enables verifiable on-chain identity for Milady by:
1. Creating a permanent, tamper-proof record of her learning history via Merkle root
2. Allowing other agents to cryptographically verify her provenance
3. Integrating with the broader BAP-578 standard for agent identity on BNB Chain
4. Providing a unified view of both ERC-8004 agent identity and NFA token state

## How
- **Plugin Architecture**: Follows ElizaOS plugin pattern with actions, service layer, and type definitions
- **Merkle Implementation**: Deterministic SHA-256 tree with sorted pair hashing for consistent roots
- **Confirmation Flow**: Write operations (mint/update) require explicit user confirmation via state machine
- **Service Layer**: `Bap578NfaService` abstracts contract interactions via MCP tools with fallback to HTTP
- **Storage**: Lightweight JSON persistence in user home directory, readable by other plugins and API routes
- **UI Integration**: New "Identity" tab in navigation with status indicators and learning entry display

## Testing
- Unit tests for Merkle tree operations (sha256, buildMerkleRoot, parseLearnings, computeLearningsData)
- Unit tests for store operations (read, write, patch, clear)
- API routes tested via client integration
- Manual verification: mint NFA via chat, confirm transaction, verify on BscScan, update learning root

https://claude.ai/code/session_01MMLFkp7yabjS7YKttQGubK