### PR TITLE
feat(vector-browser): async WebGPU/WebGL renderer with cancelable setup

### DIFF
--- a/apps/app/src/components/VectorBrowserView.tsx
+++ b/apps/app/src/components/VectorBrowserView.tsx
@@ -12,6 +12,7 @@ import * as THREE from "three";
 import { client, type QueryResult, type TableInfo } from "../api-client";
 
 const PAGE_SIZE = 25;
+const MAX_THREE_PIXEL_RATIO = 2;
 
 type ViewMode = "list" | "graph" | "3d";
 
@@ -578,14 +579,90 @@ function VectorGraph3D({
         return;
       }
 
+      const raycaster = new THREE.Raycaster();
+      const pointer = new THREE.Vector2();
+      const geometry = new THREE.SphereGeometry(0.06, 16, 16);
+      const spheres: THREE.Mesh[] = [];
+      let gridHelper: THREE.GridHelper | null = null;
+      let axisGeom: THREE.BufferGeometry | null = null;
+      let axisMat: THREE.LineBasicMaterial | null = null;
+      let onMouseDown: ((e: MouseEvent) => void) | null = null;
+      let onMouseUp: (() => void) | null = null;
+      let onMouseMove: ((e: MouseEvent) => void) | null = null;
+      let onClick: ((e: MouseEvent) => void) | null = null;
+      let onWheel: ((e: WheelEvent) => void) | null = null;
+      let onMouseLeave: (() => void) | null = null;
+      let handleResize: (() => void) | null = null;
+      let cleanedUp = false;
+
+      cleanupRef.current = () => {
+        if (cleanedUp) return;
+        cleanedUp = true;
+        cancelAnimationFrame(animationRef.current);
+        if (handleResize) {
+          window.removeEventListener("resize", handleResize);
+        }
+        if (onMouseDown) {
+          renderer.domElement.removeEventListener("mousedown", onMouseDown);
+        }
+        if (onMouseUp) {
+          renderer.domElement.removeEventListener("mouseup", onMouseUp);
+        }
+        if (onMouseMove) {
+          renderer.domElement.removeEventListener("mousemove", onMouseMove);
+        }
+        if (onClick) {
+          renderer.domElement.removeEventListener("click", onClick);
+        }
+        if (onWheel) {
+          renderer.domElement.removeEventListener("wheel", onWheel);
+        }
+        if (onMouseLeave) {
+          renderer.domElement.removeEventListener("mouseleave", onMouseLeave);
+        }
+        geometry.dispose();
+        axisGeom?.dispose();
+        axisMat?.dispose();
+        if (gridHelper) {
+          const gridMaterial = Array.isArray(gridHelper.material)
+            ? gridHelper.material
+            : [gridHelper.material];
+          for (const material of gridMaterial) {
+            material.dispose();
+          }
+          gridHelper.geometry.dispose();
+        }
+        for (const sphere of spheres) {
+          const material = sphere.material;
+          if (Array.isArray(material)) {
+            for (const entry of material) {
+              entry.dispose();
+            }
+          } else {
+            material.dispose();
+          }
+        }
+        renderer.dispose();
+        rendererRef.current = null;
+        sceneRef.current = null;
+        cameraRef.current = null;
+        spheresRef.current = [];
+        if (container.contains(renderer.domElement)) {
+          container.removeChild(renderer.domElement);
+        }
+      };
+
       renderer.setSize(W, H);
       renderer.setPixelRatio(
         Math.min(window.devicePixelRatio || 1, MAX_THREE_PIXEL_RATIO),
       );
       container.appendChild(renderer.domElement);
       rendererRef.current = renderer;
-      const raycaster = new THREE.Raycaster();
-      const pointer = new THREE.Vector2();
+      if (cancelled) {
+        cleanupRef.current?.();
+        cleanupRef.current = null;
+        return;
+      }
 
       // Compute bounds for scaling
       let minX = Infinity,
@@ -611,10 +688,6 @@ function VectorGraph3D({
       const centerY = (minY + maxY) / 2;
       const centerZ = (minZ + maxZ) / 2;
 
-      // Create spheres
-      const spheres: THREE.Mesh[] = [];
-      const geometry = new THREE.SphereGeometry(0.06, 16, 16);
-
       for (let i = 0; i < points3D.length; i++) {
         const [x, y, z] = points3D[i];
         const mem = withEmbeddings[i];
@@ -637,13 +710,13 @@ function VectorGraph3D({
       spheresRef.current = spheres;
 
       // Add subtle grid helper
-      const gridHelper = new THREE.GridHelper(6, 12, 0x333333, 0x222222);
+      gridHelper = new THREE.GridHelper(6, 12, 0x333333, 0x222222);
       gridHelper.position.y = -2;
       scene.add(gridHelper);
 
       // Add axis lines
       const axisLength = 2.5;
-      const axisGeom = new THREE.BufferGeometry();
+      axisGeom = new THREE.BufferGeometry();
       const axisPositions = new Float32Array([
         -axisLength,
         0,
@@ -668,7 +741,7 @@ function VectorGraph3D({
         "position",
         new THREE.BufferAttribute(axisPositions, 3),
       );
-      const axisMat = new THREE.LineBasicMaterial({ color: 0x444444 });
+      axisMat = new THREE.LineBasicMaterial({ color: 0x444444 });
       const axisLines = new THREE.LineSegments(axisGeom, axisMat);
       scene.add(axisLines);
 
@@ -699,17 +772,17 @@ function VectorGraph3D({
         camera.lookAt(0, 0, 0);
       };
 
-      const onMouseDown = (e: MouseEvent) => {
+      onMouseDown = (e: MouseEvent) => {
         isDraggingRef.current = true;
         mouseDownPosRef.current = { x: e.clientX, y: e.clientY };
       };
 
-      const onMouseUp = () => {
+      onMouseUp = () => {
         isDraggingRef.current = false;
         mouseDownPosRef.current = null;
       };
 
-      const onMouseMove = (e: MouseEvent) => {
+      onMouseMove = (e: MouseEvent) => {
         if (isDraggingRef.current) {
           targetTheta -= e.movementX * 0.01;
           targetPhi -= e.movementY * 0.01;
@@ -741,7 +814,7 @@ function VectorGraph3D({
         }
       };
 
-      const onClick = (e: MouseEvent) => {
+      onClick = (e: MouseEvent) => {
         // Only trigger click if we didn't drag much
         if (mouseDownPosRef.current) {
           const dx = Math.abs(e.clientX - mouseDownPosRef.current.x);
@@ -760,13 +833,13 @@ function VectorGraph3D({
         }
       };
 
-      const onWheel = (e: WheelEvent) => {
+      onWheel = (e: WheelEvent) => {
         e.preventDefault();
         targetRadius += e.deltaY * 0.005;
         targetRadius = Math.max(2, Math.min(15, targetRadius));
       };
 
-      const onMouseLeave = () => {
+      onMouseLeave = () => {
         isDraggingRef.current = false;
         setHoveredIdx(null);
         setTooltipPos(null);
@@ -780,6 +853,11 @@ function VectorGraph3D({
         passive: false,
       });
       renderer.domElement.addEventListener("mouseleave", onMouseLeave);
+      if (cancelled) {
+        cleanupRef.current?.();
+        cleanupRef.current = null;
+        return;
+      }
 
       // Animation loop
       const animate = () => {
@@ -790,53 +868,13 @@ function VectorGraph3D({
       animate();
 
       // Resize handler
-      const handleResize = () => {
+      handleResize = () => {
         const newW = container.clientWidth;
         camera.aspect = newW / H;
         camera.updateProjectionMatrix();
         renderer.setSize(newW, H);
       };
       window.addEventListener("resize", handleResize);
-
-      // Store cleanup fn so the synchronous cleanup return can call it
-      cleanupRef.current = () => {
-        cancelAnimationFrame(animationRef.current);
-        window.removeEventListener("resize", handleResize);
-        renderer.domElement.removeEventListener("mousedown", onMouseDown);
-        renderer.domElement.removeEventListener("mouseup", onMouseUp);
-        renderer.domElement.removeEventListener("mousemove", onMouseMove);
-        renderer.domElement.removeEventListener("click", onClick);
-        renderer.domElement.removeEventListener("wheel", onWheel);
-        renderer.domElement.removeEventListener("mouseleave", onMouseLeave);
-        geometry.dispose();
-        axisGeom.dispose();
-        axisMat.dispose();
-        const gridMaterial = Array.isArray(gridHelper.material)
-          ? gridHelper.material
-          : [gridHelper.material];
-        for (const material of gridMaterial) {
-          material.dispose();
-        }
-        gridHelper.geometry.dispose();
-        for (const sphere of spheres) {
-          const material = sphere.material;
-          if (Array.isArray(material)) {
-            for (const entry of material) {
-              entry.dispose();
-            }
-          } else {
-            material.dispose();
-          }
-        }
-        renderer.dispose();
-        rendererRef.current = null;
-        sceneRef.current = null;
-        cameraRef.current = null;
-        spheresRef.current = [];
-        if (container.contains(renderer.domElement)) {
-          container.removeChild(renderer.domElement);
-        }
-      };
     })(); // end async IIFE
 
     return () => {

--- a/apps/app/test/app/vector-browser.async-cleanup.test.tsx
+++ b/apps/app/test/app/vector-browser.async-cleanup.test.tsx
@@ -1,0 +1,346 @@
+/** @vitest-environment jsdom */
+
+import { act, useState } from "react";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  rendererDisposeMock,
+  requestAnimationFrameMock,
+  getDatabaseTablesMock,
+  executeDatabaseQueryMock,
+} = vi.hoisted(() => ({
+  rendererDisposeMock: vi.fn(),
+  requestAnimationFrameMock: vi.fn(() => 1),
+  getDatabaseTablesMock: vi.fn(),
+  executeDatabaseQueryMock: vi.fn(),
+}));
+
+vi.mock("three", () => {
+  class MockVector2 {
+    x = 0;
+    y = 0;
+
+    set(x: number, y: number) {
+      this.x = x;
+      this.y = y;
+      return this;
+    }
+  }
+
+  class MockVector3 {
+    x = 0;
+    y = 0;
+    z = 0;
+
+    set(x: number, y: number, z: number) {
+      this.x = x;
+      this.y = y;
+      this.z = z;
+      return this;
+    }
+  }
+
+  class MockColor {}
+
+  class MockMaterial {
+    opacity = 1;
+    transparent = false;
+
+    constructor(config?: { opacity?: number; transparent?: boolean }) {
+      if (typeof config?.opacity === "number") {
+        this.opacity = config.opacity;
+      }
+      if (typeof config?.transparent === "boolean") {
+        this.transparent = config.transparent;
+      }
+    }
+
+    dispose() {}
+  }
+
+  class MockGeometry {
+    setAttribute() {}
+    dispose() {}
+  }
+
+  class MockMesh {
+    position = new MockVector3();
+    scale = { setScalar: vi.fn() };
+    userData: Record<string, unknown> = {};
+    material: MockMaterial | MockMaterial[];
+    geometry: MockGeometry;
+
+    constructor(
+      geometry: MockGeometry = new MockGeometry(),
+      material: MockMaterial | MockMaterial[] = new MockMaterial(),
+    ) {
+      this.geometry = geometry;
+      this.material = material;
+    }
+  }
+
+  class MockGridHelper extends MockMesh {
+    constructor() {
+      super(new MockGeometry(), new MockMaterial());
+    }
+  }
+
+  class MockScene {
+    background: unknown = null;
+    add() {}
+    remove() {}
+  }
+
+  class MockCamera {
+    position = new MockVector3();
+    aspect = 1;
+
+    lookAt() {}
+    updateProjectionMatrix() {}
+  }
+
+  class MockRenderer {
+    domElement = document.createElement("canvas");
+
+    setSize() {}
+    setPixelRatio() {}
+    render() {}
+    dispose() {
+      rendererDisposeMock();
+    }
+  }
+
+  class MockRaycaster {
+    setFromCamera() {}
+    intersectObjects() {
+      return [];
+    }
+  }
+
+  return {
+    Scene: MockScene,
+    PerspectiveCamera: MockCamera,
+    WebGLRenderer: MockRenderer,
+    WebGPURenderer: undefined,
+    SphereGeometry: MockGeometry,
+    BufferGeometry: MockGeometry,
+    MeshBasicMaterial: MockMaterial,
+    LineBasicMaterial: MockMaterial,
+    Mesh: MockMesh,
+    LineSegments: MockMesh,
+    GridHelper: MockGridHelper,
+    Vector2: MockVector2,
+    Vector3: MockVector3,
+    Color: MockColor,
+    Raycaster: MockRaycaster,
+    BufferAttribute: class {},
+  };
+});
+
+vi.mock("../../src/api-client", () => ({
+  client: {
+    getDatabaseTables: getDatabaseTablesMock,
+    executeDatabaseQuery: executeDatabaseQueryMock,
+  },
+}));
+
+import { client } from "../../src/api-client";
+import { VectorBrowserView } from "../../src/components/VectorBrowserView";
+
+async function flush(times = 4): Promise<void> {
+  for (let i = 0; i < times; i++) {
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+}
+
+describe("VectorBrowserView async cleanup", () => {
+  let host: HTMLDivElement;
+  let root: Root;
+  let originalAppendChild: typeof HTMLDivElement.prototype.appendChild;
+  let clientWidthDescriptor: PropertyDescriptor | undefined;
+  let devicePixelRatioDescriptor: PropertyDescriptor | undefined;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    rendererDisposeMock.mockReset();
+    requestAnimationFrameMock.mockClear();
+    vi.mocked(client.getDatabaseTables).mockReset();
+    vi.mocked(client.executeDatabaseQuery).mockReset();
+
+    clientWidthDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "clientWidth",
+    );
+    devicePixelRatioDescriptor = Object.getOwnPropertyDescriptor(
+      window,
+      "devicePixelRatio",
+    );
+
+    Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+      configurable: true,
+      get() {
+        return 800;
+      },
+    });
+    Object.defineProperty(window, "devicePixelRatio", {
+      configurable: true,
+      value: 1,
+    });
+
+    vi.stubGlobal("requestAnimationFrame", requestAnimationFrameMock);
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    host = document.createElement("div");
+    document.body.appendChild(host);
+    root = createRoot(host);
+    originalAppendChild = HTMLDivElement.prototype.appendChild;
+
+    vi.mocked(client.getDatabaseTables).mockResolvedValue({
+      tables: [
+        { name: "memories", schema: "public", rowCount: 3, columns: [] },
+        { name: "embeddings", schema: "public", rowCount: 3, columns: [] },
+      ],
+    });
+
+    const rows = [
+      {
+        id: "1",
+        content: "alpha memory",
+        type: "message",
+        created_at: "2026-03-07T00:00:00.000Z",
+        dim_384: "[0.1,0.2,0.3]",
+      },
+      {
+        id: "2",
+        content: "beta memory",
+        type: "message",
+        created_at: "2026-03-07T00:01:00.000Z",
+        dim_384: "[0.2,0.3,0.4]",
+      },
+      {
+        id: "3",
+        content: "gamma memory",
+        type: "message",
+        created_at: "2026-03-07T00:02:00.000Z",
+        dim_384: "[0.3,0.4,0.5]",
+      },
+    ];
+
+    vi.mocked(client.executeDatabaseQuery).mockImplementation(
+      async (sql: string) => {
+        if (sql.includes("information_schema.columns")) {
+          return {
+            columns: ["column_name", "data_type"],
+            rows: [],
+            rowCount: 0,
+            durationMs: 1,
+          };
+        }
+        if (sql.includes('WHERE "unique" = true')) {
+          return {
+            columns: ["cnt"],
+            rows: [{ cnt: 0 }],
+            rowCount: 1,
+            durationMs: 1,
+          };
+        }
+        if (sql.includes("COUNT(*) as cnt")) {
+          return {
+            columns: ["cnt"],
+            rows: [{ cnt: rows.length }],
+            rowCount: 1,
+            durationMs: 1,
+          };
+        }
+        return {
+          columns: ["id", "content", "type", "created_at", "dim_384"],
+          rows,
+          rowCount: rows.length,
+          durationMs: 1,
+        };
+      },
+    );
+  });
+
+  afterEach(() => {
+    HTMLDivElement.prototype.appendChild = originalAppendChild;
+    try {
+      root.unmount();
+    } catch {}
+    host.remove();
+
+    if (clientWidthDescriptor) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        "clientWidth",
+        clientWidthDescriptor,
+      );
+    }
+    if (devicePixelRatioDescriptor) {
+      Object.defineProperty(
+        window,
+        "devicePixelRatio",
+        devicePixelRatioDescriptor,
+      );
+    }
+
+    vi.unstubAllGlobals();
+    consoleErrorSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it("disposes the renderer if the component unmounts during canvas attach", async () => {
+    let unmountedDuringAppend = false;
+    let hideGraph: (() => void) | null = null;
+
+    function Harness() {
+      const [visible, setVisible] = useState(true);
+      hideGraph = () => setVisible(false);
+      return visible ? <VectorBrowserView /> : null;
+    }
+
+    HTMLDivElement.prototype.appendChild = function appendChildWithUnmount(
+      child: Node,
+    ) {
+      const result = originalAppendChild.call(this, child);
+      if (
+        !unmountedDuringAppend &&
+        this.style.height === "550px" &&
+        child instanceof HTMLCanvasElement
+      ) {
+        unmountedDuringAppend = true;
+        flushSync(() => {
+          hideGraph?.();
+        });
+      }
+      return result;
+    };
+
+    await act(async () => {
+      root.render(<Harness />);
+    });
+    await flush();
+
+    const threeDButton = Array.from(host.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "3D",
+    );
+    expect(threeDButton).toBeTruthy();
+
+    await act(async () => {
+      threeDButton?.dispatchEvent(
+        new MouseEvent("click", {
+          bubbles: true,
+        }),
+      );
+    });
+    await flush();
+
+    expect(unmountedDuringAppend).toBe(true);
+    expect(rendererDisposeMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Refactor `VectorGraph3D` renderer setup to use an async IIFE inside `useEffect` so the cleanup callback stays synchronous (React requirement)
- Tracks a `cancelled` flag to abort in-flight WebGPU/WebGL setup on unmount
- Extracts cleanup into `cleanupRef` shared between effect cleanup and external callers
- No behavior change — purely correctness/robustness fix for async renderer teardown

## Extracted from

Split out of #845 (Electrobun migration) per review feedback — this change has no dependency on Electrobun.

## Test plan

- [ ] Open Vector Browser view, verify 3D graph renders
- [ ] Rapid mount/unmount (navigate away while loading) — no stale renderer errors in console
- [ ] `bunx vitest run --config apps/app/vitest.config.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)