### PR TITLE
fix: e2e test isolation + ephemeral orchestrator messages

### DIFF
--- a/src/api/server.ephemeral-sources.test.ts
+++ b/src/api/server.ephemeral-sources.test.ts
@@ -1,0 +1,102 @@
+import type { AgentRuntime, UUID } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { type ConversationMeta, routeAutonomyTextToUser } from "./server";
+
+function makeState(overrides?: {
+  runtime?: Partial<AgentRuntime> | null;
+  conversations?: Map<string, ConversationMeta>;
+  activeConversationId?: string;
+  broadcastWs?: (data: Record<string, unknown>) => void;
+}) {
+  const conv: ConversationMeta = {
+    id: "conv-1",
+    title: "Test Chat",
+    roomId: "00000000-0000-0000-0000-000000000001" as UUID,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+  const conversations = overrides?.conversations ?? new Map([["conv-1", conv]]);
+
+  return {
+    runtime: (overrides?.runtime === null
+      ? null
+      : {
+          agentId: "00000000-0000-0000-0000-aaaaaaaaaaaa" as UUID,
+          createMemory: vi.fn().mockResolvedValue(undefined),
+          ...overrides?.runtime,
+        }) as AgentRuntime | null,
+    conversations,
+    activeConversationId: overrides?.activeConversationId ?? "conv-1",
+    broadcastWs: overrides?.broadcastWs ?? vi.fn(),
+  } as Parameters<typeof routeAutonomyTextToUser>[0];
+}
+
+describe("routeAutonomyTextToUser — ephemeral source filtering", () => {
+  it("persists a normal message to memory", async () => {
+    const state = makeState();
+    await routeAutonomyTextToUser(state, "hello from autonomy", "autonomy");
+
+    expect(state.runtime?.createMemory).toHaveBeenCalledTimes(1);
+    expect(state.broadcastWs).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT persist coding-agent messages but still broadcasts", async () => {
+    const state = makeState();
+    await routeAutonomyTextToUser(state, "Finished task X", "coding-agent");
+
+    expect(state.runtime?.createMemory).not.toHaveBeenCalled();
+    expect(state.broadcastWs).toHaveBeenCalledTimes(1);
+    expect(state.broadcastWs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "proactive-message",
+        message: expect.objectContaining({ source: "coding-agent" }),
+      }),
+    );
+  });
+
+  it("does NOT persist coordinator messages but still broadcasts", async () => {
+    const state = makeState();
+    await routeAutonomyTextToUser(state, "Decision made", "coordinator");
+
+    expect(state.runtime?.createMemory).not.toHaveBeenCalled();
+    expect(state.broadcastWs).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT persist action messages but still broadcasts", async () => {
+    const state = makeState();
+    await routeAutonomyTextToUser(state, "Generated reply", "action");
+
+    expect(state.runtime?.createMemory).not.toHaveBeenCalled();
+    expect(state.broadcastWs).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists client_chat messages", async () => {
+    const state = makeState();
+    await routeAutonomyTextToUser(state, "user said hi", "client_chat");
+
+    expect(state.runtime?.createMemory).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists messages with no explicit source (defaults to autonomy)", async () => {
+    const state = makeState();
+    await routeAutonomyTextToUser(state, "autonomous thought");
+
+    expect(state.runtime?.createMemory).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips everything when runtime is null", async () => {
+    const broadcastWs = vi.fn();
+    const state = makeState({ runtime: null, broadcastWs });
+    await routeAutonomyTextToUser(state, "hello", "coding-agent");
+
+    expect(broadcastWs).not.toHaveBeenCalled();
+  });
+
+  it("skips everything when text is empty", async () => {
+    const state = makeState();
+    await routeAutonomyTextToUser(state, "   ", "autonomy");
+
+    expect(state.runtime?.createMemory).not.toHaveBeenCalled();
+    expect(state.broadcastWs).not.toHaveBeenCalled();
+  });
+});

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -303,7 +303,7 @@ function initializeOGCodeInState(): void {
 }
 
 /** Metadata for a web-chat conversation. */
-interface ConversationMeta {
+export interface ConversationMeta {
   id: string;
   title: string;
   roomId: UUID;
@@ -5596,7 +5596,7 @@ function serializeForRuntimeDebug(
  * Stores the message as a Memory in the conversation room and broadcasts
  * a `proactive-message` WS event to the frontend.
  */
-async function routeAutonomyTextToUser(
+export async function routeAutonomyTextToUser(
   state: ServerState,
   responseText: string,
   source = "autonomy",
@@ -5622,25 +5622,33 @@ async function routeAutonomyTextToUser(
   }
   if (!conv) return; // No conversations exist yet
 
-  // Store as memory in the conversation's room
-  const agentMessage = createMessageMemory({
-    id: crypto.randomUUID() as UUID,
-    entityId: runtime.agentId,
-    roomId: conv.roomId,
-    content: {
-      text: normalizedText,
-      source,
-    },
-  });
-  await runtime.createMemory(agentMessage, "messages");
+  // Ephemeral sources: broadcast to UI but don't persist to DB.
+  // Coding-agent status updates and coordinator decisions are transient —
+  // they bloat the database without adding long-term value.
+  const ephemeralSources = new Set(["coding-agent", "coordinator", "action"]);
+
+  const messageId = crypto.randomUUID() as UUID;
+
+  if (!ephemeralSources.has(source)) {
+    const agentMessage = createMessageMemory({
+      id: messageId,
+      entityId: runtime.agentId,
+      roomId: conv.roomId,
+      content: {
+        text: normalizedText,
+        source,
+      },
+    });
+    await runtime.createMemory(agentMessage, "messages");
+  }
   conv.updatedAt = new Date().toISOString();
 
-  // Broadcast to all WS clients
+  // Broadcast to all WS clients (always, even for ephemeral sources)
   state.broadcastWs?.({
     type: "proactive-message",
     conversationId: conv.id,
     message: {
-      id: agentMessage.id ?? `auto-${Date.now()}`,
+      id: messageId,
       role: "assistant",
       text: normalizedText,
       timestamp: Date.now(),

--- a/test/api-auth.e2e.test.ts
+++ b/test/api-auth.e2e.test.ts
@@ -13,7 +13,10 @@
  *
  * NO MOCKS — all tests spin up a real HTTP server.
  */
+import fs from "node:fs";
 import http from "node:http";
+import os from "node:os";
+import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { WebSocket } from "ws";
 import { startApiServer } from "../src/api/server";
@@ -837,10 +840,16 @@ describe("Auth + agent lifecycle", () => {
   let port: number;
   let close: () => Promise<void>;
   let envBackup: { restore: () => void };
+  let tmpConfigDir: string;
 
   beforeAll(async () => {
-    envBackup = saveEnv("MILADY_API_TOKEN");
+    envBackup = saveEnv("MILADY_API_TOKEN", "MILADY_CONFIG_PATH");
     process.env.MILADY_API_TOKEN = TEST_TOKEN;
+
+    // Isolate config writes to a temp directory so the onboarding POST
+    // never clobbers the real ~/.milady/milady.json.
+    tmpConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), "milady-auth-e2e-"));
+    process.env.MILADY_CONFIG_PATH = path.join(tmpConfigDir, "milady.json");
 
     const server = await startApiServer({ port: 0 });
     port = server.port;
@@ -850,6 +859,7 @@ describe("Auth + agent lifecycle", () => {
   afterAll(async () => {
     await close();
     envBackup.restore();
+    fs.rmSync(tmpConfigDir, { recursive: true, force: true });
   });
 
   const auth = { headers: { Authorization: `Bearer lifecycle-auth-token` } };

--- a/test/database-api.e2e.test.ts
+++ b/test/database-api.e2e.test.ts
@@ -14,7 +14,10 @@
  * - Input validation for row and query operations
  * - Routing correctness (404 for unmatched paths)
  */
+import fs from "node:fs";
 import http from "node:http";
+import os from "node:os";
+import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { startApiServer } from "../src/api/server";
 
@@ -73,8 +76,16 @@ function req(
 describe("Database API E2E (no runtime)", () => {
   let port: number;
   let close: () => Promise<void>;
+  let tmpConfigDir: string;
+  let savedConfigPath: string | undefined;
 
   beforeAll(async () => {
+    // Isolate config writes to a temp directory so tests never clobber
+    // the real ~/.milady/milady.json (which would destroy user data).
+    tmpConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), "milady-db-e2e-"));
+    savedConfigPath = process.env.MILADY_CONFIG_PATH;
+    process.env.MILADY_CONFIG_PATH = path.join(tmpConfigDir, "milady.json");
+
     const server = await startApiServer({ port: 0 });
     port = server.port;
     close = server.close;
@@ -82,6 +93,9 @@ describe("Database API E2E (no runtime)", () => {
 
   afterAll(async () => {
     await close();
+    if (savedConfigPath === undefined) delete process.env.MILADY_CONFIG_PATH;
+    else process.env.MILADY_CONFIG_PATH = savedConfigPath;
+    fs.rmSync(tmpConfigDir, { recursive: true, force: true });
   });
 
   // ── Group 1: Database Status ──────────────────────────────────────────


### PR DESCRIPTION
This PR will be reviewed by an AI agent. Provide clear context to help it assess your changes.

## Category
- [x] Bug fix
- [x] Test coverage

## What
1. E2e tests (`api-auth`, `database-api`) now isolate config writes to temp directories
2. Orchestrator status messages (`coding-agent`, `coordinator`, `action`) are no longer persisted to the database — still broadcast live via WebSocket

## Why
1. Tests were clobbering `~/.milady/milady.json` on every run, corrupting the user's agent config (name, entity ID, database path). This caused lost chat history and broken agent identity.
2. Orchestrator messages accounted for ~83% of all stored messages (1,780 of 2,486) with no long-term value — just "Finished task X" and "Launched 5/5 agents" status updates that bloat the database.

## How
- `MILADY_CONFIG_PATH` env var pointed at `fs.mkdtempSync()` temp directories in test `beforeAll`/`afterAll`
- Added an `ephemeralSources` set in `routeAutonomyTextToUser()` — matching sources skip `createMemory()` but still get broadcast via `broadcastWs()`
- Exported `routeAutonomyTextToUser` and `ConversationMeta` for testability

## Testing
- 8 new unit tests in `server.ephemeral-sources.test.ts` covering persist/skip for each source type, null runtime, and empty text
- `npx vitest run src/api/server.ephemeral-sources.test.ts` — all pass
- `npx vitest run test/api-auth.e2e.test.ts` — config isolation verified
- `npx vitest run test/database-api.e2e.test.ts` — config isolation verified
- Manual: booted server, confirmed coding agent status messages appear live in chat but are not in DB after restart