### PR TITLE
fix: install x64 bun for Electrobun Rosetta release build

### DIFF
--- a/.github/workflows/release-electrobun.yml
+++ b/.github/workflows/release-electrobun.yml
@@ -112,10 +112,31 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        if: matrix.platform.os != 'macos' || matrix.platform.artifact-name != 'macos-x64'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Setup Node.js (macOS Intel via Rosetta)
+        if: matrix.platform.os == 'macos' && matrix.platform.artifact-name == 'macos-x64'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          architecture: "x64"
+
       - name: Setup Bun
+        if: matrix.platform.os != 'macos' || matrix.platform.artifact-name != 'macos-x64'
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+
+      - name: Setup Bun (macOS Intel via Rosetta)
+        if: matrix.platform.os == 'macos' && matrix.platform.artifact-name == 'macos-x64'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+          bun-download-url: https://github.com/oven-sh/bun/releases/latest/download/bun-darwin-x64.zip
 
 
       - name: Cache Bun install

--- a/scripts/electrobun-release-workflow-drift.test.ts
+++ b/scripts/electrobun-release-workflow-drift.test.ts
@@ -47,6 +47,10 @@ describe("Electrobun release workflow drift", () => {
 
     expect(workflow).toContain("- name: macOS (Intel)");
     expect(workflow).toContain("runner: macos-14");
+    expect(workflow).toContain("name: Setup Node.js (macOS Intel via Rosetta)");
+    expect(workflow).toContain('architecture: "x64"');
+    expect(workflow).toContain("name: Setup Bun (macOS Intel via Rosetta)");
+    expect(workflow).toContain("bun-darwin-x64.zip");
     expect(workflow).toContain(
       "arch -x86_64 bun install --frozen-lockfile --ignore-scripts",
     );


### PR DESCRIPTION
## Summary
- install an x64 Node/Bun toolchain for the macOS Intel release job running under Rosetta on `macos-14`
- keep the host-arch setup for arm64 macOS, Windows, and Linux jobs
- extend the Electrobun workflow drift test to lock in the x64 Rosetta toolchain setup

## Why
The draft `v2.0.0-alpha.81` release failed in `Build macOS (Intel)` at `Install root dependencies` with `arch: posix_spawnp: bun: Bad CPU type in executable`. `setup-bun` was installing the host arm64 Bun binary, and the workflow then tried to execute it under `arch -x86_64`.

## Validation
- `/Users/home/.codex/worktrees/12cf/milady/node_modules/.bin/vitest run scripts/electrobun-release-workflow-drift.test.ts`
- `bunx @biomejs/biome check .github/workflows/release-electrobun.yml scripts/electrobun-release-workflow-drift.test.ts`