### PR TITLE
fix: install Bun manually for Electrobun Rosetta build

### DIFF
--- a/.github/workflows/release-electrobun.yml
+++ b/.github/workflows/release-electrobun.yml
@@ -133,10 +133,40 @@ jobs:
 
       - name: Setup Bun (macOS Intel via Rosetta)
         if: matrix.platform.os == 'macos' && matrix.platform.artifact-name == 'macos-x64'
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-          bun-download-url: https://github.com/oven-sh/bun/releases/latest/download/bun-darwin-x64.zip
+        run: |
+          BUN_ARCHIVE="$RUNNER_TEMP/bun-darwin-x64.zip"
+          BUN_ROOT="$RUNNER_TEMP/bun-darwin-x64"
+          BUN_HOME="$HOME/.bun"
+          BUN_BIN_DIR="$BUN_HOME/bin"
+          BUN_WRAPPER="$BUN_BIN_DIR/bun"
+          BUNX_WRAPPER="$BUN_BIN_DIR/bunx"
+
+          curl -fsSL \
+            "https://github.com/oven-sh/bun/releases/latest/download/bun-darwin-x64.zip" \
+            -o "$BUN_ARCHIVE"
+          rm -rf "$BUN_ROOT"
+          mkdir -p "$BUN_ROOT" "$BUN_BIN_DIR"
+          unzip -q "$BUN_ARCHIVE" -d "$BUN_ROOT"
+
+          BUN_REAL="$(find "$BUN_ROOT" -type f -name bun | head -n 1)"
+          if [ -z "$BUN_REAL" ]; then
+            echo "::error::Failed to locate downloaded x64 bun binary"
+            exit 1
+          fi
+          chmod +x "$BUN_REAL"
+
+          cat > "$BUN_WRAPPER" <<EOF
+          #!/bin/bash
+          exec arch -x86_64 "$BUN_REAL" "\$@"
+          EOF
+          cat > "$BUNX_WRAPPER" <<EOF
+          #!/bin/bash
+          exec arch -x86_64 "$BUN_REAL" x "\$@"
+          EOF
+          chmod +x "$BUN_WRAPPER" "$BUNX_WRAPPER"
+
+          echo "$BUN_BIN_DIR" >> "$GITHUB_PATH"
+          arch -x86_64 "$BUN_REAL" --version
 
 
       - name: Cache Bun install

--- a/scripts/electrobun-release-workflow-drift.test.ts
+++ b/scripts/electrobun-release-workflow-drift.test.ts
@@ -50,7 +50,10 @@ describe("Electrobun release workflow drift", () => {
     expect(workflow).toContain("name: Setup Node.js (macOS Intel via Rosetta)");
     expect(workflow).toContain('architecture: "x64"');
     expect(workflow).toContain("name: Setup Bun (macOS Intel via Rosetta)");
+    expect(workflow).toContain("curl -fsSL \\");
     expect(workflow).toContain("bun-darwin-x64.zip");
+    expect(workflow).toContain('exec arch -x86_64 "$BUN_REAL" "\\$@"');
+    expect(workflow).toContain('exec arch -x86_64 "$BUN_REAL" x "\\$@"');
     expect(workflow).toContain(
       "arch -x86_64 bun install --frozen-lockfile --ignore-scripts",
     );


### PR DESCRIPTION
## Summary
- replace `setup-bun` on the macOS Intel release job with a manual x64 Bun download and Rosetta wrapper
- keep `setup-bun` unchanged for arm64 macOS, Windows, and Linux jobs
- extend the Electrobun workflow drift test to lock in the wrapper-based Bun setup

## Why
`#869` fixed the first Rosetta failure by selecting x64 toolchains, but the draft release still failed earlier inside `oven-sh/setup-bun@v2` itself. The action downloads `bun-darwin-x64.zip` and then runs `bun --revision` directly, which fails on an arm64 runner before our workflow steps execute.

This PR removes that action from the `macos-x64` path and installs an x64 Bun binary manually, exposing `bun` and `bunx` wrapper scripts that always execute it under `arch -x86_64`.

## Validation
- `/Users/home/.codex/worktrees/12cf/milady/node_modules/.bin/vitest run scripts/electrobun-release-workflow-drift.test.ts`
- `bunx @biomejs/biome check .github/workflows/release-electrobun.yml scripts/electrobun-release-workflow-drift.test.ts`