### PR TITLE
release: use Intel runner for macOS x64

### DIFF
--- a/.github/workflows/release-electrobun.yml
+++ b/.github/workflows/release-electrobun.yml
@@ -90,14 +90,15 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          # Both macOS builds run on macos-14 (Apple Silicon runner). Intel build uses Rosetta (arch -x86_64) so we avoid the slow/deprecated macos-15-intel runner. Electrobun builds for host arch only (no universal binary), so we need two builds.
+          # Electrobun builds for the host architecture only (no universal binary),
+          # so we need separate Apple Silicon and Intel macOS jobs.
           - name: macOS (Apple Silicon)
             os: macos
             runner: macos-14
             artifact-name: macos-arm64
           - name: macOS (Intel)
             os: macos
-            runner: macos-14
+            runner: macos-15-intel
             artifact-name: macos-x64
           - name: Windows
             os: windows
@@ -113,60 +114,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        if: matrix.platform.os != 'macos' || matrix.platform.artifact-name != 'macos-x64'
         uses: actions/setup-node@v4
         with:
           node-version: "22"
-
-      - name: Setup Node.js (macOS Intel via Rosetta)
-        if: matrix.platform.os == 'macos' && matrix.platform.artifact-name == 'macos-x64'
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          architecture: "x64"
 
       - name: Setup Bun
-        if: matrix.platform.os != 'macos' || matrix.platform.artifact-name != 'macos-x64'
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-
-      - name: Setup Bun (macOS Intel via Rosetta)
-        if: matrix.platform.os == 'macos' && matrix.platform.artifact-name == 'macos-x64'
-        run: |
-          BUN_ARCHIVE="$RUNNER_TEMP/bun-darwin-x64.zip"
-          BUN_ROOT="$RUNNER_TEMP/bun-darwin-x64"
-          BUN_HOME="$HOME/.bun"
-          BUN_BIN_DIR="$BUN_HOME/bin"
-          BUN_WRAPPER="$BUN_BIN_DIR/bun"
-          BUNX_WRAPPER="$BUN_BIN_DIR/bunx"
-
-          curl -fsSL \
-            "https://github.com/oven-sh/bun/releases/latest/download/bun-darwin-x64.zip" \
-            -o "$BUN_ARCHIVE"
-          rm -rf "$BUN_ROOT"
-          mkdir -p "$BUN_ROOT" "$BUN_BIN_DIR"
-          unzip -q "$BUN_ARCHIVE" -d "$BUN_ROOT"
-
-          BUN_REAL="$(find "$BUN_ROOT" -type f -name bun | head -n 1)"
-          if [ -z "$BUN_REAL" ]; then
-            echo "::error::Failed to locate downloaded x64 bun binary"
-            exit 1
-          fi
-          chmod +x "$BUN_REAL"
-
-          cat > "$BUN_WRAPPER" <<EOF
-          #!/bin/bash
-          exec arch -x86_64 "$BUN_REAL" "\$@"
-          EOF
-          cat > "$BUNX_WRAPPER" <<EOF
-          #!/bin/bash
-          exec arch -x86_64 "$BUN_REAL" x "\$@"
-          EOF
-          chmod +x "$BUN_WRAPPER" "$BUNX_WRAPPER"
-
-          echo "$BUN_BIN_DIR" >> "$GITHUB_PATH"
-          arch -x86_64 "$BUN_REAL" --version
 
 
       - name: Cache Bun install
@@ -180,7 +135,8 @@ jobs:
         # --ignore-scripts skips native dependency install scripts (e.g. @tensorflow/tfjs-node
         # which has no pre-built binary for Node 22 on Windows and fails to compile).
         # Workspace prepare scripts are NOT suppressed by --ignore-scripts in bun.
-        # macOS Intel: run under Rosetta so node_modules (and later copied milady-dist) are x64.
+        # macOS Intel: keep the x64 invocation explicit in case the runner image
+        # ships with dual-arch shims.
         run: |
           if [ "${{ matrix.platform.os }}" = "macos" ] && [ "${{ matrix.platform.artifact-name }}" = "macos-x64" ]; then
             arch -x86_64 bun install --frozen-lockfile --ignore-scripts
@@ -216,8 +172,9 @@ jobs:
           RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
 
       - name: Build core dist (server bundle)
-        # tsdown output is pure JS (arch-neutral), but run under Rosetta for
-        # consistency so any native tsx/node resolution matches the x64 install.
+        # tsdown output is pure JS (arch-neutral), but keep the Intel build on
+        # an explicit x64 invocation so any native tsx/node resolution matches
+        # the x64 install.
         run: |
           if [ "${{ matrix.platform.os }}" = "macos" ] && [ "${{ matrix.platform.artifact-name }}" = "macos-x64" ]; then
             arch -x86_64 bunx tsdown
@@ -231,7 +188,7 @@ jobs:
 
       - name: Build renderer (Vite)
         # Vite output is arch-neutral JS/CSS/HTML, but bun install here may pull
-        # native optional deps, so run under Rosetta for the Intel build.
+        # native optional deps, so keep the Intel build on an explicit x64 path.
         run: |
           if [ "${{ matrix.platform.os }}" = "macos" ] && [ "${{ matrix.platform.artifact-name }}" = "macos-x64" ]; then
             arch -x86_64 bun install --ignore-scripts
@@ -272,7 +229,7 @@ jobs:
 
       # Build whisper.cpp binary for on-device speech recognition (macOS/Linux only)
       # Skipped on Windows (no make) — STT falls back to swabbleAudioChunkPush mode.
-      # macOS Intel: build under Rosetta so the binary is x64.
+      # macOS Intel: keep the whisper build on an explicit x64 path.
       - name: Build whisper.cpp (on-device STT)
         if: matrix.platform.os == 'macos' || matrix.platform.os == 'linux'
         run: |
@@ -364,7 +321,7 @@ jobs:
       # Copy the runtime package closure that the built server bundle still imports
       # by bare specifier, plus the installed @elizaos/* and @milady/plugin-* set.
       # agent.ts sets NODE_PATH to milady-dist/node_modules, which resolves to these copies.
-      # macOS Intel: run under Rosetta so we copy the x64 node_modules we installed earlier.
+      # macOS Intel: keep the x64 node_modules copy on an explicit x64 path.
       - name: Bundle backend node_modules into dist/
         run: |
           if [ "${{ matrix.platform.os }}" = "macos" ] && [ "${{ matrix.platform.artifact-name }}" = "macos-x64" ]; then
@@ -374,7 +331,7 @@ jobs:
           fi
 
       - name: Install electrobun CLI
-        # macOS Intel: install under Rosetta so the global electrobun binary is x64 for the app build.
+        # macOS Intel: keep the global electrobun install on an explicit x64 path.
         run: |
           ELECTROBUN_VERSION="$(node -p "require('./apps/app/electrobun/package.json').dependencies.electrobun.replace(/^[^0-9]*/, '')")"
           echo "Installing electrobun@$ELECTROBUN_VERSION"
@@ -428,7 +385,7 @@ jobs:
           Write-Host "electrobun CLI ready at $binBinary"
 
       - name: Build Electrobun app
-        # macOS Intel: run under Rosetta so the packaged app is x64 (Electrobun builds for host arch only).
+        # macOS Intel: keep the packaged app build on an explicit x64 path.
         run: |
           if [ "${{ matrix.platform.os }}" = "macos" ] && [ "${{ matrix.platform.artifact-name }}" = "macos-x64" ]; then
             arch -x86_64 electrobun build --env=${{ needs.prepare.outputs.env }}

--- a/scripts/electrobun-release-workflow-drift.test.ts
+++ b/scripts/electrobun-release-workflow-drift.test.ts
@@ -42,18 +42,13 @@ describe("Electrobun release workflow drift", () => {
     expect(workflow).toContain('"identifier":"com.miladyai.milady"');
   });
 
-  it("builds the Intel macOS artifact under Rosetta on macos-14", () => {
+  it("builds the Intel macOS artifact on the real Intel runner", () => {
     const workflow = fs.readFileSync(WORKFLOW_PATH, "utf8");
 
     expect(workflow).toContain("- name: macOS (Intel)");
-    expect(workflow).toContain("runner: macos-14");
-    expect(workflow).toContain("name: Setup Node.js (macOS Intel via Rosetta)");
-    expect(workflow).toContain('architecture: "x64"');
-    expect(workflow).toContain("name: Setup Bun (macOS Intel via Rosetta)");
-    expect(workflow).toContain("curl -fsSL \\");
-    expect(workflow).toContain("bun-darwin-x64.zip");
-    expect(workflow).toContain('exec arch -x86_64 "$BUN_REAL" "\\$@"');
-    expect(workflow).toContain('exec arch -x86_64 "$BUN_REAL" x "\\$@"');
+    expect(workflow).toContain("runner: macos-15-intel");
+    expect(workflow).toContain("- name: Setup Node.js");
+    expect(workflow).toContain("- name: Setup Bun");
     expect(workflow).toContain(
       "arch -x86_64 bun install --frozen-lockfile --ignore-scripts",
     );
@@ -63,7 +58,11 @@ describe("Electrobun release workflow drift", () => {
     expect(workflow).toContain(
       `arch -x86_64 electrobun build --env=\${{ needs.prepare.outputs.env }}`,
     );
-    expect(workflow).not.toContain("runner: macos-15-intel");
+    expect(workflow).not.toContain(
+      "name: Setup Node.js (macOS Intel via Rosetta)",
+    );
+    expect(workflow).not.toContain("name: Setup Bun (macOS Intel via Rosetta)");
+    expect(workflow).not.toContain("bun-darwin-x64.zip");
   });
 
   it("keeps updater transport files off the public GitHub release asset list", () => {


### PR DESCRIPTION
## Summary
- move the macOS x64 release job onto the real `macos-15-intel` runner
- remove the broken Rosetta-specific Bun bootstrap path
- lock the workflow drift test to the Intel-runner shape

## Testing
- `/Users/home/.codex/worktrees/12cf/milady/node_modules/.bin/vitest run scripts/electrobun-release-workflow-drift.test.ts`
- `bunx @biomejs/biome check .github/workflows/release-electrobun.yml scripts/electrobun-release-workflow-drift.test.ts`