### PR TITLE
ci: restrict Claude workflows to trusted write users

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -174,7 +174,6 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          allowed_non_write_users: '*'
           show_full_output: true
           claude_args: |
             --allowedTools "Read,Glob,Grep,LS,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(cat:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(wc:*),Bash(head:*),Bash(tail:*)"
@@ -1172,7 +1171,6 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          allowed_non_write_users: '*'
           show_full_output: true
           claude_args: |
             --allowedTools "Bash(gh issue comment:*),Bash(gh issue edit:*),Bash(gh issue close:*),Bash(gh issue view:*),Bash(cat:*),Read,Glob,Grep,LS"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,7 +38,6 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          allowed_non_write_users: '*'
           show_full_output: true
 
           # This is an optional setting that allows Claude to read CI results on PRs


### PR DESCRIPTION
### Motivation
- Close a CI privilege-escalation vector by preventing untrusted non-write users from invoking the `anthropics/claude-code-action` with `GITHUB_TOKEN` and shell/GitHub tools, restoring the default write-user gating for privileged workflows.

### Description
- Removed the `allowed_non_write_users: '*'` setting from `anthropics/claude-code-action` invocations in `.github/workflows/agent-review.yml` (PR review and issue triage jobs) and `.github/workflows/claude.yml` (comment-driven job) so only repository write/collaborator users can trigger tool execution with repo tokens.

### Testing
- Verified changes with `rg -n "allowed_non_write_users" .github/workflows/agent-review.yml .github/workflows/claude.yml` (no matches), ran `git diff --check` (clean), and inspected `git diff .github/workflows/agent-review.yml .github/workflows/claude.yml` to confirm the three-line removals; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae198569d4833288dd280238567d72)