### PR TITLE
ci: disable full Claude output for comment-triggered workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,7 +39,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_non_write_users: '*'
-          show_full_output: true
+          show_full_output: false
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
### Motivation
- Prevent high-risk information disclosure by stopping the Claude action from emitting full tool/Claude output to public CI logs when the workflow is triggerable by untrusted commenters and runs with repository secrets.

### Description
- Change `show_full_output` from `true` to `false` in `.github/workflows/claude.yml` to keep the workflow functional while reducing log exposure of sensitive values.

### Testing
- Ran `git diff --check`, which completed with no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae0f377b00833282b1f4e62994c509)