### PR TITLE
api: block agent transfer execution in manual-local-key mode

### DIFF
--- a/src/api/server.transfer-permissions.test.ts
+++ b/src/api/server.transfer-permissions.test.ts
@@ -1,0 +1,106 @@
+import http from "node:http";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startApiServer } from "./server";
+
+function req(
+  port: number,
+  method: string,
+  path: string,
+  body?: Record<string, unknown>,
+  headers?: Record<string, string>,
+): Promise<{ status: number; data: Record<string, unknown> }> {
+  return new Promise((resolve, reject) => {
+    const b = body ? JSON.stringify(body) : undefined;
+    const r = http.request(
+      {
+        hostname: "127.0.0.1",
+        port,
+        path,
+        method,
+        headers: {
+          "Content-Type": "application/json",
+          ...(b ? { "Content-Length": Buffer.byteLength(b) } : {}),
+          ...(headers ?? {}),
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c: Buffer) => chunks.push(c));
+        res.on("end", () => {
+          const raw = Buffer.concat(chunks).toString("utf-8");
+          let data: Record<string, unknown> = {};
+          try {
+            data = JSON.parse(raw) as Record<string, unknown>;
+          } catch {
+            data = { _raw: raw };
+          }
+          resolve({ status: res.statusCode ?? 0, data });
+        });
+      },
+    );
+    r.on("error", reject);
+    if (b) r.write(b);
+    r.end();
+  });
+}
+
+describe("wallet transfer permissions", () => {
+  let port: number;
+  let close: () => Promise<void>;
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeAll(async () => {
+    for (const key of [
+      "EVM_PRIVATE_KEY",
+      "NODEREAL_BSC_RPC_URL",
+      "QUICKNODE_BSC_RPC_URL",
+    ]) {
+      savedEnv[key] = process.env[key];
+    }
+
+    process.env.EVM_PRIVATE_KEY =
+      "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+    delete process.env.NODEREAL_BSC_RPC_URL;
+    delete process.env.QUICKNODE_BSC_RPC_URL;
+
+    const server = await startApiServer({ port: 0 });
+    port = server.port;
+    close = server.close;
+
+    const modeResponse = await req(port, "PUT", "/api/permissions/trade-mode", {
+      mode: "manual-local-key",
+    });
+    expect(modeResponse.status).toBe(200);
+  }, 30_000);
+
+  afterAll(async () => {
+    await close();
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  it("treats agent-originated transfer execution as user-sign in manual-local-key mode", async () => {
+    const { status, data } = await req(
+      port,
+      "POST",
+      "/api/wallet/transfer/execute",
+      {
+        toAddress: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+        amount: "0.001",
+        assetSymbol: "BNB",
+        confirm: true,
+      },
+      { "X-Milady-Agent-Action": "1" },
+    );
+
+    expect(status).toBe(200);
+    expect(data.executed).toBe(false);
+    expect(data.mode).toBe("user-sign");
+    expect(data.requiresUserSignature).toBe(true);
+  });
+});

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -11452,10 +11452,11 @@ async function handleRequest(
     }
 
     const tradePermissionMode = resolveTradePermissionMode(state.config);
+    const isAgentRequest = isAgentAutomationRequest(req);
     const hasLocalKey = Boolean(process.env.EVM_PRIVATE_KEY?.trim());
     const canExecuteLocally = canUseLocalTradeExecution(
       tradePermissionMode,
-      false,
+      isAgentRequest,
     );
     const addrs = getWalletAddresses();
 


### PR DESCRIPTION
### Motivation
- Prevent agent-originated requests from bypassing the `manual-local-key` guard on `/api/wallet/transfer/execute` by ensuring actor detection is used when deciding whether local-key execution is allowed.

### Description
- Use `isAgentAutomationRequest(req)` and pass the result into `canUseLocalTradeExecution` instead of hardcoding `false` so agent requests are classified correctly (`src/api/server.ts`).
- Add a regression test that sets `tradePermissionMode` to `manual-local-key`, issues a `POST /api/wallet/transfer/execute` with `X-Milady-Agent-Action: 1`, and asserts the route returns `mode: "user-sign"`, `requiresUserSignature: true`, and does not execute locally (`src/api/server.transfer-permissions.test.ts`).

### Testing
- Ran `bun test src/api/server.transfer-permissions.test.ts src/api/server.trade-permissions.test.ts`, but tests could not complete due to a missing dependency (`@elizaos/core`) in this environment and the runtime test run failing; the new test file is present in the commit.
- Attempted `bun install` to fetch deps, but the environment reported registry access errors (HTTP 403 for `ethers`, `typescript`, `@elizaos/core`), so full test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae0995892c8332a06b079bb035fc21)