### PR TITLE
retake: validate upstream API URL to prevent SSRF

### DIFF
--- a/packages/plugin-retake/src/destination.ts
+++ b/packages/plugin-retake/src/destination.ts
@@ -6,8 +6,72 @@
  * credential fetching and session start/stop via the retake.tv API.
  */
 
+import { lookup as dnsLookup } from "node:dns/promises";
+import net from "node:net";
 import { buildPresetLayout } from "@milady/plugin-streaming-base";
 import type { StreamingDestination } from "./types.ts";
+
+const BLOCKED_HOSTS = new Set(["localhost", "metadata.google.internal"]);
+
+function isBlockedIp(address: string): boolean {
+  if (address === "::1") return true;
+  if (address.startsWith("fe80:") || address.startsWith("fc")) return true;
+  if (!net.isIPv4(address)) return false;
+
+  const [a, b] = address.split(".").map((part) => Number.parseInt(part, 10));
+  if (a === 127 || a === 10 || a === 0) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  return false;
+}
+
+async function resolveRetakeApiBaseUrl(
+  configuredApiUrl: string,
+): Promise<string> {
+  let parsed: URL;
+  try {
+    parsed = new URL(configuredApiUrl);
+  } catch {
+    throw new Error("RETAKE_API_URL must be a valid absolute URL");
+  }
+
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new Error("RETAKE_API_URL must use http:// or https://");
+  }
+
+  const hostname = parsed.hostname.trim().toLowerCase();
+  if (!hostname) {
+    throw new Error("RETAKE_API_URL host is required");
+  }
+  if (
+    BLOCKED_HOSTS.has(hostname) ||
+    hostname.endsWith(".localhost") ||
+    hostname.endsWith(".local")
+  ) {
+    throw new Error(`RETAKE_API_URL host \"${hostname}\" is blocked`);
+  }
+
+  if (net.isIP(hostname)) {
+    if (isBlockedIp(hostname)) {
+      throw new Error(`RETAKE_API_URL host \"${hostname}\" is blocked`);
+    }
+  } else {
+    const resolved = await dnsLookup(hostname, { all: true });
+    if (resolved.length === 0) {
+      throw new Error(`Could not resolve RETAKE_API_URL host \"${hostname}\"`);
+    }
+    for (const entry of resolved) {
+      if (isBlockedIp(entry.address)) {
+        throw new Error(
+          `RETAKE_API_URL host \"${hostname}\" resolves to blocked address`,
+        );
+      }
+    }
+  }
+
+  return parsed.toString().replace(/\/+$/, "");
+}
 
 export function createRetakeDestination(config?: {
   accessToken?: string;
@@ -30,11 +94,11 @@ export function createRetakeDestination(config?: {
       ).trim();
       if (!token) throw new Error("Retake access token not configured");
 
-      const apiUrl = (
+      const apiUrl = await resolveRetakeApiBaseUrl(
         config?.apiUrl ??
-        process.env.RETAKE_API_URL ??
-        "https://retake.tv/api/v1"
-      ).trim();
+          process.env.RETAKE_API_URL ??
+          "https://retake.tv/api/v1",
+      );
       const headers = {
         "Content-Type": "application/json",
         Authorization: `Bearer ${token}`,
@@ -63,11 +127,11 @@ export function createRetakeDestination(config?: {
       ).trim();
       if (!token) return;
 
-      const apiUrl = (
+      const apiUrl = await resolveRetakeApiBaseUrl(
         config?.apiUrl ??
-        process.env.RETAKE_API_URL ??
-        "https://retake.tv/api/v1"
-      ).trim();
+          process.env.RETAKE_API_URL ??
+          "https://retake.tv/api/v1",
+      );
       const res = await fetch(`${apiUrl}/agent/stream/start`, {
         method: "POST",
         headers: {
@@ -90,11 +154,11 @@ export function createRetakeDestination(config?: {
       ).trim();
       if (!token) return;
 
-      const apiUrl = (
+      const apiUrl = await resolveRetakeApiBaseUrl(
         config?.apiUrl ??
-        process.env.RETAKE_API_URL ??
-        "https://retake.tv/api/v1"
-      ).trim();
+          process.env.RETAKE_API_URL ??
+          "https://retake.tv/api/v1",
+      );
       await fetch(`${apiUrl}/agent/stream/stop`, {
         method: "POST",
         headers: {

--- a/src/api/stream-routes.test.ts
+++ b/src/api/stream-routes.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as dnsPromises from "node:dns/promises";
 import {
   createMockHttpResponse,
   createMockIncomingMessage,
@@ -932,6 +933,10 @@ describe("handleStreamRoute", () => {
 // ---------------------------------------------------------------------------
 
 describe("createRetakeDestination()", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("returns a StreamingDestination with id and name", async () => {
     const { createRetakeDestination } = await import(
       "../../packages/plugin-retake/src/index.ts"
@@ -977,6 +982,34 @@ describe("createRetakeDestination()", () => {
         delete process.env.RETAKE_AGENT_TOKEN;
       }
     }
+  });
+
+  it("rejects localhost RETAKE_API_URL values", async () => {
+    const { createRetakeDestination } = await import(
+      "../../packages/plugin-retake/src/index.ts"
+    );
+    const dest = createRetakeDestination({
+      accessToken: "config-token",
+      apiUrl: "http://localhost:8080/api/v1",
+    });
+
+    await expect(dest.getCredentials()).rejects.toThrow("host \"localhost\" is blocked");
+  });
+
+  it("rejects RETAKE_API_URL values that resolve to private IPs", async () => {
+    vi.spyOn(dnsPromises, "lookup").mockResolvedValue([
+      { address: "127.0.0.1", family: 4 },
+    ] as never);
+
+    const { createRetakeDestination } = await import(
+      "../../packages/plugin-retake/src/index.ts"
+    );
+    const dest = createRetakeDestination({
+      accessToken: "config-token",
+      apiUrl: "https://example.com/api/v1",
+    });
+
+    await expect(dest.getCredentials()).rejects.toThrow("resolves to blocked address");
   });
 });
 


### PR DESCRIPTION
### Motivation
- New Retake endpoints built upstream URLs directly from `RETAKE_API_URL` and performed authenticated `fetch()` calls with no hostname/IP validation, enabling an SSRF vector when `RETAKE_API_URL` can be modified via config.
- Limit the blast radius by validating the Retake API base URL in the adapter rather than changing global config behaviour.

### Description
- Added `resolveRetakeApiBaseUrl()` to `packages/plugin-retake/src/destination.ts` to validate `RETAKE_API_URL` as an absolute `http`/`https` URL and normalize its trailing slash.
- Blocked known dangerous hostnames and patterns (e.g. `localhost`, `*.localhost`, `.local`, `metadata.google.internal`) and rejected loopback/private/link-local IP literals and DNS resolutions that yield private addresses.
- Replaced direct `process.env.RETAKE_API_URL` usage with the validated base URL in `getCredentials`, `onStreamStart`, and `onStreamStop` so all outbound Retake calls must pass validation first.
- Added unit regression tests in `src/api/stream-routes.test.ts` to assert that `RETAKE_API_URL` values pointing to `localhost` or resolving to private IPs are rejected, and restored mocks after each test for isolation.

### Testing
- Ran `bun test src/api/stream-routes.test.ts` in the environment, which failed with an unresolved dependency error for `@elizaos/core`, preventing the suite from executing here; the new tests are present and exercise blocked hostname and DNS resolution cases.
- Attempted `bun install` to fetch dependencies but it failed in this environment due to registry access returning HTTP 403 for required packages such as `@elizaos/core` and `typescript`, so full local test execution was not possible.
- The change is minimal and scoped to the Retake adapter and its unit tests; CI in the upstream environment with normal network/registry access should run the test suite and verify behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae29e28a4483328f32ff0ca7a003bf)