### PR TITLE
docs: add beginner & developer guides and update docs navigation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -41,11 +41,20 @@
           },
           {
             "group": "Configuration",
-            "pages": ["configuration", "config-schema", "model-providers"]
+            "pages": [
+              "configuration",
+              "config-schema",
+              "model-providers"
+            ]
           },
           {
             "group": "Guides",
             "pages": [
+              "guides/beginners-user-guide",
+              "guides/beginners-development-guide",
+              "guides/learning-paths",
+              "guides/developer-playbook",
+              "guides/first-extension-walkthrough",
               "guides/autonomous-mode",
               "guides/hooks",
               "guides/config-includes",
@@ -75,11 +84,17 @@
           },
           {
             "group": "Infrastructure",
-            "pages": ["deployment", "self-updates", "guides/cloud"]
+            "pages": [
+              "deployment",
+              "self-updates",
+              "guides/cloud"
+            ]
           },
           {
             "group": "Contributing",
-            "pages": ["guides/contribution-guide"]
+            "pages": [
+              "guides/contribution-guide"
+            ]
           }
         ]
       },
@@ -88,15 +103,22 @@
         "groups": [
           {
             "group": "Overview",
-            "pages": ["apps/dashboard", "dashboard/pairing"]
+            "pages": [
+              "apps/dashboard",
+              "dashboard/pairing"
+            ]
           },
           {
             "group": "Chat",
-            "pages": ["dashboard/chat"]
+            "pages": [
+              "dashboard/chat"
+            ]
           },
           {
             "group": "Stream",
-            "pages": ["dashboard/stream"]
+            "pages": [
+              "dashboard/stream"
+            ]
           },
           {
             "group": "Character",
@@ -108,11 +130,15 @@
           },
           {
             "group": "Wallets",
-            "pages": ["guides/wallet"]
+            "pages": [
+              "guides/wallet"
+            ]
           },
           {
             "group": "Knowledge",
-            "pages": ["guides/knowledge"]
+            "pages": [
+              "guides/knowledge"
+            ]
           },
           {
             "group": "Social",
@@ -127,11 +153,16 @@
           },
           {
             "group": "Apps",
-            "pages": ["dashboard/apps"]
+            "pages": [
+              "dashboard/apps"
+            ]
           },
           {
             "group": "Settings",
-            "pages": ["apps/dashboard/settings", "apps/dashboard/talk-mode"]
+            "pages": [
+              "apps/dashboard/settings",
+              "apps/dashboard/talk-mode"
+            ]
           }
         ]
       },
@@ -156,39 +187,57 @@
           },
           {
             "group": "Skills",
-            "pages": ["plugins/skills"]
+            "pages": [
+              "plugins/skills"
+            ]
           },
           {
             "group": "Actions",
-            "pages": ["guides/custom-actions"]
+            "pages": [
+              "guides/custom-actions"
+            ]
           },
           {
             "group": "Triggers",
-            "pages": ["guides/triggers"]
+            "pages": [
+              "guides/triggers"
+            ]
           },
           {
             "group": "Fine-Tuning",
-            "pages": ["guides/training"]
+            "pages": [
+              "guides/training"
+            ]
           },
           {
             "group": "Trajectories",
-            "pages": ["advanced/trajectories"]
+            "pages": [
+              "advanced/trajectories"
+            ]
           },
           {
             "group": "Runtime",
-            "pages": ["agents/runtime-and-lifecycle"]
+            "pages": [
+              "agents/runtime-and-lifecycle"
+            ]
           },
           {
             "group": "Database",
-            "pages": ["advanced/database"]
+            "pages": [
+              "advanced/database"
+            ]
           },
           {
             "group": "Logs",
-            "pages": ["advanced/logs"]
+            "pages": [
+              "advanced/logs"
+            ]
           },
           {
             "group": "Security",
-            "pages": ["guides/sandbox"]
+            "pages": [
+              "guides/sandbox"
+            ]
           }
         ]
       },
@@ -235,7 +284,10 @@
           },
           {
             "group": "DeFi & Blockchain",
-            "pages": ["plugin-registry/defi/evm", "plugin-registry/defi/solana"]
+            "pages": [
+              "plugin-registry/defi/evm",
+              "plugin-registry/defi/solana"
+            ]
           },
           {
             "group": "Feature Plugins",
@@ -298,7 +350,9 @@
           },
           {
             "group": "WebSocket",
-            "pages": ["websocket-events"]
+            "pages": [
+              "websocket-events"
+            ]
           },
           {
             "group": "Runtime Reference",
@@ -319,7 +373,9 @@
         "groups": [
           {
             "group": "Overview",
-            "pages": ["cli/overview"]
+            "pages": [
+              "cli/overview"
+            ]
           },
           {
             "group": "Commands",
@@ -338,7 +394,9 @@
           },
           {
             "group": "Environment",
-            "pages": ["cli/environment"]
+            "pages": [
+              "cli/environment"
+            ]
           }
         ]
       }
@@ -352,6 +410,12 @@
     }
   },
   "contextual": {
-    "options": ["copy", "view", "chatgpt", "claude", "perplexity"]
+    "options": [
+      "copy",
+      "view",
+      "chatgpt",
+      "claude",
+      "perplexity"
+    ]
   }
 }

--- a/docs/guides/beginners-development-guide.md
+++ b/docs/guides/beginners-development-guide.md
@@ -1,0 +1,323 @@
+---
+title: Beginner Development Guide
+sidebarTitle: Beginner Dev Guide
+description: A complete onboarding guide for new contributors to understand Milady architecture, local setup, workflow, testing, and safe first contributions.
+---
+
+This guide is for developers new to this repository who want to make safe, reviewable contributions quickly.
+
+---
+
+## 1) What this repo is optimizing for
+
+Milady is a local-first AI assistant built on elizaOS.
+
+The repository prioritizes:
+
+1. Reliability
+2. Security
+3. Test coverage
+4. Runtime compatibility (Node + Bun)
+
+For newcomers, that means:
+
+- Prefer small, scoped changes
+- Preserve existing runtime guardrails
+- Validate changes with tests/checks
+
+---
+
+## 2) Read this before writing code
+
+Required orientation reading:
+
+1. `README.md` — product and usage framing
+2. `CONTRIBUTING.md` — scope and quality bar
+3. `AGENTS.md` — repository-specific constraints
+4. `docs/agents/runtime-and-lifecycle.md` — startup/initialization truth source
+
+This reading saves you from most early review failures.
+
+---
+
+## 3) Local prerequisites
+
+- Node.js `>=22`
+- Bun
+- Git
+
+Install dependencies:
+
+```bash
+bun install
+```
+
+Recommended quick sanity checks:
+
+```bash
+node -v
+bun -v
+bun run milady --version
+```
+
+---
+
+## 4) Repo map (mental model)
+
+Core areas:
+
+- `src/runtime/` — runtime startup, plugin orchestration, lifecycle
+- `src/cli/` — CLI parsing, command registration, process behavior
+- `src/config/` — config types, loading, resolution
+- `src/actions/` — action handlers
+- `src/providers/` — context/data providers
+- `src/hooks/` — lifecycle extension hooks
+- `src/types/` — shared type contracts
+- `apps/app/` — desktop/mobile UI app
+- `apps/chrome-extension/` — browser extension integration
+- `scripts/` — build/dev/release tooling
+- `test/` + colocated tests — verification
+
+---
+
+## 5) Entry points and startup path
+
+Important files to understand first:
+
+1. `src/entry.ts` (CLI process bootstrap)
+2. `src/cli/run-main.ts` (dotenv + Commander + error handling)
+3. `src/cli/program/*` (command registration)
+4. `src/runtime/eliza.ts` (runtime boot sequence + plugin resolution)
+5. `src/index.ts` (package exports)
+
+### Suggested reading order (first 60–90 min)
+
+1. Read `src/entry.ts` top-to-bottom
+2. Trace into `run-main.ts`
+3. Open one command registration file (`register.start.ts`, etc.)
+4. Read runtime lifecycle doc and compare to `eliza.ts`
+
+---
+
+## 6) Daily commands for development
+
+```bash
+bun run build
+bun run check
+bun run test
+bun run test:e2e
+bun run test:coverage
+```
+
+CLI iteration examples:
+
+```bash
+bun run milady --help
+bun run milady start --verbose
+bun run milady config get agent.name
+```
+
+When you touch logic, at minimum run:
+
+- `bun run check`
+- `bun run test`
+
+---
+
+## 7) Test strategy for beginners
+
+### Test naming conventions
+
+- Unit: `*.test.ts` (colocated)
+- End-to-end: `*.e2e.test.ts`
+- Live/integration-style: `*.live.test.ts`
+
+### Practical rule
+
+If behavior changed, tests should reflect that behavior.
+
+### Good first testing pattern
+
+1. Reproduce bug in a test
+2. Confirm test fails
+3. Implement fix
+4. Confirm test passes
+
+---
+
+## 8) Safe first-task ideas
+
+Great first PR candidates:
+
+- Fix small CLI edge-case with regression test
+- Tighten error messaging
+- Improve docs accuracy and command examples
+- Add missing tests in under-covered files
+
+Avoid early on:
+
+- New plugins/integrations
+- Multi-subsystem refactors
+- Behavior changes without tests
+
+---
+
+## 9) Critical guardrails (do not casually remove)
+
+Known-sensitive areas in this repo:
+
+- Desktop startup error guards in electron agent startup path
+- `NODE_PATH` setup supporting dynamic plugin imports
+- Bun exports patching logic in dependency patch script
+
+If your change touches these, include explicit reasoning + verification.
+
+---
+
+## 10) Node and Bun compatibility checklist
+
+When touching startup, scripts, or import behavior, verify:
+
+- Node path works (`node --import ...`/CLI entry path)
+- Bun path works (`bun run ...` paths)
+- No hardcoded assumptions about environment
+
+If you cannot run both paths fully, explain what you validated and why.
+
+---
+
+## 11) A practical contribution workflow
+
+1. Pick one narrow objective
+2. Create branch
+3. Reproduce issue or define target behavior
+4. Add/update tests first where possible
+5. Implement minimal change
+6. Run checks/tests
+7. Self-review diff for scope creep
+8. Commit with concise action-oriented message
+9. Open PR with clear summary + test evidence
+
+---
+
+## 12) PR quality checklist (before opening)
+
+- [ ] Scope is in-bounds and focused
+- [ ] No unrelated refactors included
+- [ ] Tests updated for behavior changes
+- [ ] Lint/type checks are clean
+- [ ] Docs updated when user-facing behavior changed
+- [ ] No real secrets in examples/logs/config snippets
+
+---
+
+## 13) Common beginner mistakes
+
+- **Huge PRs** → split into smaller, reviewable units
+- **No tests for logic changes** → add regression coverage
+- **Overusing new dependencies** → avoid unless required by `src/`
+- **Ignoring platform/runtime assumptions** → test Node/Bun paths
+- **Editing generated artifacts** → edit source, regenerate output
+
+---
+
+## 14) Debugging habits that save time
+
+- Run a single focused command before full suite
+- Capture exact failing command output in PR notes
+- Use logs under `~/.milady/logs/` for runtime investigation
+- Prefer minimal reproducible cases
+
+---
+
+## 15) Suggested deep-dive path after first PR (beginner → advanced)
+
+Treat this as a curriculum. Finish each layer before moving deeper.
+
+### Layer 1 — Core contributor fluency
+
+1. **Runtime lifecycle and startup**
+   - `/agents/runtime-and-lifecycle`
+   - `/runtime/core`
+2. **CLI command model**
+   - `/cli/overview`
+   - `/cli/start`
+   - `/cli/config`
+3. **Configuration system**
+   - `/configuration`
+   - `/config-schema`
+
+### Layer 2 — Feature implementation fluency
+
+1. **Plugins and extension model**
+   - `/plugins/architecture`
+   - `/plugins/development`
+   - `/plugins/schemas`
+   - `/plugins/publish`
+2. **Skills and actions**
+   - `/plugins/skills`
+   - `/guides/custom-actions`
+3. **Triggers and automation**
+   - `/guides/triggers`
+   - `/guides/hooks`
+
+### Layer 3 — Product surface fluency
+
+1. **Dashboard feature surface**
+   - `/apps/dashboard`
+   - `/dashboard/chat`
+   - `/dashboard/stream`
+2. **Platform-specific app behavior**
+   - `/apps/desktop`
+   - `/apps/mobile`
+   - `/apps/chrome-extension`
+
+### Layer 4 — Systems and operations fluency
+
+1. **Runtime services and providers**
+   - `/runtime/services`
+   - `/runtime/providers`
+   - `/runtime/events`
+2. **Security and sandboxing**
+   - `/guides/sandbox`
+3. **Data and diagnostics**
+   - `/advanced/database`
+   - `/advanced/logs`
+
+### Layer 5 — Advanced architecture and planning docs
+
+Use these when designing non-trivial changes:
+
+- `/autonomous-loop-implementation/README`
+- `/triggers-system-implementation/README`
+- `/fast-mode-implementation-dossier/README`
+
+These documents are long-form design dossiers. Read only the sections relevant to your current change.
+
+### Advanced contributor tracks (pick one)
+
+- **Runtime track:** runtime lifecycle + services + providers + memory docs
+- **Plugin track:** plugin architecture + local plugins + registry + schemas
+- **Platform track:** desktop/mobile/chrome-extension docs + release/build docs
+- **API track:** REST docs + contracts + integration/e2e tests
+
+### What “advanced-ready” looks like
+
+You are advanced-ready when you can:
+
+- Trace a user action from CLI/UI to runtime service and back
+- Predict side effects of plugin load/order changes
+- Add tests that catch regressions in your subsystem
+- Explain security implications of your change before review asks
+
+## 16) Definition of “review-ready” for this repo
+
+A contribution is beginner-good and review-ready when it is:
+
+- Small enough to reason about quickly
+- Clearly justified
+- Backed by tests/checks
+- Compatible with existing runtime constraints
+- Documented where behavior changed
+
+When unsure, optimize for **clarity, safety, and testability** over cleverness.

--- a/docs/guides/beginners-user-guide.md
+++ b/docs/guides/beginners-user-guide.md
@@ -1,0 +1,367 @@
+---
+title: Beginner User Guide
+sidebarTitle: Beginner User Guide
+description: A complete beginner walkthrough for installing Milady, finishing first-run setup, daily usage, safety, troubleshooting, and next steps.
+---
+
+If you're brand new to Milady, this guide is for you.
+
+You do **not** need to be a developer to use Milady. The core model is:
+
+1. Milady runs locally on your machine.
+2. You connect the model providers and plugins you want.
+3. You control how private vs connected your setup is.
+
+---
+
+## 1) What Milady is (plain English)
+
+Milady is a personal AI assistant that can run from your terminal and dashboard.
+
+You can use it for:
+
+- Conversations and task support
+- Connected workflows (Discord, Telegram, etc.)
+- Plugin-based capabilities and custom behavior
+
+Main interfaces:
+
+- `milady` command (CLI/TUI)
+- Dashboard in browser
+- Desktop/mobile app builds (platform dependent)
+
+---
+
+## 2) Before you install
+
+### What you need
+
+- Internet access (for installation and cloud providers)
+- A terminal (or PowerShell on Windows)
+- Optional API key from your preferred provider (Anthropic, OpenAI, etc.)
+
+### Recommended mindset
+
+Start simple:
+
+- First get local startup working
+- Then add one model provider
+- Then optionally add connectors/plugins
+
+---
+
+## 3) Install Milady
+
+### macOS / Linux / WSL (recommended)
+
+```bash
+curl -fsSL https://milady-ai.github.io/milady/install.sh | bash
+milady setup
+```
+
+### Windows (PowerShell)
+
+```powershell
+irm https://milady-ai.github.io/milady/install.ps1 | iex
+milady setup
+```
+
+### npm global alternative
+
+```bash
+npm install -g miladyai
+milady setup
+```
+
+If `milady` is not found after install, restart your terminal and run `milady --version`.
+
+---
+
+## 4) First start and onboarding
+
+Start Milady:
+
+```bash
+milady
+```
+
+On first run, onboarding typically asks for:
+
+1. Agent name
+2. Style/personality preset
+3. Model provider + API key (or skip)
+4. Optional wallet setup
+
+After onboarding, you'll see local URLs for the dashboard and gateway.
+
+### If you skipped provider setup
+
+That is fine. You can add providers later using:
+
+```bash
+milady models
+```
+
+---
+
+## 5) Your first 10-minute success plan
+
+Use this exact path:
+
+1. Run `milady`
+2. Open the dashboard URL
+3. Send a basic prompt (e.g., "hello")
+4. Confirm a response is returned
+5. Run `milady models` and check provider status
+
+If these work, your base install is healthy.
+
+---
+
+## 6) Commands you'll use most
+
+```bash
+milady                    # start interactive mode (default)
+milady start --headless   # run server-only, no TUI
+milady dashboard          # open dashboard in browser
+milady configure          # configuration guidance
+milady config get <key>   # read config value
+milady models             # show model provider status
+milady plugins list       # list installed plugins
+milady doctor             # diagnostics
+```
+
+Tip: Use `milady <command> --help` any time you feel stuck.
+
+---
+
+## 7) Understanding run modes
+
+### Interactive mode (`milady`)
+
+- Good for active local usage
+- Includes terminal UI (status, activity, quick controls)
+
+### Headless mode (`milady start --headless`)
+
+- Good for background services
+- Useful with process managers (systemd/pm2/docker)
+
+If you're unsure, start with interactive mode.
+
+---
+
+## 8) Where files live on your machine
+
+Milady stores state under `~/.milady/`:
+
+- `~/.milady/milady.json` → main configuration
+- `~/.milady/logs/` → runtime logs
+- `~/.milady/workspace/` → agent workspace files
+
+This is essential for backup, troubleshooting, and migration to another machine.
+
+---
+
+## 9) Safety and privacy basics (must-read)
+
+### Keep API local by default
+
+Milady binds to loopback by default (`127.0.0.1`), meaning only your machine can access it.
+
+### If exposing to network, set a token
+
+If you bind to `0.0.0.0` or expose ports publicly, set an API token first:
+
+```bash
+echo "MILADY_API_TOKEN=$(openssl rand -hex 32)" >> .env
+```
+
+### Protect secrets
+
+- Keep API keys in env/config, not screenshots
+- Never post real keys in issues/chats
+- Rotate keys if you think they leaked
+
+---
+
+## 10) Connecting model providers
+
+Typical flow:
+
+1. Get key from provider dashboard
+2. Configure through setup/config/models flows
+3. Verify with `milady models`
+4. Send a test prompt
+
+If responses fail, verify:
+
+- Key is valid and active
+- Provider quota/billing is healthy
+- Model name/provider pairing is correct
+
+---
+
+## 11) Plugins and connectors (beginner version)
+
+Plugins add capabilities (tools, integrations, actions).
+
+Start with a minimal strategy:
+
+1. Install only what you need
+2. Test one plugin at a time
+3. Restart and re-check behavior
+
+Useful commands:
+
+```bash
+milady plugins list
+milady plugins add <name>
+milady plugins remove <name>
+```
+
+---
+
+## 12) Troubleshooting first-week issues
+
+### A) "Milady command not found"
+
+- Restart terminal
+- Check PATH and install method
+- Run `milady --version`
+
+### B) "Dashboard won’t load"
+
+- Ensure Milady is running
+- Check for port conflicts
+- Run `milady doctor`
+
+### C) "No responses"
+
+- Check provider configuration (`milady models`)
+- Check logs in `~/.milady/logs/`
+- Restart and retry
+
+### D) "Plugin seems broken"
+
+- Confirm plugin is installed (`plugins list`)
+- Check provider/env dependencies for plugin
+- Restart Milady
+
+---
+
+## 13) Updating and maintenance
+
+Good routine:
+
+- Update regularly
+- Re-run `milady setup` after major updates
+- Keep backups of `~/.milady/milady.json`
+- Review logs when behavior changes unexpectedly
+
+---
+
+## 14) Beginner glossary
+
+- **Provider**: the LLM backend (Anthropic/OpenAI/Ollama/etc.)
+- **Plugin**: adds capabilities/integrations
+- **Headless**: no interactive terminal UI; service-style runtime
+- **Workspace**: local files Milady uses for agent context and tasks
+- **Gateway**: service layer used by dashboard and interfaces
+
+---
+
+## 15) What to learn next (complete learning roadmap)
+
+Use this staged path so you do not get overwhelmed.
+
+### Stage A — Beginner foundations (first week)
+
+1. **Quickstart + installation refresh**
+   - `/installation`
+   - `/quickstart`
+2. **Core configuration**
+   - `/configuration`
+   - `/config-schema`
+   - `/model-providers`
+3. **Everyday commands and interfaces**
+   - `/chat-commands`
+   - `/apps/tui`
+   - `/apps/dashboard`
+4. **Safety basics**
+   - `/guides/sandbox`
+
+### Stage B — Intermediate usage (weeks 2–3)
+
+1. **Dashboard depth**
+   - `/dashboard/chat`
+   - `/dashboard/stream`
+   - `/apps/dashboard/settings`
+   - `/apps/dashboard/talk-mode`
+2. **Knowledge and memory features**
+   - `/guides/knowledge`
+   - `/agents/memory-and-state`
+3. **Connectors and channels**
+   - `/guides/connectors`
+   - `/connectors/discord`
+   - `/connectors/telegram`
+   - `/connectors/twitter`
+   - `/connectors/slack`
+4. **Wallet and autonomous workflows**
+   - `/guides/wallet`
+   - `/guides/autonomous-mode`
+
+### Stage C — Advanced user path (month 1+)
+
+1. **Plugin ecosystem mastery**
+   - `/plugins/overview`
+   - `/plugins/registry`
+   - `/plugins/local-plugins`
+   - `/plugins/patterns`
+2. **Skills and custom behavior**
+   - `/plugins/skills`
+   - `/guides/custom-actions`
+   - `/guides/triggers`
+3. **App/platform specialization**
+   - `/apps/desktop`
+   - `/apps/mobile`
+   - `/apps/chrome-extension`
+4. **Cloud and deployment**
+   - `/guides/cloud`
+   - `/deployment`
+
+### Stage D — Expert/operator track
+
+1. **Runtime internals**
+   - `/agents/runtime-and-lifecycle`
+   - `/runtime/core`
+   - `/runtime/services`
+2. **Operational troubleshooting**
+   - `/advanced/logs`
+   - `/advanced/database`
+3. **REST API control surface**
+   - `/api-reference`
+   - `/rest/system`
+   - `/rest/agents`
+   - `/rest/models`
+
+### Suggested weekly plan (simple)
+
+- **Week 1:** Stage A only
+- **Week 2:** Stage B + one connector
+- **Week 3:** Stage C plugin/skills basics
+- **Week 4+:** Stage D only if you need ops-level control
+
+This progression keeps your setup stable while your capability grows.
+
+## 16) Confidence checklist
+
+If all of these are true, you're in great shape:
+
+- [ ] `milady` starts successfully
+- [ ] Dashboard opens locally
+- [ ] A provider is configured and returns responses
+- [ ] You know where `~/.milady/` files live
+- [ ] You can run `milady doctor` and understand basic output
+
+You are now ready to move from complete beginner to regular user.

--- a/docs/guides/developer-playbook.md
+++ b/docs/guides/developer-playbook.md
@@ -1,0 +1,102 @@
+---
+title: Developer Playbook
+sidebarTitle: Dev Playbook
+description: Practical workflows, checklists, and quality gates for contributing to Milady reliably.
+---
+
+This playbook is the practical "how we build" companion to the contribution policy docs.
+
+## 1) PR sizing strategy
+
+Prefer small PRs with one clear purpose:
+
+- One bug fix
+- One behavior enhancement
+- One doc improvement batch
+
+Split when PR includes unrelated concerns.
+
+## 2) Implementation workflow (default)
+
+1. Reproduce issue / define behavior
+2. Write or update test
+3. Implement minimal change
+4. Run checks
+5. Self-review diff
+6. Commit with concise action-oriented message
+
+## 3) Quality gates before PR
+
+Minimum:
+
+```bash
+bun run check
+bun run test
+```
+
+Add targeted checks when needed (e2e, db-specific checks, docs checks).
+
+## 4) Security review checklist
+
+Before opening PR, verify:
+
+- No secrets committed
+- No hidden network/data exfil paths
+- New external calls are explicit and justified
+- Permissions/auth implications are documented
+
+## 5) Runtime stability checklist
+
+For startup/runtime/plugin-related changes:
+
+- Validate startup behavior remains intact
+- Validate plugin resolution still works
+- Validate failure paths remain user-visible and recoverable
+- Confirm Node/Bun compatibility where relevant
+
+## 6) Test planning template
+
+Use this mini-template in PR descriptions:
+
+- **Behavior changed:**
+- **What could break:**
+- **Tests added/updated:**
+- **Manual scenarios run:**
+- **Known gaps:**
+
+## 7) Docs change policy
+
+If user-facing behavior changes, docs should update in same PR whenever practical.
+
+Good doc updates include:
+
+- command examples,
+- config keys,
+- troubleshooting notes,
+- migration notes.
+
+## 8) Review ergonomics
+
+Help reviewers by including:
+
+- short summary bullets,
+- why this is needed,
+- why alternatives were not chosen,
+- explicit risk level.
+
+## 9) Release/rollback thinking
+
+For non-trivial changes, include rollback plan:
+
+- feature flag or config gate,
+- revert procedure,
+- state/data impact note.
+
+## 10) Progression after this playbook
+
+Then go deeper with:
+
+- `/guides/first-extension-walkthrough`
+- `/plugins/architecture`
+- `/agents/runtime-and-lifecycle`
+- `/advanced/logs`

--- a/docs/guides/first-extension-walkthrough.md
+++ b/docs/guides/first-extension-walkthrough.md
@@ -1,0 +1,128 @@
+---
+title: First Extension Walkthrough
+sidebarTitle: First Extension
+summary: Build your first Milady extension safely using existing plugin docs and runtime guardrails.
+description: A practical first-extension walkthrough for developers who want to extend Milady with plugins, actions, and runtime-safe patterns.
+---
+
+This guide is a practical bridge between beginner docs and full plugin architecture docs.
+
+## Goal
+
+Ship one small extension that is:
+
+- useful,
+- testable,
+- safe to review,
+- and easy to iterate.
+
+## Step 0: Pick an intentionally small extension
+
+Good first targets:
+
+- Add one new action with clear input/output
+- Add one provider that injects lightweight context
+- Add one plugin capability that does not require broad refactors
+
+Avoid for first attempt:
+
+- Multi-plugin orchestration
+- Heavy runtime lifecycle changes
+- Changes to startup resolution internals
+
+## Step 1: Read the right docs in order
+
+1. `/plugins/overview`
+2. `/plugins/architecture`
+3. `/plugins/create-a-plugin`
+4. `/plugins/development`
+5. `/plugins/local-plugins`
+
+## Step 2: Define extension contract before coding
+
+Write down:
+
+- Problem statement
+- Inputs and outputs
+- Failure behavior
+- Security constraints (secrets, external calls, data handling)
+- Test plan
+
+This keeps implementation scoped and review-friendly.
+
+## Step 3: Implement minimal behavior
+
+Implementation rules:
+
+- Keep code path small
+- Prefer explicit types
+- Add comments only where logic is non-obvious
+- Do not remove existing runtime safeguards
+
+## Step 4: Wire into local environment
+
+Use local plugin loading docs and runtime config paths to install and enable your extension for development.
+
+Then perform one deterministic manual scenario that exercises the new behavior.
+
+## Step 5: Add tests early
+
+Minimum test expectations:
+
+- Happy-path behavior
+- Known failure path
+- Regression guard for issue fixed or behavior added
+
+If external dependencies exist, mock them where possible.
+
+## Step 6: Validate and self-review
+
+Recommended checks:
+
+```bash
+bun run check
+bun run test
+```
+
+Then review your own diff for:
+
+- scope creep,
+- hidden behavior changes,
+- missing docs,
+- security assumptions.
+
+## Step 7: Document usage
+
+Update docs with:
+
+- what the extension does,
+- how to configure it,
+- how to validate it,
+- known limitations.
+
+If behavior is user-facing, include at least one copy-paste-ready example.
+
+## Step 8: Prepare PR notes reviewers actually need
+
+Include:
+
+- Scope (exactly what changed)
+- Test evidence (commands and outcomes)
+- Security considerations
+- Rollback strategy (what to disable/revert if needed)
+
+## Step 9: Common first-extension mistakes
+
+- Extension does too many unrelated things
+- No tests for failure behavior
+- Docs lag implementation
+- Adds dependencies without clear need
+- Assumes one runtime path (Node or Bun) only
+
+## Step 10: Next extensions after first success
+
+After your first extension ships, move to:
+
+- richer plugin patterns (`/plugins/patterns`)
+- publishing and versioning (`/plugins/publish`)
+- skills + custom actions + triggers integration

--- a/docs/guides/learning-paths.md
+++ b/docs/guides/learning-paths.md
@@ -1,0 +1,133 @@
+---
+title: Learning Paths
+sidebarTitle: Learning Paths
+description: Structured beginner-to-advanced learning tracks for users, builders, and contributors working with Milady.
+---
+
+This page helps you choose **what to learn next** based on your goal.
+
+Use it as a map, not a checklist. Pick one path and progress in order.
+
+## Path 1: New User → Confident Operator
+
+### Phase 1: First-day setup
+
+- `/installation`
+- `/quickstart`
+- `/chat-commands`
+- `/apps/dashboard`
+
+Outcome: you can install Milady and run a basic conversation loop.
+
+### Phase 2: Daily productivity
+
+- `/configuration`
+- `/model-providers`
+- `/apps/tui`
+- `/apps/dashboard/settings`
+
+Outcome: you can tune model/provider behavior and navigate day-to-day controls.
+
+### Phase 3: Connected workflows
+
+- `/guides/connectors`
+- `/connectors/discord`
+- `/connectors/telegram`
+- `/guides/knowledge`
+
+Outcome: you can integrate Milady with real channels and memory context.
+
+### Phase 4: Advanced operation
+
+- `/guides/autonomous-mode`
+- `/guides/sandbox`
+- `/advanced/logs`
+- `/advanced/database`
+
+Outcome: you can operate safely and debug production-like usage.
+
+---
+
+## Path 2: New Contributor → Productive Developer
+
+### Phase 1: Repo orientation
+
+- `README.md`
+- `CONTRIBUTING.md`
+- `AGENTS.md`
+- `/agents/runtime-and-lifecycle`
+
+Outcome: you understand scope, standards, and runtime shape.
+
+### Phase 2: Core code navigation
+
+- `/cli/overview`
+- `/runtime/core`
+- `/runtime/services`
+- `/runtime/providers`
+
+Outcome: you can trace the control flow from CLI to runtime services.
+
+### Phase 3: Safe implementation flow
+
+- `/guides/beginners-development-guide`
+- `/guides/contribution-guide`
+- `/guides/hooks`
+
+Outcome: you can ship focused PRs with tests and clear rationale.
+
+### Phase 4: Advanced contributions
+
+- `/plugins/architecture`
+- `/plugins/development`
+- `/guides/custom-actions`
+- `/guides/triggers`
+
+Outcome: you can extend behavior without destabilizing runtime guarantees.
+
+---
+
+## Path 3: Extension Builder → Plugin Author
+
+### Phase 1: Understand extension primitives
+
+- `/plugins/overview`
+- `/plugins/architecture`
+- `/plugins/schemas`
+
+Outcome: you understand plugin lifecycle, contracts, and boundaries.
+
+### Phase 2: Build your first plugin
+
+- `/plugins/create-a-plugin`
+- `/plugins/development`
+- `/plugins/local-plugins`
+
+Outcome: you can build, run, and test a local plugin end-to-end.
+
+### Phase 3: Productionize your plugin
+
+- `/plugins/patterns`
+- `/plugins/publish`
+- `/plugins/registry`
+
+Outcome: you can package and publish a maintainable plugin.
+
+### Phase 4: Advanced extension patterns
+
+- `/plugins/skills`
+- `/guides/custom-actions`
+- `/guides/triggers`
+- `/guides/sandbox`
+
+Outcome: you can combine tools/actions/triggers with safer execution practices.
+
+---
+
+## Role-based quick picks
+
+- **I just want to use Milady well:** Path 1
+- **I want to contribute code:** Path 2
+- **I want to build plugins/extensions:** Path 3
+
+If you are unsure, finish **Path 1 Phase 1–2** first, then branch to your long-term goal.


### PR DESCRIPTION
### Motivation

- Provide comprehensive onboarding for new users and new contributors with step-by-step guides and checklists.  
- Give beginners a clear development workflow, safe-first contribution playbook, and a guided first-extension walkthrough.  
- Surface these resources in the site navigation so they are discoverable from the "Getting Started" section.

### Description

- Add five new documentation pages: `docs/guides/beginners-user-guide.md`, `docs/guides/beginners-development-guide.md`, `docs/guides/developer-playbook.md`, `docs/guides/first-extension-walkthrough.md`, and `docs/guides/learning-paths.md`.  
- Populate each guide with onboarding content, checklists, commands, workflows, and recommended learning paths for users and contributors.  
- Update `docs/docs.json` navigation to include the new guide pages under the "Getting Started" tab and adjust several array formatting instances to multi-line entries for readability.  
- Tidy `contextual.options` formatting in `docs/docs.json` to match the multi-line array style.

### Testing

- No automated tests were run for these documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae02336c2483329312f8399599d65f)