### PR TITLE
Auto-approve fork workflow runs for trusted contributors in agent-review workflow

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -640,6 +640,7 @@ jobs:
       issues: write
       checks: write
       statuses: write
+      actions: write
     steps:
       - name: Checkout trusted base ref
         uses: actions/checkout@v4
@@ -858,6 +859,71 @@ jobs:
             });
 
             console.log(`Trust/category updated: ${author} → ${result.score}/100 (${result.tier}), category=${category}, ${result.breakdown.recencyWeightedPoints} weighted pts`);
+
+      - name: Auto-approve pending fork workflows for trusted contributors
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            if (!pr) {
+              console.log('Not a pull request event; skipping workflow approval gate.');
+              return;
+            }
+
+            const isFork = pr.head?.repo?.full_name !== context.repo.owner + '/' + context.repo.repo;
+            if (!isFork) {
+              console.log('PR comes from this repository; no fork workflow approval needed.');
+              return;
+            }
+
+            const { data: issue } = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+            });
+
+            const labels = (issue.labels || []).map((label) =>
+              typeof label === 'string' ? label : label.name,
+            );
+            const trustLabel = labels.find((name) => /^trust:/.test(name || '')) || 'trust:probationary';
+            const autoApproveTiers = new Set([
+              'trust:contributing',
+              'trust:established',
+              'trust:trusted',
+              'trust:legendary',
+            ]);
+
+            if (!autoApproveTiers.has(trustLabel)) {
+              console.log(`Trust tier ${trustLabel} is below contributing; maintainer workflow approval required.`);
+              return;
+            }
+
+            const { data: runs } = await github.rest.actions.listWorkflowRunsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head_sha: pr.head.sha,
+              event: 'pull_request',
+              per_page: 100,
+            });
+
+            const pendingApprovals = (runs.workflow_runs || []).filter(
+              (run) => run.status === 'action_required',
+            );
+
+            if (pendingApprovals.length === 0) {
+              console.log('No pending fork workflow approvals for this commit.');
+              return;
+            }
+
+            for (const run of pendingApprovals) {
+              await github.request('POST /repos/{owner}/{repo}/actions/runs/{run_id}/approve', {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.id,
+              });
+              console.log(`Approved workflow run ${run.id} (${run.name}) for ${trustLabel}.`);
+            }
 
   auto-merge:
     name: Auto-merge approved PRs


### PR DESCRIPTION
### Motivation

- Reduce manual maintainer workload by automatically approving required forked workflow runs when the PR author has a sufficiently high trust tier.
- Ensure the `review-postprocess` job has the required permission to perform these approvals.

### Description

- Added `actions: write` to the `review-postprocess` job permissions so the workflow can approve other workflow runs. 
- Introduced a new step `Auto-approve pending fork workflows for trusted contributors` in the `review-postprocess` job that uses `actions/github-script@v7` to detect fork PRs, resolve the PR author's `trust:*` label (defaulting to `trust:probationary`), and auto-approve any workflow runs with `status === 'action_required'` when the trust label is one of `trust:contributing`, `trust:established`, `trust:trusted`, or `trust:legendary`.
- The step queries issue labels via `github.rest.issues.get`, lists workflow runs with `github.rest.actions.listWorkflowRunsForRepo`, and approves runs using the `POST /repos/{owner}/{repo}/actions/runs/{run_id}/approve` endpoint, with logging for skipped conditions and approved runs.

### Testing

- No automated tests were executed for this workflow change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae5da2b52c8332b54817697a1125ee)