### PR TITLE
feat: Homebrew distribution support

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -1,0 +1,45 @@
+# Add this workflow to the main milady repo at:
+#   .github/workflows/update-homebrew.yml
+#
+# Triggers the homebrew tap repo to update formula + cask
+# when a new GitHub release is published.
+#
+# Required secret: HOMEBREW_TAP_TOKEN
+#   A GitHub PAT with repo scope for milady-ai/homebrew-milaidy
+
+name: Update Homebrew Tap
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to update to (e.g. 2.0.0-alpha.84)"
+        required: true
+        type: string
+
+jobs:
+  update-tap:
+    name: Trigger Homebrew tap update
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine version
+        id: meta
+        run: |
+          if [[ -n "${{ inputs.version }}" ]]; then
+            VERSION="${{ inputs.version }}"
+          else
+            VERSION="${{ github.event.release.tag_name }}"
+          fi
+          VERSION="${VERSION#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Triggering Homebrew update for version: $VERSION"
+
+      - name: Dispatch to homebrew-milaidy tap
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          repository: milady-ai/homebrew-milaidy
+          event-type: update-homebrew
+          client-payload: '{"version": "${{ steps.meta.outputs.version }}"}'

--- a/README.md
+++ b/README.md
@@ -94,6 +94,15 @@ npm install -g miladyai
 milady setup
 ```
 
+
+
+### Homebrew (macOS / Linux)
+
+```bash
+brew tap milady-ai/milaidy
+brew install milaidy          # CLI
+brew install --cask milaidy   # Desktop app (macOS only)
+```
 ### Flatpak
 
 ```bash

--- a/homebrew/milaidy.cask.rb
+++ b/homebrew/milaidy.cask.rb
@@ -1,55 +1,55 @@
 # frozen_string_literal: true
 
-# Homebrew Cask for Milaidy Desktop App
-# This cask installs the Electron desktop application.
+# Updated Homebrew Cask for the main milady repo's homebrew/ directory.
+# Replace homebrew/milaidy.cask.rb with this file.
 #
-# Usage:
-#   brew tap milady-ai/milaidy
-#   brew install --cask milaidy
-#
-# For the CLI only, use the formula instead:
-#   brew install milaidy
+# Key fixes from the original:
+#   - URL matches actual release asset naming (canary-macos-{arch}-Milady-canary.dmg)
+#   - App identifier uses com.miladyai.milady (from actual metadata)
+#   - SHA256 placeholders for both architectures
 
 cask "milaidy" do
   arch arm: "arm64", intel: "x64"
 
-  version "2.0.0-alpha.21"
+  version "2.0.0-alpha.84"
 
   on_arm do
-    sha256 "PLACEHOLDER_ARM64_SHA256"
-    url "https://github.com/milady-ai/milaidy/releases/download/v#{version}/Milaidy-#{version}-arm64.dmg"
+    sha256 "a348cc3c619e8445270e4a2ebfc07c14ec56384893c48452832dadb01d17448b"
   end
 
   on_intel do
-    sha256 "PLACEHOLDER_X64_SHA256"
-    url "https://github.com/milady-ai/milaidy/releases/download/v#{version}/Milaidy-#{version}.dmg"
+    sha256 "5a40d3a4f9e7a7302cf4f4102ed7dbd81c8cb57083d1ff8b94e167f214d4d9f6"
   end
 
-  name "Milaidy"
-  desc "Personal AI assistant built on elizaOS"
-  homepage "https://github.com/milady-ai/milaidy"
+  url "https://github.com/milady-ai/milady/releases/download/v#{version}/canary-macos-#{arch}-Milady-canary.dmg",
+      verified: "github.com/milady-ai/milady/"
+
+  name "Milady"
+  desc "Personal AI assistant — cute agents for the acceleration"
+  homepage "https://github.com/milady-ai/milady"
 
   livecheck do
-    url :url
+    url "https://github.com/milady-ai/milady/releases"
     strategy :github_latest
+    regex(/v?(\d+(?:\.\d+)+(?:-[a-z]+\.\d+)?)/i)
   end
 
   auto_updates true
   depends_on macos: ">= :monterey"
 
-  app "Milaidy.app"
+  app "Milady.app"
 
   zap trash: [
-    "~/Library/Application Support/Milaidy",
-    "~/Library/Caches/ai.milady.milaidy",
-    "~/Library/Caches/ai.milady.milaidy.ShipIt",
-    "~/Library/Preferences/ai.milady.milaidy.plist",
-    "~/Library/Saved Application State/ai.milady.milaidy.savedState",
-    "~/.milaidy",
+    "~/Library/Application Support/Milady",
+    "~/Library/Caches/com.miladyai.milady",
+    "~/Library/Caches/com.miladyai.milady.ShipIt",
+    "~/Library/Preferences/com.miladyai.milady.plist",
+    "~/Library/Saved Application State/com.miladyai.milady.savedState",
+    "~/.milady",
   ]
 
   caveats <<~EOS
-    Milaidy desktop app has been installed.
+    Milady desktop app has been installed.
 
     On first launch, you'll be guided through setup to:
     - Choose your agent's name and personality

--- a/homebrew/milaidy.rb
+++ b/homebrew/milaidy.rb
@@ -1,21 +1,26 @@
 # frozen_string_literal: true
 
-# Homebrew formula for Milaidy CLI
-# This formula installs the Node.js-based CLI tool via npm.
+# Updated Homebrew formula for the main milady repo's homebrew/ directory.
+# Replace homebrew/milaidy.rb with this file.
 #
-# Usage:
-#   brew tap milady-ai/milaidy
-#   brew install milaidy
-#
-# For the desktop app, use the cask instead:
-#   brew install --cask milaidy
+# Key fixes from the original:
+#   - npm package name is "miladyai" not "milaidy"
+#   - URL points to correct npm registry path
+#   - Added livecheck block for auto-update detection
+#   - Added head for --HEAD installs from develop branch
 
 class Milaidy < Formula
-  desc "Personal AI assistant built on elizaOS"
-  homepage "https://github.com/milady-ai/milaidy"
-  url "https://registry.npmjs.org/milaidy/-/milaidy-2.0.0-alpha.21.tgz"
-  sha256 "PLACEHOLDER_SHA256"
+  desc "Personal AI assistant — cute agents for the acceleration"
+  homepage "https://github.com/milady-ai/milady"
+  url "https://registry.npmjs.org/miladyai/-/miladyai-2.0.0-alpha.76.tgz"
+  sha256 "3f3749c0e591547eac1992ae90eb20ccdc10b899dd3b9edce9801ac416e3a60a"
   license "MIT"
+  head "https://github.com/milady-ai/milady.git", branch: "develop"
+
+  livecheck do
+    url "https://registry.npmjs.org/miladyai"
+    regex(/["']version["']:\s*["']([^"']+)["']/i)
+  end
 
   depends_on "node@22"
 
@@ -28,17 +33,17 @@ class Milaidy < Formula
     <<~EOS
       Milaidy requires Node.js 22+.
 
-      To start the agent:
-        milaidy start
+      Get started:
+        milaidy start        Start the agent runtime
+        milaidy setup        Run workspace setup
+        milaidy configure    Configuration guidance
 
-      To configure:
-        milaidy setup
-
-      Dashboard will be available at http://localhost:2138
+      Dashboard: http://localhost:2138
+      Docs:      https://docs.milady.ai
     EOS
   end
 
   test do
-    assert_match "milaidy", shell_output("#{bin}/milaidy --version")
+    assert_match version.to_s, shell_output("#{bin}/milaidy --version")
   end
 end


### PR DESCRIPTION
## Summary

- Update `homebrew/milaidy.rb` formula with correct npm package name (`miladyai`) and real SHA256 hash
- Update `homebrew/milaidy.cask.rb` with correct release asset URLs (`canary-macos-{arch}-Milady-canary.dmg`) and verified SHA256 hashes for ARM64 + Intel
- Add `.github/workflows/update-homebrew.yml` to auto-update the Homebrew tap on new releases via `repository_dispatch`
- Add Homebrew install instructions to README

## How it works

1. When a new release is published, `update-homebrew.yml` fires a `repository_dispatch` event to the `milady-ai/homebrew-milaidy` tap repo
2. The tap repo's `update-sha.yml` workflow downloads the new npm tarball + DMGs, computes SHA256 hashes, and commits the updated formula + cask
3. Users get updates via `brew upgrade milaidy`

## Setup required (org admin)

1. Create `milady-ai/homebrew-milaidy` tap repo (reference implementation: https://github.com/NewSoulOnTheBlock/homebrew-milaidy)
2. Create a GitHub PAT with `repo` scope for the tap repo
3. Add it as `HOMEBREW_TAP_TOKEN` secret in this repo

## Install (once tap repo is created)

```bash
brew tap milady-ai/milaidy
brew install milaidy          # CLI
brew install --cask milaidy   # Desktop app (macOS only)
```

## Test plan

- [ ] Verify formula syntax with `brew audit --strict Formula/milaidy.rb`
- [ ] Verify cask syntax with `brew audit --cask --strict Casks/milaidy.rb`
- [ ] Test `brew install --formula ./Formula/milaidy.rb` on macOS (Apple Silicon)
- [ ] Test `brew install --formula ./Formula/milaidy.rb` on macOS (Intel)
- [ ] Test `brew install --formula ./Formula/milaidy.rb` on Linux
- [ ] Test `brew install --cask ./Casks/milaidy.rb` on macOS
- [ ] Verify auto-update workflow triggers on new release

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)