### PR TITLE
app: prefer direct electrobun renderer rpc

### DIFF
--- a/apps/app/electrobun/src/bridge/electrobun-bridge.ts
+++ b/apps/app/electrobun/src/bridge/electrobun-bridge.ts
@@ -484,6 +484,52 @@ const electronAPI = {
   },
 };
 
+type RpcMessageListener = (payload: unknown) => void;
+
+const rpcListenerWrappers: Record<
+  string,
+  Map<RpcMessageListener, IpcListener>
+> = {};
+
+const miladyElectrobunRpc = {
+  request: rpcRequest,
+  onMessage: (messageName: string, listener: RpcMessageListener): void => {
+    const channel = RPC_TO_PUSH_CHANNEL[messageName];
+    if (!channel) {
+      console.warn(
+        `[ElectrobunBridge] Unknown RPC message for onMessage: ${messageName}`,
+      );
+      return;
+    }
+
+    if (!rpcListenerWrappers[messageName]) {
+      rpcListenerWrappers[messageName] = new Map();
+    }
+    if (rpcListenerWrappers[messageName].has(listener)) {
+      return;
+    }
+
+    const wrappedListener: IpcListener = (_event, payload) => {
+      listener(payload);
+    };
+    rpcListenerWrappers[messageName].set(listener, wrappedListener);
+    electronAPI.ipcRenderer.on(channel, wrappedListener);
+  },
+  offMessage: (messageName: string, listener: RpcMessageListener): void => {
+    const channel = RPC_TO_PUSH_CHANNEL[messageName];
+    const wrappedListener = rpcListenerWrappers[messageName]?.get(listener);
+    if (!channel || !wrappedListener) {
+      return;
+    }
+
+    electronAPI.ipcRenderer.removeListener(channel, wrappedListener);
+    rpcListenerWrappers[messageName]?.delete(listener);
+    if (rpcListenerWrappers[messageName]?.size === 0) {
+      delete rpcListenerWrappers[messageName];
+    }
+  },
+};
+
 // Initialize platform version asynchronously
 electronAPI.ipcRenderer
   .invoke("desktop:getVersion")
@@ -503,9 +549,12 @@ declare global {
   interface Window {
     __MILADY_API_BASE__: string;
     __MILADY_API_TOKEN__: string;
+    __MILADY_ELECTROBUN_RPC__: typeof miladyElectrobunRpc;
     electron: typeof electronAPI;
   }
 }
+
+window.__MILADY_ELECTROBUN_RPC__ = miladyElectrobunRpc;
 
 // Expose as window.electron for backward compatibility
 window.electron = electronAPI;

--- a/apps/app/src/AppContext.tsx
+++ b/apps/app/src/AppContext.tsx
@@ -60,7 +60,10 @@ import {
   type WhitelistStatus,
   type WorkbenchOverview,
 } from "@milady/app-core/api";
-import { getBackendStartupTimeoutMs } from "@milady/app-core/bridge";
+import {
+  getBackendStartupTimeoutMs,
+  invokeDesktopBridgeRequest,
+} from "@milady/app-core/bridge";
 import {
   createTranslator,
   normalizeLanguage,
@@ -1558,17 +1561,11 @@ export function AppProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const restartBackend = useCallback(async () => {
-    const electron = (
-      window as {
-        electron?: {
-          ipcRenderer: { invoke: (channel: string) => Promise<unknown> };
-        };
-      }
-    ).electron;
-    if (electron?.ipcRenderer) {
-      // Electron: Use IPC to restart embedded agent
-      await electron.ipcRenderer.invoke("agent:restart");
-    } else {
+    const restarted = await invokeDesktopBridgeRequest({
+      rpcMethod: "agentRestart",
+      ipcChannel: "agent:restart",
+    });
+    if (restarted === null) {
       // Fallback for web: call API restart endpoint
       await client.restart();
     }

--- a/apps/app/src/components/GameView.tsx
+++ b/apps/app/src/components/GameView.tsx
@@ -9,6 +9,7 @@
  */
 
 import { client, type LogEntry } from "@milady/app-core/api";
+import { invokeDesktopBridgeRequest } from "@milady/app-core/bridge";
 import { formatTime } from "@milady/app-core/components";
 import { Button, Input } from "@milady/ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -174,17 +175,19 @@ export function GameView() {
 
     let cancelled = false;
 
-    window.electron.ipcRenderer
-      .invoke("game:openWindow", {
+    void invokeDesktopBridgeRequest<{ id: string }>({
+      rpcMethod: "gameOpenWindow",
+      ipcChannel: "game:openWindow",
+      params: {
         url: activeGameViewerUrl,
         title: activeGameDisplayName || activeGameApp || "Game",
-      })
+      },
+    })
       .then((result) => {
         if (cancelled) return;
-        const res = result as { id: string } | null;
-        if (res?.id) {
-          gameWindowIdRef.current = res.id;
-          setGameWindowId(res.id);
+        if (result?.id) {
+          gameWindowIdRef.current = result.id;
+          setGameWindowId(result.id);
           setConnectionStatus("connected");
         }
       })
@@ -197,9 +200,11 @@ export function GameView() {
       cancelled = true;
       // Close the game window when GameView unmounts or the URL changes
       if (gameWindowIdRef.current) {
-        window.electron.ipcRenderer
-          .invoke("canvas:destroyWindow", { id: gameWindowIdRef.current })
-          .catch(() => {});
+        void invokeDesktopBridgeRequest({
+          rpcMethod: "canvasDestroyWindow",
+          ipcChannel: "canvas:destroyWindow",
+          params: { id: gameWindowIdRef.current },
+        }).catch(() => {});
         gameWindowIdRef.current = null;
         setGameWindowId(null);
       }

--- a/apps/app/src/components/PermissionsSection.tsx
+++ b/apps/app/src/components/PermissionsSection.tsx
@@ -16,6 +16,7 @@ import {
   type PluginInfo,
   type SystemPermissionId,
 } from "@milady/app-core/api";
+import { invokeDesktopBridgeRequest } from "@milady/app-core/bridge";
 import { StatusBadge, Switch } from "@milady/app-core/components";
 import { Button } from "@milady/ui";
 import {
@@ -307,20 +308,14 @@ function usePermissionActions(
 
   const handleOpenSettings = useCallback(async (id: SystemPermissionId) => {
     try {
-      // Use IPC directly — the REST endpoint only returns an action code and
-      // never actually opens System Preferences in Electrobun.
-      const electron = (
-        window as {
-          electron?: {
-            ipcRenderer: {
-              invoke: (ch: string, p?: unknown) => Promise<unknown>;
-            };
-          };
-        }
-      ).electron;
-      if (electron?.ipcRenderer) {
-        await electron.ipcRenderer.invoke("permissions:openSettings", { id });
-      } else {
+      // The REST endpoint only returns an action code; desktop runtimes need the
+      // native bridge to actually open system settings.
+      const opened = await invokeDesktopBridgeRequest({
+        rpcMethod: "permissionsOpenSettings",
+        ipcChannel: "permissions:openSettings",
+        params: { id },
+      });
+      if (opened === null) {
         await client.openPermissionSettings(id);
       }
     } catch (err) {

--- a/apps/app/src/components/stream/helpers.ts
+++ b/apps/app/src/components/stream/helpers.ts
@@ -3,6 +3,7 @@
  */
 
 import type { StreamEventEnvelope } from "@milady/app-core/api";
+import { invokeDesktopBridgeRequest } from "@milady/app-core/bridge";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -118,18 +119,12 @@ export async function toggleAlwaysOnTop(pinned: boolean): Promise<boolean> {
         return pinned;
       }
     }
-    // Fallback: try Electron IPC directly
-    const electron = (window as unknown as Record<string, unknown>).electron as
-      | {
-          ipcRenderer?: {
-            invoke: (channel: string, ...args: unknown[]) => Promise<unknown>;
-          };
-        }
-      | undefined;
-    if (electron?.ipcRenderer) {
-      await electron.ipcRenderer.invoke("desktop:setAlwaysOnTop", {
-        flag: pinned,
-      });
+    const result = await invokeDesktopBridgeRequest({
+      rpcMethod: "desktopSetAlwaysOnTop",
+      ipcChannel: "desktop:setAlwaysOnTop",
+      params: { flag: pinned },
+    });
+    if (result !== null) {
       return pinned;
     }
   } catch {

--- a/apps/app/src/hooks/useContextMenu.ts
+++ b/apps/app/src/hooks/useContextMenu.ts
@@ -1,8 +1,9 @@
 /**
- * Listens for context-menu IPC events from the Electron main process
+ * Listens for native desktop context-menu events
  * and dispatches actions into the app state.
  */
 
+import { subscribeDesktopBridgeEvent } from "@milady/app-core/bridge";
 import { useCallback, useEffect, useState } from "react";
 import { useApp } from "../AppContext";
 import {
@@ -35,63 +36,63 @@ export function useContextMenu(): ContextMenuState {
     useState<CustomCommand[]>(loadCustomCommands);
 
   useEffect(() => {
-    const electron = (
-      window as {
-        electron?: {
-          ipcRenderer: {
-            on: (
-              channel: string,
-              listener: (...args: unknown[]) => void,
-            ) => void;
-            removeAllListeners: (channel: string) => void;
-          };
-        };
-      }
-    ).electron;
-    if (!electron) return;
-
-    const { ipcRenderer } = electron;
-
-    const onSaveAsCommand = (...args: unknown[]) => {
-      const payload = args[0] as { text: string } | undefined;
-      if (!payload?.text) return;
-      setSaveCommandText(payload.text);
+    const onSaveAsCommand = (payload: unknown) => {
+      const command = payload as { text: string } | undefined;
+      if (!command?.text) return;
+      setSaveCommandText(command.text);
       setSaveCommandModalOpen(true);
     };
 
-    const onAskAgent = (...args: unknown[]) => {
-      const payload = args[0] as { text: string } | undefined;
-      if (!payload?.text) return;
-      setState("chatInput", payload.text);
+    const onAskAgent = (payload: unknown) => {
+      const command = payload as { text: string } | undefined;
+      if (!command?.text) return;
+      setState("chatInput", command.text);
       // Defer send to next tick so chatInput state propagates
       setTimeout(() => handleChatSend(), 0);
     };
 
-    const onCreateSkill = (...args: unknown[]) => {
-      const payload = args[0] as { text: string } | undefined;
-      if (!payload?.text) return;
-      const prompt = `Create a skill from the following content:\n\n"""${payload.text}"""\n\nAnalyze this and create a reusable skill.`;
+    const onCreateSkill = (payload: unknown) => {
+      const command = payload as { text: string } | undefined;
+      if (!command?.text) return;
+      const prompt = `Create a skill from the following content:\n\n"""${command.text}"""\n\nAnalyze this and create a reusable skill.`;
       setState("chatInput", prompt);
       setTimeout(() => handleChatSend(), 0);
     };
 
-    const onQuoteInChat = (...args: unknown[]) => {
-      const payload = args[0] as { text: string } | undefined;
-      if (!payload?.text) return;
-      const quoted = `> ${payload.text}\n\n`;
+    const onQuoteInChat = (payload: unknown) => {
+      const command = payload as { text: string } | undefined;
+      if (!command?.text) return;
+      const quoted = `> ${command.text}\n\n`;
       setState("chatInput", quoted + chatInput);
     };
 
-    ipcRenderer.on("contextMenu:saveAsCommand", onSaveAsCommand);
-    ipcRenderer.on("contextMenu:askAgent", onAskAgent);
-    ipcRenderer.on("contextMenu:createSkill", onCreateSkill);
-    ipcRenderer.on("contextMenu:quoteInChat", onQuoteInChat);
+    const unsubscribers = [
+      subscribeDesktopBridgeEvent({
+        rpcMessage: "contextMenuSaveAsCommand",
+        ipcChannel: "contextMenu:saveAsCommand",
+        listener: onSaveAsCommand,
+      }),
+      subscribeDesktopBridgeEvent({
+        rpcMessage: "contextMenuAskAgent",
+        ipcChannel: "contextMenu:askAgent",
+        listener: onAskAgent,
+      }),
+      subscribeDesktopBridgeEvent({
+        rpcMessage: "contextMenuCreateSkill",
+        ipcChannel: "contextMenu:createSkill",
+        listener: onCreateSkill,
+      }),
+      subscribeDesktopBridgeEvent({
+        rpcMessage: "contextMenuQuoteInChat",
+        ipcChannel: "contextMenu:quoteInChat",
+        listener: onQuoteInChat,
+      }),
+    ];
 
     return () => {
-      ipcRenderer.removeAllListeners("contextMenu:saveAsCommand");
-      ipcRenderer.removeAllListeners("contextMenu:askAgent");
-      ipcRenderer.removeAllListeners("contextMenu:createSkill");
-      ipcRenderer.removeAllListeners("contextMenu:quoteInChat");
+      for (const unsubscribe of unsubscribers) {
+        unsubscribe();
+      }
     };
   }, [setState, chatInput, handleChatSend]);
 

--- a/apps/app/src/hooks/useRetakeCapture.ts
+++ b/apps/app/src/hooks/useRetakeCapture.ts
@@ -1,28 +1,19 @@
 /**
- * Hook that controls Electron main-process frame capture for retake.tv streaming.
+ * Hook that controls desktop native frame capture for retake.tv streaming.
  *
- * Uses Electron's `webContents.capturePage()` via IPC — this captures the full
- * compositor output including cross-origin iframes (unlike the old canvas approach
+ * Uses the native desktop capture path through the renderer bridge — this captures
+ * the full compositor output including cross-origin iframes (unlike the old canvas approach
  * which was blocked by same-origin policy).
  *
  * The main process handles capture + HTTP POST to /api/stream/frame directly.
  * This hook just sends start/stop signals.
  */
 
+import { invokeDesktopBridgeRequest } from "@milady/app-core/bridge";
 import { useEffect, useRef } from "react";
 
 const DEFAULT_FPS = 15;
 const JPEG_QUALITY = 70;
-
-declare global {
-  interface Window {
-    electron?: {
-      ipcRenderer: {
-        invoke: (channel: string, ...args: unknown[]) => Promise<unknown>;
-      };
-    };
-  }
-}
 
 export function useRetakeCapture(
   _iframeRef: React.RefObject<HTMLIFrameElement | null>,
@@ -32,20 +23,22 @@ export function useRetakeCapture(
   const activeRef = useRef(false);
 
   useEffect(() => {
-    const ipc = window.electron?.ipcRenderer;
-    if (!ipc) {
-      // Not running in Electron — fall back to no-op
-      return;
-    }
-
     if (active && !activeRef.current) {
       activeRef.current = true;
-      ipc
-        .invoke("screencapture:startFrameCapture", {
+      void invokeDesktopBridgeRequest({
+        rpcMethod: "screencaptureStartFrameCapture",
+        ipcChannel: "screencapture:startFrameCapture",
+        params: {
           fps,
           quality: JPEG_QUALITY,
           apiBase: window.__MILADY_API_BASE__ ?? "http://localhost:2138",
           endpoint: "/api/stream/frame",
+        },
+      })
+        .then((result) => {
+          if (result === null) {
+            activeRef.current = false;
+          }
         })
         .catch((err) => {
           console.warn("[retake] Failed to start frame capture:", err);
@@ -53,7 +46,10 @@ export function useRetakeCapture(
         });
     } else if (!active && activeRef.current) {
       activeRef.current = false;
-      ipc.invoke("screencapture:stopFrameCapture").catch((err) => {
+      void invokeDesktopBridgeRequest({
+        rpcMethod: "screencaptureStopFrameCapture",
+        ipcChannel: "screencapture:stopFrameCapture",
+      }).catch((err) => {
         console.warn("[retake] Failed to stop frame capture:", err);
       });
     }
@@ -61,7 +57,10 @@ export function useRetakeCapture(
     return () => {
       if (activeRef.current) {
         activeRef.current = false;
-        ipc.invoke("screencapture:stopFrameCapture").catch(() => {});
+        void invokeDesktopBridgeRequest({
+          rpcMethod: "screencaptureStopFrameCapture",
+          ipcChannel: "screencapture:stopFrameCapture",
+        }).catch(() => {});
       }
     };
   }, [active, fps]);

--- a/apps/app/src/utils/clipboard.ts
+++ b/apps/app/src/utils/clipboard.ts
@@ -1,13 +1,4 @@
-type ElectronBridge = {
-  ipcRenderer?: {
-    invoke: (channel: string, params?: unknown) => Promise<unknown>;
-  };
-};
-
-function getElectronBridge(): ElectronBridge["ipcRenderer"] | undefined {
-  return (window as typeof window & { electron?: ElectronBridge }).electron
-    ?.ipcRenderer;
-}
+import { invokeDesktopBridgeRequest } from "@milady/app-core/bridge";
 
 function copyTextWithExecCommand(text: string): void {
   const ta = document.createElement("textarea");
@@ -24,9 +15,12 @@ function copyTextWithExecCommand(text: string): void {
 }
 
 export async function copyTextToClipboard(text: string): Promise<void> {
-  const ipc = getElectronBridge();
-  if (ipc) {
-    await ipc.invoke("desktop:writeToClipboard", { text });
+  const copied = await invokeDesktopBridgeRequest({
+    rpcMethod: "desktopWriteToClipboard",
+    ipcChannel: "desktop:writeToClipboard",
+    params: { text },
+  });
+  if (copied !== null) {
     return;
   }
 

--- a/apps/app/src/utils/desktop-dialogs.ts
+++ b/apps/app/src/utils/desktop-dialogs.ts
@@ -1,8 +1,4 @@
-type ElectronBridge = {
-  ipcRenderer?: {
-    invoke: (channel: string, params?: unknown) => Promise<unknown>;
-  };
-};
+import { invokeDesktopBridgeRequest } from "@milady/app-core/bridge";
 
 type DesktopMessageBoxType = "info" | "warning" | "error" | "question";
 
@@ -37,11 +33,6 @@ interface DesktopAlertOptions {
   type?: DesktopMessageBoxType;
 }
 
-function getElectronBridge(): ElectronBridge["ipcRenderer"] | undefined {
-  return (window as typeof window & { electron?: ElectronBridge }).electron
-    ?.ipcRenderer;
-}
-
 function buildFallbackMessage(options: {
   title?: string;
   message?: string;
@@ -57,15 +48,11 @@ function buildFallbackMessage(options: {
 async function showDesktopMessageBox(
   options: DesktopMessageBoxOptions,
 ): Promise<DesktopMessageBoxResult | null> {
-  const ipc = getElectronBridge();
-  if (!ipc) {
-    return null;
-  }
-
-  return (await ipc.invoke(
-    "desktop:showMessageBox",
-    options,
-  )) as DesktopMessageBoxResult;
+  return await invokeDesktopBridgeRequest<DesktopMessageBoxResult>({
+    rpcMethod: "desktopShowMessageBox",
+    ipcChannel: "desktop:showMessageBox",
+    params: options,
+  });
 }
 
 export async function confirmDesktopAction(

--- a/apps/app/src/utils/openExternalUrl.ts
+++ b/apps/app/src/utils/openExternalUrl.ts
@@ -1,15 +1,12 @@
-type ElectronBridge = {
-  ipcRenderer?: {
-    invoke: (channel: string, params?: unknown) => Promise<unknown>;
-  };
-};
+import { invokeDesktopBridgeRequest } from "@milady/app-core/bridge";
 
 export async function openExternalUrl(url: string): Promise<void> {
-  const electron = (window as typeof window & { electron?: ElectronBridge })
-    .electron;
-
-  if (electron?.ipcRenderer) {
-    await electron.ipcRenderer.invoke("desktop:openExternal", { url });
+  const opened = await invokeDesktopBridgeRequest({
+    rpcMethod: "desktopOpenExternal",
+    ipcChannel: "desktop:openExternal",
+    params: { url },
+  });
+  if (opened !== null) {
     return;
   }
 

--- a/apps/app/test/app/desktop-utils.test.ts
+++ b/apps/app/test/app/desktop-utils.test.ts
@@ -8,6 +8,17 @@ import {
 } from "../../src/utils/desktop-dialogs";
 
 type TestWindow = Window & {
+  __MILADY_ELECTROBUN_RPC__?: {
+    request: Record<string, (params?: unknown) => Promise<unknown>>;
+    onMessage: (
+      messageName: string,
+      listener: (payload: unknown) => void,
+    ) => void;
+    offMessage: (
+      messageName: string,
+      listener: (payload: unknown) => void,
+    ) => void;
+  };
   electron?: {
     ipcRenderer?: {
       invoke: (channel: string, params?: unknown) => Promise<unknown>;
@@ -36,13 +47,18 @@ describe("desktop dialog and clipboard helpers", () => {
   });
 
   afterEach(() => {
+    delete (window as TestWindow).__MILADY_ELECTROBUN_RPC__;
     delete (window as TestWindow).electron;
     vi.restoreAllMocks();
   });
 
   it("uses the Electrobun message-box RPC for confirm dialogs", async () => {
-    const invoke = vi.fn().mockResolvedValue({ response: 0 });
-    (window as TestWindow).electron = { ipcRenderer: { invoke } };
+    const request = vi.fn().mockResolvedValue({ response: 0 });
+    (window as TestWindow).__MILADY_ELECTROBUN_RPC__ = {
+      request: { desktopShowMessageBox: request },
+      onMessage: vi.fn(),
+      offMessage: vi.fn(),
+    };
     const confirmSpy = vi.spyOn(window, "confirm");
 
     await expect(
@@ -52,7 +68,7 @@ describe("desktop dialog and clipboard helpers", () => {
       }),
     ).resolves.toBe(true);
 
-    expect(invoke).toHaveBeenCalledWith("desktop:showMessageBox", {
+    expect(request).toHaveBeenCalledWith({
       type: "question",
       title: "Delete Item",
       message: "Delete this item?",
@@ -78,8 +94,12 @@ describe("desktop dialog and clipboard helpers", () => {
   });
 
   it("uses the Electrobun message-box RPC for alerts", async () => {
-    const invoke = vi.fn().mockResolvedValue({ response: 0 });
-    (window as TestWindow).electron = { ipcRenderer: { invoke } };
+    const request = vi.fn().mockResolvedValue({ response: 0 });
+    (window as TestWindow).__MILADY_ELECTROBUN_RPC__ = {
+      request: { desktopShowMessageBox: request },
+      onMessage: vi.fn(),
+      offMessage: vi.fn(),
+    };
     const alertSpy = vi.spyOn(window, "alert");
 
     await expect(
@@ -90,7 +110,7 @@ describe("desktop dialog and clipboard helpers", () => {
       }),
     ).resolves.toBeUndefined();
 
-    expect(invoke).toHaveBeenCalledWith("desktop:showMessageBox", {
+    expect(request).toHaveBeenCalledWith({
       type: "error",
       title: "Reset Failed",
       message: "Check the logs.",
@@ -103,13 +123,17 @@ describe("desktop dialog and clipboard helpers", () => {
   });
 
   it("uses the Electrobun clipboard RPC when available", async () => {
-    const invoke = vi.fn().mockResolvedValue(undefined);
-    (window as TestWindow).electron = { ipcRenderer: { invoke } };
+    const request = vi.fn().mockResolvedValue(undefined);
+    (window as TestWindow).__MILADY_ELECTROBUN_RPC__ = {
+      request: { desktopWriteToClipboard: request },
+      onMessage: vi.fn(),
+      offMessage: vi.fn(),
+    };
     const clipboardSpy = vi.spyOn(navigator.clipboard, "writeText");
 
     await copyTextToClipboard("milady");
 
-    expect(invoke).toHaveBeenCalledWith("desktop:writeToClipboard", {
+    expect(request).toHaveBeenCalledWith({
       text: "milady",
     });
     expect(clipboardSpy).not.toHaveBeenCalled();

--- a/apps/app/test/app/electrobun-rpc-bridge.test.ts
+++ b/apps/app/test/app/electrobun-rpc-bridge.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+
+import {
+  type ElectrobunRendererRpc,
+  type ElectronIpcRenderer,
+  invokeDesktopBridgeRequest,
+  subscribeDesktopBridgeEvent,
+} from "@milady/app-core/bridge";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type TestWindow = Window & {
+  __MILADY_ELECTROBUN_RPC__?: ElectrobunRendererRpc;
+  electron?: { ipcRenderer?: ElectronIpcRenderer };
+};
+
+describe("electrobun rpc bridge", () => {
+  afterEach(() => {
+    delete (window as TestWindow).__MILADY_ELECTROBUN_RPC__;
+    delete (window as TestWindow).electron;
+    vi.restoreAllMocks();
+  });
+
+  it("prefers direct Electrobun RPC requests over Electron IPC", async () => {
+    const rpcRequest = vi.fn().mockResolvedValue({ ok: true });
+    const ipcInvoke = vi.fn().mockResolvedValue({ ok: false });
+    (window as TestWindow).__MILADY_ELECTROBUN_RPC__ = {
+      request: { desktopOpenExternal: rpcRequest },
+      onMessage: vi.fn(),
+      offMessage: vi.fn(),
+    };
+    (window as TestWindow).electron = { ipcRenderer: { invoke: ipcInvoke } };
+
+    await expect(
+      invokeDesktopBridgeRequest({
+        rpcMethod: "desktopOpenExternal",
+        ipcChannel: "desktop:openExternal",
+        params: { url: "https://example.com" },
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    expect(rpcRequest).toHaveBeenCalledWith({ url: "https://example.com" });
+    expect(ipcInvoke).not.toHaveBeenCalled();
+  });
+
+  it("falls back to Electron IPC when direct Electrobun RPC is unavailable", async () => {
+    const ipcInvoke = vi.fn().mockResolvedValue({ ok: true });
+    (window as TestWindow).electron = { ipcRenderer: { invoke: ipcInvoke } };
+
+    await expect(
+      invokeDesktopBridgeRequest({
+        rpcMethod: "desktopOpenExternal",
+        ipcChannel: "desktop:openExternal",
+        params: { url: "https://example.com" },
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    expect(ipcInvoke).toHaveBeenCalledWith("desktop:openExternal", {
+      url: "https://example.com",
+    });
+  });
+
+  it("subscribes to direct Electrobun RPC messages when available", () => {
+    const listeners = new Map<string, Set<(payload: unknown) => void>>();
+    (window as TestWindow).__MILADY_ELECTROBUN_RPC__ = {
+      request: {},
+      onMessage: vi.fn(
+        (messageName: string, listener: (payload: unknown) => void) => {
+          const entry = listeners.get(messageName) ?? new Set();
+          entry.add(listener);
+          listeners.set(messageName, entry);
+        },
+      ),
+      offMessage: vi.fn(
+        (messageName: string, listener: (payload: unknown) => void) => {
+          listeners.get(messageName)?.delete(listener);
+        },
+      ),
+    };
+
+    const listener = vi.fn();
+    const unsubscribe = subscribeDesktopBridgeEvent({
+      rpcMessage: "contextMenuSaveAsCommand",
+      ipcChannel: "contextMenu:saveAsCommand",
+      listener,
+    });
+
+    listeners.get("contextMenuSaveAsCommand")?.forEach((fn) => {
+      fn({ text: "hello" });
+    });
+
+    expect(listener).toHaveBeenCalledWith({ text: "hello" });
+
+    unsubscribe();
+    expect(listeners.get("contextMenuSaveAsCommand")?.size ?? 0).toBe(0);
+  });
+});

--- a/apps/app/test/app/open-external-url.test.ts
+++ b/apps/app/test/app/open-external-url.test.ts
@@ -4,6 +4,17 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { openExternalUrl } from "../../src/utils/openExternalUrl";
 
 type TestWindow = Window & {
+  __MILADY_ELECTROBUN_RPC__?: {
+    request: Record<string, (params?: unknown) => Promise<unknown>>;
+    onMessage: (
+      messageName: string,
+      listener: (payload: unknown) => void,
+    ) => void;
+    offMessage: (
+      messageName: string,
+      listener: (payload: unknown) => void,
+    ) => void;
+  };
   electron?: {
     ipcRenderer?: {
       invoke: (channel: string, params?: unknown) => Promise<unknown>;
@@ -13,18 +24,23 @@ type TestWindow = Window & {
 
 describe("openExternalUrl", () => {
   afterEach(() => {
+    delete (window as TestWindow).__MILADY_ELECTROBUN_RPC__;
     delete (window as TestWindow).electron;
     vi.restoreAllMocks();
   });
 
   it("uses the Electrobun desktop bridge when available", async () => {
-    const invoke = vi.fn().mockResolvedValue(undefined);
-    (window as TestWindow).electron = { ipcRenderer: { invoke } };
+    const request = vi.fn().mockResolvedValue(undefined);
+    (window as TestWindow).__MILADY_ELECTROBUN_RPC__ = {
+      request: { desktopOpenExternal: request },
+      onMessage: vi.fn(),
+      offMessage: vi.fn(),
+    };
     const openSpy = vi.spyOn(window, "open");
 
     await openExternalUrl("https://claude.ai");
 
-    expect(invoke).toHaveBeenCalledWith("desktop:openExternal", {
+    expect(request).toHaveBeenCalledWith({
       url: "https://claude.ai",
     });
     expect(openSpy).not.toHaveBeenCalled();

--- a/apps/app/test/app/retake-capture.test.ts
+++ b/apps/app/test/app/retake-capture.test.ts
@@ -18,22 +18,30 @@ function HookHost({
 }
 
 describe("useRetakeCapture", () => {
-  const mockInvoke = vi.fn().mockResolvedValue(undefined);
+  const mockStart = vi.fn().mockResolvedValue(undefined);
+  const mockStop = vi.fn().mockResolvedValue(undefined);
 
   beforeEach(() => {
-    // The hook now uses window.electron?.ipcRenderer.invoke
-    Object.defineProperty(window, "electron", {
-      value: { ipcRenderer: { invoke: mockInvoke } },
+    Object.defineProperty(window, "__MILADY_ELECTROBUN_RPC__", {
+      value: {
+        request: {
+          screencaptureStartFrameCapture: mockStart,
+          screencaptureStopFrameCapture: mockStop,
+        },
+        onMessage: vi.fn(),
+        offMessage: vi.fn(),
+      },
       writable: true,
       configurable: true,
     });
-    mockInvoke.mockReset().mockResolvedValue(undefined);
+    mockStart.mockReset().mockResolvedValue(undefined);
+    mockStop.mockReset().mockResolvedValue(undefined);
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
-    // @ts-expect-error cleanup electron stub
-    delete window.electron;
+    // @ts-expect-error cleanup rpc stub
+    delete window.__MILADY_ELECTROBUN_RPC__;
   });
 
   it("does not start capture when active is false", () => {
@@ -47,10 +55,7 @@ describe("useRetakeCapture", () => {
       );
     });
 
-    expect(mockInvoke).not.toHaveBeenCalledWith(
-      "screencapture:startFrameCapture",
-      expect.anything(),
-    );
+    expect(mockStart).not.toHaveBeenCalled();
   });
 
   it("cleans up capture on unmount", () => {
@@ -65,8 +70,7 @@ describe("useRetakeCapture", () => {
       );
     });
 
-    expect(mockInvoke).toHaveBeenCalledWith(
-      "screencapture:startFrameCapture",
+    expect(mockStart).toHaveBeenCalledWith(
       expect.objectContaining({ fps: expect.any(Number) }),
     );
 
@@ -74,6 +78,6 @@ describe("useRetakeCapture", () => {
       renderer.unmount();
     });
 
-    expect(mockInvoke).toHaveBeenCalledWith("screencapture:stopFrameCapture");
+    expect(mockStop).toHaveBeenCalledWith(undefined);
   });
 });

--- a/apps/app/test/app/stream-helpers.test.ts
+++ b/apps/app/test/app/stream-helpers.test.ts
@@ -4,6 +4,17 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { toggleAlwaysOnTop } from "../../src/components/stream/helpers";
 
 type TestWindow = Window & {
+  __MILADY_ELECTROBUN_RPC__?: {
+    request: Record<string, (params?: unknown) => Promise<unknown>>;
+    onMessage: (
+      messageName: string,
+      listener: (payload: unknown) => void,
+    ) => void;
+    offMessage: (
+      messageName: string,
+      listener: (payload: unknown) => void,
+    ) => void;
+  };
   electron?: {
     ipcRenderer?: {
       invoke: (channel: string, params?: unknown) => Promise<unknown>;
@@ -14,17 +25,27 @@ type TestWindow = Window & {
 describe("toggleAlwaysOnTop", () => {
   afterEach(() => {
     delete (window as typeof window & { Capacitor?: unknown }).Capacitor;
+    delete (window as TestWindow).__MILADY_ELECTROBUN_RPC__;
     delete (window as TestWindow).electron;
     vi.restoreAllMocks();
   });
 
-  it("uses the Electrobun ipcRenderer fallback", async () => {
-    const invoke = vi.fn().mockResolvedValue(undefined);
-    (window as TestWindow).electron = { ipcRenderer: { invoke } };
+  it("uses the direct Electrobun RPC bridge", async () => {
+    const request = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window, "Capacitor", {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+    (window as TestWindow).__MILADY_ELECTROBUN_RPC__ = {
+      request: { desktopSetAlwaysOnTop: request },
+      onMessage: vi.fn(),
+      offMessage: vi.fn(),
+    };
 
     await expect(toggleAlwaysOnTop(true)).resolves.toBe(true);
 
-    expect(invoke).toHaveBeenCalledWith("desktop:setAlwaysOnTop", {
+    expect(request).toHaveBeenCalledWith({
       flag: true,
     });
   });

--- a/packages/app-core/src/bridge/electrobun-rpc.ts
+++ b/packages/app-core/src/bridge/electrobun-rpc.ts
@@ -1,0 +1,101 @@
+export type ElectrobunRequestHandler = (params?: unknown) => Promise<unknown>;
+
+export type ElectrobunMessageListener = (payload: unknown) => void;
+
+export interface ElectrobunRendererRpc {
+  request: Record<string, ElectrobunRequestHandler>;
+  onMessage: (messageName: string, listener: ElectrobunMessageListener) => void;
+  offMessage: (
+    messageName: string,
+    listener: ElectrobunMessageListener,
+  ) => void;
+}
+
+export interface ElectronIpcRenderer {
+  invoke: (channel: string, params?: unknown) => Promise<unknown>;
+  on?: (
+    channel: string,
+    listener: (event: unknown, payload: unknown) => void,
+  ) => void;
+  removeListener?: (
+    channel: string,
+    listener: (event: unknown, payload: unknown) => void,
+  ) => void;
+  removeAllListeners?: (channel: string) => void;
+}
+
+interface DesktopBridgeWindow extends Window {
+  __MILADY_ELECTROBUN_RPC__?: ElectrobunRendererRpc;
+  electron?: {
+    ipcRenderer?: ElectronIpcRenderer;
+  };
+}
+
+function getDesktopBridgeWindow(): DesktopBridgeWindow | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  return window as DesktopBridgeWindow;
+}
+
+export function getElectrobunRendererRpc(): ElectrobunRendererRpc | undefined {
+  return getDesktopBridgeWindow()?.__MILADY_ELECTROBUN_RPC__;
+}
+
+export function getElectronIpcRenderer(): ElectronIpcRenderer | undefined {
+  return getDesktopBridgeWindow()?.electron?.ipcRenderer;
+}
+
+export async function invokeDesktopBridgeRequest<T>(options: {
+  rpcMethod: string;
+  ipcChannel: string;
+  params?: unknown;
+}): Promise<T | null> {
+  const rpc = getElectrobunRendererRpc();
+  const request = rpc?.request?.[options.rpcMethod];
+  if (request) {
+    return (await request(options.params)) as T;
+  }
+
+  const ipc = getElectronIpcRenderer();
+  if (ipc) {
+    return (await ipc.invoke(options.ipcChannel, options.params)) as T;
+  }
+
+  return null;
+}
+
+export function subscribeDesktopBridgeEvent(options: {
+  rpcMessage: string;
+  ipcChannel: string;
+  listener: ElectrobunMessageListener;
+}): () => void {
+  const rpc = getElectrobunRendererRpc();
+  if (rpc) {
+    rpc.onMessage(options.rpcMessage, options.listener);
+    return () => {
+      rpc.offMessage(options.rpcMessage, options.listener);
+    };
+  }
+
+  const ipc = getElectronIpcRenderer();
+  if (!ipc?.on) {
+    return () => {};
+  }
+
+  const ipcListener = (_event: unknown, payload: unknown) => {
+    options.listener(payload);
+  };
+
+  ipc.on(options.ipcChannel, ipcListener);
+
+  return () => {
+    if (ipc.removeListener) {
+      ipc.removeListener(options.ipcChannel, ipcListener);
+      return;
+    }
+
+    ipc.removeAllListeners?.(options.ipcChannel);
+  };
+}

--- a/packages/app-core/src/bridge/index.ts
+++ b/packages/app-core/src/bridge/index.ts
@@ -1,4 +1,5 @@
 export * from "./capacitor-bridge";
+export * from "./electrobun-rpc";
 export * from "./electrobun-runtime";
 export * from "./plugin-bridge";
 export * from "./storage-bridge";

--- a/packages/app-core/src/hooks/useCanvasWindow.ts
+++ b/packages/app-core/src/hooks/useCanvasWindow.ts
@@ -6,15 +6,15 @@
  * appears to be "embedded" because it is always kept aligned with the div.
  *
  * Works in:
- *   - Electrobun — calls via window.electron.ipcRenderer (wired through
- *     electrobun-bridge.ts which maps channel → electroview RPC)
- *   - Electron — same window.electron.ipcRenderer path works directly
+ *   - Electrobun — calls via the preload-exposed renderer RPC
+ *   - Electron — falls back to window.electron.ipcRenderer
  *
  * Falls back gracefully (isReady=false, no window created) when neither
  * runtime is detected (web / Capacitor / SSR).
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { invokeDesktopBridgeRequest } from "../bridge";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -42,23 +42,6 @@ export interface UseCanvasWindowResult {
   show: () => void;
   /** Hide the canvas window. */
   hide: () => void;
-}
-
-// ---------------------------------------------------------------------------
-// IPC helper
-// ---------------------------------------------------------------------------
-
-function getIpc(): {
-  invoke: (channel: string, ...args: unknown[]) => Promise<unknown>;
-} | null {
-  // Both Electrobun (via electrobun-bridge.ts) and Electron expose this.
-  return (
-    ((window as Window & { electron?: { ipcRenderer?: unknown } }).electron
-      ?.ipcRenderer as
-      | { invoke: (channel: string, ...args: unknown[]) => Promise<unknown> }
-      | null
-      | undefined) ?? null
-  );
 }
 
 // ---------------------------------------------------------------------------
@@ -100,7 +83,7 @@ export function useCanvasWindow(
   const titleRef = useRef(title);
   titleRef.current = title;
 
-  // Track last-synced bounds to avoid redundant IPC calls.
+  // Track last-synced bounds to avoid redundant bridge calls.
   const lastBoundsRef = useRef<{
     x: number;
     y: number;
@@ -118,8 +101,7 @@ export function useCanvasWindow(
   const syncBounds = useCallback(() => {
     const el = containerRef.current;
     const id = windowIdRef.current;
-    const ipc = getIpc();
-    if (!el || !id || !ipc) return;
+    if (!el || !id) return;
 
     const bounds = getScreenRect(el);
 
@@ -131,12 +113,16 @@ export function useCanvasWindow(
       last.width === bounds.width &&
       last.height === bounds.height
     ) {
-      return; // Nothing changed — skip the IPC call.
+      return; // Nothing changed — skip the bridge call.
     }
 
     lastBoundsRef.current = bounds;
 
-    ipc.invoke("canvas:setBounds", { id, ...bounds }).catch((err: unknown) => {
+    void invokeDesktopBridgeRequest({
+      rpcMethod: "canvasSetBounds",
+      ipcChannel: "canvas:setBounds",
+      params: { id, ...bounds },
+    }).catch((err: unknown) => {
       console.warn("[useCanvasWindow] canvas:setBounds failed", err);
     });
   }, []);
@@ -167,12 +153,6 @@ export function useCanvasWindow(
   useEffect(() => {
     if (!enabled) return;
 
-    const ipc = getIpc();
-    if (!ipc) {
-      // Not in a supported desktop runtime — stay in fallback state.
-      return;
-    }
-
     let destroyed = false;
     let createdId: string | null = null;
 
@@ -182,26 +162,36 @@ export function useCanvasWindow(
       ? getScreenRect(el)
       : { x: 100, y: 100, width: 800, height: 600 };
 
-    ipc
-      .invoke("canvas:createWindow", {
+    void invokeDesktopBridgeRequest<{ id?: string }>({
+      rpcMethod: "canvasCreateWindow",
+      ipcChannel: "canvas:createWindow",
+      params: {
         url: urlRef.current,
         title: titleRef.current ?? "Canvas",
         x: initial.x,
         y: initial.y,
         width: initial.width,
         height: initial.height,
-      })
+      },
+    })
       .then((result) => {
+        if (!result) {
+          return;
+        }
         if (destroyed) {
           // Component unmounted before the promise resolved — clean up.
-          const id = (result as { id?: string })?.id;
+          const id = result.id;
           if (id) {
-            ipc.invoke("canvas:destroyWindow", { id }).catch(() => {});
+            void invokeDesktopBridgeRequest({
+              rpcMethod: "canvasDestroyWindow",
+              ipcChannel: "canvas:destroyWindow",
+              params: { id },
+            }).catch(() => {});
           }
           return;
         }
 
-        const id = (result as { id?: string })?.id;
+        const id = result.id;
         if (!id) {
           console.warn("[useCanvasWindow] canvasCreateWindow returned no id");
           return;
@@ -238,7 +228,11 @@ export function useCanvasWindow(
         setWindowId(null);
         setIsReady(false);
         lastBoundsRef.current = null;
-        ipc.invoke("canvas:destroyWindow", { id }).catch(() => {});
+        void invokeDesktopBridgeRequest({
+          rpcMethod: "canvasDestroyWindow",
+          ipcChannel: "canvas:destroyWindow",
+          params: { id },
+        }).catch(() => {});
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -249,28 +243,37 @@ export function useCanvasWindow(
   // ---------------------------------------------------------------------------
 
   const navigate = useCallback((newUrl: string) => {
-    const ipc = getIpc();
     const id = windowIdRef.current;
-    if (!ipc || !id) return;
-    ipc.invoke("canvas:navigate", { id, url: newUrl }).catch((err: unknown) => {
+    if (!id) return;
+    void invokeDesktopBridgeRequest({
+      rpcMethod: "canvasNavigate",
+      ipcChannel: "canvas:navigate",
+      params: { id, url: newUrl },
+    }).catch((err: unknown) => {
       console.warn("[useCanvasWindow] canvas:navigate failed", err);
     });
   }, []);
 
   const show = useCallback(() => {
-    const ipc = getIpc();
     const id = windowIdRef.current;
-    if (!ipc || !id) return;
-    ipc.invoke("canvas:show", { id }).catch((err: unknown) => {
+    if (!id) return;
+    void invokeDesktopBridgeRequest({
+      rpcMethod: "canvasShow",
+      ipcChannel: "canvas:show",
+      params: { id },
+    }).catch((err: unknown) => {
       console.warn("[useCanvasWindow] canvas:show failed", err);
     });
   }, []);
 
   const hide = useCallback(() => {
-    const ipc = getIpc();
     const id = windowIdRef.current;
-    if (!ipc || !id) return;
-    ipc.invoke("canvas:hide", { id }).catch((err: unknown) => {
+    if (!id) return;
+    void invokeDesktopBridgeRequest({
+      rpcMethod: "canvasHide",
+      ipcChannel: "canvas:hide",
+      params: { id },
+    }).catch((err: unknown) => {
       console.warn("[useCanvasWindow] canvas:hide failed", err);
     });
   }, []);


### PR DESCRIPTION
## Summary
- move app-owned Electrobun desktop calls to the direct renderer RPC helper
- keep the preload compatibility layer for legacy Electron-style consumers and plugin adapters
- add focused bridge tests for RPC request and event subscription behavior

## Validation
- bun run check
- bun run pre-review:local