### PR TITLE
app: migrate location plugin to electrobun rpc

### DIFF
--- a/apps/app/plugins/location/electron/src/index.ts
+++ b/apps/app/plugins/location/electron/src/index.ts
@@ -254,12 +254,14 @@ export class LocationElectron implements LocationPlugin {
     watchId: string,
     data: unknown,
   ): LocationResult | null {
-    if (
-      this.isNativeWatchPayload(data) &&
-      data.watchId === watchId &&
-      this.isNativePosition(data.location)
-    ) {
-      return data.location;
+    if (this.isNativeWatchPayload(data) && data.watchId === watchId) {
+      if (this.isLocationResult(data.location)) {
+        return data.location;
+      }
+
+      if (this.isNativePosition(data.location)) {
+        return this.toNativeLocationResult(data.location);
+      }
     }
 
     if (this.isNativePosition(data)) {
@@ -271,13 +273,35 @@ export class LocationElectron implements LocationPlugin {
 
   private isNativeWatchPayload(
     value: unknown,
-  ): value is { watchId: string; location: LocationResult } {
+  ): value is { watchId: string; location: unknown } {
     return (
       typeof value === "object" &&
       value !== null &&
       "watchId" in value &&
       typeof value.watchId === "string" &&
       "location" in value
+    );
+  }
+
+  private isLocationResult(value: unknown): value is LocationResult {
+    if (typeof value !== "object" || value === null || !("coords" in value)) {
+      return false;
+    }
+
+    const { coords, cached } = value;
+    return (
+      typeof coords === "object" &&
+      coords !== null &&
+      "latitude" in coords &&
+      typeof coords.latitude === "number" &&
+      "longitude" in coords &&
+      typeof coords.longitude === "number" &&
+      "accuracy" in coords &&
+      typeof coords.accuracy === "number" &&
+      "timestamp" in coords &&
+      typeof coords.timestamp === "number" &&
+      "cached" in value &&
+      typeof cached === "boolean"
     );
   }
 

--- a/apps/app/test/app/location-electron-rpc.test.ts
+++ b/apps/app/test/app/location-electron-rpc.test.ts
@@ -113,4 +113,88 @@ describe("LocationElectron direct Electrobun RPC bridge", () => {
     });
     expect(listeners.get("locationUpdate")?.size ?? 0).toBe(0);
   });
+
+  it("handles wrapped IPC fallback watch payloads for native location updates", async () => {
+    const ipcListeners = new Map<
+      string,
+      Set<(event: unknown, payload: unknown) => void>
+    >();
+    const invoke = vi.fn(async (channel: string) => {
+      if (channel === "location:watchPosition") {
+        return { watchId: "ipc-watch-1" };
+      }
+
+      if (channel === "location:clearWatch") {
+        return undefined;
+      }
+
+      throw new Error(`Unexpected channel: ${channel}`);
+    });
+
+    (window as TestWindow).electron = {
+      ipcRenderer: {
+        invoke,
+        on: vi.fn(
+          (
+            channel: string,
+            listener: (event: unknown, payload: unknown) => void,
+          ) => {
+            const entry = ipcListeners.get(channel) ?? new Set();
+            entry.add(listener);
+            ipcListeners.set(channel, entry);
+          },
+        ),
+        removeListener: vi.fn(
+          (
+            channel: string,
+            listener: (event: unknown, payload: unknown) => void,
+          ) => {
+            ipcListeners.get(channel)?.delete(listener);
+          },
+        ),
+      },
+    };
+
+    const plugin = new LocationElectron();
+    const changeListener = vi.fn();
+    await plugin.addListener("locationChange", changeListener);
+
+    await expect(plugin.watchPosition()).resolves.toEqual({
+      watchId: "ipc-watch-1",
+    });
+
+    ipcListeners.get("location:update")?.forEach((listener) => {
+      listener(
+        { sender: "test" },
+        {
+          watchId: "ipc-watch-1",
+          location: {
+            coords: {
+              latitude: 37.7749,
+              longitude: -122.4194,
+              accuracy: 18,
+              timestamp: 24681012,
+            },
+            cached: false,
+          },
+        },
+      );
+    });
+
+    expect(changeListener).toHaveBeenCalledWith({
+      coords: {
+        latitude: 37.7749,
+        longitude: -122.4194,
+        accuracy: 18,
+        timestamp: 24681012,
+      },
+      cached: false,
+    });
+
+    await plugin.clearWatch({ watchId: "ipc-watch-1" });
+    expect(invoke).toHaveBeenCalledWith("location:clearWatch", {
+      watchId: "ipc-watch-1",
+    });
+    expect(ipcListeners.get("location:update")?.size ?? 0).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary
- migrate the location electron adapter to the shared Electrobun desktop bridge
- preserve the legacy IPC fallback path for wrapped watch payloads
- add focused bridge coverage for direct RPC and IPC fallback watch updates

## Testing
- bunx vitest run apps/app/test/app/location-electron-rpc.test.ts
- bun run check
- bun run pre-review:local