### PR TITLE
app: migrate gateway discovery to electrobun rpc

### DIFF
--- a/apps/app/plugins/gateway/electron/src/index.ts
+++ b/apps/app/plugins/gateway/electron/src/index.ts
@@ -9,6 +9,10 @@
  */
 
 import type { PluginListenerHandle } from "@capacitor/core";
+import {
+  invokeDesktopBridgeRequest,
+  subscribeDesktopBridgeEvent,
+} from "@milady/app-core/bridge";
 import type {
   GatewayConnectOptions,
   GatewayConnectResult,
@@ -37,32 +41,6 @@ type GatewayEventName = "gatewayEvent" | "stateChange" | "error" | "discovery";
 interface ListenerEntry {
   eventName: GatewayEventName;
   callback: EventCallback<GatewayEventData>;
-}
-
-type IpcPrimitive = string | number | boolean | null | undefined;
-type IpcObject = { [key: string]: IpcValue };
-type IpcValue =
-  | IpcPrimitive
-  | IpcObject
-  | IpcValue[]
-  | ArrayBuffer
-  | Float32Array
-  | Uint8Array;
-type IpcListener = (...args: IpcValue[]) => void;
-
-// Type for Electron IPC
-interface ElectronAPI {
-  ipcRenderer: {
-    invoke(channel: string, ...args: IpcValue[]): Promise<IpcValue>;
-    on(channel: string, listener: IpcListener): void;
-    removeListener(channel: string, listener: IpcListener): void;
-  };
-}
-
-declare global {
-  interface Window {
-    electron?: ElectronAPI;
-  }
 }
 
 interface PendingRequest {
@@ -137,8 +115,7 @@ export class GatewayElectron implements GatewayPlugin {
   private listeners: ListenerEntry[] = [];
   private discoveredGateways: Map<string, GatewayEndpoint> = new Map();
   private isDiscovering = false;
-  private discoveryIPCHandler: ((event: GatewayDiscoveryEvent) => void) | null =
-    null;
+  private discoveryUnsubscribe: (() => void) | null = null;
 
   // MARK: - Connection Methods
 
@@ -489,42 +466,40 @@ export class GatewayElectron implements GatewayPlugin {
       };
     }
 
-    if (window.electron?.ipcRenderer) {
-      try {
-        this.isDiscovering = true;
-        this.discoveredGateways.clear();
+    try {
+      this.isDiscovering = true;
+      this.discoveredGateways.clear();
+      this.clearDiscoverySubscription();
 
-        this.discoveryIPCHandler = (event: GatewayDiscoveryEvent) => {
-          this.handleDiscoveryEvent(event);
-        };
-        window.electron.ipcRenderer.on(
-          "gateway:discovery",
-          this.discoveryIPCHandler,
-        );
+      this.discoveryUnsubscribe = subscribeDesktopBridgeEvent({
+        rpcMessage: "gatewayDiscovery",
+        ipcChannel: "gateway:discovery",
+        listener: (event) => {
+          if (this.isGatewayDiscoveryEvent(event)) {
+            this.handleDiscoveryEvent(event);
+          }
+        },
+      });
 
-        await window.electron.ipcRenderer.invoke("gateway:startDiscovery", {
+      const result = await invokeDesktopBridgeRequest<GatewayDiscoveryResult>({
+        rpcMethod: "gatewayStartDiscovery",
+        ipcChannel: "gateway:startDiscovery",
+        params: {
           wideAreaDomain: options?.wideAreaDomain,
           timeout: options?.timeout || 30000,
-        });
+        },
+      });
 
-        return {
-          gateways: [],
-          status: "Discovery started",
-        };
-      } catch (error) {
-        this.isDiscovering = false;
-        if (this.discoveryIPCHandler && window.electron?.ipcRenderer) {
-          window.electron.ipcRenderer.removeListener(
-            "gateway:discovery",
-            this.discoveryIPCHandler,
-          );
-          this.discoveryIPCHandler = null;
-        }
-        console.warn(
-          "[Gateway] Native discovery failed, using fallback:",
-          error,
-        );
+      if (result) {
+        return result;
       }
+
+      this.isDiscovering = false;
+      this.clearDiscoverySubscription();
+    } catch (error) {
+      this.isDiscovering = false;
+      this.clearDiscoverySubscription();
+      console.warn("[Gateway] Native discovery failed, using fallback:", error);
     }
 
     console.warn(
@@ -539,19 +514,14 @@ export class GatewayElectron implements GatewayPlugin {
   async stopDiscovery(): Promise<void> {
     this.isDiscovering = false;
 
-    if (window.electron?.ipcRenderer) {
-      if (this.discoveryIPCHandler) {
-        window.electron.ipcRenderer.removeListener(
-          "gateway:discovery",
-          this.discoveryIPCHandler,
-        );
-        this.discoveryIPCHandler = null;
-      }
-      try {
-        await window.electron.ipcRenderer.invoke("gateway:stopDiscovery");
-      } catch {
-        // Ignore errors when stopping
-      }
+    this.clearDiscoverySubscription();
+    try {
+      await invokeDesktopBridgeRequest({
+        rpcMethod: "gatewayStopDiscovery",
+        ipcChannel: "gateway:stopDiscovery",
+      });
+    } catch {
+      // Ignore errors when stopping
     }
   }
 
@@ -573,6 +543,45 @@ export class GatewayElectron implements GatewayPlugin {
         break;
     }
     this.notifyListeners("discovery", event);
+  }
+
+  private clearDiscoverySubscription(): void {
+    this.discoveryUnsubscribe?.();
+    this.discoveryUnsubscribe = null;
+  }
+
+  private isGatewayDiscoveryEvent(
+    value: unknown,
+  ): value is GatewayDiscoveryEvent {
+    return (
+      typeof value === "object" &&
+      value !== null &&
+      "type" in value &&
+      (value.type === "found" ||
+        value.type === "updated" ||
+        value.type === "lost") &&
+      "gateway" in value &&
+      this.isGatewayEndpoint(value.gateway)
+    );
+  }
+
+  private isGatewayEndpoint(value: unknown): value is GatewayEndpoint {
+    return (
+      typeof value === "object" &&
+      value !== null &&
+      "stableId" in value &&
+      typeof value.stableId === "string" &&
+      "name" in value &&
+      typeof value.name === "string" &&
+      "host" in value &&
+      typeof value.host === "string" &&
+      "port" in value &&
+      typeof value.port === "number" &&
+      "tlsEnabled" in value &&
+      typeof value.tlsEnabled === "boolean" &&
+      "isLocal" in value &&
+      typeof value.isLocal === "boolean"
+    );
   }
 
   // MARK: - Event Listeners

--- a/apps/app/test/app/gateway-electron-rpc.test.ts
+++ b/apps/app/test/app/gateway-electron-rpc.test.ts
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+
+import type {
+  ElectrobunRendererRpc,
+  ElectronIpcRenderer,
+} from "@milady/app-core/bridge";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GatewayElectron } from "../../plugins/gateway/electron/src/index.ts";
+
+type TestWindow = Window & {
+  __MILADY_ELECTROBUN_RPC__?: ElectrobunRendererRpc;
+  electron?: { ipcRenderer?: ElectronIpcRenderer };
+};
+
+const sampleGateway = {
+  stableId: "gw-1",
+  name: "Local Gateway",
+  host: "127.0.0.1",
+  port: 7777,
+  tlsEnabled: false,
+  isLocal: true,
+};
+
+describe("GatewayElectron desktop bridge", () => {
+  afterEach(() => {
+    delete (window as TestWindow).__MILADY_ELECTROBUN_RPC__;
+    delete (window as TestWindow).electron;
+    vi.restoreAllMocks();
+  });
+
+  it("prefers direct Electrobun RPC for discovery and gateway events", async () => {
+    const listeners = new Map<string, Set<(payload: unknown) => void>>();
+    const gatewayStartDiscovery = vi.fn().mockResolvedValue({
+      gateways: [],
+      status: "Discovery started",
+    });
+    const gatewayStopDiscovery = vi.fn().mockResolvedValue(undefined);
+
+    (window as TestWindow).__MILADY_ELECTROBUN_RPC__ = {
+      request: {
+        gatewayStartDiscovery,
+        gatewayStopDiscovery,
+      },
+      onMessage: vi.fn(
+        (messageName: string, listener: (payload: unknown) => void) => {
+          const entry = listeners.get(messageName) ?? new Set();
+          entry.add(listener);
+          listeners.set(messageName, entry);
+        },
+      ),
+      offMessage: vi.fn(
+        (messageName: string, listener: (payload: unknown) => void) => {
+          listeners.get(messageName)?.delete(listener);
+        },
+      ),
+    };
+
+    const plugin = new GatewayElectron();
+    const discoveryListener = vi.fn();
+    await plugin.addListener("discovery", discoveryListener);
+
+    await expect(plugin.startDiscovery({ timeout: 5000 })).resolves.toEqual({
+      gateways: [],
+      status: "Discovery started",
+    });
+
+    listeners.get("gatewayDiscovery")?.forEach((listener) => {
+      listener({
+        type: "found",
+        gateway: sampleGateway,
+      });
+    });
+
+    expect(discoveryListener).toHaveBeenCalledWith({
+      type: "found",
+      gateway: sampleGateway,
+    });
+    await expect(plugin.getDiscoveredGateways()).resolves.toEqual({
+      gateways: [sampleGateway],
+      status: "Discovering",
+    });
+
+    await plugin.stopDiscovery();
+    expect(gatewayStopDiscovery).toHaveBeenCalled();
+    expect(listeners.get("gatewayDiscovery")?.size ?? 0).toBe(0);
+  });
+
+  it("handles IPC fallback discovery events when direct Electrobun RPC is unavailable", async () => {
+    const ipcListeners = new Map<
+      string,
+      Set<(event: unknown, payload: unknown) => void>
+    >();
+    const invoke = vi.fn(async (channel: string) => {
+      if (channel === "gateway:startDiscovery") {
+        return { gateways: [], status: "Discovery started" };
+      }
+
+      if (channel === "gateway:stopDiscovery") {
+        return undefined;
+      }
+
+      throw new Error(`Unexpected channel: ${channel}`);
+    });
+
+    (window as TestWindow).electron = {
+      ipcRenderer: {
+        invoke,
+        on: vi.fn(
+          (
+            channel: string,
+            listener: (event: unknown, payload: unknown) => void,
+          ) => {
+            const entry = ipcListeners.get(channel) ?? new Set();
+            entry.add(listener);
+            ipcListeners.set(channel, entry);
+          },
+        ),
+        removeListener: vi.fn(
+          (
+            channel: string,
+            listener: (event: unknown, payload: unknown) => void,
+          ) => {
+            ipcListeners.get(channel)?.delete(listener);
+          },
+        ),
+      },
+    };
+
+    const plugin = new GatewayElectron();
+    const discoveryListener = vi.fn();
+    await plugin.addListener("discovery", discoveryListener);
+
+    await expect(plugin.startDiscovery()).resolves.toEqual({
+      gateways: [],
+      status: "Discovery started",
+    });
+
+    ipcListeners.get("gateway:discovery")?.forEach((listener) => {
+      listener(
+        { sender: "test" },
+        {
+          type: "found",
+          gateway: sampleGateway,
+        },
+      );
+    });
+
+    expect(discoveryListener).toHaveBeenCalledWith({
+      type: "found",
+      gateway: sampleGateway,
+    });
+
+    await plugin.stopDiscovery();
+    expect(invoke).toHaveBeenCalledWith("gateway:stopDiscovery", undefined);
+    expect(ipcListeners.get("gateway:discovery")?.size ?? 0).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- move the gateway electron discovery path to the shared Electrobun desktop bridge
- preserve the IPC fallback path through the same bridge abstraction
- add focused tests for direct RPC and IPC fallback discovery events

## Testing
- bunx vitest run apps/app/test/app/gateway-electron-rpc.test.ts
- bun run check
- bun run pre-review:local