### PR TITLE
app: migrate swabble plugin to electrobun rpc

### DIFF
--- a/apps/app/plugins/swabble/electron/src/index.ts
+++ b/apps/app/plugins/swabble/electron/src/index.ts
@@ -1,5 +1,11 @@
 /// <reference path="./global.d.ts" />
 import type { PluginListenerHandle } from "@capacitor/core";
+import {
+  getElectrobunRendererRpc,
+  getElectronIpcRenderer,
+  invokeDesktopBridgeRequest,
+  subscribeDesktopBridgeEvent,
+} from "@milady/app-core/bridge";
 import type {
   SwabbleAudioLevelEvent,
   SwabbleConfig,
@@ -27,31 +33,24 @@ interface ListenerEntry {
   callback: EventCallback<SwabbleEvent>;
 }
 
-type IpcPrimitive = string | number | boolean | null | undefined;
-type IpcObject = { [key: string]: IpcValue };
-type IpcValue =
-  | IpcPrimitive
-  | IpcObject
-  | IpcValue[]
-  | ArrayBuffer
-  | Float32Array
-  | Uint8Array;
-type IpcListener = (...args: IpcValue[]) => void;
+type IpcPayload = unknown;
+type IpcListener = (event: unknown, payload: IpcPayload) => void;
 
-interface ElectronAPI {
-  ipcRenderer: {
-    invoke(channel: string, ...args: IpcValue[]): Promise<IpcValue>;
-    send(channel: string, ...args: IpcValue[]): void;
-    on(channel: string, listener: IpcListener): void;
-    removeListener(channel: string, listener: IpcListener): void;
-  };
+interface ElectronAudioIpcRenderer {
+  invoke: (channel: string, params?: unknown) => Promise<unknown>;
+  send?: (channel: string, params?: unknown) => void;
+  on?: (channel: string, listener: IpcListener) => void;
+  removeListener?: (channel: string, listener: IpcListener) => void;
 }
 
-declare global {
-  interface Window {
-    electron?: ElectronAPI;
-  }
-}
+const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const isSwabbleState = (value: unknown): value is SwabbleStateEvent["state"] =>
+  value === "idle" ||
+  value === "listening" ||
+  value === "processing" ||
+  value === "error";
 /**
  * WakeWordGate detects trigger phrases in transcripts.
  *
@@ -128,10 +127,31 @@ export class SwabbleElectron implements SwabblePlugin {
   private captureProcessor: ScriptProcessorNode | null = null;
   private captureGain: GainNode | null = null;
   private captureSampleRate = 16000;
+  private bridgeSubscriptions: Array<() => void> = [];
   private ipcHandlers: Array<{
     channel: string;
-    handler: (data: IpcValue) => void;
+    handler: IpcListener;
   }> = [];
+
+  private get ipc(): ElectronAudioIpcRenderer | undefined {
+    return getElectronIpcRenderer() as ElectronAudioIpcRenderer | undefined;
+  }
+
+  private async invokeBridge<T>(
+    rpcMethod: string,
+    ipcChannel: string,
+    params?: unknown,
+  ): Promise<T | null> {
+    try {
+      return await invokeDesktopBridgeRequest<T>({
+        rpcMethod,
+        ipcChannel,
+        params,
+      });
+    } catch {
+      return null;
+    }
+  }
 
   async start(options: SwabbleStartOptions): Promise<SwabbleStartResult> {
     if (this.isActive) {
@@ -144,21 +164,23 @@ export class SwabbleElectron implements SwabblePlugin {
     this.captureSampleRate = options.config.sampleRate ?? 16000;
 
     // Try native Whisper via Electron IPC first
-    if (window.electron?.ipcRenderer) {
-      try {
-        const result = (await window.electron.ipcRenderer.invoke(
-          "swabble:start",
-          options as unknown as IpcValue,
-        )) as unknown as SwabbleStartResult;
-        if (result.started) {
-          this.isActive = true;
-          this.setupIpcListeners();
-          await this.startAudioCapture();
-          return result;
-        }
-      } catch {
-        // Fall through to web implementation
-      }
+    const nativeResult = await this.invokeBridge<SwabbleStartResult>(
+      "swabbleStart",
+      "swabble:start",
+      options,
+    );
+    if (nativeResult?.started) {
+      this.isActive = true;
+      this.setupNativeListeners();
+      await this.startAudioCapture();
+      return nativeResult;
+    }
+
+    if (nativeResult) {
+      // Fall through to web implementation when the native bridge is present
+      // but cannot start whisper.cpp.
+    } else if (this.ipc || getElectrobunRendererRpc()) {
+      // Native bridge exists but returned no result. Fall through to the web path.
     }
 
     const SpeechRecognitionAPI =
@@ -272,42 +294,52 @@ export class SwabbleElectron implements SwabblePlugin {
     }
   }
 
-  private setupIpcListeners(): void {
-    if (!window.electron?.ipcRenderer) return;
+  private setupNativeListeners(): void {
+    this.removeNativeListeners();
 
-    this.removeIpcListeners();
+    const bridgeHandlers = [
+      {
+        eventName: "wakeWord" as const,
+        rpcMessage: "swabbleWakeWord",
+        ipcChannel: "swabble:wakeWord",
+        normalize: (data: unknown) => this.normalizeWakeWordEvent(data),
+      },
+      {
+        eventName: "stateChange" as const,
+        rpcMessage: "swabbleStateChanged",
+        ipcChannel: "swabble:stateChange",
+        normalize: (data: unknown) => this.normalizeStateEvent(data),
+      },
+    ];
+
+    for (const entry of bridgeHandlers) {
+      const unsubscribe = subscribeDesktopBridgeEvent({
+        rpcMessage: entry.rpcMessage,
+        ipcChannel: entry.ipcChannel,
+        listener: (data) => {
+          this.notifyListeners(entry.eventName, entry.normalize(data));
+        },
+      });
+      this.bridgeSubscriptions.push(unsubscribe);
+    }
+
+    if (!this.ipc?.on) return;
 
     const handlers: Array<{
       channel: string;
-      handler: (data: IpcValue) => void;
+      handler: IpcListener;
     }> = [
       {
         channel: "swabble:transcript",
-        handler: (data) =>
+        handler: (_event, data) =>
           this.notifyListeners(
             "transcript",
             data as unknown as SwabbleTranscriptEvent,
           ),
       },
       {
-        channel: "swabble:wakeWord",
-        handler: (data) =>
-          this.notifyListeners(
-            "wakeWord",
-            data as unknown as SwabbleWakeWordEvent,
-          ),
-      },
-      {
-        channel: "swabble:stateChange",
-        handler: (data) =>
-          this.notifyListeners(
-            "stateChange",
-            data as unknown as SwabbleStateEvent,
-          ),
-      },
-      {
         channel: "swabble:audioLevel",
-        handler: (data) =>
+        handler: (_event, data) =>
           this.notifyListeners(
             "audioLevel",
             data as unknown as SwabbleAudioLevelEvent,
@@ -315,28 +347,37 @@ export class SwabbleElectron implements SwabblePlugin {
       },
       {
         channel: "swabble:error",
-        handler: (data) =>
+        handler: (_event, data) =>
           this.notifyListeners("error", data as unknown as SwabbleErrorEvent),
       },
     ];
 
     for (const entry of handlers) {
-      window.electron.ipcRenderer.on(entry.channel, entry.handler);
+      this.ipc.on(entry.channel, entry.handler);
       this.ipcHandlers.push(entry);
     }
   }
 
-  private removeIpcListeners(): void {
-    if (!window.electron?.ipcRenderer) return;
+  private removeNativeListeners(): void {
+    for (const unsubscribe of this.bridgeSubscriptions) {
+      unsubscribe();
+    }
+    this.bridgeSubscriptions = [];
 
     for (const entry of this.ipcHandlers) {
-      window.electron.ipcRenderer.removeListener(entry.channel, entry.handler);
+      this.ipc?.removeListener?.(entry.channel, entry.handler);
     }
     this.ipcHandlers = [];
   }
 
   private async startAudioCapture(): Promise<void> {
-    if (this.captureContext || !window.electron?.ipcRenderer) return;
+    if (
+      this.captureContext ||
+      (!this.ipc?.send &&
+        !getElectrobunRendererRpc()?.request?.swabbleAudioChunk)
+    ) {
+      return;
+    }
 
     const constraints: MediaStreamConstraints = {
       audio: this.selectedDeviceId
@@ -367,7 +408,7 @@ export class SwabbleElectron implements SwabblePlugin {
         this.captureSampleRate,
       );
       if (downsampled.length > 0) {
-        window.electron?.ipcRenderer.send("swabble:audioChunk", downsampled);
+        this.sendAudioChunk(downsampled);
       }
 
       const level = this.computeRms(input);
@@ -453,6 +494,69 @@ export class SwabbleElectron implements SwabblePlugin {
     return peak;
   }
 
+  private sendAudioChunk(downsampled: Float32Array): void {
+    const rpcRequest = getElectrobunRendererRpc()?.request?.swabbleAudioChunk;
+    if (rpcRequest) {
+      const bytes = new Uint8Array(
+        downsampled.buffer,
+        downsampled.byteOffset,
+        downsampled.byteLength,
+      );
+      let binary = "";
+      for (let i = 0; i < bytes.length; i++) {
+        binary += String.fromCharCode(bytes[i]);
+      }
+      void rpcRequest({ data: btoa(binary) }).catch(() => {});
+      return;
+    }
+
+    this.ipc?.send?.("swabble:audioChunk", downsampled);
+  }
+
+  private normalizeWakeWordEvent(data: unknown): SwabbleWakeWordEvent {
+    if (!isObjectRecord(data)) {
+      return {
+        wakeWord: "",
+        command: "",
+        transcript: "",
+        postGap: -1,
+      };
+    }
+
+    return {
+      wakeWord:
+        typeof data.wakeWord === "string"
+          ? data.wakeWord
+          : typeof data.trigger === "string"
+            ? data.trigger
+            : "",
+      command: typeof data.command === "string" ? data.command : "",
+      transcript: typeof data.transcript === "string" ? data.transcript : "",
+      postGap: typeof data.postGap === "number" ? data.postGap : -1,
+      confidence:
+        typeof data.confidence === "number" ? data.confidence : undefined,
+    };
+  }
+
+  private normalizeStateEvent(data: unknown): SwabbleStateEvent {
+    if (!isObjectRecord(data)) {
+      return { state: "idle" };
+    }
+
+    if (isSwabbleState(data.state)) {
+      return {
+        state: data.state,
+        reason: typeof data.reason === "string" ? data.reason : undefined,
+      };
+    }
+
+    if (typeof data.listening === "boolean") {
+      return { state: data.listening ? "listening" : "idle" };
+    }
+
+    return { state: "idle" };
+  }
+
   private async startAudioLevelMonitoring(): Promise<void> {
     try {
       const constraints: MediaStreamConstraints = {
@@ -518,17 +622,11 @@ export class SwabbleElectron implements SwabblePlugin {
 
   async stop(): Promise<void> {
     this.isActive = false;
-    this.removeIpcListeners();
+    this.removeNativeListeners();
     this.stopAudioCapture();
     this.stopAudioLevelMonitoring();
 
-    if (window.electron?.ipcRenderer) {
-      try {
-        await window.electron.ipcRenderer.invoke("swabble:stop");
-      } catch {
-        // Ignore
-      }
-    }
+    await this.invokeBridge("swabbleStop", "swabble:stop");
 
     if (this.recognition) {
       this.recognition.stop();
@@ -539,10 +637,25 @@ export class SwabbleElectron implements SwabblePlugin {
   }
 
   async isListening(): Promise<{ listening: boolean }> {
+    const nativeState = await this.invokeBridge<{ listening: boolean }>(
+      "swabbleIsListening",
+      "swabble:isListening",
+    );
+    if (nativeState) {
+      this.isActive = nativeState.listening;
+      return nativeState;
+    }
     return { listening: this.isActive };
   }
 
   async getConfig(): Promise<{ config: SwabbleConfig | null }> {
+    const nativeConfig = await this.invokeBridge<Record<string, unknown>>(
+      "swabbleGetConfig",
+      "swabble:getConfig",
+    );
+    if (nativeConfig && isObjectRecord(nativeConfig)) {
+      return { config: nativeConfig as unknown as SwabbleConfig };
+    }
     return { config: this.config };
   }
 
@@ -555,15 +668,11 @@ export class SwabbleElectron implements SwabblePlugin {
       this.captureSampleRate = this.config.sampleRate ?? this.captureSampleRate;
     }
 
-    if (window.electron?.ipcRenderer) {
-      try {
-        await window.electron.ipcRenderer.invoke("swabble:updateConfig", {
-          config: options.config,
-        });
-      } catch {
-        // Ignore
-      }
-    }
+    await this.invokeBridge(
+      "swabbleUpdateConfig",
+      "swabble:updateConfig",
+      options.config,
+    );
   }
 
   async checkPermissions(): Promise<SwabblePermissionStatus> {
@@ -590,19 +699,12 @@ export class SwabbleElectron implements SwabblePlugin {
     let speechRecognition: SwabblePermissionStatus["speechRecognition"] =
       SpeechRecognitionAPI ? "granted" : "not_supported";
 
-    if (window.electron?.ipcRenderer) {
-      try {
-        const whisperStatus = (await window.electron.ipcRenderer.invoke(
-          "swabble:isWhisperAvailable",
-        )) as {
-          available: boolean;
-        };
-        if (whisperStatus.available) {
-          speechRecognition = "granted";
-        }
-      } catch {
-        // Ignore
-      }
+    const whisperStatus = await this.invokeBridge<{ available: boolean }>(
+      "swabbleIsWhisperAvailable",
+      "swabble:isWhisperAvailable",
+    );
+    if (whisperStatus?.available) {
+      speechRecognition = "granted";
     }
 
     return {
@@ -646,7 +748,7 @@ export class SwabbleElectron implements SwabblePlugin {
   async setAudioDevice(_options: { deviceId: string }): Promise<void> {
     this.selectedDeviceId = _options.deviceId;
 
-    if (window.electron?.ipcRenderer && this.captureContext) {
+    if ((this.ipc || getElectrobunRendererRpc()) && this.captureContext) {
       this.stopAudioCapture();
       await this.startAudioCapture();
       return;

--- a/apps/app/test/app/swabble-electron-rpc.test.ts
+++ b/apps/app/test/app/swabble-electron-rpc.test.ts
@@ -1,0 +1,328 @@
+// @vitest-environment jsdom
+
+import type {
+  ElectrobunRendererRpc,
+  ElectronIpcRenderer,
+} from "@milady/app-core/bridge";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SwabbleElectron } from "../../plugins/swabble/electron/src/index";
+
+type TestWindow = Window & {
+  __MILADY_ELECTROBUN_RPC__?: ElectrobunRendererRpc;
+  electron?: {
+    ipcRenderer?: ElectronIpcRenderer & {
+      send?: (channel: string, payload?: unknown) => void;
+    };
+  };
+};
+
+interface ProcessorStub {
+  connect: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+  onaudioprocess: ((event: AudioProcessingEvent) => void) | null;
+}
+
+let originalAudioContext: typeof globalThis.AudioContext | undefined;
+let processorStub: ProcessorStub;
+
+function installAudioCaptureStubs(): void {
+  const mockStream = {
+    getTracks: () => [{ stop: vi.fn() }],
+  } as unknown as MediaStream;
+
+  if (!navigator.mediaDevices) {
+    Object.defineProperty(navigator, "mediaDevices", {
+      value: {},
+      writable: true,
+      configurable: true,
+    });
+  }
+
+  Object.defineProperty(navigator.mediaDevices, "getUserMedia", {
+    value: vi.fn().mockResolvedValue(mockStream),
+    writable: true,
+    configurable: true,
+  });
+
+  Object.defineProperty(navigator, "permissions", {
+    value: {
+      query: vi.fn().mockResolvedValue({ state: "granted" }),
+    },
+    writable: true,
+    configurable: true,
+  });
+
+  processorStub = {
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    onaudioprocess: null,
+  };
+
+  originalAudioContext = globalThis.AudioContext;
+
+  class MockAudioContext {
+    sampleRate = 48000;
+    destination = {};
+    createMediaStreamSource = vi.fn(() => ({
+      connect: vi.fn(),
+    }));
+    createScriptProcessor = vi.fn(() => processorStub);
+    createGain = vi.fn(() => ({
+      gain: { value: 0 },
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    }));
+    createAnalyser = vi.fn(() => ({
+      fftSize: 256,
+      frequencyBinCount: 8,
+      connect: vi.fn(),
+      getByteFrequencyData: vi.fn((array: Uint8Array) => {
+        array.fill(0);
+      }),
+    }));
+    close = vi.fn(async () => {});
+  }
+
+  Object.defineProperty(globalThis, "AudioContext", {
+    value: MockAudioContext,
+    writable: true,
+    configurable: true,
+  });
+}
+
+describe("SwabbleElectron direct Electrobun RPC bridge", () => {
+  beforeEach(() => {
+    installAudioCaptureStubs();
+  });
+
+  afterEach(() => {
+    delete (window as TestWindow).__MILADY_ELECTROBUN_RPC__;
+    delete (window as TestWindow).electron;
+    vi.restoreAllMocks();
+
+    if (originalAudioContext) {
+      Object.defineProperty(globalThis, "AudioContext", {
+        value: originalAudioContext,
+        writable: true,
+        configurable: true,
+      });
+    }
+  });
+
+  it("prefers direct Electrobun RPC for native swabble requests and normalizes native payloads", async () => {
+    const listeners = new Map<string, Set<(payload: unknown) => void>>();
+    const swabbleStart = vi.fn().mockResolvedValue({ started: true });
+    const swabbleStop = vi.fn().mockResolvedValue(undefined);
+    const swabbleIsListening = vi.fn().mockResolvedValue({ listening: true });
+    const swabbleGetConfig = vi.fn().mockResolvedValue({
+      triggers: ["milady"],
+      minCommandLength: 2,
+    });
+    const swabbleUpdateConfig = vi.fn().mockResolvedValue(undefined);
+    const swabbleIsWhisperAvailable = vi
+      .fn()
+      .mockResolvedValue({ available: true });
+    const swabbleAudioChunk = vi.fn().mockResolvedValue(undefined);
+    const ipcInvoke = vi.fn();
+
+    (window as TestWindow).__MILADY_ELECTROBUN_RPC__ = {
+      request: {
+        swabbleStart,
+        swabbleStop,
+        swabbleIsListening,
+        swabbleGetConfig,
+        swabbleUpdateConfig,
+        swabbleIsWhisperAvailable,
+        swabbleAudioChunk,
+      },
+      onMessage: vi.fn(
+        (messageName: string, listener: (payload: unknown) => void) => {
+          const entry = listeners.get(messageName) ?? new Set();
+          entry.add(listener);
+          listeners.set(messageName, entry);
+        },
+      ),
+      offMessage: vi.fn(
+        (messageName: string, listener: (payload: unknown) => void) => {
+          listeners.get(messageName)?.delete(listener);
+        },
+      ),
+    };
+    (window as TestWindow).electron = {
+      ipcRenderer: {
+        invoke: ipcInvoke,
+      },
+    };
+
+    const plugin = new SwabbleElectron();
+    const wakeListener = vi.fn();
+    const stateListener = vi.fn();
+    await plugin.addListener("wakeWord", wakeListener);
+    await plugin.addListener("stateChange", stateListener);
+
+    await expect(
+      plugin.start({
+        config: { triggers: ["milady"], sampleRate: 16000 },
+      }),
+    ).resolves.toEqual({ started: true });
+
+    expect(swabbleStart).toHaveBeenCalledWith({
+      config: { triggers: ["milady"], sampleRate: 16000 },
+    });
+    expect(ipcInvoke).not.toHaveBeenCalled();
+
+    listeners.get("swabbleWakeWord")?.forEach((listener) => {
+      listener({
+        trigger: "milady",
+        command: "open settings",
+        transcript: "milady open settings",
+        postGap: 0.8,
+      });
+    });
+    expect(wakeListener).toHaveBeenCalledWith({
+      wakeWord: "milady",
+      command: "open settings",
+      transcript: "milady open settings",
+      postGap: 0.8,
+      confidence: undefined,
+    });
+
+    listeners.get("swabbleStateChanged")?.forEach((listener) => {
+      listener({ listening: true });
+    });
+    expect(stateListener).toHaveBeenCalledWith({ state: "listening" });
+
+    await expect(plugin.isListening()).resolves.toEqual({ listening: true });
+    await expect(plugin.getConfig()).resolves.toEqual({
+      config: { triggers: ["milady"], minCommandLength: 2 },
+    });
+
+    await plugin.updateConfig({ config: { minCommandLength: 3 } });
+    expect(swabbleUpdateConfig).toHaveBeenCalledWith({
+      minCommandLength: 3,
+    });
+
+    await expect(plugin.checkPermissions()).resolves.toEqual({
+      microphone: "granted",
+      speechRecognition: "granted",
+    });
+
+    processorStub.onaudioprocess?.({
+      inputBuffer: {
+        getChannelData: () =>
+          new Float32Array([0.25, -0.5, 0.25, -0.5, 0.25, -0.5]),
+      },
+    } as AudioProcessingEvent);
+
+    expect(swabbleAudioChunk).toHaveBeenCalledTimes(1);
+    expect(swabbleAudioChunk).toHaveBeenCalledWith({
+      data: expect.any(String),
+    });
+
+    await plugin.stop();
+    expect(swabbleStop).toHaveBeenCalledWith(undefined);
+    expect(listeners.get("swabbleWakeWord")?.size ?? 0).toBe(0);
+    expect(listeners.get("swabbleStateChanged")?.size ?? 0).toBe(0);
+  });
+
+  it("keeps transcript and error events on IPC fallback when Electrobun exposes no direct push message", async () => {
+    const rpcListeners = new Map<string, Set<(payload: unknown) => void>>();
+    const ipcListeners = new Map<
+      string,
+      Set<(event: unknown, payload: unknown) => void>
+    >();
+    const swabbleStop = vi.fn().mockResolvedValue(undefined);
+
+    (window as TestWindow).__MILADY_ELECTROBUN_RPC__ = {
+      request: {
+        swabbleStart: vi.fn().mockResolvedValue({ started: true }),
+        swabbleStop,
+        swabbleAudioChunk: vi.fn().mockResolvedValue(undefined),
+      },
+      onMessage: vi.fn(
+        (messageName: string, listener: (payload: unknown) => void) => {
+          const entry = rpcListeners.get(messageName) ?? new Set();
+          entry.add(listener);
+          rpcListeners.set(messageName, entry);
+        },
+      ),
+      offMessage: vi.fn(
+        (messageName: string, listener: (payload: unknown) => void) => {
+          rpcListeners.get(messageName)?.delete(listener);
+        },
+      ),
+    };
+    (window as TestWindow).electron = {
+      ipcRenderer: {
+        invoke: vi.fn(),
+        on: vi.fn(
+          (
+            channel: string,
+            listener: (event: unknown, payload: unknown) => void,
+          ) => {
+            const entry = ipcListeners.get(channel) ?? new Set();
+            entry.add(listener);
+            ipcListeners.set(channel, entry);
+          },
+        ),
+        removeListener: vi.fn(
+          (
+            channel: string,
+            listener: (event: unknown, payload: unknown) => void,
+          ) => {
+            ipcListeners.get(channel)?.delete(listener);
+          },
+        ),
+      },
+    };
+
+    const plugin = new SwabbleElectron();
+    const transcriptListener = vi.fn();
+    const errorListener = vi.fn();
+    await plugin.addListener("transcript", transcriptListener);
+    await plugin.addListener("error", errorListener);
+
+    await plugin.start({
+      config: { triggers: ["milady"], sampleRate: 16000 },
+    });
+
+    ipcListeners.get("swabble:transcript")?.forEach((listener) => {
+      listener(
+        { sender: "test" },
+        {
+          transcript: "milady open settings",
+          segments: [],
+          isFinal: true,
+          confidence: 0.99,
+        },
+      );
+    });
+    expect(transcriptListener).toHaveBeenCalledWith({
+      transcript: "milady open settings",
+      segments: [],
+      isFinal: true,
+      confidence: 0.99,
+    });
+
+    ipcListeners.get("swabble:error")?.forEach((listener) => {
+      listener(
+        { sender: "test" },
+        {
+          code: "native-error",
+          message: "microphone busy",
+          recoverable: true,
+        },
+      );
+    });
+    expect(errorListener).toHaveBeenCalledWith({
+      code: "native-error",
+      message: "microphone busy",
+      recoverable: true,
+    });
+
+    await plugin.stop();
+    expect(swabbleStop).toHaveBeenCalledWith(undefined);
+    expect(ipcListeners.get("swabble:transcript")?.size ?? 0).toBe(0);
+    expect(ipcListeners.get("swabble:error")?.size ?? 0).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- migrate the swabble electron adapter to prefer direct Electrobun RPC for supported request and push paths
- normalize native swabble payload mismatches for wake-word and state events
- keep IPC fallback only for transcript and error events that do not yet have direct Electrobun push messages

## Testing
- bunx vitest run apps/app/test/app/swabble-electron-rpc.test.ts apps/app/test/plugins/swabble.test.ts
- bun run check
- bun run pre-review:local