### PR TITLE
app: migrate swabble web plugin to electrobun rpc

### DIFF
--- a/apps/app/plugins/swabble/src/web.ts
+++ b/apps/app/plugins/swabble/src/web.ts
@@ -43,6 +43,28 @@ interface SpeechRecognitionResultList {
 
 type SpeechRecognitionCtor = new () => SpeechRecognitionInstance;
 
+type DesktopMessageListener = (payload: unknown) => void;
+
+interface ElectrobunRendererRpc {
+  request?: Record<string, (params?: unknown) => Promise<unknown>>;
+  onMessage?: (messageName: string, listener: DesktopMessageListener) => void;
+  offMessage?: (messageName: string, listener: DesktopMessageListener) => void;
+}
+
+interface DesktopIpcRenderer {
+  invoke(ch: string, ...a: unknown[]): Promise<unknown>;
+  send?(ch: string, ...a: unknown[]): void;
+  on?(ch: string, fn: (...a: unknown[]) => void): void;
+  removeListener?(ch: string, fn: (...a: unknown[]) => void): void;
+}
+
+interface DesktopBridgeWindow extends Window {
+  __MILADY_ELECTROBUN_RPC__?: ElectrobunRendererRpc;
+  electron?: {
+    ipcRenderer?: DesktopIpcRenderer;
+  };
+}
+
 const getSpeechRecognition = (): SpeechRecognitionCtor | null =>
   ((window as unknown as Record<string, unknown>)
     .SpeechRecognition as SpeechRecognitionCtor) ||
@@ -120,65 +142,103 @@ export class SwabbleWeb extends WebPlugin {
     channel: string;
     listener: (...args: unknown[]) => void;
   }> = [];
+  private bridgeSubscriptions: Array<() => void> = [];
   private usingNativeIpc = false;
 
-  private getIpc(): {
-    invoke(ch: string, ...a: unknown[]): Promise<unknown>;
-    send(ch: string, ...a: unknown[]): void;
-    on(ch: string, fn: (...a: unknown[]) => void): void;
-    removeListener(ch: string, fn: (...a: unknown[]) => void): void;
-  } | null {
+  private getRendererRpc(): ElectrobunRendererRpc | null {
     return (
-      (
-        window as {
-          electron?: {
-            ipcRenderer?: {
-              invoke(ch: string, ...a: unknown[]): Promise<unknown>;
-              send(ch: string, ...a: unknown[]): void;
-              on(ch: string, fn: (...a: unknown[]) => void): void;
-              removeListener(ch: string, fn: (...a: unknown[]) => void): void;
-            };
-          };
-        }
-      ).electron?.ipcRenderer ?? null
+      (window as unknown as DesktopBridgeWindow).__MILADY_ELECTROBUN_RPC__ ??
+      null
     );
   }
 
-  /** True when running inside Electrobun (vs plain Electron). */
-  private isElectrobun(): boolean {
-    return !!(window as unknown as Record<string, unknown>).__ELECTROBUN__;
+  private getIpc(): DesktopIpcRenderer | null {
+    return (
+      (window as unknown as DesktopBridgeWindow).electron?.ipcRenderer ?? null
+    );
+  }
+
+  private async invokeDesktopRequest<T>(options: {
+    rpcMethod: string;
+    ipcChannel: string;
+    params?: unknown;
+  }): Promise<T | null> {
+    const rpcRequest = this.getRendererRpc()?.request?.[options.rpcMethod];
+    if (rpcRequest) {
+      return (await rpcRequest(options.params)) as T;
+    }
+
+    const ipc = this.getIpc();
+    if (ipc) {
+      return (await ipc.invoke(options.ipcChannel, options.params)) as T;
+    }
+
+    return null;
   }
 
   private setupNativeListeners(): void {
+    this.removeNativeListeners();
+
+    const rpc = this.getRendererRpc();
+    if (rpc?.onMessage && rpc?.offMessage) {
+      const wakeWordListener: DesktopMessageListener = (payload) => {
+        this.notifyListeners("wakeWord", payload as Record<string, unknown>);
+      };
+      rpc.onMessage("swabbleWakeWord", wakeWordListener);
+      this.bridgeSubscriptions.push(() => {
+        rpc.offMessage?.("swabbleWakeWord", wakeWordListener);
+      });
+
+      const stateChangeListener: DesktopMessageListener = (payload) => {
+        const listening =
+          typeof (payload as { listening?: unknown }).listening === "boolean"
+            ? (payload as { listening: boolean }).listening
+            : false;
+        this.isActive = listening;
+        this.notifyListeners("stateChange", {
+          state: listening ? "listening" : "idle",
+        });
+      };
+      rpc.onMessage("swabbleStateChanged", stateChangeListener);
+      this.bridgeSubscriptions.push(() => {
+        rpc.offMessage?.("swabbleStateChanged", stateChangeListener);
+      });
+    }
+
     const ipc = this.getIpc();
-    if (!ipc) return;
-    const map: Array<[string, string]> = [
-      ["swabble:wakeWord", "wakeWord"],
-      ["swabble:stateChange", "stateChange"],
+    if (!ipc?.on) return;
+
+    const ipcOnlyEvents: Array<[string, string]> = [
       ["swabble:audioLevel", "audioLevel"],
       ["swabble:transcript", "transcript"],
       ["swabble:error", "error"],
     ];
-    for (const [ch, ev] of map) {
+    for (const [channel, eventName] of ipcOnlyEvents) {
       const listener = (...args: unknown[]) => {
-        this.notifyListeners(ev, args[0] as Record<string, unknown>);
+        this.notifyListeners(eventName, args[0] as Record<string, unknown>);
       };
-      ipc.on(ch, listener);
-      this.ipcHandlers.push({ channel: ch, listener });
+      ipc.on(channel, listener);
+      this.ipcHandlers.push({ channel, listener });
     }
   }
 
   private removeNativeListeners(): void {
+    for (const unsubscribe of this.bridgeSubscriptions) {
+      unsubscribe();
+    }
+    this.bridgeSubscriptions = [];
+
     const ipc = this.getIpc();
     for (const { channel, listener } of this.ipcHandlers) {
-      ipc?.removeListener(channel, listener);
+      ipc?.removeListener?.(channel, listener);
     }
     this.ipcHandlers = [];
   }
 
   private async startNativeAudioCapture(sampleRate = 16000): Promise<void> {
     const ipc = this.getIpc();
-    if (!ipc) return;
+    const rpcRequest = this.getRendererRpc()?.request?.swabbleAudioChunk;
+    if (!ipc && !rpcRequest) return;
     const stream = await navigator.mediaDevices
       .getUserMedia({ audio: true })
       .catch(() => null);
@@ -204,7 +264,7 @@ export class SwabbleWeb extends WebPlugin {
         }
         out[i] = cnt > 0 ? acc / cnt : 0;
       }
-      if (this.isElectrobun()) {
+      if (rpcRequest) {
         // Electrobun: handleRequest expects invoke + base64-encoded Float32 PCM
         const bytes = new Uint8Array(
           out.buffer,
@@ -214,10 +274,14 @@ export class SwabbleWeb extends WebPlugin {
         let binary = "";
         for (let i = 0; i < bytes.length; i++)
           binary += String.fromCharCode(bytes[i]);
-        ipc
-          .invoke("swabble:audioChunk", { data: btoa(binary) })
-          .catch(() => {});
-      } else {
+        if (rpcRequest) {
+          void rpcRequest({ data: btoa(binary) }).catch(() => {});
+        } else {
+          ipc
+            ?.invoke("swabble:audioChunk", { data: btoa(binary) })
+            .catch(() => {});
+        }
+      } else if (ipc?.send) {
         // Electron: ipcMain.on expects send + raw typed array
         ipc.send("swabble:audioChunk", out);
       }
@@ -244,13 +308,15 @@ export class SwabbleWeb extends WebPlugin {
     if (this.isActive) return { started: true };
 
     // Delegate to native IPC when running in Electron or Electrobun
+    const rpc = this.getRendererRpc();
     const ipc = this.getIpc();
-    if (ipc) {
+    if (rpc || ipc) {
       try {
-        const result = (await ipc.invoke(
-          "swabble:start",
-          options as unknown,
-        )) as SwabbleStartResult;
+        const result = await this.invokeDesktopRequest<SwabbleStartResult>({
+          rpcMethod: "swabbleStart",
+          ipcChannel: "swabble:start",
+          params: options,
+        });
         if (result?.started) {
           this.isActive = true;
           this.usingNativeIpc = true;
@@ -404,9 +470,10 @@ export class SwabbleWeb extends WebPlugin {
       this.usingNativeIpc = false;
       this.removeNativeListeners();
       this.stopNativeAudioCapture();
-      this.getIpc()
-        ?.invoke("swabble:stop")
-        .catch(() => {});
+      void this.invokeDesktopRequest({
+        rpcMethod: "swabbleStop",
+        ipcChannel: "swabble:stop",
+      });
       this.notifyListeners("stateChange", { state: "idle" });
       return;
     }
@@ -441,9 +508,11 @@ export class SwabbleWeb extends WebPlugin {
 
     // Sync to native IPC if active
     if (this.usingNativeIpc) {
-      this.getIpc()
-        ?.invoke("swabble:updateConfig", options)
-        .catch(() => {});
+      void this.invokeDesktopRequest({
+        rpcMethod: "swabbleUpdateConfig",
+        ipcChannel: "swabble:updateConfig",
+        params: options.config,
+      });
     }
   }
 
@@ -457,9 +526,21 @@ export class SwabbleWeb extends WebPlugin {
     } catch {
       /* permissions.query not supported for microphone in some browsers */
     }
+    let speechRecognition: SwabblePermissionStatus["speechRecognition"] =
+      getSpeechRecognition() ? "granted" : "not_supported";
+    const whisperStatus = await this.invokeDesktopRequest<{
+      available: boolean;
+    }>({
+      rpcMethod: "swabbleIsWhisperAvailable",
+      ipcChannel: "swabble:isWhisperAvailable",
+    });
+    if (whisperStatus?.available) {
+      speechRecognition = "granted";
+    }
+
     return {
       microphone,
-      speechRecognition: getSpeechRecognition() ? "granted" : "not_supported",
+      speechRecognition,
     };
   }
 

--- a/apps/app/test/app/swabble-web-rpc.test.ts
+++ b/apps/app/test/app/swabble-web-rpc.test.ts
@@ -1,0 +1,307 @@
+// @vitest-environment jsdom
+
+import type {
+  ElectrobunRendererRpc,
+  ElectronIpcRenderer,
+} from "@milady/app-core/bridge";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SwabbleWeb } from "../../plugins/swabble/src/web.ts";
+
+type TestWindow = Window & {
+  __MILADY_ELECTROBUN_RPC__?: ElectrobunRendererRpc;
+  electron?: {
+    ipcRenderer?: ElectronIpcRenderer & {
+      send?: (channel: string, payload?: unknown) => void;
+      on?: (channel: string, listener: (...args: unknown[]) => void) => void;
+      removeListener?: (
+        channel: string,
+        listener: (...args: unknown[]) => void,
+      ) => void;
+    };
+  };
+};
+
+interface ProcessorStub {
+  connect: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+  onaudioprocess: ((event: AudioProcessingEvent) => void) | null;
+}
+
+let originalAudioContext: typeof globalThis.AudioContext | undefined;
+let processorStub: ProcessorStub;
+
+function installAudioStubs(): void {
+  const mockStream = {
+    getTracks: () => [{ stop: vi.fn() }],
+  } as unknown as MediaStream;
+
+  if (!navigator.mediaDevices) {
+    Object.defineProperty(navigator, "mediaDevices", {
+      value: {},
+      writable: true,
+      configurable: true,
+    });
+  }
+
+  Object.defineProperty(navigator.mediaDevices, "getUserMedia", {
+    value: vi.fn().mockResolvedValue(mockStream),
+    writable: true,
+    configurable: true,
+  });
+  Object.defineProperty(navigator.mediaDevices, "enumerateDevices", {
+    value: vi.fn().mockResolvedValue([]),
+    writable: true,
+    configurable: true,
+  });
+  Object.defineProperty(navigator, "permissions", {
+    value: {
+      query: vi.fn().mockResolvedValue({ state: "granted" }),
+    },
+    writable: true,
+    configurable: true,
+  });
+
+  processorStub = {
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    onaudioprocess: null,
+  };
+
+  originalAudioContext = globalThis.AudioContext;
+
+  class MockAudioContext {
+    sampleRate = 48000;
+    destination = {};
+    createMediaStreamSource = vi.fn(() => ({
+      connect: vi.fn(),
+    }));
+    createScriptProcessor = vi.fn(() => processorStub);
+    createGain = vi.fn(() => ({
+      gain: { value: 0 },
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    }));
+    createAnalyser = vi.fn(() => ({
+      fftSize: 256,
+      frequencyBinCount: 8,
+      connect: vi.fn(),
+      getByteFrequencyData: vi.fn((array: Uint8Array) => {
+        array.fill(0);
+      }),
+    }));
+    close = vi.fn(async () => {});
+  }
+
+  Object.defineProperty(globalThis, "AudioContext", {
+    value: MockAudioContext,
+    writable: true,
+    configurable: true,
+  });
+}
+
+describe("SwabbleWeb desktop bridge", () => {
+  beforeEach(() => {
+    installAudioStubs();
+  });
+
+  afterEach(() => {
+    delete (window as TestWindow).__MILADY_ELECTROBUN_RPC__;
+    delete (window as TestWindow).electron;
+    vi.restoreAllMocks();
+
+    if (originalAudioContext) {
+      Object.defineProperty(globalThis, "AudioContext", {
+        value: originalAudioContext,
+        writable: true,
+        configurable: true,
+      });
+    }
+  });
+
+  it("prefers direct Electrobun RPC for the live SwabbleWeb desktop path", async () => {
+    const directListeners = new Map<string, Set<(payload: unknown) => void>>();
+    const swabbleStart = vi.fn().mockResolvedValue({ started: true });
+    const swabbleStop = vi.fn().mockResolvedValue(undefined);
+    const swabbleUpdateConfig = vi.fn().mockResolvedValue(undefined);
+    const swabbleIsWhisperAvailable = vi
+      .fn()
+      .mockResolvedValue({ available: true });
+    const swabbleAudioChunk = vi.fn().mockResolvedValue(undefined);
+    const ipcInvoke = vi.fn();
+
+    (window as TestWindow).__MILADY_ELECTROBUN_RPC__ = {
+      request: {
+        swabbleStart,
+        swabbleStop,
+        swabbleUpdateConfig,
+        swabbleIsWhisperAvailable,
+        swabbleAudioChunk,
+      },
+      onMessage: vi.fn(
+        (messageName: string, listener: (payload: unknown) => void) => {
+          const entry = directListeners.get(messageName) ?? new Set();
+          entry.add(listener);
+          directListeners.set(messageName, entry);
+        },
+      ),
+      offMessage: vi.fn(
+        (messageName: string, listener: (payload: unknown) => void) => {
+          directListeners.get(messageName)?.delete(listener);
+        },
+      ),
+    };
+    (window as TestWindow).electron = {
+      ipcRenderer: {
+        invoke: ipcInvoke,
+      },
+    };
+
+    const sw = new SwabbleWeb();
+    const wakeListener = vi.fn();
+    const stateListener = vi.fn();
+    await sw.addListener("wakeWord", wakeListener);
+    await sw.addListener("stateChange", stateListener);
+
+    await expect(
+      sw.start({
+        config: { triggers: ["milady"], sampleRate: 16000 },
+      }),
+    ).resolves.toEqual({ started: true });
+
+    expect(swabbleStart).toHaveBeenCalledWith({
+      config: { triggers: ["milady"], sampleRate: 16000 },
+    });
+    expect(ipcInvoke).not.toHaveBeenCalled();
+
+    directListeners.get("swabbleStateChanged")?.forEach((listener) => {
+      listener({ listening: true });
+    });
+    expect(stateListener).toHaveBeenCalledWith({ state: "listening" });
+
+    directListeners.get("swabbleWakeWord")?.forEach((listener) => {
+      listener({
+        wakeWord: "milady",
+        command: "open settings",
+        transcript: "milady open settings",
+        postGap: 0.8,
+      });
+    });
+    expect(wakeListener).toHaveBeenCalledWith({
+      wakeWord: "milady",
+      command: "open settings",
+      transcript: "milady open settings",
+      postGap: 0.8,
+    });
+
+    await sw.updateConfig({ config: { minCommandLength: 2 } });
+    expect(swabbleUpdateConfig).toHaveBeenCalledWith({
+      minCommandLength: 2,
+    });
+
+    await expect(sw.checkPermissions()).resolves.toEqual({
+      microphone: "granted",
+      speechRecognition: "granted",
+    });
+
+    processorStub.onaudioprocess?.({
+      inputBuffer: {
+        getChannelData: () =>
+          new Float32Array([0.25, -0.5, 0.25, -0.5, 0.25, -0.5]),
+      },
+    } as AudioProcessingEvent);
+    expect(swabbleAudioChunk).toHaveBeenCalledTimes(1);
+    expect(swabbleAudioChunk).toHaveBeenCalledWith({
+      data: expect.any(String),
+    });
+
+    await sw.stop();
+    expect(swabbleStop).toHaveBeenCalledWith(undefined);
+    expect(directListeners.get("swabbleStateChanged")?.size ?? 0).toBe(0);
+    expect(directListeners.get("swabbleWakeWord")?.size ?? 0).toBe(0);
+  });
+
+  it("keeps transcript and error desktop events on the IPC fallback path", async () => {
+    const directListeners = new Map<string, Set<(payload: unknown) => void>>();
+    const ipcListeners = new Map<string, Set<(...args: unknown[]) => void>>();
+
+    (window as TestWindow).__MILADY_ELECTROBUN_RPC__ = {
+      request: {
+        swabbleStart: vi.fn().mockResolvedValue({ started: true }),
+        swabbleStop: vi.fn().mockResolvedValue(undefined),
+        swabbleIsWhisperAvailable: vi
+          .fn()
+          .mockResolvedValue({ available: false }),
+      },
+      onMessage: vi.fn(
+        (messageName: string, listener: (payload: unknown) => void) => {
+          const entry = directListeners.get(messageName) ?? new Set();
+          entry.add(listener);
+          directListeners.set(messageName, entry);
+        },
+      ),
+      offMessage: vi.fn(
+        (messageName: string, listener: (payload: unknown) => void) => {
+          directListeners.get(messageName)?.delete(listener);
+        },
+      ),
+    };
+    (window as TestWindow).electron = {
+      ipcRenderer: {
+        invoke: vi.fn(),
+        send: vi.fn(),
+        on: vi.fn((channel: string, listener: (...args: unknown[]) => void) => {
+          const entry = ipcListeners.get(channel) ?? new Set();
+          entry.add(listener);
+          ipcListeners.set(channel, entry);
+        }),
+        removeListener: vi.fn(
+          (channel: string, listener: (...args: unknown[]) => void) => {
+            ipcListeners.get(channel)?.delete(listener);
+          },
+        ),
+      },
+    };
+
+    const sw = new SwabbleWeb();
+    const transcriptListener = vi.fn();
+    const errorListener = vi.fn();
+    await sw.addListener("transcript", transcriptListener);
+    await sw.addListener("error", errorListener);
+
+    await expect(
+      sw.start({
+        config: { triggers: ["milady"], sampleRate: 16000 },
+      }),
+    ).resolves.toEqual({ started: true });
+
+    ipcListeners.get("swabble:transcript")?.forEach((listener) => {
+      listener({
+        transcript: "hello world",
+        segments: [],
+        isFinal: true,
+      });
+    });
+    expect(transcriptListener).toHaveBeenCalledWith({
+      transcript: "hello world",
+      segments: [],
+      isFinal: true,
+    });
+
+    ipcListeners.get("swabble:error")?.forEach((listener) => {
+      listener({
+        code: "native_error",
+        message: "boom",
+        recoverable: true,
+      });
+    });
+    expect(errorListener).toHaveBeenCalledWith({
+      code: "native_error",
+      message: "boom",
+      recoverable: true,
+    });
+
+    await sw.stop();
+    expect(ipcListeners.get("swabble:transcript")?.size ?? 0).toBe(0);
+    expect(ipcListeners.get("swabble:error")?.size ?? 0).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary\n- migrate the live SwabbleWeb desktop bridge to prefer direct Electrobun RPC for requests and supported push events\n- keep transcript/audio-level/error on the IPC-only fallback until Electrobun exposes matching push messages\n- add focused coverage for the live desktop web-plugin path\n\n## Testing\n- bunx vitest run apps/app/test/app/swabble-web-rpc.test.ts apps/app/test/plugins/swabble.test.ts\n- bun run check\n- bun run pre-review:local