### PR TITLE
app: use electrobun runtime probe in desktop views

### DIFF
--- a/apps/app/src/components/GameView.tsx
+++ b/apps/app/src/components/GameView.tsx
@@ -9,7 +9,10 @@
  */
 
 import { client, type LogEntry } from "@milady/app-core/api";
-import { invokeDesktopBridgeRequest } from "@milady/app-core/bridge";
+import {
+  invokeDesktopBridgeRequest,
+  isElectrobunRuntime,
+} from "@milady/app-core/bridge";
 import { formatTime } from "@milady/app-core/components";
 import { Button, Input } from "@milady/ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -57,7 +60,7 @@ export function GameView() {
     setActionNotice,
     t,
   } = useApp();
-  const isElectrobun = !!window.electron;
+  const isElectrobun = isElectrobunRuntime();
   const [stopping, setStopping] = useState(false);
   const [showLogsPanel, setShowLogsPanel] = useState(false);
   const [connectionStatus, setConnectionStatus] = useState<

--- a/apps/app/src/components/StreamView.tsx
+++ b/apps/app/src/components/StreamView.tsx
@@ -12,6 +12,7 @@
  */
 
 import { client, isApiError } from "@milady/app-core/api";
+import { isElectrobunRuntime } from "@milady/app-core/bridge";
 import {
   type CSSProperties,
   useCallback,
@@ -58,7 +59,7 @@ export function StreamView({ inModal }: { inModal?: boolean } = {}) {
   } = useApp();
 
   const agentName = agentStatus?.agentName ?? "Milady";
-  const isElectrobun = !!window.electron;
+  const isElectrobun = isElectrobunRuntime();
 
   // ── Stream status polling ─────────────────────────────────────────────
   const [streamLive, setStreamLive] = useState(false);

--- a/apps/app/src/components/stream/StatusBar.tsx
+++ b/apps/app/src/components/stream/StatusBar.tsx
@@ -1,3 +1,4 @@
+import { isElectrobunRuntime } from "@milady/app-core/bridge";
 import { Button, Input, Slider } from "@milady/ui";
 import {
   ChevronDown,
@@ -76,7 +77,7 @@ export function StatusBar({
   onOpenSettings?: () => void;
 }) {
   const { t } = useApp();
-  const isElectrobun = !!window.electron;
+  const isElectrobun = isElectrobunRuntime();
   const isLive = streamLive;
   const [pinned, setPinned] = useState(IS_POPOUT); // popout starts pinned
   const [sourceOpen, setSourceOpen] = useState(false);

--- a/apps/app/test/app/game-view.test.ts
+++ b/apps/app/test/app/game-view.test.ts
@@ -28,6 +28,13 @@ interface GameContextStub {
   ) => void;
 }
 
+type TestWindow = Window & {
+  __MILADY_ELECTROBUN_RPC__?: {
+    request: Record<string, (params?: unknown) => Promise<unknown>>;
+  };
+  __electrobunWindowId?: number;
+};
+
 const { mockClientFns, mockUseApp } = vi.hoisted(() => ({
   mockClientFns: {
     getCodingAgentStatus: vi.fn(async () => null),
@@ -97,7 +104,8 @@ describe("GameView", () => {
   });
 
   afterEach(() => {
-    delete (window as typeof window & { electron?: unknown }).electron;
+    delete (window as TestWindow).__MILADY_ELECTROBUN_RPC__;
+    delete (window as TestWindow).__electrobunWindowId;
     vi.restoreAllMocks();
   });
 
@@ -162,13 +170,16 @@ describe("GameView", () => {
 
   it("uses the Electrobun shell bridge when opening the viewer externally", async () => {
     const ctx = createContext();
-    const invoke = vi.fn(async () => undefined);
+    const desktopOpenExternal = vi.fn(async () => undefined);
+    const gameOpenWindow = vi.fn(async () => ({ id: "game-window-1" }));
     mockUseApp.mockReturnValue(ctx);
-    Object.defineProperty(window, "electron", {
-      configurable: true,
-      writable: true,
-      value: { ipcRenderer: { invoke } },
-    });
+    (window as TestWindow).__electrobunWindowId = 1;
+    (window as TestWindow).__MILADY_ELECTROBUN_RPC__ = {
+      request: {
+        desktopOpenExternal,
+        gameOpenWindow,
+      },
+    };
     const openSpy = vi.spyOn(window, "open");
 
     let tree: TestRenderer.ReactTestRenderer;
@@ -181,7 +192,11 @@ describe("GameView", () => {
       await findButtonByText(tree?.root, "game.openInNewTab").props.onClick();
     });
 
-    expect(invoke).toHaveBeenCalledWith("desktop:openExternal", {
+    expect(gameOpenWindow).toHaveBeenCalledWith({
+      url: ctx.activeGameViewerUrl,
+      title: ctx.activeGameDisplayName || ctx.activeGameApp,
+    });
+    expect(desktopOpenExternal).toHaveBeenCalledWith({
       url: ctx.activeGameViewerUrl,
     });
     expect(openSpy).not.toHaveBeenCalled();

--- a/apps/app/test/app/stream-status-bar.test.tsx
+++ b/apps/app/test/app/stream-status-bar.test.tsx
@@ -4,6 +4,10 @@ import React from "react";
 import TestRenderer, { act } from "react-test-renderer";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+type TestWindow = Window & {
+  __electrobunWindowId?: number;
+};
+
 const mockUseApp = vi.fn(() => ({
   t: (key: string) => key,
 }));
@@ -53,16 +57,12 @@ function renderStatusBar() {
 
 describe("StatusBar stream popout button", () => {
   afterEach(() => {
-    delete (window as typeof window & { electron?: unknown }).electron;
+    delete (window as TestWindow).__electrobunWindowId;
     vi.restoreAllMocks();
   });
 
   it("hides the browser popout control inside Electrobun", () => {
-    Object.defineProperty(window, "electron", {
-      configurable: true,
-      writable: true,
-      value: { ipcRenderer: { invoke: vi.fn() } },
-    });
+    (window as TestWindow).__electrobunWindowId = 1;
 
     const tree = renderStatusBar();
 


### PR DESCRIPTION
## Summary\n- switch remaining app desktop-mode checks from \ to the shared \ probe\n- keep desktop-only behavior tied to the actual Electrobun runtime instead of Electron-shaped globals\n- update focused GameView and StatusBar tests to assert the runtime-marker contract\n\n## Testing\n- bunx vitest run apps/app/test/app/game-view.test.ts apps/app/test/app/stream-status-bar.test.tsx\n- bun run check\n- bun run pre-review:local