### PR TITLE
app: add direct swabble push messages for electrobun

### DIFF
--- a/apps/app/electrobun/src/__tests__/bridge.test.ts
+++ b/apps/app/electrobun/src/__tests__/bridge.test.ts
@@ -184,6 +184,10 @@ describe("PUSH_CHANNEL_TO_RPC_MESSAGE mapping", () => {
     expect(PUSH_CHANNEL_TO_RPC_MESSAGE["swabble:stateChange"]).toBe(
       "swabbleStateChanged",
     );
+    expect(PUSH_CHANNEL_TO_RPC_MESSAGE["swabble:transcript"]).toBe(
+      "swabbleTranscript",
+    );
+    expect(PUSH_CHANNEL_TO_RPC_MESSAGE["swabble:error"]).toBe("swabbleError");
   });
 
   it("maps GPU window push events", () => {

--- a/apps/app/electrobun/src/__tests__/kitchen-sink.test.ts
+++ b/apps/app/electrobun/src/__tests__/kitchen-sink.test.ts
@@ -1097,6 +1097,10 @@ describe("Channel mapping — push events", () => {
     expect(PUSH_CHANNEL_TO_RPC_MESSAGE["swabble:stateChange"]).toBe(
       "swabbleStateChanged",
     );
+    expect(PUSH_CHANNEL_TO_RPC_MESSAGE["swabble:transcript"]).toBe(
+      "swabbleTranscript",
+    );
+    expect(PUSH_CHANNEL_TO_RPC_MESSAGE["swabble:error"]).toBe("swabbleError");
     expect(PUSH_CHANNEL_TO_RPC_MESSAGE["swabble:audioChunkPush"]).toBe(
       "swabbleAudioChunkPush",
     );
@@ -1166,6 +1170,9 @@ describe("Reverse mapping consistency", () => {
     );
     expect(RPC_MESSAGE_TO_PUSH_CHANNEL.swabbleWakeWord).toBe(
       "swabble:wakeWord",
+    );
+    expect(RPC_MESSAGE_TO_PUSH_CHANNEL.swabbleTranscript).toBe(
+      "swabble:transcript",
     );
   });
 });

--- a/apps/app/electrobun/src/bridge/electrobun-bridge.ts
+++ b/apps/app/electrobun/src/bridge/electrobun-bridge.ts
@@ -253,6 +253,8 @@ const PUSH_CHANNEL_TO_RPC: Record<string, string> = {
   "talkmode:transcript": "talkmodeTranscript",
   "swabble:wakeWord": "swabbleWakeWord",
   "swabble:stateChange": "swabbleStateChanged",
+  "swabble:transcript": "swabbleTranscript",
+  "swabble:error": "swabbleError",
   "swabble:audioChunkPush": "swabbleAudioChunkPush",
   "contextMenu:askAgent": "contextMenuAskAgent",
   "contextMenu:createSkill": "contextMenuCreateSkill",

--- a/apps/app/electrobun/src/native/__tests__/swabble.test.ts
+++ b/apps/app/electrobun/src/native/__tests__/swabble.test.ts
@@ -280,6 +280,23 @@ describe("SwabbleManager", () => {
 
       await manager.audioChunk({ data: makeBase64Chunk(CHUNK_BYTES) });
 
+      const transcriptMsg = webviewMessages.find(
+        (m) => m.message === "swabble:transcript",
+      );
+      expect(transcriptMsg).toBeDefined();
+      expect(transcriptMsg?.payload).toEqual({
+        transcript: "milady what time is it",
+        segments: [
+          {
+            text: "milady what time is it",
+            start: 0,
+            duration: 3,
+            isFinal: true,
+          },
+        ],
+        isFinal: true,
+      });
+
       const wakeMsg = webviewMessages.find(
         (m) => m.message === "swabble:wakeWord",
       );
@@ -319,6 +336,15 @@ describe("SwabbleManager", () => {
       await expect(
         manager.audioChunk({ data: makeBase64Chunk(CHUNK_BYTES) }),
       ).resolves.toBeUndefined();
+
+      expect(webviewMessages).toContainEqual({
+        message: "swabble:error",
+        payload: {
+          code: "transcription_failed",
+          message: "whisper crashed",
+          recoverable: true,
+        },
+      });
     });
   });
 

--- a/apps/app/electrobun/src/native/swabble.ts
+++ b/apps/app/electrobun/src/native/swabble.ts
@@ -299,6 +299,17 @@ export class SwabbleManager {
 
       if (!result) return;
 
+      this.sendToWebview?.("swabble:transcript", {
+        transcript: result.text,
+        segments: result.segments.map((segment) => ({
+          text: segment.text,
+          start: segment.start,
+          duration: Math.max(0, segment.end - segment.start),
+          isFinal: true,
+        })),
+        isFinal: true,
+      });
+
       // Check for wake word
       const match = this.wakeGate.match(result);
       if (match) {
@@ -310,6 +321,11 @@ export class SwabbleManager {
         });
       }
     } catch (err) {
+      this.sendToWebview?.("swabble:error", {
+        code: "transcription_failed",
+        message: err instanceof Error ? err.message : String(err),
+        recoverable: true,
+      });
       console.error("[Swabble] processBuffer error:", err);
     } finally {
       this.processing = false;

--- a/apps/app/electrobun/src/rpc-schema.ts
+++ b/apps/app/electrobun/src/rpc-schema.ts
@@ -885,6 +885,22 @@ export type MiladyRPCSchema = {
         transcript: string;
       };
       swabbleStateChanged: { listening: boolean };
+      swabbleTranscript: {
+        transcript: string;
+        segments: Array<{
+          text: string;
+          start: number;
+          duration: number;
+          isFinal: boolean;
+        }>;
+        isFinal: boolean;
+        confidence?: number;
+      };
+      swabbleError: {
+        code: string;
+        message: string;
+        recoverable: boolean;
+      };
       // Swabble: audio chunk fallback (whisper.cpp binary missing)
       swabbleAudioChunkPush: { data: string };
 
@@ -1152,6 +1168,8 @@ export const PUSH_CHANNEL_TO_RPC_MESSAGE: Record<string, string> = {
   "talkmode:transcript": "talkmodeTranscript",
   "swabble:wakeWord": "swabbleWakeWord",
   "swabble:stateChange": "swabbleStateChanged",
+  "swabble:transcript": "swabbleTranscript",
+  "swabble:error": "swabbleError",
   "swabble:audioChunkPush": "swabbleAudioChunkPush",
   "contextMenu:askAgent": "contextMenuAskAgent",
   "contextMenu:createSkill": "contextMenuCreateSkill",

--- a/apps/app/plugins/swabble/electron/src/index.ts
+++ b/apps/app/plugins/swabble/electron/src/index.ts
@@ -310,6 +310,18 @@ export class SwabbleElectron implements SwabblePlugin {
         ipcChannel: "swabble:stateChange",
         normalize: (data: unknown) => this.normalizeStateEvent(data),
       },
+      {
+        eventName: "transcript" as const,
+        rpcMessage: "swabbleTranscript",
+        ipcChannel: "swabble:transcript",
+        normalize: (data: unknown) => data as unknown as SwabbleTranscriptEvent,
+      },
+      {
+        eventName: "error" as const,
+        rpcMessage: "swabbleError",
+        ipcChannel: "swabble:error",
+        normalize: (data: unknown) => data as unknown as SwabbleErrorEvent,
+      },
     ];
 
     for (const entry of bridgeHandlers) {
@@ -321,40 +333,6 @@ export class SwabbleElectron implements SwabblePlugin {
         },
       });
       this.bridgeSubscriptions.push(unsubscribe);
-    }
-
-    if (!this.ipc?.on) return;
-
-    const handlers: Array<{
-      channel: string;
-      handler: IpcListener;
-    }> = [
-      {
-        channel: "swabble:transcript",
-        handler: (_event, data) =>
-          this.notifyListeners(
-            "transcript",
-            data as unknown as SwabbleTranscriptEvent,
-          ),
-      },
-      {
-        channel: "swabble:audioLevel",
-        handler: (_event, data) =>
-          this.notifyListeners(
-            "audioLevel",
-            data as unknown as SwabbleAudioLevelEvent,
-          ),
-      },
-      {
-        channel: "swabble:error",
-        handler: (_event, data) =>
-          this.notifyListeners("error", data as unknown as SwabbleErrorEvent),
-      },
-    ];
-
-    for (const entry of handlers) {
-      this.ipc.on(entry.channel, entry.handler);
-      this.ipcHandlers.push(entry);
     }
   }
 

--- a/apps/app/plugins/swabble/src/web.ts
+++ b/apps/app/plugins/swabble/src/web.ts
@@ -158,6 +158,34 @@ export class SwabbleWeb extends WebPlugin {
     );
   }
 
+  private subscribeDesktopEvent(options: {
+    rpcMessage: string;
+    ipcChannel: string;
+    listener: DesktopMessageListener;
+  }): void {
+    const rpc = this.getRendererRpc();
+    if (rpc?.onMessage && rpc?.offMessage) {
+      rpc.onMessage(options.rpcMessage, options.listener);
+      this.bridgeSubscriptions.push(() => {
+        rpc.offMessage?.(options.rpcMessage, options.listener);
+      });
+      return;
+    }
+
+    const ipc = this.getIpc();
+    if (!ipc?.on) return;
+
+    const ipcListener = (...args: unknown[]) => {
+      const payload = args.length > 1 ? args[1] : args[0];
+      options.listener(payload);
+    };
+    ipc.on(options.ipcChannel, ipcListener);
+    this.ipcHandlers.push({
+      channel: options.ipcChannel,
+      listener: ipcListener,
+    });
+  }
+
   private async invokeDesktopRequest<T>(options: {
     rpcMethod: string;
     ipcChannel: string;
@@ -178,18 +206,17 @@ export class SwabbleWeb extends WebPlugin {
 
   private setupNativeListeners(): void {
     this.removeNativeListeners();
-
-    const rpc = this.getRendererRpc();
-    if (rpc?.onMessage && rpc?.offMessage) {
-      const wakeWordListener: DesktopMessageListener = (payload) => {
+    this.subscribeDesktopEvent({
+      rpcMessage: "swabbleWakeWord",
+      ipcChannel: "swabble:wakeWord",
+      listener: (payload) => {
         this.notifyListeners("wakeWord", payload as Record<string, unknown>);
-      };
-      rpc.onMessage("swabbleWakeWord", wakeWordListener);
-      this.bridgeSubscriptions.push(() => {
-        rpc.offMessage?.("swabbleWakeWord", wakeWordListener);
-      });
-
-      const stateChangeListener: DesktopMessageListener = (payload) => {
+      },
+    });
+    this.subscribeDesktopEvent({
+      rpcMessage: "swabbleStateChanged",
+      ipcChannel: "swabble:stateChange",
+      listener: (payload) => {
         const listening =
           typeof (payload as { listening?: unknown }).listening === "boolean"
             ? (payload as { listening: boolean }).listening
@@ -198,28 +225,22 @@ export class SwabbleWeb extends WebPlugin {
         this.notifyListeners("stateChange", {
           state: listening ? "listening" : "idle",
         });
-      };
-      rpc.onMessage("swabbleStateChanged", stateChangeListener);
-      this.bridgeSubscriptions.push(() => {
-        rpc.offMessage?.("swabbleStateChanged", stateChangeListener);
-      });
-    }
-
-    const ipc = this.getIpc();
-    if (!ipc?.on) return;
-
-    const ipcOnlyEvents: Array<[string, string]> = [
-      ["swabble:audioLevel", "audioLevel"],
-      ["swabble:transcript", "transcript"],
-      ["swabble:error", "error"],
-    ];
-    for (const [channel, eventName] of ipcOnlyEvents) {
-      const listener = (...args: unknown[]) => {
-        this.notifyListeners(eventName, args[0] as Record<string, unknown>);
-      };
-      ipc.on(channel, listener);
-      this.ipcHandlers.push({ channel, listener });
-    }
+      },
+    });
+    this.subscribeDesktopEvent({
+      rpcMessage: "swabbleTranscript",
+      ipcChannel: "swabble:transcript",
+      listener: (payload) => {
+        this.notifyListeners("transcript", payload as Record<string, unknown>);
+      },
+    });
+    this.subscribeDesktopEvent({
+      rpcMessage: "swabbleError",
+      ipcChannel: "swabble:error",
+      listener: (payload) => {
+        this.notifyListeners("error", payload as Record<string, unknown>);
+      },
+    });
   }
 
   private removeNativeListeners(): void {
@@ -251,6 +272,10 @@ export class SwabbleWeb extends WebPlugin {
     const inputRate = this.captureContext.sampleRate;
     processor.onaudioprocess = (e: AudioProcessingEvent) => {
       const input = e.inputBuffer.getChannelData(0);
+      this.notifyListeners("audioLevel", {
+        level: this.computeRms(input),
+        peak: this.computePeak(input),
+      });
       const ratio = inputRate / sampleRate;
       const out = new Float32Array(Math.round(input.length / ratio));
       for (let i = 0; i < out.length; i++) {
@@ -291,6 +316,23 @@ export class SwabbleWeb extends WebPlugin {
     sink.gain.value = 0;
     processor.connect(sink);
     sink.connect(this.captureContext.destination);
+  }
+
+  private computeRms(samples: Float32Array): number {
+    let sum = 0;
+    for (let i = 0; i < samples.length; i++) {
+      sum += samples[i] * samples[i];
+    }
+    return Math.sqrt(sum / samples.length);
+  }
+
+  private computePeak(samples: Float32Array): number {
+    let peak = 0;
+    for (let i = 0; i < samples.length; i++) {
+      const value = Math.abs(samples[i]);
+      if (value > peak) peak = value;
+    }
+    return peak;
   }
 
   private stopNativeAudioCapture(): void {

--- a/apps/app/test/app/swabble-electron-rpc.test.ts
+++ b/apps/app/test/app/swabble-electron-rpc.test.ts
@@ -225,7 +225,7 @@ describe("SwabbleElectron direct Electrobun RPC bridge", () => {
     expect(listeners.get("swabbleStateChanged")?.size ?? 0).toBe(0);
   });
 
-  it("keeps transcript and error events on IPC fallback when Electrobun exposes no direct push message", async () => {
+  it("uses direct swabble transcript and error push messages when Electrobun exposes them", async () => {
     const rpcListeners = new Map<string, Set<(payload: unknown) => void>>();
     const ipcListeners = new Map<
       string,
@@ -286,16 +286,13 @@ describe("SwabbleElectron direct Electrobun RPC bridge", () => {
       config: { triggers: ["milady"], sampleRate: 16000 },
     });
 
-    ipcListeners.get("swabble:transcript")?.forEach((listener) => {
-      listener(
-        { sender: "test" },
-        {
-          transcript: "milady open settings",
-          segments: [],
-          isFinal: true,
-          confidence: 0.99,
-        },
-      );
+    rpcListeners.get("swabbleTranscript")?.forEach((listener) => {
+      listener({
+        transcript: "milady open settings",
+        segments: [],
+        isFinal: true,
+        confidence: 0.99,
+      });
     });
     expect(transcriptListener).toHaveBeenCalledWith({
       transcript: "milady open settings",
@@ -304,15 +301,12 @@ describe("SwabbleElectron direct Electrobun RPC bridge", () => {
       confidence: 0.99,
     });
 
-    ipcListeners.get("swabble:error")?.forEach((listener) => {
-      listener(
-        { sender: "test" },
-        {
-          code: "native-error",
-          message: "microphone busy",
-          recoverable: true,
-        },
-      );
+    rpcListeners.get("swabbleError")?.forEach((listener) => {
+      listener({
+        code: "native-error",
+        message: "microphone busy",
+        recoverable: true,
+      });
     });
     expect(errorListener).toHaveBeenCalledWith({
       code: "native-error",
@@ -322,6 +316,8 @@ describe("SwabbleElectron direct Electrobun RPC bridge", () => {
 
     await plugin.stop();
     expect(swabbleStop).toHaveBeenCalledWith(undefined);
+    expect(rpcListeners.get("swabbleTranscript")?.size ?? 0).toBe(0);
+    expect(rpcListeners.get("swabbleError")?.size ?? 0).toBe(0);
     expect(ipcListeners.get("swabble:transcript")?.size ?? 0).toBe(0);
     expect(ipcListeners.get("swabble:error")?.size ?? 0).toBe(0);
   });

--- a/apps/app/test/app/swabble-web-rpc.test.ts
+++ b/apps/app/test/app/swabble-web-rpc.test.ts
@@ -220,9 +220,16 @@ describe("SwabbleWeb desktop bridge", () => {
     expect(directListeners.get("swabbleWakeWord")?.size ?? 0).toBe(0);
   });
 
-  it("keeps transcript and error desktop events on the IPC fallback path", async () => {
+  it("uses direct swabble transcript and error push messages and keeps audio levels local", async () => {
     const directListeners = new Map<string, Set<(payload: unknown) => void>>();
     const ipcListeners = new Map<string, Set<(...args: unknown[]) => void>>();
+    const ipcOn = vi.fn(
+      (channel: string, listener: (...args: unknown[]) => void) => {
+        const entry = ipcListeners.get(channel) ?? new Set();
+        entry.add(listener);
+        ipcListeners.set(channel, entry);
+      },
+    );
 
     (window as TestWindow).__MILADY_ELECTROBUN_RPC__ = {
       request: {
@@ -249,11 +256,7 @@ describe("SwabbleWeb desktop bridge", () => {
       ipcRenderer: {
         invoke: vi.fn(),
         send: vi.fn(),
-        on: vi.fn((channel: string, listener: (...args: unknown[]) => void) => {
-          const entry = ipcListeners.get(channel) ?? new Set();
-          entry.add(listener);
-          ipcListeners.set(channel, entry);
-        }),
+        on: ipcOn,
         removeListener: vi.fn(
           (channel: string, listener: (...args: unknown[]) => void) => {
             ipcListeners.get(channel)?.delete(listener);
@@ -265,8 +268,10 @@ describe("SwabbleWeb desktop bridge", () => {
     const sw = new SwabbleWeb();
     const transcriptListener = vi.fn();
     const errorListener = vi.fn();
+    const audioLevelListener = vi.fn();
     await sw.addListener("transcript", transcriptListener);
     await sw.addListener("error", errorListener);
+    await sw.addListener("audioLevel", audioLevelListener);
 
     await expect(
       sw.start({
@@ -274,7 +279,7 @@ describe("SwabbleWeb desktop bridge", () => {
       }),
     ).resolves.toEqual({ started: true });
 
-    ipcListeners.get("swabble:transcript")?.forEach((listener) => {
+    directListeners.get("swabbleTranscript")?.forEach((listener) => {
       listener({
         transcript: "hello world",
         segments: [],
@@ -287,7 +292,7 @@ describe("SwabbleWeb desktop bridge", () => {
       isFinal: true,
     });
 
-    ipcListeners.get("swabble:error")?.forEach((listener) => {
+    directListeners.get("swabbleError")?.forEach((listener) => {
       listener({
         code: "native_error",
         message: "boom",
@@ -300,8 +305,27 @@ describe("SwabbleWeb desktop bridge", () => {
       recoverable: true,
     });
 
+    processorStub.onaudioprocess?.({
+      inputBuffer: {
+        getChannelData: () =>
+          new Float32Array([0.25, -0.5, 0.25, -0.5, 0.25, -0.5]),
+      },
+    } as AudioProcessingEvent);
+    expect(audioLevelListener).toHaveBeenCalledWith({
+      level: expect.any(Number),
+      peak: 0.5,
+    });
+
     await sw.stop();
-    expect(ipcListeners.get("swabble:transcript")?.size ?? 0).toBe(0);
-    expect(ipcListeners.get("swabble:error")?.size ?? 0).toBe(0);
+    expect(directListeners.get("swabbleTranscript")?.size ?? 0).toBe(0);
+    expect(directListeners.get("swabbleError")?.size ?? 0).toBe(0);
+    expect(ipcOn).not.toHaveBeenCalledWith(
+      "swabble:transcript",
+      expect.any(Function),
+    );
+    expect(ipcOn).not.toHaveBeenCalledWith(
+      "swabble:error",
+      expect.any(Function),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add direct Electrobun swabble transcript and error push messages to the RPC schema and renderer bridge
- wire both swabble desktop adapters to those push messages instead of IPC-only transcript/error listeners
- keep swabble audio-level events local to the plugin audio capture path so the live desktop flow drops more IPC without losing behavior

## Testing
- bunx vitest run apps/app/test/app/swabble-web-rpc.test.ts apps/app/test/app/swabble-electron-rpc.test.ts apps/app/electrobun/src/native/__tests__/swabble.test.ts apps/app/electrobun/src/__tests__/bridge.test.ts
- bunx vitest run apps/app/electrobun/src/__tests__/kitchen-sink.test.ts -t "swabble push events|resolves specific reverse lookups"
- bun run check
- bun run pre-review:local