### PR TITLE
app: add direct talkmode error messages for electrobun

### DIFF
--- a/apps/app/electrobun/src/__tests__/bridge.test.ts
+++ b/apps/app/electrobun/src/__tests__/bridge.test.ts
@@ -175,6 +175,7 @@ describe("PUSH_CHANNEL_TO_RPC_MESSAGE mapping", () => {
     expect(PUSH_CHANNEL_TO_RPC_MESSAGE["talkmode:speakComplete"]).toBe(
       "talkmodeSpeakComplete",
     );
+    expect(PUSH_CHANNEL_TO_RPC_MESSAGE["talkmode:error"]).toBe("talkmodeError");
   });
 
   it("maps swabble push events", () => {

--- a/apps/app/electrobun/src/__tests__/kitchen-sink.test.ts
+++ b/apps/app/electrobun/src/__tests__/kitchen-sink.test.ts
@@ -1088,6 +1088,7 @@ describe("Channel mapping — push events", () => {
     expect(PUSH_CHANNEL_TO_RPC_MESSAGE["talkmode:transcript"]).toBe(
       "talkmodeTranscript",
     );
+    expect(PUSH_CHANNEL_TO_RPC_MESSAGE["talkmode:error"]).toBe("talkmodeError");
   });
 
   it("swabble push events", () => {
@@ -1168,6 +1169,7 @@ describe("Reverse mapping consistency", () => {
     expect(RPC_MESSAGE_TO_PUSH_CHANNEL.desktopWindowFocus).toBe(
       "desktop:windowFocus",
     );
+    expect(RPC_MESSAGE_TO_PUSH_CHANNEL.talkmodeError).toBe("talkmode:error");
     expect(RPC_MESSAGE_TO_PUSH_CHANNEL.swabbleWakeWord).toBe(
       "swabble:wakeWord",
     );

--- a/apps/app/electrobun/src/bridge/electrobun-bridge.ts
+++ b/apps/app/electrobun/src/bridge/electrobun-bridge.ts
@@ -251,6 +251,7 @@ const PUSH_CHANNEL_TO_RPC: Record<string, string> = {
   "talkmode:stateChanged": "talkmodeStateChanged",
   "talkmode:speakComplete": "talkmodeSpeakComplete",
   "talkmode:transcript": "talkmodeTranscript",
+  "talkmode:error": "talkmodeError",
   "swabble:wakeWord": "swabbleWakeWord",
   "swabble:stateChange": "swabbleStateChanged",
   "swabble:transcript": "swabbleTranscript",

--- a/apps/app/electrobun/src/native/__tests__/talkmode.test.ts
+++ b/apps/app/electrobun/src/native/__tests__/talkmode.test.ts
@@ -21,7 +21,24 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../whisper", () => ({
   isWhisperAvailable: vi.fn(() => false),
   isWhisperBinaryAvailable: vi.fn(() => false),
+  transcribeBunSpawn: vi.fn(),
+  writeWavFile: vi.fn(),
 }));
+
+vi.mock("node:fs", () => ({
+  default: { unlinkSync: vi.fn() },
+  unlinkSync: vi.fn(),
+}));
+
+vi.mock("node:os", () => ({
+  default: { tmpdir: vi.fn(() => "/tmp") },
+  tmpdir: vi.fn(() => "/tmp"),
+}));
+
+vi.mock("node:path", async () => {
+  const actual = await vi.importActual<typeof import("node:path")>("node:path");
+  return { default: actual, ...actual };
+});
 
 vi.stubGlobal("fetch", vi.fn());
 
@@ -40,6 +57,10 @@ import * as whisperMod from "../whisper";
 const mockIsWhisperAvailable = whisperMod.isWhisperAvailable as ReturnType<
   typeof vi.fn
 >;
+const mockTranscribeBunSpawn = whisperMod.transcribeBunSpawn as ReturnType<
+  typeof vi.fn
+>;
+const mockWriteWavFile = whisperMod.writeWavFile as ReturnType<typeof vi.fn>;
 const mockFetch = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
 
 // ---------------------------------------------------------------------------
@@ -70,6 +91,7 @@ function makeErrorResponse(status = 500) {
 describe("TalkModeManager", () => {
   let manager: TalkModeManager;
   let webviewMessages: Array<{ message: string; payload: unknown }>;
+  const TALKMODE_AUDIO_BUFFER_THRESHOLD = 16000 * 3 * 4;
 
   beforeEach(() => {
     manager = new TalkModeManager();
@@ -79,6 +101,8 @@ describe("TalkModeManager", () => {
     });
     mockFetch.mockReset();
     mockIsWhisperAvailable.mockReturnValue(false);
+    mockTranscribeBunSpawn.mockReset();
+    mockWriteWavFile.mockReset();
   });
 
   afterEach(() => {
@@ -349,6 +373,55 @@ describe("TalkModeManager", () => {
       await expect(
         manager.audioChunk({ data: "dGVzdA==" }),
       ).resolves.toBeUndefined();
+    });
+
+    it("emits talkmode:transcript when whisper transcription succeeds", async () => {
+      mockIsWhisperAvailable.mockReturnValue(true);
+      mockTranscribeBunSpawn.mockResolvedValue({
+        text: "hello world",
+        segments: [{ text: "hello world", start: 0, end: 1 }],
+      });
+      await manager.start();
+
+      await expect(
+        manager.audioChunk({
+          data: Buffer.alloc(TALKMODE_AUDIO_BUFFER_THRESHOLD).toString(
+            "base64",
+          ),
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(mockWriteWavFile).toHaveBeenCalledTimes(1);
+      expect(webviewMessages).toContainEqual({
+        message: "talkmode:transcript",
+        payload: {
+          text: "hello world",
+          segments: [{ text: "hello world", start: 0, end: 1 }],
+        },
+      });
+    });
+
+    it("emits talkmode:error when whisper transcription fails", async () => {
+      mockIsWhisperAvailable.mockReturnValue(true);
+      mockTranscribeBunSpawn.mockRejectedValue(new Error("whisper crashed"));
+      await manager.start();
+
+      await expect(
+        manager.audioChunk({
+          data: Buffer.alloc(TALKMODE_AUDIO_BUFFER_THRESHOLD).toString(
+            "base64",
+          ),
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(webviewMessages).toContainEqual({
+        message: "talkmode:error",
+        payload: {
+          code: "transcription_failed",
+          message: "whisper crashed",
+          recoverable: true,
+        },
+      });
     });
   });
 

--- a/apps/app/electrobun/src/native/talkmode.ts
+++ b/apps/app/electrobun/src/native/talkmode.ts
@@ -319,6 +319,11 @@ export class TalkModeManager {
         })),
       });
     } catch (err) {
+      this.sendToWebview?.("talkmode:error", {
+        code: "transcription_failed",
+        message: err instanceof Error ? err.message : String(err),
+        recoverable: true,
+      });
       console.error("[TalkMode] _processBuffer error:", err);
     } finally {
       this._processing = false;

--- a/apps/app/electrobun/src/rpc-schema.ts
+++ b/apps/app/electrobun/src/rpc-schema.ts
@@ -877,6 +877,11 @@ export type MiladyRPCSchema = {
         text: string;
         segments: Array<{ text: string; start: number; end: number }>;
       };
+      talkmodeError: {
+        code: string;
+        message: string;
+        recoverable: boolean;
+      };
 
       // Swabble: Wake word detection
       swabbleWakeWord: {
@@ -1166,6 +1171,7 @@ export const PUSH_CHANNEL_TO_RPC_MESSAGE: Record<string, string> = {
   "talkmode:stateChanged": "talkmodeStateChanged",
   "talkmode:speakComplete": "talkmodeSpeakComplete",
   "talkmode:transcript": "talkmodeTranscript",
+  "talkmode:error": "talkmodeError",
   "swabble:wakeWord": "swabbleWakeWord",
   "swabble:stateChange": "swabbleStateChanged",
   "swabble:transcript": "swabbleTranscript",

--- a/apps/app/plugins/talkmode/electron/src/index.ts
+++ b/apps/app/plugins/talkmode/electron/src/index.ts
@@ -314,6 +314,13 @@ export class TalkModeElectron implements TalkModePlugin {
           );
         },
       },
+      {
+        rpcMessage: "talkmodeError",
+        ipcChannel: "talkmode:error",
+        listener: (data: unknown) => {
+          this.notifyListeners("error", data as TalkModeErrorEvent);
+        },
+      },
     ];
 
     for (const entry of bridgeHandlers) {
@@ -323,24 +330,6 @@ export class TalkModeElectron implements TalkModePlugin {
         listener: entry.listener,
       });
       this.bridgeSubscriptions.push(unsubscribe);
-    }
-
-    if (!this.ipc?.on) return;
-
-    const handlers: Array<{
-      channel: string;
-      handler: IpcListener;
-    }> = [
-      {
-        channel: "talkmode:error",
-        handler: (_event, data) =>
-          this.notifyListeners("error", data as TalkModeErrorEvent),
-      },
-    ];
-
-    for (const entry of handlers) {
-      this.ipc.on(entry.channel, entry.handler);
-      this.ipcHandlers.push(entry);
     }
   }
 

--- a/apps/app/test/app/talkmode-electron-rpc.test.ts
+++ b/apps/app/test/app/talkmode-electron-rpc.test.ts
@@ -274,7 +274,8 @@ describe("TalkModeElectron direct Electrobun RPC bridge", () => {
     expect(directListeners.get("talkmodeTranscript")?.size ?? 0).toBe(0);
   });
 
-  it("keeps legacy talkmode error events on IPC fallback when Electrobun exposes no direct push message", async () => {
+  it("uses direct talkmode error push messages when Electrobun exposes them", async () => {
+    const directListeners = new Map<string, Set<(payload: unknown) => void>>();
     const ipcListeners = new Map<
       string,
       Set<(event: unknown, payload: unknown) => void>
@@ -282,8 +283,18 @@ describe("TalkModeElectron direct Electrobun RPC bridge", () => {
 
     (window as TestWindow).__MILADY_ELECTROBUN_RPC__ = {
       request: {},
-      onMessage: vi.fn(),
-      offMessage: vi.fn(),
+      onMessage: vi.fn(
+        (messageName: string, listener: (payload: unknown) => void) => {
+          const entry = directListeners.get(messageName) ?? new Set();
+          entry.add(listener);
+          directListeners.set(messageName, entry);
+        },
+      ),
+      offMessage: vi.fn(
+        (messageName: string, listener: (payload: unknown) => void) => {
+          directListeners.get(messageName)?.delete(listener);
+        },
+      ),
     };
     (window as TestWindow).electron = {
       ipcRenderer: {
@@ -312,12 +323,6 @@ describe("TalkModeElectron direct Electrobun RPC bridge", () => {
     const plugin = new TalkModeElectron();
     const invokeBridge = vi.fn(async (rpcMethod: string) => {
       switch (rpcMethod) {
-        case "talkmodeStart":
-          return { available: true };
-        case "talkmodeIsWhisperAvailable":
-          return { available: false };
-        case "talkmodeStop":
-          return undefined;
         default:
           return null;
       }
@@ -329,16 +334,15 @@ describe("TalkModeElectron direct Electrobun RPC bridge", () => {
 
     (plugin as TalkModeElectronPrivate).setupNativeListeners();
 
-    ipcListeners.get("talkmode:error")?.forEach((listener) => {
-      listener(
-        {},
-        { code: "native_error", message: "boom", recoverable: true },
-      );
+    directListeners.get("talkmodeError")?.forEach((listener) => {
+      listener({ code: "native_error", message: "boom", recoverable: true });
     });
     expect(errorListener).toHaveBeenCalledWith({
       code: "native_error",
       message: "boom",
       recoverable: true,
     });
+    expect(directListeners.get("talkmodeError")?.size ?? 0).toBe(1);
+    expect(ipcListeners.get("talkmode:error")?.size ?? 0).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- add direct talkmode error push messages to the Electrobun RPC schema and bridge
- emit native talkmode transcription failures to the renderer instead of relying on IPC-only error paths
- cover the bridge, native manager, kitchen sink, and plugin adapter with focused regression tests

## Testing
- bunx vitest run apps/app/test/app/talkmode-electron-rpc.test.ts apps/app/electrobun/src/native/__tests__/talkmode.test.ts apps/app/electrobun/src/__tests__/bridge.test.ts
- bunx vitest run apps/app/electrobun/src/__tests__/kitchen-sink.test.ts -t "maps talkmode push events|talkmode push events|resolves specific reverse lookups"
- bun run check
- bun run pre-review:local