### PR TITLE
app: drop desktop ipc-only event fallbacks

### DIFF
--- a/apps/app/plugins/desktop/electron/src/index.ts
+++ b/apps/app/plugins/desktop/electron/src/index.ts
@@ -17,7 +17,6 @@
 
 import type { PluginListenerHandle } from "@capacitor/core";
 import {
-  getElectronIpcRenderer,
   invokeDesktopBridgeRequest,
   subscribeDesktopBridgeEvent,
 } from "@milady/app-core/bridge";
@@ -144,10 +143,6 @@ export class DesktopElectron implements DesktopPlugin {
     this.setupDesktopListeners();
   }
 
-  private get ipc() {
-    return getElectronIpcRenderer();
-  }
-
   private async invokeBridge<T>(
     feature: string,
     rpcMethod: string,
@@ -190,35 +185,21 @@ export class DesktopElectron implements DesktopPlugin {
 
     for (const eventName of events) {
       const rpcEvent = DESKTOP_RPC_EVENTS[eventName];
-      if (rpcEvent) {
-        const unsubscribe = subscribeDesktopBridgeEvent({
-          rpcMessage: rpcEvent.rpcMessage,
-          ipcChannel: rpcEvent.ipcChannel,
-          listener: (data) => {
-            this.notifyListeners(
-              eventName,
-              data as DesktopEventPayloads[typeof eventName],
-            );
-          },
-        });
-        this.internalSubscriptions.push(unsubscribe);
+      if (!rpcEvent) {
         continue;
       }
 
-      if (!this.ipc?.on) {
-        continue;
-      }
-
-      const handler = (_event: unknown, payload: unknown) => {
-        this.notifyListeners(
-          eventName,
-          payload as DesktopEventPayloads[typeof eventName],
-        );
-      };
-      this.ipc.on(`desktop:${eventName}`, handler);
-      this.internalSubscriptions.push(() => {
-        this.ipc?.removeListener?.(`desktop:${eventName}`, handler);
+      const unsubscribe = subscribeDesktopBridgeEvent({
+        rpcMessage: rpcEvent.rpcMessage,
+        ipcChannel: rpcEvent.ipcChannel,
+        listener: (data) => {
+          this.notifyListeners(
+            eventName,
+            data as DesktopEventPayloads[typeof eventName],
+          );
+        },
       });
+      this.internalSubscriptions.push(unsubscribe);
     }
   }
 

--- a/apps/app/test/app/desktop-electron-rpc.test.ts
+++ b/apps/app/test/app/desktop-electron-rpc.test.ts
@@ -94,7 +94,7 @@ describe("DesktopElectron desktop bridge", () => {
     expect(invoke).toHaveBeenCalledWith("desktop:beep", undefined);
   });
 
-  it("keeps IPC-only fallback events wired for unsupported desktop push messages", async () => {
+  it("does not wire unsupported desktop push messages through plugin-level IPC fallbacks", async () => {
     const ipcListeners = new Map<
       string,
       Set<(event: unknown, payload: unknown) => void>
@@ -128,10 +128,7 @@ describe("DesktopElectron desktop bridge", () => {
     const suspendListener = vi.fn();
     await plugin.addListener("powerSuspend", suspendListener);
 
-    ipcListeners.get("desktop:powerSuspend")?.forEach((listener) => {
-      listener({ sender: "test" }, undefined);
-    });
-
-    expect(suspendListener).toHaveBeenCalledWith(undefined);
+    expect(ipcListeners.has("desktop:powerSuspend")).toBe(false);
+    expect(suspendListener).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- remove plugin-level raw IPC event wiring from DesktopElectron for unsupported desktop push messages
- keep desktop requests on the shared bridge while making the desktop event surface RPC-only
- update the desktop bridge test to assert those unsupported IPC-only push paths are no longer wired

## Testing
- bunx vitest run apps/app/test/app/desktop-electron-rpc.test.ts
- bun run check
- bun run pre-review:local