### PR TITLE
app: remove voice plugin ipc audio fallbacks

### DIFF
--- a/apps/app/plugins/swabble/electron/src/index.ts
+++ b/apps/app/plugins/swabble/electron/src/index.ts
@@ -2,7 +2,6 @@
 import type { PluginListenerHandle } from "@capacitor/core";
 import {
   getElectrobunRendererRpc,
-  getElectronIpcRenderer,
   invokeDesktopBridgeRequest,
   subscribeDesktopBridgeEvent,
 } from "@milady/app-core/bridge";
@@ -31,16 +30,6 @@ type SwabbleEvent =
 interface ListenerEntry {
   eventName: string;
   callback: EventCallback<SwabbleEvent>;
-}
-
-type IpcPayload = unknown;
-type IpcListener = (event: unknown, payload: IpcPayload) => void;
-
-interface ElectronAudioIpcRenderer {
-  invoke: (channel: string, params?: unknown) => Promise<unknown>;
-  send?: (channel: string, params?: unknown) => void;
-  on?: (channel: string, listener: IpcListener) => void;
-  removeListener?: (channel: string, listener: IpcListener) => void;
 }
 
 const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
@@ -128,14 +117,6 @@ export class SwabbleElectron implements SwabblePlugin {
   private captureGain: GainNode | null = null;
   private captureSampleRate = 16000;
   private bridgeSubscriptions: Array<() => void> = [];
-  private ipcHandlers: Array<{
-    channel: string;
-    handler: IpcListener;
-  }> = [];
-
-  private get ipc(): ElectronAudioIpcRenderer | undefined {
-    return getElectronIpcRenderer() as ElectronAudioIpcRenderer | undefined;
-  }
 
   private async invokeBridge<T>(
     rpcMethod: string,
@@ -179,7 +160,7 @@ export class SwabbleElectron implements SwabblePlugin {
     if (nativeResult) {
       // Fall through to web implementation when the native bridge is present
       // but cannot start whisper.cpp.
-    } else if (this.ipc || getElectrobunRendererRpc()) {
+    } else if (getElectrobunRendererRpc()) {
       // Native bridge exists but returned no result. Fall through to the web path.
     }
 
@@ -341,18 +322,12 @@ export class SwabbleElectron implements SwabblePlugin {
       unsubscribe();
     }
     this.bridgeSubscriptions = [];
-
-    for (const entry of this.ipcHandlers) {
-      this.ipc?.removeListener?.(entry.channel, entry.handler);
-    }
-    this.ipcHandlers = [];
   }
 
   private async startAudioCapture(): Promise<void> {
     if (
       this.captureContext ||
-      (!this.ipc?.send &&
-        !getElectrobunRendererRpc()?.request?.swabbleAudioChunk)
+      !getElectrobunRendererRpc()?.request?.swabbleAudioChunk
     ) {
       return;
     }
@@ -474,21 +449,20 @@ export class SwabbleElectron implements SwabblePlugin {
 
   private sendAudioChunk(downsampled: Float32Array): void {
     const rpcRequest = getElectrobunRendererRpc()?.request?.swabbleAudioChunk;
-    if (rpcRequest) {
-      const bytes = new Uint8Array(
-        downsampled.buffer,
-        downsampled.byteOffset,
-        downsampled.byteLength,
-      );
-      let binary = "";
-      for (let i = 0; i < bytes.length; i++) {
-        binary += String.fromCharCode(bytes[i]);
-      }
-      void rpcRequest({ data: btoa(binary) }).catch(() => {});
+    if (!rpcRequest) {
       return;
     }
 
-    this.ipc?.send?.("swabble:audioChunk", downsampled);
+    const bytes = new Uint8Array(
+      downsampled.buffer,
+      downsampled.byteOffset,
+      downsampled.byteLength,
+    );
+    let binary = "";
+    for (let i = 0; i < bytes.length; i++) {
+      binary += String.fromCharCode(bytes[i]);
+    }
+    void rpcRequest({ data: btoa(binary) }).catch(() => {});
   }
 
   private normalizeWakeWordEvent(data: unknown): SwabbleWakeWordEvent {
@@ -726,7 +700,7 @@ export class SwabbleElectron implements SwabblePlugin {
   async setAudioDevice(_options: { deviceId: string }): Promise<void> {
     this.selectedDeviceId = _options.deviceId;
 
-    if ((this.ipc || getElectrobunRendererRpc()) && this.captureContext) {
+    if (getElectrobunRendererRpc() && this.captureContext) {
       this.stopAudioCapture();
       await this.startAudioCapture();
       return;

--- a/apps/app/plugins/talkmode/electron/src/index.ts
+++ b/apps/app/plugins/talkmode/electron/src/index.ts
@@ -15,10 +15,8 @@
  */
 
 import type { PluginListenerHandle } from "@capacitor/core";
-import type { ElectronIpcRenderer } from "@milady/app-core/bridge";
 import {
   getElectrobunRendererRpc,
-  getElectronIpcRenderer,
   invokeDesktopBridgeRequest,
   subscribeDesktopBridgeEvent,
 } from "@milady/app-core/bridge";
@@ -47,14 +45,6 @@ type TalkModeEvent =
 interface ListenerEntry {
   eventName: string;
   callback: EventCallback<TalkModeEvent>;
-}
-
-type IpcListener = (event: unknown, payload: unknown) => void;
-
-interface ElectronTalkModeIpcRenderer extends ElectronIpcRenderer {
-  send?: (channel: string, payload?: unknown) => void;
-  on?: (channel: string, listener: IpcListener) => void;
-  removeListener?: (channel: string, listener: IpcListener) => void;
 }
 
 interface NativeTalkModeConfig {
@@ -146,19 +136,11 @@ export class TalkModeElectron implements TalkModePlugin {
   private captureSampleRate = 16000;
 
   private bridgeSubscriptions: Array<() => void> = [];
-  private ipcHandlers: Array<{
-    channel: string;
-    handler: IpcListener;
-  }> = [];
 
   constructor() {
     if (typeof window !== "undefined" && window.speechSynthesis) {
       this.synthesis = window.speechSynthesis;
     }
-  }
-
-  private get ipc(): ElectronTalkModeIpcRenderer | undefined {
-    return getElectronIpcRenderer() as ElectronTalkModeIpcRenderer | undefined;
   }
 
   private async invokeBridge<T>(
@@ -338,11 +320,6 @@ export class TalkModeElectron implements TalkModePlugin {
       unsubscribe();
     }
     this.bridgeSubscriptions = [];
-
-    for (const entry of this.ipcHandlers) {
-      this.ipc?.removeListener?.(entry.channel, entry.handler);
-    }
-    this.ipcHandlers = [];
   }
 
   async stop(): Promise<void> {
@@ -521,8 +498,7 @@ export class TalkModeElectron implements TalkModePlugin {
   private async startAudioCapture(): Promise<void> {
     if (
       this.captureContext ||
-      (!this.ipc?.send &&
-        !getElectrobunRendererRpc()?.request?.talkmodeAudioChunk)
+      !getElectrobunRendererRpc()?.request?.talkmodeAudioChunk
     ) {
       return;
     }
@@ -562,21 +538,20 @@ export class TalkModeElectron implements TalkModePlugin {
 
   private sendAudioChunk(downsampled: Float32Array): void {
     const rpcRequest = getElectrobunRendererRpc()?.request?.talkmodeAudioChunk;
-    if (rpcRequest) {
-      const bytes = new Uint8Array(
-        downsampled.buffer,
-        downsampled.byteOffset,
-        downsampled.byteLength,
-      );
-      let binary = "";
-      for (let i = 0; i < bytes.length; i++) {
-        binary += String.fromCharCode(bytes[i]);
-      }
-      void rpcRequest({ data: btoa(binary) }).catch(() => {});
+    if (!rpcRequest) {
       return;
     }
 
-    this.ipc?.send?.("talkmode:audioChunk", downsampled);
+    const bytes = new Uint8Array(
+      downsampled.buffer,
+      downsampled.byteOffset,
+      downsampled.byteLength,
+    );
+    let binary = "";
+    for (let i = 0; i < bytes.length; i++) {
+      binary += String.fromCharCode(bytes[i]);
+    }
+    void rpcRequest({ data: btoa(binary) }).catch(() => {});
   }
 
   private stopAudioCapture(): void {

--- a/apps/app/test/app/swabble-electron-rpc.test.ts
+++ b/apps/app/test/app/swabble-electron-rpc.test.ts
@@ -1,19 +1,11 @@
 // @vitest-environment jsdom
 
-import type {
-  ElectrobunRendererRpc,
-  ElectronIpcRenderer,
-} from "@milady/app-core/bridge";
+import type { ElectrobunRendererRpc } from "@milady/app-core/bridge";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SwabbleElectron } from "../../plugins/swabble/electron/src/index";
 
 type TestWindow = Window & {
   __MILADY_ELECTROBUN_RPC__?: ElectrobunRendererRpc;
-  electron?: {
-    ipcRenderer?: ElectronIpcRenderer & {
-      send?: (channel: string, payload?: unknown) => void;
-    };
-  };
 };
 
 interface ProcessorStub {
@@ -97,7 +89,6 @@ describe("SwabbleElectron direct Electrobun RPC bridge", () => {
 
   afterEach(() => {
     delete (window as TestWindow).__MILADY_ELECTROBUN_RPC__;
-    delete (window as TestWindow).electron;
     vi.restoreAllMocks();
 
     if (originalAudioContext) {
@@ -123,7 +114,6 @@ describe("SwabbleElectron direct Electrobun RPC bridge", () => {
       .fn()
       .mockResolvedValue({ available: true });
     const swabbleAudioChunk = vi.fn().mockResolvedValue(undefined);
-    const ipcInvoke = vi.fn();
 
     (window as TestWindow).__MILADY_ELECTROBUN_RPC__ = {
       request: {
@@ -148,11 +138,6 @@ describe("SwabbleElectron direct Electrobun RPC bridge", () => {
         },
       ),
     };
-    (window as TestWindow).electron = {
-      ipcRenderer: {
-        invoke: ipcInvoke,
-      },
-    };
 
     const plugin = new SwabbleElectron();
     const wakeListener = vi.fn();
@@ -169,7 +154,6 @@ describe("SwabbleElectron direct Electrobun RPC bridge", () => {
     expect(swabbleStart).toHaveBeenCalledWith({
       config: { triggers: ["milady"], sampleRate: 16000 },
     });
-    expect(ipcInvoke).not.toHaveBeenCalled();
 
     listeners.get("swabbleWakeWord")?.forEach((listener) => {
       listener({
@@ -227,10 +211,6 @@ describe("SwabbleElectron direct Electrobun RPC bridge", () => {
 
   it("uses direct swabble transcript and error push messages when Electrobun exposes them", async () => {
     const rpcListeners = new Map<string, Set<(payload: unknown) => void>>();
-    const ipcListeners = new Map<
-      string,
-      Set<(event: unknown, payload: unknown) => void>
-    >();
     const swabbleStop = vi.fn().mockResolvedValue(undefined);
 
     (window as TestWindow).__MILADY_ELECTROBUN_RPC__ = {
@@ -251,29 +231,6 @@ describe("SwabbleElectron direct Electrobun RPC bridge", () => {
           rpcListeners.get(messageName)?.delete(listener);
         },
       ),
-    };
-    (window as TestWindow).electron = {
-      ipcRenderer: {
-        invoke: vi.fn(),
-        on: vi.fn(
-          (
-            channel: string,
-            listener: (event: unknown, payload: unknown) => void,
-          ) => {
-            const entry = ipcListeners.get(channel) ?? new Set();
-            entry.add(listener);
-            ipcListeners.set(channel, entry);
-          },
-        ),
-        removeListener: vi.fn(
-          (
-            channel: string,
-            listener: (event: unknown, payload: unknown) => void,
-          ) => {
-            ipcListeners.get(channel)?.delete(listener);
-          },
-        ),
-      },
     };
 
     const plugin = new SwabbleElectron();
@@ -318,7 +275,5 @@ describe("SwabbleElectron direct Electrobun RPC bridge", () => {
     expect(swabbleStop).toHaveBeenCalledWith(undefined);
     expect(rpcListeners.get("swabbleTranscript")?.size ?? 0).toBe(0);
     expect(rpcListeners.get("swabbleError")?.size ?? 0).toBe(0);
-    expect(ipcListeners.get("swabble:transcript")?.size ?? 0).toBe(0);
-    expect(ipcListeners.get("swabble:error")?.size ?? 0).toBe(0);
   });
 });

--- a/apps/app/test/app/talkmode-electron-rpc.test.ts
+++ b/apps/app/test/app/talkmode-electron-rpc.test.ts
@@ -1,27 +1,11 @@
 // @vitest-environment jsdom
 
-import type {
-  ElectrobunRendererRpc,
-  ElectronIpcRenderer,
-} from "@milady/app-core/bridge";
+import type { ElectrobunRendererRpc } from "@milady/app-core/bridge";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TalkModeElectron } from "../../plugins/talkmode/electron/src/index.ts";
 
 type TestWindow = Window & {
   __MILADY_ELECTROBUN_RPC__?: ElectrobunRendererRpc;
-  electron?: {
-    ipcRenderer?: ElectronIpcRenderer & {
-      send?: (channel: string, payload?: unknown) => void;
-      on?: (
-        channel: string,
-        listener: (event: unknown, payload: unknown) => void,
-      ) => void;
-      removeListener?: (
-        channel: string,
-        listener: (event: unknown, payload: unknown) => void,
-      ) => void;
-    };
-  };
 };
 
 type TalkModeElectronPrivate = TalkModeElectron & {
@@ -106,7 +90,6 @@ describe("TalkModeElectron direct Electrobun RPC bridge", () => {
 
   afterEach(() => {
     delete (window as TestWindow).__MILADY_ELECTROBUN_RPC__;
-    delete (window as TestWindow).electron;
     vi.restoreAllMocks();
 
     if (originalAudioContext) {
@@ -121,7 +104,6 @@ describe("TalkModeElectron direct Electrobun RPC bridge", () => {
   it("prefers direct Electrobun RPC for talkmode control and syncs the native config shape", async () => {
     const directListeners = new Map<string, Set<(payload: unknown) => void>>();
     const talkmodeAudioChunk = vi.fn().mockResolvedValue(undefined);
-    const ipcInvoke = vi.fn();
 
     (window as TestWindow).__MILADY_ELECTROBUN_RPC__ = {
       request: {
@@ -139,11 +121,6 @@ describe("TalkModeElectron direct Electrobun RPC bridge", () => {
           directListeners.get(messageName)?.delete(listener);
         },
       ),
-    };
-    (window as TestWindow).electron = {
-      ipcRenderer: {
-        invoke: ipcInvoke,
-      },
     };
 
     const plugin = new TalkModeElectron();
@@ -210,7 +187,6 @@ describe("TalkModeElectron direct Electrobun RPC bridge", () => {
       "talkmodeIsWhisperAvailable",
       "talkmode:isWhisperAvailable",
     );
-    expect(ipcInvoke).not.toHaveBeenCalled();
 
     directListeners.get("talkmodeStateChanged")?.forEach((listener) => {
       listener({ state: "processing" });
@@ -276,10 +252,6 @@ describe("TalkModeElectron direct Electrobun RPC bridge", () => {
 
   it("uses direct talkmode error push messages when Electrobun exposes them", async () => {
     const directListeners = new Map<string, Set<(payload: unknown) => void>>();
-    const ipcListeners = new Map<
-      string,
-      Set<(event: unknown, payload: unknown) => void>
-    >();
 
     (window as TestWindow).__MILADY_ELECTROBUN_RPC__ = {
       request: {},
@@ -295,29 +267,6 @@ describe("TalkModeElectron direct Electrobun RPC bridge", () => {
           directListeners.get(messageName)?.delete(listener);
         },
       ),
-    };
-    (window as TestWindow).electron = {
-      ipcRenderer: {
-        invoke: vi.fn(),
-        on: vi.fn(
-          (
-            channel: string,
-            listener: (event: unknown, payload: unknown) => void,
-          ) => {
-            const entry = ipcListeners.get(channel) ?? new Set();
-            entry.add(listener);
-            ipcListeners.set(channel, entry);
-          },
-        ),
-        removeListener: vi.fn(
-          (
-            channel: string,
-            listener: (event: unknown, payload: unknown) => void,
-          ) => {
-            ipcListeners.get(channel)?.delete(listener);
-          },
-        ),
-      },
     };
 
     const plugin = new TalkModeElectron();
@@ -343,6 +292,5 @@ describe("TalkModeElectron direct Electrobun RPC bridge", () => {
       recoverable: true,
     });
     expect(directListeners.get("talkmodeError")?.size ?? 0).toBe(1);
-    expect(ipcListeners.get("talkmode:error")?.size ?? 0).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- remove raw IPC audio chunk fallbacks from TalkModeElectron and SwabbleElectron
- keep native voice capture on direct Electrobun RPC only
- update the focused bridge tests so they assert the RPC-only native audio path

## Testing
- bunx vitest run apps/app/test/app/talkmode-electron-rpc.test.ts apps/app/test/app/swabble-electron-rpc.test.ts
- bun run check
- bun run pre-review:local