### PR TITLE
app: remove electrobun ipc compat fallback

### DIFF
--- a/apps/app/plugins/swabble/src/web.ts
+++ b/apps/app/plugins/swabble/src/web.ts
@@ -55,24 +55,8 @@ interface ElectrobunRendererRpc {
   ) => void;
 }
 
-interface ElectronIpcRenderer {
-  invoke: (channel: string, params?: unknown) => Promise<unknown>;
-  on?: (
-    channel: string,
-    listener: (event: unknown, payload: unknown) => void,
-  ) => void;
-  removeListener?: (
-    channel: string,
-    listener: (event: unknown, payload: unknown) => void,
-  ) => void;
-  removeAllListeners?: (channel: string) => void;
-}
-
 type DesktopBridgeWindow = Window & {
   __MILADY_ELECTROBUN_RPC__?: ElectrobunRendererRpc;
-  electron?: {
-    ipcRenderer?: ElectronIpcRenderer;
-  };
 };
 
 function getDesktopBridgeWindow(): DesktopBridgeWindow | null {
@@ -87,10 +71,6 @@ function getElectrobunRendererRpc(): ElectrobunRendererRpc | null {
   return getDesktopBridgeWindow()?.__MILADY_ELECTROBUN_RPC__ ?? null;
 }
 
-function getElectronIpcRenderer(): ElectronIpcRenderer | null {
-  return getDesktopBridgeWindow()?.electron?.ipcRenderer ?? null;
-}
-
 async function invokeDesktopBridgeRequest<T>(options: {
   rpcMethod: string;
   ipcChannel: string;
@@ -100,11 +80,6 @@ async function invokeDesktopBridgeRequest<T>(options: {
   const request = rpc?.request?.[options.rpcMethod];
   if (request) {
     return (await request(options.params)) as T;
-  }
-
-  const ipc = getElectronIpcRenderer();
-  if (ipc) {
-    return (await ipc.invoke(options.ipcChannel, options.params)) as T;
   }
 
   return null;
@@ -123,25 +98,7 @@ function subscribeDesktopBridgeEvent(options: {
     };
   }
 
-  const ipc = getElectronIpcRenderer();
-  if (!ipc?.on) {
-    return () => {};
-  }
-
-  const ipcListener = (_event: unknown, payload: unknown) => {
-    options.listener(payload);
-  };
-
-  ipc.on(options.ipcChannel, ipcListener);
-
-  return () => {
-    if (ipc.removeListener) {
-      ipc.removeListener(options.ipcChannel, ipcListener);
-      return;
-    }
-
-    ipc.removeAllListeners?.(options.ipcChannel);
-  };
+  return () => {};
 }
 
 const getSpeechRecognition = (): SpeechRecognitionCtor | null =>
@@ -224,10 +181,6 @@ export class SwabbleWeb extends WebPlugin {
     return getElectrobunRendererRpc() ?? null;
   }
 
-  private getIpc(): ElectronIpcRenderer | null {
-    return getElectronIpcRenderer() ?? null;
-  }
-
   private subscribeDesktopEvent(options: {
     rpcMessage: string;
     ipcChannel: string;
@@ -291,9 +244,7 @@ export class SwabbleWeb extends WebPlugin {
   }
 
   private async startNativeAudioCapture(sampleRate = 16000): Promise<void> {
-    const ipc = this.getIpc();
     const rpcRequest = this.getRendererRpc()?.request?.swabbleAudioChunk;
-    if (!ipc && !rpcRequest) return;
     const stream = await navigator.mediaDevices
       .getUserMedia({ audio: true })
       .catch(() => null);
@@ -323,22 +274,13 @@ export class SwabbleWeb extends WebPlugin {
         }
         out[i] = cnt > 0 ? acc / cnt : 0;
       }
-      if (rpcRequest || ipc) {
-        const bytes = new Uint8Array(
-          out.buffer,
-          out.byteOffset,
-          out.byteLength,
-        );
-        let binary = "";
-        for (let i = 0; i < bytes.length; i++) {
-          binary += String.fromCharCode(bytes[i]);
-        }
-        const payload = { data: btoa(binary) };
-        if (rpcRequest) {
-          void rpcRequest(payload).catch(() => {});
-        } else {
-          void ipc?.invoke("swabble:audioChunk", payload).catch(() => {});
-        }
+      const bytes = new Uint8Array(out.buffer, out.byteOffset, out.byteLength);
+      let binary = "";
+      for (let i = 0; i < bytes.length; i++) {
+        binary += String.fromCharCode(bytes[i]);
+      }
+      if (rpcRequest) {
+        void rpcRequest({ data: btoa(binary) }).catch(() => {});
       }
     };
     source.connect(processor);
@@ -379,10 +321,9 @@ export class SwabbleWeb extends WebPlugin {
   async start(options: SwabbleStartOptions): Promise<SwabbleStartResult> {
     if (this.isActive) return { started: true };
 
-    // Delegate to native IPC when running in Electron or Electrobun
+    // Delegate to the native desktop bridge when available.
     const rpc = this.getRendererRpc();
-    const ipc = this.getIpc();
-    if (rpc || ipc) {
+    if (rpc) {
       try {
         const result = await this.invokeDesktopRequest<SwabbleStartResult>({
           rpcMethod: "swabbleStart",

--- a/apps/app/test/app/apps-view.test.ts
+++ b/apps/app/test/app/apps-view.test.ts
@@ -436,7 +436,7 @@ describe("AppsView", () => {
   it("uses the Electrobun shell bridge for external app launches", async () => {
     const setState = vi.fn<AppsContextStub["setState"]>();
     const setActionNotice = vi.fn<AppsContextStub["setActionNotice"]>();
-    const invoke = vi.fn(async () => undefined);
+    const request = vi.fn(async () => undefined);
     mockUseApp.mockReturnValue({
       uiLanguage: "en",
       t: tStub,
@@ -452,10 +452,14 @@ describe("AppsView", () => {
         viewer: null,
       }),
     );
-    Object.defineProperty(window, "electron", {
+    Object.defineProperty(window, "__MILADY_ELECTROBUN_RPC__", {
       configurable: true,
       writable: true,
-      value: { ipcRenderer: { invoke } },
+      value: {
+        request: { desktopOpenExternal: request },
+        onMessage: vi.fn(),
+        offMessage: vi.fn(),
+      },
     });
     const popupSpy = vi.spyOn(window, "open");
 
@@ -469,7 +473,7 @@ describe("AppsView", () => {
       await findButtonByText(tree?.root, "Launch").props.onClick();
     });
 
-    expect(invoke).toHaveBeenCalledWith("desktop:openExternal", {
+    expect(request).toHaveBeenCalledWith({
       url: "https://example.com/babylon",
     });
     expect(popupSpy).not.toHaveBeenCalled();

--- a/apps/app/test/app/desktop-electron-rpc.test.ts
+++ b/apps/app/test/app/desktop-electron-rpc.test.ts
@@ -1,21 +1,16 @@
 // @vitest-environment jsdom
 
-import type {
-  ElectrobunRendererRpc,
-  ElectronIpcRenderer,
-} from "@milady/app-core/bridge";
+import type { ElectrobunRendererRpc } from "@milady/app-core/bridge";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { DesktopElectron } from "../../plugins/desktop/electron/src/index.ts";
 
 type TestWindow = Window & {
   __MILADY_ELECTROBUN_RPC__?: ElectrobunRendererRpc;
-  electron?: { ipcRenderer?: ElectronIpcRenderer };
 };
 
 describe("DesktopElectron desktop bridge", () => {
   afterEach(() => {
     delete (window as TestWindow).__MILADY_ELECTROBUN_RPC__;
-    delete (window as TestWindow).electron;
     vi.restoreAllMocks();
   });
 
@@ -25,8 +20,6 @@ describe("DesktopElectron desktop bridge", () => {
       name: "Milady",
       runtime: "electrobun",
     });
-    const ipcInvoke = vi.fn();
-
     (window as TestWindow).__MILADY_ELECTROBUN_RPC__ = {
       request: {
         desktopGetVersion,
@@ -34,7 +27,6 @@ describe("DesktopElectron desktop bridge", () => {
       onMessage: vi.fn(),
       offMessage: vi.fn(),
     };
-    (window as TestWindow).electron = { ipcRenderer: { invoke: ipcInvoke } };
 
     const plugin = new DesktopElectron();
     await expect(plugin.getVersion()).resolves.toEqual({
@@ -46,7 +38,6 @@ describe("DesktopElectron desktop bridge", () => {
     });
 
     expect(desktopGetVersion).toHaveBeenCalledWith(undefined);
-    expect(ipcInvoke).not.toHaveBeenCalled();
   });
 
   it("subscribes window events through direct Electrobun RPC when available", async () => {
@@ -79,56 +70,18 @@ describe("DesktopElectron desktop bridge", () => {
     expect(focusListener).toHaveBeenCalledWith(undefined);
   });
 
-  it("uses IPC invoke fallback for desktop requests when direct Electrobun RPC is unavailable", async () => {
-    const invoke = vi.fn().mockResolvedValue(undefined);
-
-    (window as TestWindow).electron = {
-      ipcRenderer: {
-        invoke,
-      },
-    };
-
+  it("throws when desktop-only requests are called without direct Electrobun RPC", async () => {
     const plugin = new DesktopElectron();
-    await expect(plugin.beep()).resolves.toBeUndefined();
-
-    expect(invoke).toHaveBeenCalledWith("desktop:beep", undefined);
+    await expect(plugin.beep()).rejects.toThrow(
+      "beep is not available: Electron IPC bridge not found.",
+    );
   });
 
-  it("does not wire unsupported desktop push messages through plugin-level IPC fallbacks", async () => {
-    const ipcListeners = new Map<
-      string,
-      Set<(event: unknown, payload: unknown) => void>
-    >();
-
-    (window as TestWindow).electron = {
-      ipcRenderer: {
-        invoke: vi.fn(),
-        on: vi.fn(
-          (
-            channel: string,
-            listener: (event: unknown, payload: unknown) => void,
-          ) => {
-            const entry = ipcListeners.get(channel) ?? new Set();
-            entry.add(listener);
-            ipcListeners.set(channel, entry);
-          },
-        ),
-        removeListener: vi.fn(
-          (
-            channel: string,
-            listener: (event: unknown, payload: unknown) => void,
-          ) => {
-            ipcListeners.get(channel)?.delete(listener);
-          },
-        ),
-      },
-    };
-
+  it("does not emit unsupported desktop events without direct Electrobun RPC", async () => {
     const plugin = new DesktopElectron();
     const suspendListener = vi.fn();
     await plugin.addListener("powerSuspend", suspendListener);
 
-    expect(ipcListeners.has("desktop:powerSuspend")).toBe(false);
     expect(suspendListener).not.toHaveBeenCalled();
   });
 });

--- a/apps/app/test/app/electrobun-rpc-bridge.test.ts
+++ b/apps/app/test/app/electrobun-rpc-bridge.test.ts
@@ -2,7 +2,6 @@
 
 import {
   type ElectrobunRendererRpc,
-  type ElectronIpcRenderer,
   invokeDesktopBridgeRequest,
   subscribeDesktopBridgeEvent,
 } from "@milady/app-core/bridge";
@@ -10,25 +9,21 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 type TestWindow = Window & {
   __MILADY_ELECTROBUN_RPC__?: ElectrobunRendererRpc;
-  electron?: { ipcRenderer?: ElectronIpcRenderer };
 };
 
 describe("electrobun rpc bridge", () => {
   afterEach(() => {
     delete (window as TestWindow).__MILADY_ELECTROBUN_RPC__;
-    delete (window as TestWindow).electron;
     vi.restoreAllMocks();
   });
 
   it("prefers direct Electrobun RPC requests over Electron IPC", async () => {
     const rpcRequest = vi.fn().mockResolvedValue({ ok: true });
-    const ipcInvoke = vi.fn().mockResolvedValue({ ok: false });
     (window as TestWindow).__MILADY_ELECTROBUN_RPC__ = {
       request: { desktopOpenExternal: rpcRequest },
       onMessage: vi.fn(),
       offMessage: vi.fn(),
     };
-    (window as TestWindow).electron = { ipcRenderer: { invoke: ipcInvoke } };
 
     await expect(
       invokeDesktopBridgeRequest({
@@ -39,24 +34,16 @@ describe("electrobun rpc bridge", () => {
     ).resolves.toEqual({ ok: true });
 
     expect(rpcRequest).toHaveBeenCalledWith({ url: "https://example.com" });
-    expect(ipcInvoke).not.toHaveBeenCalled();
   });
 
-  it("falls back to Electron IPC when direct Electrobun RPC is unavailable", async () => {
-    const ipcInvoke = vi.fn().mockResolvedValue({ ok: true });
-    (window as TestWindow).electron = { ipcRenderer: { invoke: ipcInvoke } };
-
+  it("returns null when direct Electrobun RPC is unavailable", async () => {
     await expect(
       invokeDesktopBridgeRequest({
         rpcMethod: "desktopOpenExternal",
         ipcChannel: "desktop:openExternal",
         params: { url: "https://example.com" },
       }),
-    ).resolves.toEqual({ ok: true });
-
-    expect(ipcInvoke).toHaveBeenCalledWith("desktop:openExternal", {
-      url: "https://example.com",
-    });
+    ).resolves.toBeNull();
   });
 
   it("subscribes to direct Electrobun RPC messages when available", () => {

--- a/apps/app/test/app/gateway-electron-rpc.test.ts
+++ b/apps/app/test/app/gateway-electron-rpc.test.ts
@@ -1,15 +1,11 @@
 // @vitest-environment jsdom
 
-import type {
-  ElectrobunRendererRpc,
-  ElectronIpcRenderer,
-} from "@milady/app-core/bridge";
+import type { ElectrobunRendererRpc } from "@milady/app-core/bridge";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { GatewayElectron } from "../../plugins/gateway/electron/src/index.ts";
 
 type TestWindow = Window & {
   __MILADY_ELECTROBUN_RPC__?: ElectrobunRendererRpc;
-  electron?: { ipcRenderer?: ElectronIpcRenderer };
 };
 
 const sampleGateway = {
@@ -24,7 +20,6 @@ const sampleGateway = {
 describe("GatewayElectron desktop bridge", () => {
   afterEach(() => {
     delete (window as TestWindow).__MILADY_ELECTROBUN_RPC__;
-    delete (window as TestWindow).electron;
     vi.restoreAllMocks();
   });
 
@@ -85,73 +80,17 @@ describe("GatewayElectron desktop bridge", () => {
     expect(listeners.get("gatewayDiscovery")?.size ?? 0).toBe(0);
   });
 
-  it("handles IPC fallback discovery events when direct Electrobun RPC is unavailable", async () => {
-    const ipcListeners = new Map<
-      string,
-      Set<(event: unknown, payload: unknown) => void>
-    >();
-    const invoke = vi.fn(async (channel: string) => {
-      if (channel === "gateway:startDiscovery") {
-        return { gateways: [], status: "Discovery started" };
-      }
-
-      if (channel === "gateway:stopDiscovery") {
-        return undefined;
-      }
-
-      throw new Error(`Unexpected channel: ${channel}`);
-    });
-
-    (window as TestWindow).electron = {
-      ipcRenderer: {
-        invoke,
-        on: vi.fn(
-          (
-            channel: string,
-            listener: (event: unknown, payload: unknown) => void,
-          ) => {
-            const entry = ipcListeners.get(channel) ?? new Set();
-            entry.add(listener);
-            ipcListeners.set(channel, entry);
-          },
-        ),
-        removeListener: vi.fn(
-          (
-            channel: string,
-            listener: (event: unknown, payload: unknown) => void,
-          ) => {
-            ipcListeners.get(channel)?.delete(listener);
-          },
-        ),
-      },
-    };
-
+  it("reports discovery as unavailable when direct Electrobun RPC is unavailable", async () => {
     const plugin = new GatewayElectron();
     const discoveryListener = vi.fn();
     await plugin.addListener("discovery", discoveryListener);
 
     await expect(plugin.startDiscovery()).resolves.toEqual({
       gateways: [],
-      status: "Discovery started",
-    });
-
-    ipcListeners.get("gateway:discovery")?.forEach((listener) => {
-      listener(
-        { sender: "test" },
-        {
-          type: "found",
-          gateway: sampleGateway,
-        },
-      );
-    });
-
-    expect(discoveryListener).toHaveBeenCalledWith({
-      type: "found",
-      gateway: sampleGateway,
+      status: "Discovery not available on this platform",
     });
 
     await plugin.stopDiscovery();
-    expect(invoke).toHaveBeenCalledWith("gateway:stopDiscovery", undefined);
-    expect(ipcListeners.get("gateway:discovery")?.size ?? 0).toBe(0);
+    expect(discoveryListener).not.toHaveBeenCalled();
   });
 });

--- a/apps/app/test/app/location-electron-rpc.test.ts
+++ b/apps/app/test/app/location-electron-rpc.test.ts
@@ -1,21 +1,16 @@
 // @vitest-environment jsdom
 
-import type {
-  ElectrobunRendererRpc,
-  ElectronIpcRenderer,
-} from "@milady/app-core/bridge";
+import type { ElectrobunRendererRpc } from "@milady/app-core/bridge";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { LocationElectron } from "../../plugins/location/electron/src/index";
 
 type TestWindow = Window & {
   __MILADY_ELECTROBUN_RPC__?: ElectrobunRendererRpc;
-  electron?: { ipcRenderer?: ElectronIpcRenderer };
 };
 
 describe("LocationElectron direct Electrobun RPC bridge", () => {
   afterEach(() => {
     delete (window as TestWindow).__MILADY_ELECTROBUN_RPC__;
-    delete (window as TestWindow).electron;
     vi.restoreAllMocks();
   });
 
@@ -26,8 +21,6 @@ describe("LocationElectron direct Electrobun RPC bridge", () => {
       accuracy: 25,
       timestamp: 123456789,
     });
-    const ipcInvoke = vi.fn();
-
     (window as TestWindow).__MILADY_ELECTROBUN_RPC__ = {
       request: {
         locationGetCurrentPosition: rpcRequest,
@@ -35,7 +28,6 @@ describe("LocationElectron direct Electrobun RPC bridge", () => {
       onMessage: vi.fn(),
       offMessage: vi.fn(),
     };
-    (window as TestWindow).electron = { ipcRenderer: { invoke: ipcInvoke } };
 
     const plugin = new LocationElectron();
     await expect(
@@ -51,7 +43,6 @@ describe("LocationElectron direct Electrobun RPC bridge", () => {
     });
 
     expect(rpcRequest).toHaveBeenCalledWith({ accuracy: "high" });
-    expect(ipcInvoke).not.toHaveBeenCalled();
   });
 
   it("subscribes and unsubscribes native location watch events through direct Electrobun RPC", async () => {
@@ -114,71 +105,42 @@ describe("LocationElectron direct Electrobun RPC bridge", () => {
     expect(listeners.get("locationUpdate")?.size ?? 0).toBe(0);
   });
 
-  it("handles wrapped IPC fallback watch payloads for native location updates", async () => {
-    const ipcListeners = new Map<
-      string,
-      Set<(event: unknown, payload: unknown) => void>
-    >();
-    const invoke = vi.fn(async (channel: string) => {
-      if (channel === "location:watchPosition") {
-        return { watchId: "ipc-watch-1" };
-      }
-
-      if (channel === "location:clearWatch") {
-        return undefined;
-      }
-
-      throw new Error(`Unexpected channel: ${channel}`);
+  it("falls back to browser geolocation watch when direct Electrobun RPC is unavailable", async () => {
+    const getCurrentPosition = vi.fn();
+    const watchPosition = vi.fn((success: PositionCallback) => {
+      success({
+        coords: {
+          latitude: 37.7749,
+          longitude: -122.4194,
+          accuracy: 18,
+          altitude: null,
+          altitudeAccuracy: null,
+          heading: null,
+          speed: null,
+          toJSON: () => ({}),
+        },
+        timestamp: 24681012,
+        toJSON: () => ({}),
+      } as GeolocationPosition);
+      return 7;
     });
-
-    (window as TestWindow).electron = {
-      ipcRenderer: {
-        invoke,
-        on: vi.fn(
-          (
-            channel: string,
-            listener: (event: unknown, payload: unknown) => void,
-          ) => {
-            const entry = ipcListeners.get(channel) ?? new Set();
-            entry.add(listener);
-            ipcListeners.set(channel, entry);
-          },
-        ),
-        removeListener: vi.fn(
-          (
-            channel: string,
-            listener: (event: unknown, payload: unknown) => void,
-          ) => {
-            ipcListeners.get(channel)?.delete(listener);
-          },
-        ),
+    const clearWatch = vi.fn();
+    Object.defineProperty(navigator, "geolocation", {
+      configurable: true,
+      writable: true,
+      value: {
+        getCurrentPosition,
+        watchPosition,
+        clearWatch,
       },
-    };
+    });
 
     const plugin = new LocationElectron();
     const changeListener = vi.fn();
     await plugin.addListener("locationChange", changeListener);
 
     await expect(plugin.watchPosition()).resolves.toEqual({
-      watchId: "ipc-watch-1",
-    });
-
-    ipcListeners.get("location:update")?.forEach((listener) => {
-      listener(
-        { sender: "test" },
-        {
-          watchId: "ipc-watch-1",
-          location: {
-            coords: {
-              latitude: 37.7749,
-              longitude: -122.4194,
-              accuracy: 18,
-              timestamp: 24681012,
-            },
-            cached: false,
-          },
-        },
-      );
+      watchId: "watch_1",
     });
 
     expect(changeListener).toHaveBeenCalledWith({
@@ -191,10 +153,7 @@ describe("LocationElectron direct Electrobun RPC bridge", () => {
       cached: false,
     });
 
-    await plugin.clearWatch({ watchId: "ipc-watch-1" });
-    expect(invoke).toHaveBeenCalledWith("location:clearWatch", {
-      watchId: "ipc-watch-1",
-    });
-    expect(ipcListeners.get("location:update")?.size ?? 0).toBe(0);
+    await plugin.clearWatch({ watchId: "watch_1" });
+    expect(clearWatch).toHaveBeenCalledWith(7);
   });
 });

--- a/apps/app/test/app/plugins-view-game-modal.test.tsx
+++ b/apps/app/test/app/plugins-view-game-modal.test.tsx
@@ -190,7 +190,7 @@ describe("PluginsView game modal", () => {
         dispatchEvent: vi.fn(),
       })),
     });
-    Object.defineProperty(window, "electron", {
+    Object.defineProperty(window, "__MILADY_ELECTROBUN_RPC__", {
       configurable: true,
       writable: true,
       value: undefined,
@@ -375,13 +375,15 @@ describe("PluginsView game modal", () => {
     const openSpy = vi
       .spyOn(window, "open")
       .mockImplementation(() => null as unknown as Window);
-    Object.defineProperty(window, "electron", {
+    Object.defineProperty(window, "__MILADY_ELECTROBUN_RPC__", {
       configurable: true,
       writable: true,
       value: {
-        ipcRenderer: {
-          invoke: mockOpenExternalInvoke,
+        request: {
+          desktopOpenExternal: mockOpenExternalInvoke,
         },
+        onMessage: vi.fn(),
+        offMessage: vi.fn(),
       },
     });
 
@@ -430,14 +432,11 @@ describe("PluginsView game modal", () => {
       setupButton.props.onClick();
       await Promise.resolve();
     });
-    expect(mockOpenExternalInvoke).toHaveBeenCalledWith(
-      "desktop:openExternal",
-      {
-        url: "https://docs.milady.ai/plugin-setup-guide#retaketv",
-      },
-    );
+    expect(mockOpenExternalInvoke).toHaveBeenCalledWith({
+      url: "https://docs.milady.ai/plugin-setup-guide#retaketv",
+    });
 
-    Object.defineProperty(window, "electron", {
+    Object.defineProperty(window, "__MILADY_ELECTROBUN_RPC__", {
       configurable: true,
       writable: true,
       value: undefined,

--- a/apps/app/test/app/screencapture-electron-rpc.test.ts
+++ b/apps/app/test/app/screencapture-electron-rpc.test.ts
@@ -1,16 +1,12 @@
 // @vitest-environment jsdom
 
-import type {
-  ElectrobunRendererRpc,
-  ElectronIpcRenderer,
-} from "@milady/app-core/bridge";
+import type { ElectrobunRendererRpc } from "@milady/app-core/bridge";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ScreenCaptureElectron } from "../../plugins/screencapture/electron/src/index.ts";
 import { ScreenCaptureWeb } from "../../plugins/screencapture/src/web";
 
 type TestWindow = Window & {
   __MILADY_ELECTROBUN_RPC__?: ElectrobunRendererRpc;
-  electron?: { ipcRenderer?: ElectronIpcRenderer };
 };
 
 const SAMPLE_DATA_URL = "data:image/png;base64,ZmFrZQ==";
@@ -50,7 +46,6 @@ describe("ScreenCaptureElectron desktop bridge", () => {
 
   afterEach(() => {
     delete (window as TestWindow).__MILADY_ELECTROBUN_RPC__;
-    delete (window as TestWindow).electron;
     Object.defineProperty(globalThis, "Image", {
       configurable: true,
       writable: true,
@@ -69,8 +64,6 @@ describe("ScreenCaptureElectron desktop bridge", () => {
       available: true,
       data: SAMPLE_DATA_URL,
     });
-    const ipcInvoke = vi.fn();
-
     (window as TestWindow).__MILADY_ELECTROBUN_RPC__ = {
       request: {
         screencaptureTakeScreenshot,
@@ -78,7 +71,6 @@ describe("ScreenCaptureElectron desktop bridge", () => {
       onMessage: vi.fn(),
       offMessage: vi.fn(),
     };
-    (window as TestWindow).electron = { ipcRenderer: { invoke: ipcInvoke } };
 
     const plugin = new ScreenCaptureElectron();
     await expect(plugin.captureScreenshot()).resolves.toEqual({
@@ -90,33 +82,23 @@ describe("ScreenCaptureElectron desktop bridge", () => {
     });
 
     expect(screencaptureTakeScreenshot).toHaveBeenCalledWith(undefined);
-    expect(ipcInvoke).not.toHaveBeenCalled();
   });
 
-  it("uses IPC fallback for screenshots when direct Electrobun RPC is unavailable", async () => {
-    const invoke = vi
-      .fn()
-      .mockResolvedValue({ available: true, data: SAMPLE_DATA_URL });
-
-    (window as TestWindow).electron = {
-      ipcRenderer: {
-        invoke,
-      },
+  it("falls back to the web implementation when direct Electrobun RPC is unavailable", async () => {
+    const fallbackResult = {
+      base64: "fallback-rpcless",
+      format: "png",
+      width: 400,
+      height: 240,
+      timestamp: 5678,
     };
+    const fallbackCapture = vi
+      .spyOn(ScreenCaptureWeb.prototype, "captureScreenshot")
+      .mockResolvedValue(fallbackResult);
 
     const plugin = new ScreenCaptureElectron();
-    await expect(plugin.captureScreenshot()).resolves.toEqual({
-      base64: "ZmFrZQ==",
-      format: "png",
-      width: SAMPLE_WIDTH,
-      height: SAMPLE_HEIGHT,
-      timestamp: expect.any(Number),
-    });
-
-    expect(invoke).toHaveBeenCalledWith(
-      "screencapture:takeScreenshot",
-      undefined,
-    );
+    await expect(plugin.captureScreenshot()).resolves.toEqual(fallbackResult);
+    expect(fallbackCapture).toHaveBeenCalledWith(undefined);
   });
 
   it("falls back to the web implementation when native screenshot capture is unavailable", async () => {

--- a/apps/app/test/app/swabble-web-rpc.test.ts
+++ b/apps/app/test/app/swabble-web-rpc.test.ts
@@ -1,24 +1,11 @@
 // @vitest-environment jsdom
 
-import type {
-  ElectrobunRendererRpc,
-  ElectronIpcRenderer,
-} from "@milady/app-core/bridge";
+import type { ElectrobunRendererRpc } from "@milady/app-core/bridge";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SwabbleWeb } from "../../plugins/swabble/src/web.ts";
 
 type TestWindow = Window & {
   __MILADY_ELECTROBUN_RPC__?: ElectrobunRendererRpc;
-  electron?: {
-    ipcRenderer?: ElectronIpcRenderer & {
-      send?: (channel: string, payload?: unknown) => void;
-      on?: (channel: string, listener: (...args: unknown[]) => void) => void;
-      removeListener?: (
-        channel: string,
-        listener: (...args: unknown[]) => void,
-      ) => void;
-    };
-  };
 };
 
 interface ProcessorStub {
@@ -106,7 +93,6 @@ describe("SwabbleWeb desktop bridge", () => {
 
   afterEach(() => {
     delete (window as TestWindow).__MILADY_ELECTROBUN_RPC__;
-    delete (window as TestWindow).electron;
     vi.restoreAllMocks();
 
     if (originalAudioContext) {
@@ -127,8 +113,6 @@ describe("SwabbleWeb desktop bridge", () => {
       .fn()
       .mockResolvedValue({ available: true });
     const swabbleAudioChunk = vi.fn().mockResolvedValue(undefined);
-    const ipcInvoke = vi.fn();
-
     (window as TestWindow).__MILADY_ELECTROBUN_RPC__ = {
       request: {
         swabbleStart,
@@ -150,11 +134,6 @@ describe("SwabbleWeb desktop bridge", () => {
         },
       ),
     };
-    (window as TestWindow).electron = {
-      ipcRenderer: {
-        invoke: ipcInvoke,
-      },
-    };
 
     const sw = new SwabbleWeb();
     const wakeListener = vi.fn();
@@ -171,7 +150,6 @@ describe("SwabbleWeb desktop bridge", () => {
     expect(swabbleStart).toHaveBeenCalledWith({
       config: { triggers: ["milady"], sampleRate: 16000 },
     });
-    expect(ipcInvoke).not.toHaveBeenCalled();
 
     directListeners.get("swabbleStateChanged")?.forEach((listener) => {
       listener({ listening: true });
@@ -222,15 +200,6 @@ describe("SwabbleWeb desktop bridge", () => {
 
   it("uses direct swabble transcript and error push messages and keeps audio levels local", async () => {
     const directListeners = new Map<string, Set<(payload: unknown) => void>>();
-    const ipcListeners = new Map<string, Set<(...args: unknown[]) => void>>();
-    const ipcOn = vi.fn(
-      (channel: string, listener: (...args: unknown[]) => void) => {
-        const entry = ipcListeners.get(channel) ?? new Set();
-        entry.add(listener);
-        ipcListeners.set(channel, entry);
-      },
-    );
-
     (window as TestWindow).__MILADY_ELECTROBUN_RPC__ = {
       request: {
         swabbleStart: vi.fn().mockResolvedValue({ started: true }),
@@ -251,18 +220,6 @@ describe("SwabbleWeb desktop bridge", () => {
           directListeners.get(messageName)?.delete(listener);
         },
       ),
-    };
-    (window as TestWindow).electron = {
-      ipcRenderer: {
-        invoke: vi.fn().mockResolvedValue(undefined),
-        send: vi.fn(),
-        on: ipcOn,
-        removeListener: vi.fn(
-          (channel: string, listener: (...args: unknown[]) => void) => {
-            ipcListeners.get(channel)?.delete(listener);
-          },
-        ),
-      },
     };
 
     const sw = new SwabbleWeb();
@@ -315,20 +272,9 @@ describe("SwabbleWeb desktop bridge", () => {
       level: expect.any(Number),
       peak: 0.5,
     });
-    expect(
-      (window as TestWindow).electron?.ipcRenderer?.invoke,
-    ).toHaveBeenCalledWith("swabble:audioChunk", { data: expect.any(String) });
 
     await sw.stop();
     expect(directListeners.get("swabbleTranscript")?.size ?? 0).toBe(0);
     expect(directListeners.get("swabbleError")?.size ?? 0).toBe(0);
-    expect(ipcOn).not.toHaveBeenCalledWith(
-      "swabble:transcript",
-      expect.any(Function),
-    );
-    expect(ipcOn).not.toHaveBeenCalledWith(
-      "swabble:error",
-      expect.any(Function),
-    );
   });
 });

--- a/packages/app-core/src/bridge/electrobun-rpc.ts
+++ b/packages/app-core/src/bridge/electrobun-rpc.ts
@@ -11,24 +11,8 @@ export interface ElectrobunRendererRpc {
   ) => void;
 }
 
-export interface ElectronIpcRenderer {
-  invoke: (channel: string, params?: unknown) => Promise<unknown>;
-  on?: (
-    channel: string,
-    listener: (event: unknown, payload: unknown) => void,
-  ) => void;
-  removeListener?: (
-    channel: string,
-    listener: (event: unknown, payload: unknown) => void,
-  ) => void;
-  removeAllListeners?: (channel: string) => void;
-}
-
 interface DesktopBridgeWindow extends Window {
   __MILADY_ELECTROBUN_RPC__?: ElectrobunRendererRpc;
-  electron?: {
-    ipcRenderer?: ElectronIpcRenderer;
-  };
 }
 
 function getDesktopBridgeWindow(): DesktopBridgeWindow | null {
@@ -43,10 +27,6 @@ export function getElectrobunRendererRpc(): ElectrobunRendererRpc | undefined {
   return getDesktopBridgeWindow()?.__MILADY_ELECTROBUN_RPC__;
 }
 
-export function getElectronIpcRenderer(): ElectronIpcRenderer | undefined {
-  return getDesktopBridgeWindow()?.electron?.ipcRenderer;
-}
-
 export async function invokeDesktopBridgeRequest<T>(options: {
   rpcMethod: string;
   ipcChannel: string;
@@ -56,11 +36,6 @@ export async function invokeDesktopBridgeRequest<T>(options: {
   const request = rpc?.request?.[options.rpcMethod];
   if (request) {
     return (await request(options.params)) as T;
-  }
-
-  const ipc = getElectronIpcRenderer();
-  if (ipc) {
-    return (await ipc.invoke(options.ipcChannel, options.params)) as T;
   }
 
   return null;
@@ -79,23 +54,5 @@ export function subscribeDesktopBridgeEvent(options: {
     };
   }
 
-  const ipc = getElectronIpcRenderer();
-  if (!ipc?.on) {
-    return () => {};
-  }
-
-  const ipcListener = (_event: unknown, payload: unknown) => {
-    options.listener(payload);
-  };
-
-  ipc.on(options.ipcChannel, ipcListener);
-
-  return () => {
-    if (ipc.removeListener) {
-      ipc.removeListener(options.ipcChannel, ipcListener);
-      return;
-    }
-
-    ipc.removeAllListeners?.(options.ipcChannel);
-  };
+  return () => {};
 }


### PR DESCRIPTION
## Summary
- remove shared app-core Electron IPC fallback from the Electrobun desktop bridge helpers
- switch the remaining live Swabble web desktop path to direct Electrobun RPC only
- update the affected desktop bridge tests to assert RPC-first behavior without IPC fallback

## Testing
- bunx vitest run apps/app/test/app/electrobun-rpc-bridge.test.ts apps/app/test/app/desktop-electron-rpc.test.ts apps/app/test/app/gateway-electron-rpc.test.ts apps/app/test/app/location-electron-rpc.test.ts apps/app/test/app/screencapture-electron-rpc.test.ts apps/app/test/app/swabble-web-rpc.test.ts apps/app/test/app/apps-view.test.ts apps/app/test/app/plugins-view-game-modal.test.tsx
- bun run check
- bun run pre-review:local