### PR TITLE
app: switch preload to direct electrobun rpc bridge

### DIFF
--- a/apps/app/electrobun/src/__tests__/bridge-runtime.test.ts
+++ b/apps/app/electrobun/src/__tests__/bridge-runtime.test.ts
@@ -42,13 +42,11 @@ describe("electrobun bridge runtime", () => {
     };
     defineRpc.mockReturnValue({ request });
 
-    await import("../bridge/electrobun-bridge");
+    await import("../bridge/electrobun-direct-rpc");
 
-    expect(window.__MILADY_ELECTROBUN_RPC__).toEqual({
-      request,
-      onMessage: expect.any(Function),
-      offMessage: expect.any(Function),
-    });
+    expect(window.__MILADY_ELECTROBUN_RPC__.request).toBe(request);
+    expect(typeof window.__MILADY_ELECTROBUN_RPC__.onMessage).toBe("function");
+    expect(typeof window.__MILADY_ELECTROBUN_RPC__.offMessage).toBe("function");
     expect((window as typeof window & { electron?: unknown }).electron).toBe(
       undefined,
     );
@@ -77,7 +75,7 @@ describe("electrobun bridge runtime", () => {
       },
     );
 
-    await import("../bridge/electrobun-bridge");
+    await import("../bridge/electrobun-direct-rpc");
 
     const listener = vi.fn();
     window.__MILADY_ELECTROBUN_RPC__.onMessage("shareTargetReceived", listener);
@@ -98,5 +96,61 @@ describe("electrobun bridge runtime", () => {
     );
     wildcardHandler?.("shareTargetReceived", { files: ["other.md"] });
     expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("de-duplicates message listeners and keeps other listeners subscribed", async () => {
+    let wildcardHandler:
+      | ((messageName: unknown, payload: unknown) => void)
+      | undefined;
+    defineRpc.mockImplementation(
+      (config: {
+        handlers: {
+          messages: Record<
+            string,
+            (messageName: unknown, payload: unknown) => void
+          >;
+        };
+      }) => {
+        wildcardHandler = config.handlers.messages["*"];
+        return {
+          request: {
+            desktopGetVersion: vi.fn().mockResolvedValue({ version: "1.0.0" }),
+          },
+        };
+      },
+    );
+
+    await import("../bridge/electrobun-direct-rpc");
+
+    const firstListener = vi.fn();
+    const secondListener = vi.fn();
+
+    window.__MILADY_ELECTROBUN_RPC__.onMessage(
+      "shareTargetReceived",
+      firstListener,
+    );
+    window.__MILADY_ELECTROBUN_RPC__.onMessage(
+      "shareTargetReceived",
+      firstListener,
+    );
+    window.__MILADY_ELECTROBUN_RPC__.onMessage(
+      "shareTargetReceived",
+      secondListener,
+    );
+
+    wildcardHandler?.("shareTargetReceived", { files: ["first.md"] });
+    expect(firstListener).toHaveBeenCalledTimes(1);
+    expect(firstListener).toHaveBeenCalledWith({ files: ["first.md"] });
+    expect(secondListener).toHaveBeenCalledTimes(1);
+
+    window.__MILADY_ELECTROBUN_RPC__.offMessage(
+      "shareTargetReceived",
+      firstListener,
+    );
+    wildcardHandler?.("shareTargetReceived", { files: ["second.md"] });
+
+    expect(firstListener).toHaveBeenCalledTimes(1);
+    expect(secondListener).toHaveBeenCalledTimes(2);
+    expect(secondListener).toHaveBeenLastCalledWith({ files: ["second.md"] });
   });
 });

--- a/apps/app/electrobun/src/bridge/electrobun-direct-rpc.ts
+++ b/apps/app/electrobun/src/bridge/electrobun-direct-rpc.ts
@@ -1,0 +1,109 @@
+/**
+ * Electrobun Renderer Bridge
+ *
+ * Exposes the direct Milady Electrobun RPC surface in the webview context.
+ *
+ * This script runs in the webview context (injected as a preload).
+ * It uses `Electroview.defineRPC()` + `new Electroview()` to connect to
+ * the Bun main process via the Electrobun WebSocket RPC channel.
+ *
+ * `window.__MILADY_ELECTROBUN_RPC__` is the only public desktop bridge exposed
+ * to renderer code. It mirrors the native Electrobun RPC surface directly:
+ * `request.<method>(params)` plus `onMessage(<message>, listener)`.
+ */
+
+import { Electroview } from "electrobun/view";
+
+type RpcMessageListener = (payload: unknown) => void;
+type RendererRequestHandler = (params: unknown) => Promise<unknown>;
+type RendererBridgeRpc = {
+  request: Record<string, RendererRequestHandler>;
+};
+
+const listenersByRpcMessage: Record<string, Set<RpcMessageListener>> = {};
+
+// Electrobun's native layer sets these globals before preloads run.
+// __electrobun must exist before Electroview.init() tries to write to it.
+// If the built-in preload hasn't fired yet (rare edge case), stub it.
+if (typeof window.__electrobun === "undefined") {
+  (
+    window as unknown as {
+      __electrobun: {
+        receiveMessageFromBun: (m: unknown) => void;
+        receiveInternalMessageFromBun: (m: unknown) => void;
+      };
+    }
+  ).__electrobun = {
+    receiveMessageFromBun: (_m: unknown) => {},
+    receiveInternalMessageFromBun: (_m: unknown) => {},
+  };
+}
+
+function dispatchMessage(messageName: string, payload: unknown): void {
+  if (messageName === "apiBaseUpdate") {
+    const apiBaseUpdate = payload as { base: string; token?: string };
+    window.__MILADY_API_BASE__ = apiBaseUpdate.base;
+    if (apiBaseUpdate.token) {
+      window.__MILADY_API_TOKEN__ = apiBaseUpdate.token;
+    }
+  }
+
+  const listeners = listenersByRpcMessage[messageName];
+  if (!listeners) {
+    return;
+  }
+
+  for (const listener of Array.from(listeners)) {
+    try {
+      listener(payload);
+    } catch (err) {
+      console.error(
+        `[ElectrobunBridge] Listener error for ${messageName}:`,
+        err,
+      );
+    }
+  }
+}
+
+function handleWildcardMessage(messageName: unknown, payload: unknown): void {
+  if (typeof messageName === "string") {
+    dispatchMessage(messageName, payload);
+  }
+}
+
+const rpc = Electroview.defineRPC({
+  handlers: {
+    requests: {},
+    messages: {
+      "*": handleWildcardMessage,
+    },
+  },
+}) as unknown as RendererBridgeRpc;
+
+new Electroview({ rpc });
+
+const miladyElectrobunRpc = {
+  request: rpc.request,
+  onMessage: (messageName: string, listener: RpcMessageListener): void => {
+    if (!listenersByRpcMessage[messageName]) {
+      listenersByRpcMessage[messageName] = new Set();
+    }
+    listenersByRpcMessage[messageName].add(listener);
+  },
+  offMessage: (messageName: string, listener: RpcMessageListener): void => {
+    listenersByRpcMessage[messageName]?.delete(listener);
+    if (listenersByRpcMessage[messageName]?.size === 0) {
+      delete listenersByRpcMessage[messageName];
+    }
+  },
+};
+
+declare global {
+  interface Window {
+    __MILADY_API_BASE__: string;
+    __MILADY_API_TOKEN__: string;
+    __MILADY_ELECTROBUN_RPC__: typeof miladyElectrobunRpc;
+  }
+}
+
+window.__MILADY_ELECTROBUN_RPC__ = miladyElectrobunRpc;

--- a/apps/app/electrobun/src/bridge/electrobun-preload.ts
+++ b/apps/app/electrobun/src/bridge/electrobun-preload.ts
@@ -9,4 +9,4 @@
  * config and run before any page content loads.
  */
 
-import "./electrobun-bridge";
+import "./electrobun-direct-rpc";


### PR DESCRIPTION
## Summary
- switch the active preload entrypoint to a dedicated direct Electrobun RPC bridge module
- keep the public renderer bridge surface on request/onMessage/offMessage while removing the active preload dependency on legacy compat internals
- add bridge runtime coverage for duplicate listener registration and unsubscribe behavior on the new path

## Validation
- bunx vitest run apps/app/electrobun/src/__tests__/bridge-runtime.test.ts apps/app/electrobun/src/__tests__/bridge.test.ts
- bun run check
- bun run pre-review:local