### PR TITLE
app: lock preload entrypoint to direct rpc bridge

### DIFF
--- a/apps/app/electrobun/src/__tests__/preload-entrypoint.test.ts
+++ b/apps/app/electrobun/src/__tests__/preload-entrypoint.test.ts
@@ -1,0 +1,23 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const directRpcBridgeLoaded = vi.fn();
+
+vi.mock("../bridge/electrobun-direct-rpc", () => {
+  directRpcBridgeLoaded();
+  return {};
+});
+
+describe("electrobun preload entrypoint", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    directRpcBridgeLoaded.mockClear();
+  });
+
+  it("loads the direct electrobun rpc bridge", async () => {
+    await import("../bridge/electrobun-preload");
+
+    expect(directRpcBridgeLoaded).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/app/electrobun/src/native/screencapture.ts
+++ b/apps/app/electrobun/src/native/screencapture.ts
@@ -123,7 +123,7 @@ export class ScreenCaptureManager {
    * full screen, not a specific webview. The setter is retained because it is
    * wired into the RPC schema (screencapture:setCaptureTarget) and called by
    * StreamView popout logic. Removing it would require coordinated changes
-   * across rpc-schema.ts, rpc-handlers.ts, electrobun-bridge.ts, and the
+   * across rpc-schema.ts, rpc-handlers.ts, electrobun-direct-rpc.ts, and the
    * renderer.
    */
   setCaptureTarget(_webview: Webview | null): void {


### PR DESCRIPTION
## Summary
- add a preload regression test that proves the active entrypoint imports the direct Electrobun RPC bridge
- update the last stale native screencapture comment to point at electrobun-direct-rpc.ts instead of the legacy bridge filename

## Validation
- bunx vitest run apps/app/electrobun/src/__tests__/preload-entrypoint.test.ts apps/app/electrobun/src/__tests__/bridge-runtime.test.ts apps/app/electrobun/src/__tests__/bridge.test.ts
- bun run check
- bun run pre-review:local