### PR TITLE
app: drop stale ipc channel plumbing from electrobun rpc

### DIFF
--- a/apps/app/plugins/desktop/electron/src/index.ts
+++ b/apps/app/plugins/desktop/electron/src/index.ts
@@ -12,7 +12,7 @@
  * - Shell operations
  *
  * This file should be loaded in the Electron main process and
- * its API exposed to the renderer via IPC.
+ * its API exposed to the renderer via the desktop RPC bridge.
  */
 
 import type { PluginListenerHandle } from "@capacitor/core";
@@ -84,56 +84,48 @@ type DesktopVersionResult =
     };
 
 const DESKTOP_RPC_EVENTS: Partial<
-  Record<DesktopEventName, { rpcMessage: string; ipcChannel: string }>
+  Record<DesktopEventName, { rpcMessage: string }>
 > = {
   trayClick: {
     rpcMessage: "desktopTrayClick",
-    ipcChannel: "desktop:trayClick",
   },
   trayMenuClick: {
     rpcMessage: "desktopTrayMenuClick",
-    ipcChannel: "desktop:trayMenuClick",
   },
   shortcutPressed: {
     rpcMessage: "desktopShortcutPressed",
-    ipcChannel: "desktop:shortcutPressed",
   },
   windowFocus: {
     rpcMessage: "desktopWindowFocus",
-    ipcChannel: "desktop:windowFocus",
   },
   windowBlur: {
     rpcMessage: "desktopWindowBlur",
-    ipcChannel: "desktop:windowBlur",
   },
   windowMaximize: {
     rpcMessage: "desktopWindowMaximize",
-    ipcChannel: "desktop:windowMaximize",
   },
   windowUnmaximize: {
     rpcMessage: "desktopWindowUnmaximize",
-    ipcChannel: "desktop:windowUnmaximize",
   },
   windowClose: {
     rpcMessage: "desktopWindowClose",
-    ipcChannel: "desktop:windowClose",
   },
 };
 
 /**
- * Helper to throw when Electron IPC is unavailable.
- * Desktop plugin features require Electron's main process access.
+ * Helper to throw when the desktop bridge is unavailable.
+ * Desktop plugin features require Electrobun's native desktop runtime.
  */
-function requireIPC(feature: string): never {
+function requireDesktopBridge(feature: string): never {
   throw new Error(
-    `${feature} is not available: Electron IPC bridge not found. ` +
-      "The Desktop plugin requires the Electron main process with properly configured IPC handlers.",
+    `${feature} is not available: desktop RPC bridge not found. ` +
+      "The Desktop plugin requires the native desktop runtime with configured RPC handlers.",
   );
 }
 
 /**
  * Desktop Plugin implementation for Electron
- * Uses IPC to communicate with the main process
+ * Uses the desktop RPC bridge to communicate with the native runtime.
  */
 export class DesktopElectron implements DesktopPlugin {
   private listeners: ListenerEntry[] = [];
@@ -146,16 +138,14 @@ export class DesktopElectron implements DesktopPlugin {
   private async invokeBridge<T>(
     feature: string,
     rpcMethod: string,
-    ipcChannel: string,
     params?: unknown,
   ): Promise<T> {
     const result = await invokeDesktopBridgeRequest<T>({
       rpcMethod,
-      ipcChannel,
       params,
     });
     if (result === null) {
-      requireIPC(feature);
+      requireDesktopBridge(feature);
     }
     return result as T;
   }
@@ -191,7 +181,6 @@ export class DesktopElectron implements DesktopPlugin {
 
       const unsubscribe = subscribeDesktopBridgeEvent({
         rpcMessage: rpcEvent.rpcMessage,
-        ipcChannel: rpcEvent.ipcChannel,
         listener: (data) => {
           this.notifyListeners(
             eventName,
@@ -205,38 +194,19 @@ export class DesktopElectron implements DesktopPlugin {
 
   // System Tray
   async createTray(options: TrayOptions): Promise<void> {
-    await this.invokeBridge(
-      "createTray",
-      "desktopCreateTray",
-      "desktop:createTray",
-      options,
-    );
+    await this.invokeBridge("createTray", "desktopCreateTray", options);
   }
 
   async updateTray(options: Partial<TrayOptions>): Promise<void> {
-    await this.invokeBridge(
-      "updateTray",
-      "desktopUpdateTray",
-      "desktop:updateTray",
-      options,
-    );
+    await this.invokeBridge("updateTray", "desktopUpdateTray", options);
   }
 
   async destroyTray(): Promise<void> {
-    await this.invokeBridge(
-      "destroyTray",
-      "desktopDestroyTray",
-      "desktop:destroyTray",
-    );
+    await this.invokeBridge("destroyTray", "desktopDestroyTray");
   }
 
   async setTrayMenu(options: { menu: TrayMenuItem[] }): Promise<void> {
-    await this.invokeBridge(
-      "setTrayMenu",
-      "desktopSetTrayMenu",
-      "desktop:setTrayMenu",
-      options,
-    );
+    await this.invokeBridge("setTrayMenu", "desktopSetTrayMenu", options);
   }
 
   // Global Shortcuts
@@ -246,7 +216,6 @@ export class DesktopElectron implements DesktopPlugin {
     return await this.invokeBridge<{ success: boolean }>(
       "registerShortcut",
       "desktopRegisterShortcut",
-      "desktop:registerShortcut",
       options,
     );
   }
@@ -255,7 +224,6 @@ export class DesktopElectron implements DesktopPlugin {
     await this.invokeBridge(
       "unregisterShortcut",
       "desktopUnregisterShortcut",
-      "desktop:unregisterShortcut",
       options,
     );
   }
@@ -264,7 +232,6 @@ export class DesktopElectron implements DesktopPlugin {
     await this.invokeBridge(
       "unregisterAllShortcuts",
       "desktopUnregisterAllShortcuts",
-      "desktop:unregisterAllShortcuts",
     );
   }
 
@@ -274,19 +241,13 @@ export class DesktopElectron implements DesktopPlugin {
     return await this.invokeBridge<{ registered: boolean }>(
       "isShortcutRegistered",
       "desktopIsShortcutRegistered",
-      "desktop:isShortcutRegistered",
       options,
     );
   }
 
   // Auto Launch
   async setAutoLaunch(options: AutoLaunchOptions): Promise<void> {
-    await this.invokeBridge(
-      "setAutoLaunch",
-      "desktopSetAutoLaunch",
-      "desktop:setAutoLaunch",
-      options,
-    );
+    await this.invokeBridge("setAutoLaunch", "desktopSetAutoLaunch", options);
   }
 
   async getAutoLaunchStatus(): Promise<{
@@ -296,11 +257,7 @@ export class DesktopElectron implements DesktopPlugin {
     return await this.invokeBridge<{
       enabled: boolean;
       openAsHidden: boolean;
-    }>(
-      "getAutoLaunchStatus",
-      "desktopGetAutoLaunchStatus",
-      "desktop:getAutoLaunchStatus",
-    );
+    }>("getAutoLaunchStatus", "desktopGetAutoLaunchStatus");
   }
 
   // Window Management
@@ -308,7 +265,6 @@ export class DesktopElectron implements DesktopPlugin {
     await this.invokeBridge(
       "setWindowOptions",
       "desktopSetWindowOptions",
-      "desktop:setWindowOptions",
       options,
     );
   }
@@ -317,7 +273,6 @@ export class DesktopElectron implements DesktopPlugin {
     return await this.invokeBridge<WindowBounds>(
       "getWindowBounds",
       "desktopGetWindowBounds",
-      "desktop:getWindowBounds",
     );
   }
 
@@ -325,72 +280,42 @@ export class DesktopElectron implements DesktopPlugin {
     await this.invokeBridge(
       "setWindowBounds",
       "desktopSetWindowBounds",
-      "desktop:setWindowBounds",
       options,
     );
   }
 
   async minimizeWindow(): Promise<void> {
-    await this.invokeBridge(
-      "minimizeWindow",
-      "desktopMinimizeWindow",
-      "desktop:minimizeWindow",
-    );
+    await this.invokeBridge("minimizeWindow", "desktopMinimizeWindow");
   }
 
   async maximizeWindow(): Promise<void> {
-    await this.invokeBridge(
-      "maximizeWindow",
-      "desktopMaximizeWindow",
-      "desktop:maximizeWindow",
-    );
+    await this.invokeBridge("maximizeWindow", "desktopMaximizeWindow");
   }
 
   async unmaximizeWindow(): Promise<void> {
-    await this.invokeBridge(
-      "unmaximizeWindow",
-      "desktopUnmaximizeWindow",
-      "desktop:unmaximizeWindow",
-    );
+    await this.invokeBridge("unmaximizeWindow", "desktopUnmaximizeWindow");
   }
 
   async closeWindow(): Promise<void> {
-    await this.invokeBridge(
-      "closeWindow",
-      "desktopCloseWindow",
-      "desktop:closeWindow",
-    );
+    await this.invokeBridge("closeWindow", "desktopCloseWindow");
   }
 
   async showWindow(): Promise<void> {
-    await this.invokeBridge(
-      "showWindow",
-      "desktopShowWindow",
-      "desktop:showWindow",
-    );
+    await this.invokeBridge("showWindow", "desktopShowWindow");
   }
 
   async hideWindow(): Promise<void> {
-    await this.invokeBridge(
-      "hideWindow",
-      "desktopHideWindow",
-      "desktop:hideWindow",
-    );
+    await this.invokeBridge("hideWindow", "desktopHideWindow");
   }
 
   async focusWindow(): Promise<void> {
-    await this.invokeBridge(
-      "focusWindow",
-      "desktopFocusWindow",
-      "desktop:focusWindow",
-    );
+    await this.invokeBridge("focusWindow", "desktopFocusWindow");
   }
 
   async isWindowMaximized(): Promise<{ maximized: boolean }> {
     return await this.invokeBridge<{ maximized: boolean }>(
       "isWindowMaximized",
       "desktopIsWindowMaximized",
-      "desktop:isWindowMaximized",
     );
   }
 
@@ -398,7 +323,6 @@ export class DesktopElectron implements DesktopPlugin {
     return await this.invokeBridge<{ minimized: boolean }>(
       "isWindowMinimized",
       "desktopIsWindowMinimized",
-      "desktop:isWindowMinimized",
     );
   }
 
@@ -406,7 +330,6 @@ export class DesktopElectron implements DesktopPlugin {
     return await this.invokeBridge<{ visible: boolean }>(
       "isWindowVisible",
       "desktopIsWindowVisible",
-      "desktop:isWindowVisible",
     );
   }
 
@@ -414,7 +337,6 @@ export class DesktopElectron implements DesktopPlugin {
     return await this.invokeBridge<{ focused: boolean }>(
       "isWindowFocused",
       "desktopIsWindowFocused",
-      "desktop:isWindowFocused",
     );
   }
 
@@ -422,30 +344,15 @@ export class DesktopElectron implements DesktopPlugin {
     flag: boolean;
     level?: AlwaysOnTopLevel;
   }): Promise<void> {
-    await this.invokeBridge(
-      "setAlwaysOnTop",
-      "desktopSetAlwaysOnTop",
-      "desktop:setAlwaysOnTop",
-      options,
-    );
+    await this.invokeBridge("setAlwaysOnTop", "desktopSetAlwaysOnTop", options);
   }
 
   async setFullscreen(options: { flag: boolean }): Promise<void> {
-    await this.invokeBridge(
-      "setFullscreen",
-      "desktopSetFullscreen",
-      "desktop:setFullscreen",
-      options,
-    );
+    await this.invokeBridge("setFullscreen", "desktopSetFullscreen", options);
   }
 
   async setOpacity(options: { opacity: number }): Promise<void> {
-    await this.invokeBridge(
-      "setOpacity",
-      "desktopSetOpacity",
-      "desktop:setOpacity",
-      options,
-    );
+    await this.invokeBridge("setOpacity", "desktopSetOpacity", options);
   }
 
   // Notifications
@@ -455,7 +362,6 @@ export class DesktopElectron implements DesktopPlugin {
     return await this.invokeBridge<{ id: string }>(
       "showNotification",
       "desktopShowNotification",
-      "desktop:showNotification",
       options,
     );
   }
@@ -464,7 +370,6 @@ export class DesktopElectron implements DesktopPlugin {
     await this.invokeBridge(
       "closeNotification",
       "desktopCloseNotification",
-      "desktop:closeNotification",
       options,
     );
   }
@@ -474,17 +379,16 @@ export class DesktopElectron implements DesktopPlugin {
     return await this.invokeBridge<PowerMonitorState>(
       "getPowerState",
       "desktopGetPowerState",
-      "desktop:getPowerState",
     );
   }
 
   // App
   async quit(): Promise<void> {
-    await this.invokeBridge("quit", "desktopQuit", "desktop:quit");
+    await this.invokeBridge("quit", "desktopQuit");
   }
 
   async relaunch(): Promise<void> {
-    await this.invokeBridge("relaunch", "desktopRelaunch", "desktop:relaunch");
+    await this.invokeBridge("relaunch", "desktopRelaunch");
   }
 
   async getVersion(): Promise<{
@@ -497,7 +401,6 @@ export class DesktopElectron implements DesktopPlugin {
     const version = await this.invokeBridge<DesktopVersionResult>(
       "getVersion",
       "desktopGetVersion",
-      "desktop:getVersion",
     );
     if ("runtime" in version) {
       return {
@@ -515,7 +418,6 @@ export class DesktopElectron implements DesktopPlugin {
     return await this.invokeBridge<{ packaged: boolean }>(
       "isPackaged",
       "desktopIsPackaged",
-      "desktop:isPackaged",
     );
   }
 
@@ -523,7 +425,6 @@ export class DesktopElectron implements DesktopPlugin {
     return await this.invokeBridge<{ path: string }>(
       "getPath",
       "desktopGetPath",
-      "desktop:getPath",
       options,
     );
   }
@@ -538,7 +439,6 @@ export class DesktopElectron implements DesktopPlugin {
     await this.invokeBridge(
       "writeToClipboard",
       "desktopWriteToClipboard",
-      "desktop:writeToClipboard",
       options,
     );
   }
@@ -554,42 +454,28 @@ export class DesktopElectron implements DesktopPlugin {
       html?: string;
       rtf?: string;
       hasImage: boolean;
-    }>(
-      "readFromClipboard",
-      "desktopReadFromClipboard",
-      "desktop:readFromClipboard",
-    );
+    }>("readFromClipboard", "desktopReadFromClipboard");
   }
 
   async clearClipboard(): Promise<void> {
-    await this.invokeBridge(
-      "clearClipboard",
-      "desktopClearClipboard",
-      "desktop:clearClipboard",
-    );
+    await this.invokeBridge("clearClipboard", "desktopClearClipboard");
   }
 
   // Shell
   async openExternal(options: { url: string }): Promise<void> {
-    await this.invokeBridge(
-      "openExternal",
-      "desktopOpenExternal",
-      "desktop:openExternal",
-      options,
-    );
+    await this.invokeBridge("openExternal", "desktopOpenExternal", options);
   }
 
   async showItemInFolder(options: { path: string }): Promise<void> {
     await this.invokeBridge(
       "showItemInFolder",
       "desktopShowItemInFolder",
-      "desktop:showItemInFolder",
       options,
     );
   }
 
   async beep(): Promise<void> {
-    await this.invokeBridge("beep", "desktopBeep", "desktop:beep");
+    await this.invokeBridge("beep", "desktopBeep");
   }
 
   // Events

--- a/apps/app/plugins/gateway/electron/src/index.ts
+++ b/apps/app/plugins/gateway/electron/src/index.ts
@@ -473,7 +473,6 @@ export class GatewayElectron implements GatewayPlugin {
 
       this.discoveryUnsubscribe = subscribeDesktopBridgeEvent({
         rpcMessage: "gatewayDiscovery",
-        ipcChannel: "gateway:discovery",
         listener: (event) => {
           if (this.isGatewayDiscoveryEvent(event)) {
             this.handleDiscoveryEvent(event);
@@ -483,7 +482,6 @@ export class GatewayElectron implements GatewayPlugin {
 
       const result = await invokeDesktopBridgeRequest<GatewayDiscoveryResult>({
         rpcMethod: "gatewayStartDiscovery",
-        ipcChannel: "gateway:startDiscovery",
         params: {
           wideAreaDomain: options?.wideAreaDomain,
           timeout: options?.timeout || 30000,
@@ -503,7 +501,7 @@ export class GatewayElectron implements GatewayPlugin {
     }
 
     console.warn(
-      "[Gateway] mDNS discovery not available - Electron IPC bridge not configured",
+      "[Gateway] mDNS discovery not available - desktop RPC bridge not configured",
     );
     return {
       gateways: [],
@@ -518,7 +516,6 @@ export class GatewayElectron implements GatewayPlugin {
     try {
       await invokeDesktopBridgeRequest({
         rpcMethod: "gatewayStopDiscovery",
-        ipcChannel: "gateway:stopDiscovery",
       });
     } catch {
       // Ignore errors when stopping

--- a/apps/app/plugins/location/electron/src/index.ts
+++ b/apps/app/plugins/location/electron/src/index.ts
@@ -6,7 +6,7 @@
  * Location methods:
  * - Browser Geolocation API (requires permission, may use WiFi/IP)
  * - IP-based geolocation fallback (less accurate, no permission needed)
- * - Native location services via Electron IPC (platform-specific)
+ * - Native location services via the desktop RPC bridge
  */
 
 import type { PluginListenerHandle } from "@capacitor/core";
@@ -53,7 +53,6 @@ export class LocationElectron implements LocationPlugin {
     try {
       const result = await invokeDesktopBridgeRequest<NativeLocationPosition>({
         rpcMethod: "locationGetCurrentPosition",
-        ipcChannel: "location:getCurrentPosition",
         params: options,
       });
       if (result) {
@@ -100,14 +99,12 @@ export class LocationElectron implements LocationPlugin {
       const nativeWatch = await invokeDesktopBridgeRequest<{ watchId: string }>(
         {
           rpcMethod: "locationWatchPosition",
-          ipcChannel: "location:watchPosition",
           params: options,
         },
       );
       if (nativeWatch?.watchId) {
         const unsubscribe = subscribeDesktopBridgeEvent({
           rpcMessage: "locationUpdate",
-          ipcChannel: "location:update",
           listener: (data) => {
             const location = this.extractNativeWatchLocation(
               nativeWatch.watchId,
@@ -169,7 +166,6 @@ export class LocationElectron implements LocationPlugin {
     try {
       await invokeDesktopBridgeRequest({
         rpcMethod: "locationClearWatch",
-        ipcChannel: "location:clearWatch",
         params: options,
       });
     } catch {

--- a/apps/app/plugins/screencapture/electron/src/index.ts
+++ b/apps/app/plugins/screencapture/electron/src/index.ts
@@ -29,7 +29,6 @@ export class ScreenCaptureElectron
       const screenshot =
         await invokeDesktopBridgeRequest<NativeScreenshotResponse>({
           rpcMethod: "screencaptureTakeScreenshot",
-          ipcChannel: "screencapture:takeScreenshot",
         });
 
       if (screenshot?.available && screenshot.data) {

--- a/apps/app/plugins/swabble/electron/src/index.ts
+++ b/apps/app/plugins/swabble/electron/src/index.ts
@@ -43,7 +43,7 @@ const isSwabbleState = (value: unknown): value is SwabbleStateEvent["state"] =>
 /**
  * WakeWordGate detects trigger phrases in transcripts.
  *
- * NOTE: When using the Web Speech API fallback (no Whisper IPC),
+ * NOTE: When using the Web Speech API fallback (no native Whisper bridge),
  * word-level timing is unavailable. In that mode, `postGap` is -1
  * and minPostTriggerGap is not enforced.
  */
@@ -96,7 +96,7 @@ class WakeWordGate {
 /**
  * Swabble Plugin for Electron
  *
- * Uses Whisper.cpp via Electron IPC when available for full timing parity,
+ * Uses Whisper.cpp via the native desktop bridge when available for full timing parity,
  * with Web Speech API fallback when Whisper bindings are unavailable.
  */
 export class SwabbleElectron implements SwabblePlugin {
@@ -120,13 +120,11 @@ export class SwabbleElectron implements SwabblePlugin {
 
   private async invokeBridge<T>(
     rpcMethod: string,
-    ipcChannel: string,
     params?: unknown,
   ): Promise<T | null> {
     try {
       return await invokeDesktopBridgeRequest<T>({
         rpcMethod,
-        ipcChannel,
         params,
       });
     } catch {
@@ -144,10 +142,9 @@ export class SwabbleElectron implements SwabblePlugin {
     this.segments = [];
     this.captureSampleRate = options.config.sampleRate ?? 16000;
 
-    // Try native Whisper via Electron IPC first
+    // Try the native desktop bridge first.
     const nativeResult = await this.invokeBridge<SwabbleStartResult>(
       "swabbleStart",
-      "swabble:start",
       options,
     );
     if (nativeResult?.started) {
@@ -282,25 +279,21 @@ export class SwabbleElectron implements SwabblePlugin {
       {
         eventName: "wakeWord" as const,
         rpcMessage: "swabbleWakeWord",
-        ipcChannel: "swabble:wakeWord",
         normalize: (data: unknown) => this.normalizeWakeWordEvent(data),
       },
       {
         eventName: "stateChange" as const,
         rpcMessage: "swabbleStateChanged",
-        ipcChannel: "swabble:stateChange",
         normalize: (data: unknown) => this.normalizeStateEvent(data),
       },
       {
         eventName: "transcript" as const,
         rpcMessage: "swabbleTranscript",
-        ipcChannel: "swabble:transcript",
         normalize: (data: unknown) => data as unknown as SwabbleTranscriptEvent,
       },
       {
         eventName: "error" as const,
         rpcMessage: "swabbleError",
-        ipcChannel: "swabble:error",
         normalize: (data: unknown) => data as unknown as SwabbleErrorEvent,
       },
     ];
@@ -308,7 +301,6 @@ export class SwabbleElectron implements SwabblePlugin {
     for (const entry of bridgeHandlers) {
       const unsubscribe = subscribeDesktopBridgeEvent({
         rpcMessage: entry.rpcMessage,
-        ipcChannel: entry.ipcChannel,
         listener: (data) => {
           this.notifyListeners(entry.eventName, entry.normalize(data));
         },
@@ -578,7 +570,7 @@ export class SwabbleElectron implements SwabblePlugin {
     this.stopAudioCapture();
     this.stopAudioLevelMonitoring();
 
-    await this.invokeBridge("swabbleStop", "swabble:stop");
+    await this.invokeBridge("swabbleStop");
 
     if (this.recognition) {
       this.recognition.stop();
@@ -591,7 +583,6 @@ export class SwabbleElectron implements SwabblePlugin {
   async isListening(): Promise<{ listening: boolean }> {
     const nativeState = await this.invokeBridge<{ listening: boolean }>(
       "swabbleIsListening",
-      "swabble:isListening",
     );
     if (nativeState) {
       this.isActive = nativeState.listening;
@@ -601,10 +592,8 @@ export class SwabbleElectron implements SwabblePlugin {
   }
 
   async getConfig(): Promise<{ config: SwabbleConfig | null }> {
-    const nativeConfig = await this.invokeBridge<Record<string, unknown>>(
-      "swabbleGetConfig",
-      "swabble:getConfig",
-    );
+    const nativeConfig =
+      await this.invokeBridge<Record<string, unknown>>("swabbleGetConfig");
     if (nativeConfig && isObjectRecord(nativeConfig)) {
       return { config: nativeConfig as unknown as SwabbleConfig };
     }
@@ -620,11 +609,7 @@ export class SwabbleElectron implements SwabblePlugin {
       this.captureSampleRate = this.config.sampleRate ?? this.captureSampleRate;
     }
 
-    await this.invokeBridge(
-      "swabbleUpdateConfig",
-      "swabble:updateConfig",
-      options.config,
-    );
+    await this.invokeBridge("swabbleUpdateConfig", options.config);
   }
 
   async checkPermissions(): Promise<SwabblePermissionStatus> {
@@ -653,7 +638,6 @@ export class SwabbleElectron implements SwabblePlugin {
 
     const whisperStatus = await this.invokeBridge<{ available: boolean }>(
       "swabbleIsWhisperAvailable",
-      "swabble:isWhisperAvailable",
     );
     if (whisperStatus?.available) {
       speechRecognition = "granted";

--- a/apps/app/plugins/swabble/src/web.ts
+++ b/apps/app/plugins/swabble/src/web.ts
@@ -73,7 +73,6 @@ function getElectrobunRendererRpc(): ElectrobunRendererRpc | null {
 
 async function invokeDesktopBridgeRequest<T>(options: {
   rpcMethod: string;
-  ipcChannel: string;
   params?: unknown;
 }): Promise<T | null> {
   const rpc = getElectrobunRendererRpc();
@@ -87,7 +86,6 @@ async function invokeDesktopBridgeRequest<T>(options: {
 
 function subscribeDesktopBridgeEvent(options: {
   rpcMessage: string;
-  ipcChannel: string;
   listener: ElectrobunMessageListener;
 }): () => void {
   const rpc = getElectrobunRendererRpc();
@@ -170,12 +168,12 @@ export class SwabbleWeb extends WebPlugin {
   private mediaStream: MediaStream | null = null;
   private levelInterval: ReturnType<typeof setInterval> | null = null;
 
-  // Native IPC state (Electron/Electrobun)
+  // Native desktop bridge state.
   private captureStream: MediaStream | null = null;
   private captureContext: AudioContext | null = null;
   private captureProcessor: ScriptProcessorNode | null = null;
   private bridgeSubscriptions: Array<() => void> = [];
-  private usingNativeIpc = false;
+  private usingNativeBridge = false;
 
   private getRendererRpc() {
     return getElectrobunRendererRpc() ?? null;
@@ -183,7 +181,6 @@ export class SwabbleWeb extends WebPlugin {
 
   private subscribeDesktopEvent(options: {
     rpcMessage: string;
-    ipcChannel: string;
     listener: (payload: unknown) => void;
   }): void {
     this.bridgeSubscriptions.push(subscribeDesktopBridgeEvent(options));
@@ -191,7 +188,6 @@ export class SwabbleWeb extends WebPlugin {
 
   private async invokeDesktopRequest<T>(options: {
     rpcMethod: string;
-    ipcChannel: string;
     params?: unknown;
   }): Promise<T | null> {
     return await invokeDesktopBridgeRequest<T>(options);
@@ -201,14 +197,12 @@ export class SwabbleWeb extends WebPlugin {
     this.removeNativeListeners();
     this.subscribeDesktopEvent({
       rpcMessage: "swabbleWakeWord",
-      ipcChannel: "swabble:wakeWord",
       listener: (payload) => {
         this.notifyListeners("wakeWord", payload as Record<string, unknown>);
       },
     });
     this.subscribeDesktopEvent({
       rpcMessage: "swabbleStateChanged",
-      ipcChannel: "swabble:stateChange",
       listener: (payload) => {
         const listening =
           typeof (payload as { listening?: unknown }).listening === "boolean"
@@ -222,14 +216,12 @@ export class SwabbleWeb extends WebPlugin {
     });
     this.subscribeDesktopEvent({
       rpcMessage: "swabbleTranscript",
-      ipcChannel: "swabble:transcript",
       listener: (payload) => {
         this.notifyListeners("transcript", payload as Record<string, unknown>);
       },
     });
     this.subscribeDesktopEvent({
       rpcMessage: "swabbleError",
-      ipcChannel: "swabble:error",
       listener: (payload) => {
         this.notifyListeners("error", payload as Record<string, unknown>);
       },
@@ -327,12 +319,11 @@ export class SwabbleWeb extends WebPlugin {
       try {
         const result = await this.invokeDesktopRequest<SwabbleStartResult>({
           rpcMethod: "swabbleStart",
-          ipcChannel: "swabble:start",
           params: options,
         });
         if (result?.started) {
           this.isActive = true;
-          this.usingNativeIpc = true;
+          this.usingNativeBridge = true;
           this.config = options.config;
           this.setupNativeListeners();
           await this.startNativeAudioCapture(
@@ -478,14 +469,13 @@ export class SwabbleWeb extends WebPlugin {
   async stop(): Promise<void> {
     this.isActive = false;
 
-    // Clean up native IPC if in native mode
-    if (this.usingNativeIpc) {
-      this.usingNativeIpc = false;
+    // Clean up native desktop bridge resources if native mode is active.
+    if (this.usingNativeBridge) {
+      this.usingNativeBridge = false;
       this.removeNativeListeners();
       this.stopNativeAudioCapture();
       void this.invokeDesktopRequest({
         rpcMethod: "swabbleStop",
-        ipcChannel: "swabble:stop",
       });
       this.notifyListeners("stateChange", { state: "idle" });
       return;
@@ -519,11 +509,10 @@ export class SwabbleWeb extends WebPlugin {
       }
     }
 
-    // Sync to native IPC if active
-    if (this.usingNativeIpc) {
+    // Sync to the native desktop bridge when active.
+    if (this.usingNativeBridge) {
       void this.invokeDesktopRequest({
         rpcMethod: "swabbleUpdateConfig",
-        ipcChannel: "swabble:updateConfig",
         params: options.config,
       });
     }
@@ -545,7 +534,6 @@ export class SwabbleWeb extends WebPlugin {
       available: boolean;
     }>({
       rpcMethod: "swabbleIsWhisperAvailable",
-      ipcChannel: "swabble:isWhisperAvailable",
     });
     if (whisperStatus?.available) {
       speechRecognition = "granted";

--- a/apps/app/plugins/talkmode/electron/src/index.ts
+++ b/apps/app/plugins/talkmode/electron/src/index.ts
@@ -11,7 +11,7 @@
  * TTS Options:
  * - ElevenLabs API streaming (online, high quality)
  * - System TTS via speechSynthesis API
- * - Native TTS via Electron IPC (platform-specific)
+ * - Native desktop TTS via the Electrobun RPC bridge
  */
 
 import type { PluginListenerHandle } from "@capacitor/core";
@@ -145,13 +145,11 @@ export class TalkModeElectron implements TalkModePlugin {
 
   private async invokeBridge<T>(
     rpcMethod: string,
-    ipcChannel: string,
     params?: unknown,
   ): Promise<T | null> {
     try {
       return await invokeDesktopBridgeRequest<T>({
         rpcMethod,
-        ipcChannel,
         params,
       });
     } catch {
@@ -170,20 +168,16 @@ export class TalkModeElectron implements TalkModePlugin {
 
     const nativeConfig = toNativeTalkModeConfig(options?.config);
     if (nativeConfig) {
-      await this.invokeBridge(
-        "talkmodeUpdateConfig",
-        "talkmode:updateConfig",
-        nativeConfig,
-      );
+      await this.invokeBridge("talkmodeUpdateConfig", nativeConfig);
     }
 
-    // Try native STT/TTS via Electrobun RPC or Electron IPC first
+    // Try the native desktop bridge before falling back to Web Speech APIs.
     const nativeResult = await this.invokeBridge<{
       available?: boolean;
       started?: boolean;
       reason?: string;
       error?: string;
-    }>("talkmodeStart", "talkmode:start");
+    }>("talkmodeStart");
     if (nativeResult) {
       const started = nativeResult.available ?? nativeResult.started ?? false;
       if (started) {
@@ -193,7 +187,6 @@ export class TalkModeElectron implements TalkModePlugin {
 
         const whisperStatus = await this.invokeBridge<{ available: boolean }>(
           "talkmodeIsWhisperAvailable",
-          "talkmode:isWhisperAvailable",
         );
         if (whisperStatus?.available) {
           this.captureSampleRate = this.config.stt?.sampleRate ?? 16000;
@@ -281,14 +274,12 @@ export class TalkModeElectron implements TalkModePlugin {
     const bridgeHandlers = [
       {
         rpcMessage: "talkmodeStateChanged",
-        ipcChannel: "talkmode:stateChanged",
         listener: (data: unknown) => {
           this.handleNativeStateChanged(data);
         },
       },
       {
         rpcMessage: "talkmodeTranscript",
-        ipcChannel: "talkmode:transcript",
         listener: (data: unknown) => {
           this.notifyListeners(
             "transcript",
@@ -298,7 +289,6 @@ export class TalkModeElectron implements TalkModePlugin {
       },
       {
         rpcMessage: "talkmodeError",
-        ipcChannel: "talkmode:error",
         listener: (data: unknown) => {
           this.notifyListeners("error", data as TalkModeErrorEvent);
         },
@@ -308,7 +298,6 @@ export class TalkModeElectron implements TalkModePlugin {
     for (const entry of bridgeHandlers) {
       const unsubscribe = subscribeDesktopBridgeEvent({
         rpcMessage: entry.rpcMessage,
-        ipcChannel: entry.ipcChannel,
         listener: entry.listener,
       });
       this.bridgeSubscriptions.push(unsubscribe);
@@ -326,7 +315,7 @@ export class TalkModeElectron implements TalkModePlugin {
     this.enabled = false;
     this.stopAudioCapture();
     this.removeNativeListeners();
-    await this.invokeBridge("talkmodeStop", "talkmode:stop");
+    await this.invokeBridge("talkmodeStop");
 
     this.recognition?.stop();
     this.recognition = null;
@@ -339,7 +328,6 @@ export class TalkModeElectron implements TalkModePlugin {
   async isEnabled(): Promise<{ enabled: boolean }> {
     const nativeEnabled = await this.invokeBridge<{ enabled: boolean }>(
       "talkmodeIsEnabled",
-      "talkmode:isEnabled",
     );
     if (nativeEnabled) {
       this.enabled = nativeEnabled.enabled;
@@ -351,7 +339,6 @@ export class TalkModeElectron implements TalkModePlugin {
   async getState(): Promise<{ state: TalkModeState; statusText: string }> {
     const nativeState = await this.invokeBridge<{ state: TalkModeState }>(
       "talkmodeGetState",
-      "talkmode:getState",
     );
     if (nativeState?.state) {
       this.state = nativeState.state;
@@ -373,11 +360,7 @@ export class TalkModeElectron implements TalkModePlugin {
       return;
     }
 
-    await this.invokeBridge(
-      "talkmodeUpdateConfig",
-      "talkmode:updateConfig",
-      nativeConfig,
-    );
+    await this.invokeBridge("talkmodeUpdateConfig", nativeConfig);
   }
 
   async speak(options: SpeakOptions): Promise<SpeakResult> {
@@ -716,7 +699,6 @@ export class TalkModeElectron implements TalkModePlugin {
   async isSpeaking(): Promise<{ speaking: boolean }> {
     const nativeSpeaking = await this.invokeBridge<{ speaking: boolean }>(
       "talkmodeIsSpeaking",
-      "talkmode:isSpeaking",
     );
     if (nativeSpeaking) {
       this.isSpeakingValue = nativeSpeaking.speaking;
@@ -757,7 +739,6 @@ export class TalkModeElectron implements TalkModePlugin {
 
     const whisperStatus = await this.invokeBridge<{ available: boolean }>(
       "talkmodeIsWhisperAvailable",
-      "talkmode:isWhisperAvailable",
     );
     if (whisperStatus?.available) {
       speechRecognition = "granted";

--- a/apps/app/src/AppContext.tsx
+++ b/apps/app/src/AppContext.tsx
@@ -1563,7 +1563,6 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const restartBackend = useCallback(async () => {
     const restarted = await invokeDesktopBridgeRequest({
       rpcMethod: "agentRestart",
-      ipcChannel: "agent:restart",
     });
     if (restarted === null) {
       // Fallback for web: call API restart endpoint

--- a/apps/app/src/components/GameView.tsx
+++ b/apps/app/src/components/GameView.tsx
@@ -180,7 +180,6 @@ export function GameView() {
 
     void invokeDesktopBridgeRequest<{ id: string }>({
       rpcMethod: "gameOpenWindow",
-      ipcChannel: "game:openWindow",
       params: {
         url: activeGameViewerUrl,
         title: activeGameDisplayName || activeGameApp || "Game",
@@ -205,7 +204,6 @@ export function GameView() {
       if (gameWindowIdRef.current) {
         void invokeDesktopBridgeRequest({
           rpcMethod: "canvasDestroyWindow",
-          ipcChannel: "canvas:destroyWindow",
           params: { id: gameWindowIdRef.current },
         }).catch(() => {});
         gameWindowIdRef.current = null;

--- a/apps/app/src/components/PermissionsSection.tsx
+++ b/apps/app/src/components/PermissionsSection.tsx
@@ -312,7 +312,6 @@ function usePermissionActions(
       // native bridge to actually open system settings.
       const opened = await invokeDesktopBridgeRequest({
         rpcMethod: "permissionsOpenSettings",
-        ipcChannel: "permissions:openSettings",
         params: { id },
       });
       if (opened === null) {

--- a/apps/app/src/components/stream/helpers.ts
+++ b/apps/app/src/components/stream/helpers.ts
@@ -121,7 +121,6 @@ export async function toggleAlwaysOnTop(pinned: boolean): Promise<boolean> {
     }
     const result = await invokeDesktopBridgeRequest({
       rpcMethod: "desktopSetAlwaysOnTop",
-      ipcChannel: "desktop:setAlwaysOnTop",
       params: { flag: pinned },
     });
     if (result !== null) {

--- a/apps/app/src/hooks/useContextMenu.ts
+++ b/apps/app/src/hooks/useContextMenu.ts
@@ -69,22 +69,18 @@ export function useContextMenu(): ContextMenuState {
     const unsubscribers = [
       subscribeDesktopBridgeEvent({
         rpcMessage: "contextMenuSaveAsCommand",
-        ipcChannel: "contextMenu:saveAsCommand",
         listener: onSaveAsCommand,
       }),
       subscribeDesktopBridgeEvent({
         rpcMessage: "contextMenuAskAgent",
-        ipcChannel: "contextMenu:askAgent",
         listener: onAskAgent,
       }),
       subscribeDesktopBridgeEvent({
         rpcMessage: "contextMenuCreateSkill",
-        ipcChannel: "contextMenu:createSkill",
         listener: onCreateSkill,
       }),
       subscribeDesktopBridgeEvent({
         rpcMessage: "contextMenuQuoteInChat",
-        ipcChannel: "contextMenu:quoteInChat",
         listener: onQuoteInChat,
       }),
     ];

--- a/apps/app/src/hooks/useRetakeCapture.ts
+++ b/apps/app/src/hooks/useRetakeCapture.ts
@@ -27,7 +27,6 @@ export function useRetakeCapture(
       activeRef.current = true;
       void invokeDesktopBridgeRequest({
         rpcMethod: "screencaptureStartFrameCapture",
-        ipcChannel: "screencapture:startFrameCapture",
         params: {
           fps,
           quality: JPEG_QUALITY,
@@ -48,7 +47,6 @@ export function useRetakeCapture(
       activeRef.current = false;
       void invokeDesktopBridgeRequest({
         rpcMethod: "screencaptureStopFrameCapture",
-        ipcChannel: "screencapture:stopFrameCapture",
       }).catch((err) => {
         console.warn("[retake] Failed to stop frame capture:", err);
       });
@@ -59,7 +57,6 @@ export function useRetakeCapture(
         activeRef.current = false;
         void invokeDesktopBridgeRequest({
           rpcMethod: "screencaptureStopFrameCapture",
-          ipcChannel: "screencapture:stopFrameCapture",
         }).catch(() => {});
       }
     };

--- a/apps/app/src/utils/clipboard.ts
+++ b/apps/app/src/utils/clipboard.ts
@@ -17,7 +17,6 @@ function copyTextWithExecCommand(text: string): void {
 export async function copyTextToClipboard(text: string): Promise<void> {
   const copied = await invokeDesktopBridgeRequest({
     rpcMethod: "desktopWriteToClipboard",
-    ipcChannel: "desktop:writeToClipboard",
     params: { text },
   });
   if (copied !== null) {

--- a/apps/app/src/utils/desktop-dialogs.ts
+++ b/apps/app/src/utils/desktop-dialogs.ts
@@ -50,7 +50,6 @@ async function showDesktopMessageBox(
 ): Promise<DesktopMessageBoxResult | null> {
   return await invokeDesktopBridgeRequest<DesktopMessageBoxResult>({
     rpcMethod: "desktopShowMessageBox",
-    ipcChannel: "desktop:showMessageBox",
     params: options,
   });
 }

--- a/apps/app/src/utils/openExternalUrl.ts
+++ b/apps/app/src/utils/openExternalUrl.ts
@@ -3,7 +3,6 @@ import { invokeDesktopBridgeRequest } from "@milady/app-core/bridge";
 export async function openExternalUrl(url: string): Promise<void> {
   const opened = await invokeDesktopBridgeRequest({
     rpcMethod: "desktopOpenExternal",
-    ipcChannel: "desktop:openExternal",
     params: { url },
   });
   if (opened !== null) {

--- a/apps/app/test/app/desktop-electron-rpc.test.ts
+++ b/apps/app/test/app/desktop-electron-rpc.test.ts
@@ -73,7 +73,7 @@ describe("DesktopElectron desktop bridge", () => {
   it("throws when desktop-only requests are called without direct Electrobun RPC", async () => {
     const plugin = new DesktopElectron();
     await expect(plugin.beep()).rejects.toThrow(
-      "beep is not available: Electron IPC bridge not found.",
+      "beep is not available: desktop RPC bridge not found.",
     );
   });
 

--- a/apps/app/test/app/electrobun-rpc-bridge.test.ts
+++ b/apps/app/test/app/electrobun-rpc-bridge.test.ts
@@ -17,7 +17,7 @@ describe("electrobun rpc bridge", () => {
     vi.restoreAllMocks();
   });
 
-  it("prefers direct Electrobun RPC requests over Electron IPC", async () => {
+  it("prefers direct Electrobun RPC requests when available", async () => {
     const rpcRequest = vi.fn().mockResolvedValue({ ok: true });
     (window as TestWindow).__MILADY_ELECTROBUN_RPC__ = {
       request: { desktopOpenExternal: rpcRequest },
@@ -28,7 +28,6 @@ describe("electrobun rpc bridge", () => {
     await expect(
       invokeDesktopBridgeRequest({
         rpcMethod: "desktopOpenExternal",
-        ipcChannel: "desktop:openExternal",
         params: { url: "https://example.com" },
       }),
     ).resolves.toEqual({ ok: true });
@@ -40,7 +39,6 @@ describe("electrobun rpc bridge", () => {
     await expect(
       invokeDesktopBridgeRequest({
         rpcMethod: "desktopOpenExternal",
-        ipcChannel: "desktop:openExternal",
         params: { url: "https://example.com" },
       }),
     ).resolves.toBeNull();
@@ -67,7 +65,6 @@ describe("electrobun rpc bridge", () => {
     const listener = vi.fn();
     const unsubscribe = subscribeDesktopBridgeEvent({
       rpcMessage: "contextMenuSaveAsCommand",
-      ipcChannel: "contextMenu:saveAsCommand",
       listener,
     });
 

--- a/apps/app/test/app/talkmode-electron-rpc.test.ts
+++ b/apps/app/test/app/talkmode-electron-rpc.test.ts
@@ -9,11 +9,7 @@ type TestWindow = Window & {
 };
 
 type TalkModeElectronPrivate = TalkModeElectron & {
-  invokeBridge: (
-    rpcMethod: string,
-    ipcChannel: string,
-    params?: unknown,
-  ) => Promise<unknown>;
+  invokeBridge: (rpcMethod: string, params?: unknown) => Promise<unknown>;
   setupNativeListeners: () => void;
 };
 
@@ -166,26 +162,16 @@ describe("TalkModeElectron direct Electrobun RPC bridge", () => {
       }),
     ).resolves.toEqual({ started: true });
 
-    expect(invokeBridge).toHaveBeenNthCalledWith(
-      1,
-      "talkmodeUpdateConfig",
-      "talkmode:updateConfig",
-      {
-        engine: "whisper",
-        modelSize: "base",
-        language: "en",
-        voiceId: "voice-1",
-      },
-    );
-    expect(invokeBridge).toHaveBeenNthCalledWith(
-      2,
-      "talkmodeStart",
-      "talkmode:start",
-    );
+    expect(invokeBridge).toHaveBeenNthCalledWith(1, "talkmodeUpdateConfig", {
+      engine: "whisper",
+      modelSize: "base",
+      language: "en",
+      voiceId: "voice-1",
+    });
+    expect(invokeBridge).toHaveBeenNthCalledWith(2, "talkmodeStart");
     expect(invokeBridge).toHaveBeenNthCalledWith(
       3,
       "talkmodeIsWhisperAvailable",
-      "talkmode:isWhisperAvailable",
     );
 
     directListeners.get("talkmodeStateChanged")?.forEach((listener) => {
@@ -224,14 +210,10 @@ describe("TalkModeElectron direct Electrobun RPC bridge", () => {
         silenceWindowMs: 1000,
       },
     });
-    expect(invokeBridge).toHaveBeenCalledWith(
-      "talkmodeUpdateConfig",
-      "talkmode:updateConfig",
-      {
-        modelSize: "small",
-        voiceId: "voice-2",
-      },
-    );
+    expect(invokeBridge).toHaveBeenCalledWith("talkmodeUpdateConfig", {
+      modelSize: "small",
+      voiceId: "voice-2",
+    });
 
     processorStub.onaudioprocess?.({
       inputBuffer: {
@@ -245,7 +227,7 @@ describe("TalkModeElectron direct Electrobun RPC bridge", () => {
     });
 
     await plugin.stop();
-    expect(invokeBridge).toHaveBeenCalledWith("talkmodeStop", "talkmode:stop");
+    expect(invokeBridge).toHaveBeenCalledWith("talkmodeStop");
     expect(directListeners.get("talkmodeStateChanged")?.size ?? 0).toBe(0);
     expect(directListeners.get("talkmodeTranscript")?.size ?? 0).toBe(0);
   });

--- a/packages/app-core/src/bridge/electrobun-rpc.ts
+++ b/packages/app-core/src/bridge/electrobun-rpc.ts
@@ -29,7 +29,6 @@ export function getElectrobunRendererRpc(): ElectrobunRendererRpc | undefined {
 
 export async function invokeDesktopBridgeRequest<T>(options: {
   rpcMethod: string;
-  ipcChannel: string;
   params?: unknown;
 }): Promise<T | null> {
   const rpc = getElectrobunRendererRpc();
@@ -43,7 +42,6 @@ export async function invokeDesktopBridgeRequest<T>(options: {
 
 export function subscribeDesktopBridgeEvent(options: {
   rpcMessage: string;
-  ipcChannel: string;
   listener: ElectrobunMessageListener;
 }): () => void {
   const rpc = getElectrobunRendererRpc();

--- a/packages/app-core/src/hooks/useCanvasWindow.ts
+++ b/packages/app-core/src/hooks/useCanvasWindow.ts
@@ -7,10 +7,9 @@
  *
  * Works in:
  *   - Electrobun — calls via the preload-exposed renderer RPC
- *   - Legacy Electron — falls back to the historical Electron bridge
  *
- * Falls back gracefully (isReady=false, no window created) when neither
- * runtime is detected (web / Capacitor / SSR).
+ * Falls back gracefully (isReady=false, no window created) when the
+ * desktop runtime is unavailable (web / Capacitor / SSR).
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -120,7 +119,6 @@ export function useCanvasWindow(
 
     void invokeDesktopBridgeRequest({
       rpcMethod: "canvasSetBounds",
-      ipcChannel: "canvas:setBounds",
       params: { id, ...bounds },
     }).catch((err: unknown) => {
       console.warn("[useCanvasWindow] canvas:setBounds failed", err);
@@ -164,7 +162,6 @@ export function useCanvasWindow(
 
     void invokeDesktopBridgeRequest<{ id?: string }>({
       rpcMethod: "canvasCreateWindow",
-      ipcChannel: "canvas:createWindow",
       params: {
         url: urlRef.current,
         title: titleRef.current ?? "Canvas",
@@ -184,7 +181,6 @@ export function useCanvasWindow(
           if (id) {
             void invokeDesktopBridgeRequest({
               rpcMethod: "canvasDestroyWindow",
-              ipcChannel: "canvas:destroyWindow",
               params: { id },
             }).catch(() => {});
           }
@@ -230,7 +226,6 @@ export function useCanvasWindow(
         lastBoundsRef.current = null;
         void invokeDesktopBridgeRequest({
           rpcMethod: "canvasDestroyWindow",
-          ipcChannel: "canvas:destroyWindow",
           params: { id },
         }).catch(() => {});
       }
@@ -247,7 +242,6 @@ export function useCanvasWindow(
     if (!id) return;
     void invokeDesktopBridgeRequest({
       rpcMethod: "canvasNavigate",
-      ipcChannel: "canvas:navigate",
       params: { id, url: newUrl },
     }).catch((err: unknown) => {
       console.warn("[useCanvasWindow] canvas:navigate failed", err);
@@ -259,7 +253,6 @@ export function useCanvasWindow(
     if (!id) return;
     void invokeDesktopBridgeRequest({
       rpcMethod: "canvasShow",
-      ipcChannel: "canvas:show",
       params: { id },
     }).catch((err: unknown) => {
       console.warn("[useCanvasWindow] canvas:show failed", err);
@@ -271,7 +264,6 @@ export function useCanvasWindow(
     if (!id) return;
     void invokeDesktopBridgeRequest({
       rpcMethod: "canvasHide",
-      ipcChannel: "canvas:hide",
       params: { id },
     }).catch((err: unknown) => {
       console.warn("[useCanvasWindow] canvas:hide failed", err);


### PR DESCRIPTION
## Summary
- remove dead `ipcChannel` parameters from the shared Electrobun bridge helpers and all live callers
- collapse plugin-local helper signatures to RPC-only request/message shapes
- update adapter tests and stale desktop bridge wording to match the active RPC transport

## Testing
- bunx vitest run apps/app/test/app/electrobun-rpc-bridge.test.ts apps/app/test/app/talkmode-electron-rpc.test.ts apps/app/test/app/swabble-electron-rpc.test.ts apps/app/test/app/swabble-web-rpc.test.ts apps/app/test/app/location-electron-rpc.test.ts apps/app/test/app/gateway-electron-rpc.test.ts apps/app/test/app/desktop-electron-rpc.test.ts apps/app/test/app/screencapture-electron-rpc.test.ts
- bun run check
- bun run pre-review:local