### PR TITLE
build: fix electrobun release core dependency resolution

### DIFF
--- a/.github/workflows/release-electrobun.yml
+++ b/.github/workflows/release-electrobun.yml
@@ -412,6 +412,19 @@ jobs:
             bun install -g "electrobun@$ELECTROBUN_VERSION"
           fi
 
+      - name: Materialize local electrobun package for build
+        run: |
+          node -e "
+            const fs = require('node:fs');
+            const path = require('node:path');
+            const src = fs.realpathSync('node_modules/electrobun');
+            const dest = path.resolve('apps/app/electrobun/node_modules/electrobun');
+            fs.rmSync(dest, { recursive: true, force: true });
+            fs.mkdirSync(path.dirname(dest), { recursive: true });
+            fs.cpSync(src, dest, { recursive: true });
+            console.log('Materialized local electrobun package:', dest, '<-', src);
+          "
+
       - name: Ensure Windows rcedit binary is available for Electrobun
         if: matrix.platform.os == 'windows'
         shell: pwsh

--- a/scripts/electrobun-release-workflow-drift.test.ts
+++ b/scripts/electrobun-release-workflow-drift.test.ts
@@ -110,6 +110,22 @@ describe("Electrobun release workflow drift", () => {
     expect(workflow).toContain("electrobun CLI checksum mismatch");
     expect(workflow).toContain("Verified electrobun CLI SHA256:");
   });
+
+  it("materializes a local electrobun package before packaging", () => {
+    const workflow = fs.readFileSync(WORKFLOW_PATH, "utf8");
+
+    expect(workflow).toContain(
+      "name: Materialize local electrobun package for build",
+    );
+    expect(workflow).toContain(
+      "const src = fs.realpathSync('node_modules/electrobun');",
+    );
+    expect(workflow).toContain(
+      "const dest = path.resolve('apps/app/electrobun/node_modules/electrobun');",
+    );
+    expect(workflow).toContain("fs.cpSync(src, dest, { recursive: true });");
+  });
+
   it("keeps updater transport files off the public GitHub release asset list", () => {
     const workflow = fs.readFileSync(WORKFLOW_PATH, "utf8");
 

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -53,6 +53,10 @@ const requiredWorkflowSnippets = [
   "$expectedHash = $asset.digest.Substring(7).ToLowerInvariant()",
   "$actualHash = (Get-FileHash -Path $tarPath -Algorithm SHA256).Hash.ToLowerInvariant()",
   "electrobun CLI checksum mismatch",
+  "name: Materialize local electrobun package for build",
+  "const src = fs.realpathSync('node_modules/electrobun');",
+  "const dest = path.resolve('apps/app/electrobun/node_modules/electrobun');",
+  "fs.cpSync(src, dest, { recursive: true });",
 ];
 const forbiddenWorkflowSnippets = [' -name "*.exe" -o \\'];
 const requiredElectrobunConfigSnippets = [

--- a/src/auth/apply-stealth.ts
+++ b/src/auth/apply-stealth.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { installClaudeCodeStealthFetchInterceptor } from "./claude-code-stealth";
 
 /**


### PR DESCRIPTION
## Summary
- materialize a local `apps/app/electrobun/node_modules/electrobun` package before `electrobun build`
- guard that release workflow requirement in the workflow drift test and `release:check`
- remove an unrelated unused import so repo lint stays green

## Why
The draft release run for `v2.0.0-alpha.88` failed on macOS arm64 and Linux because Electrobun fell back to `releases/download/latest/...` and 404ed. The CLI in `1.15.1` reads `apps/app/electrobun/node_modules/electrobun/package.json` relative to the workspace, and CI did not guarantee that local package path existed.

## Validation
- `bunx vitest run scripts/electrobun-release-workflow-drift.test.ts`
- `bun run release:check`
- `bun run check`
- `bun run pre-review:local`
- resolver simulation: `before: latest` -> `after: v1.15.1`
