### PR TITLE
ci: run Windows signing step under pwsh

### DIFF
--- a/.github/workflows/release-electrobun.yml
+++ b/.github/workflows/release-electrobun.yml
@@ -706,6 +706,7 @@ jobs:
           WINDOWS_SIGN_CERT_BASE64: ${{ secrets.WINDOWS_SIGN_CERT_BASE64 }}
           WINDOWS_SIGN_CERT_PASSWORD: ${{ secrets.WINDOWS_SIGN_CERT_PASSWORD }}
           WINDOWS_SIGN_TIMESTAMP_URL: ${{ secrets.WINDOWS_SIGN_TIMESTAMP_URL }}
+        shell: pwsh
         run: pwsh -File apps/app/electrobun/scripts/sign-windows.ps1 -ArtifactsDir (Join-Path $PWD "apps/app/electrobun/artifacts") -BuildDir (Join-Path $PWD "apps/app/electrobun/build")
 
       - name: Verify Windows code signature


### PR DESCRIPTION
## Summary\n- run the Windows signing workflow step under PowerShell instead of the job default Bash shell\n- keep the existing signing script invocation and artifact paths unchanged\n- unblock the Electrobun release after Windows packaged smoke and renderer bootstrap already passed\n\n## Validation\n- bunx vitest run scripts/electrobun-release-workflow-drift.test.ts\n- bun run release:check\n- bun run pre-review:local\n\n## Failure fixed\nThe merged release run on develop passed Windows packaged smoke and renderer bootstrap, then failed in `Sign Windows executables` because Bash parsed PowerShell `(Join-Path ...)` syntax before `sign-windows.ps1` was invoked. This PR sets `shell: pwsh` for that workflow step.