### PR TITLE
ci: preserve macOS launcher arch in staged app

### DIFF
--- a/apps/app/electrobun/scripts/stage-macos-release-artifacts.sh
+++ b/apps/app/electrobun/scripts/stage-macos-release-artifacts.sh
@@ -104,10 +104,30 @@ if [[ "$SKIP_SIGNATURE_CHECK" != "1" && -n "${ELECTROBUN_DEVELOPER_ID:-}" ]]; th
 fi
 
 TMP_LAUNCHER_PATH="$TMP_ROOT/direct-launcher"
+LAUNCHER_ARCHES="$(lipo -archs "$LAUNCHER_PATH" 2>/dev/null || true)"
+if [[ -z "$LAUNCHER_ARCHES" ]]; then
+  echo "stage-macos-release-artifacts: failed to determine launcher architecture for $LAUNCHER_PATH"
+  exit 1
+fi
+
+clang_arch_args=()
+for arch in $LAUNCHER_ARCHES; do
+  case "$arch" in
+    arm64|x86_64)
+      clang_arch_args+=(-arch "$arch")
+      ;;
+    *)
+      echo "stage-macos-release-artifacts: unsupported launcher architecture: $arch"
+      exit 1
+      ;;
+  esac
+done
+
 /usr/bin/clang \
   -O2 \
   -Wall \
   -Wextra \
+  "${clang_arch_args[@]}" \
   -mmacosx-version-min=11.0 \
   "$DIRECT_LAUNCHER_SOURCE" \
   -o "$TMP_LAUNCHER_PATH"

--- a/apps/app/electrobun/src/__tests__/stage-macos-release-artifacts.test.ts
+++ b/apps/app/electrobun/src/__tests__/stage-macos-release-artifacts.test.ts
@@ -1,0 +1,25 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const STAGE_MACOS_RELEASE_ARTIFACTS_PATH = path.resolve(
+  import.meta.dirname,
+  "../../scripts/stage-macos-release-artifacts.sh",
+);
+
+describe("stage-macos-release-artifacts.sh", () => {
+  it("rebuilds the direct launcher using the packaged launcher architecture", () => {
+    const script = fs.readFileSync(STAGE_MACOS_RELEASE_ARTIFACTS_PATH, "utf8");
+
+    expect(script).toContain(
+      'LAUNCHER_ARCHES="$(lipo -archs "$LAUNCHER_PATH" 2>/dev/null || true)"',
+    );
+    expect(script).toContain("clang_arch_args=()");
+    expect(script).toContain('clang_arch_args+=(-arch "$arch")');
+    expect(script).toContain(
+      'echo "stage-macos-release-artifacts: unsupported launcher architecture: $arch"',
+    );
+    expect(script).toContain('"${clang_arch_args[@]}"');
+  });
+});

--- a/scripts/electrobun-release-workflow-drift.test.ts
+++ b/scripts/electrobun-release-workflow-drift.test.ts
@@ -173,6 +173,20 @@ describe("Electrobun release workflow drift", () => {
     expect(stageScript).toContain('xcrun stapler staple "$TEMP_DMG_PATH"');
   });
 
+  it("rebuilds the staged macOS direct launcher with the packaged launcher architecture", () => {
+    const stageScript = fs.readFileSync(MACOS_STAGE_SCRIPT_PATH, "utf8");
+
+    expect(stageScript).toContain(
+      'LAUNCHER_ARCHES="$(lipo -archs "$LAUNCHER_PATH" 2>/dev/null || true)"',
+    );
+    expect(stageScript).toContain("clang_arch_args=()");
+    expect(stageScript).toContain('clang_arch_args+=(-arch "$arch")');
+    expect(stageScript).toContain(
+      'echo "stage-macos-release-artifacts: unsupported launcher architecture: $arch"',
+    );
+    expect(stageScript).toContain('"${clang_arch_args[@]}"');
+  });
+
   it("pins the native macOS effects build to C++17", () => {
     const buildScript = fs.readFileSync(
       MACOS_EFFECTS_BUILD_SCRIPT_PATH,


### PR DESCRIPTION
## Summary
- preserve the staged macOS direct launcher architecture by rebuilding it to match the packaged launcher Mach-O archs
- add focused regression coverage for the staging script and release workflow drift
- fix the Intel macOS release path without touching the already-green Windows packaging flow

## Validation
- bunx vitest run apps/app/electrobun/src/__tests__/stage-macos-release-artifacts.test.ts scripts/electrobun-release-workflow-drift.test.ts
- bun run release:check
- bun run pre-review:local