### PR TITLE
fix: dev:desktop renderer loading and codesign skip

### DIFF
--- a/scripts/dev-platform.mjs
+++ b/scripts/dev-platform.mjs
@@ -2,24 +2,36 @@
 /**
  * dev:desktop — Full Milady desktop development environment.
  *
- * Runs in parallel:
- *   1. API server (bun --watch on port 31337)
- *   2. Vite (build --watch) — continuously rebuilds the renderer to apps/app/dist/
- *   3. Electrobun (dev) — watches bun-side + ../dist, relaunches on change
+ * 1. Blocking vite build (renderer assets for electrobun)
+ * 2. Then starts in parallel:
+ *    - API server (bun --watch on port 31337)
+ *    - Electrobun (dev) — bundles renderer from ../dist, watches for changes
+ *
+ * Electrobun watches ../dist (via electrobun.config.ts watch config),
+ * so subsequent vite rebuilds trigger an electrobun reload automatically.
+ * Run `bun run vite build` in apps/app/ to push UI changes to the desktop.
  *
  * Pass --no-api to skip the backend (e.g. if running it separately).
  *
  * Ctrl-C cleanly kills all processes.
  */
 
-import { spawn } from "node:child_process";
+import { execSync, spawn } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, "..");
+const appDir = path.join(repoRoot, "apps/app");
+const electrobunDir = path.join(appDir, "electrobun");
 const skipApi = process.argv.includes("--no-api");
 
+// Step 1: blocking vite build so electrobun has renderer assets to bundle
+console.log("\n[milady] Building renderer...");
+execSync("bun run vite build", { cwd: appDir, stdio: "inherit" });
+console.log("[milady] Renderer ready.\n");
+
+// Step 2: start API + electrobun in parallel
 const services = [
   ...(!skipApi
     ? [
@@ -36,18 +48,11 @@ const services = [
       ]
     : []),
   {
-    name: "vite",
-    cmd: "bun",
-    args: ["run", "vite", "build", "--watch"],
-    cwd: path.join(repoRoot, "apps/app"),
-    env: {},
-  },
-  {
     name: "electrobun",
     cmd: "bun",
     args: ["run", "dev"],
-    cwd: path.join(repoRoot, "apps/app/electrobun"),
-    env: {},
+    cwd: electrobunDir,
+    env: { ELECTROBUN_SKIP_CODESIGN: "1" },
   },
 ];
 
@@ -63,7 +68,7 @@ function prefixStream(name, stream) {
 }
 
 console.log(
-  `\nMilady desktop dev${skipApi ? " (no API)" : ""}\n` +
+  `Milady desktop dev${skipApi ? " (no API)" : ""}\n` +
     `  Services: ${services.map((s) => s.name).join(", ")}\n`,
 );
 


### PR DESCRIPTION
## Summary

Fixes `bun run dev:desktop` showing a white "Not Found" screen.

**Root cause:** The parallel `vite build --watch` from #972 raced with electrobun's bundle copy. Vite's `emptyOutDir: true` wiped `apps/app/dist/` mid-copy, so electrobun bundled an empty renderer directory.

**Fix:**
- Blocking `vite build` first, then start API + electrobun (no parallel vite watcher)
- `ELECTROBUN_SKIP_CODESIGN=1` in dev mode — codesign only needed for production
- Electrobun watches `../dist` via its own config, so UI changes still propagate when you rebuild vite manually

**Verified:** renderer `index.html` now present in the electrobun bundle, app loads correctly.

## Test plan

- [x] `bun run lint` — pass
- [x] `bun run format` — pass
- [x] `bun run typecheck` — pass
- [x] `bun run build` — pass
- [x] `bun run test` — 881 passed, 0 failed
- [x] `bun run dev:desktop` — app opens with UI loaded (no white screen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)