### PR TITLE
feat: homepage hero dock bar + downloads redesign

### DIFF
--- a/apps/homepage/src/components/Downloads.tsx
+++ b/apps/homepage/src/components/Downloads.tsx
@@ -1,219 +1,264 @@
+import { useCallback, useEffect, useRef } from "react";
 import { releaseData } from "../generated/release-data";
-
-const ELIZA_CLOUD_LOGIN_URL =
-  "https://elizacloud.ai/login?returnTo=%2Fdashboard%2Fmilady";
+import { AppleIcon, WindowsIcon, LinuxIcon } from "./Hero";
 
 const shellCommand = releaseData.scripts.shell.command;
 const powershellCommand = releaseData.scripts.powershell.command;
-const checksumCommand = releaseData.release.checksum
-  ? [
-      "cd ~/Downloads",
-      `curl -fsSLO ${releaseData.release.checksum.url}`,
-      "shasum -a 256 --check --ignore-missing SHA256SUMS.txt",
-    ].join("\n")
-  : "";
+
+function PlatformIcon({ id }: { id: string }) {
+  if (id.includes("macos")) return <AppleIcon />;
+  if (id.includes("windows")) return <WindowsIcon />;
+  return <LinuxIcon />;
+}
+
+function platformShortLabel(id: string): string {
+  if (id.includes("arm64")) return "Mac M1+";
+  if (id.includes("x64") && id.includes("macos")) return "Mac Intel";
+  if (id.includes("windows")) return "Windows";
+  return "Linux";
+}
+
+/* ── Code Rain Canvas ──────────────────────────────────────────────── */
+
+const CHARS = "MILADY".split("");
+const FONT_SIZE = 14;
+const RAIN_COLOR = "rgba(0,0,0,0.08)";
+const RAIN_HEAD_COLOR = "rgba(0,0,0,0.25)";
+
+function CodeRainBackground() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const columnsRef = useRef<number[]>([]);
+  const rafRef = useRef<number>(0);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const resize = () => {
+      canvas.width = canvas.offsetWidth * window.devicePixelRatio;
+      canvas.height = canvas.offsetHeight * window.devicePixelRatio;
+      ctx.scale(window.devicePixelRatio, window.devicePixelRatio);
+      const cols = Math.floor(canvas.offsetWidth / FONT_SIZE);
+      columnsRef.current = Array.from({ length: cols }, () =>
+        Math.floor(Math.random() * canvas.offsetHeight / FONT_SIZE)
+      );
+    };
+
+    resize();
+    window.addEventListener("resize", resize);
+
+    let lastTime = 0;
+    const draw = (time: number) => {
+      if (time - lastTime < 50) {
+        rafRef.current = requestAnimationFrame(draw);
+        return;
+      }
+      lastTime = time;
+
+      const w = canvas.offsetWidth;
+      const h = canvas.offsetHeight;
+
+      // Fade existing content
+      ctx.fillStyle = "rgba(255,255,255,0.15)";
+      ctx.fillRect(0, 0, w, h);
+
+      ctx.font = `${FONT_SIZE}px monospace`;
+
+      const columns = columnsRef.current;
+      for (let i = 0; i < columns.length; i++) {
+        const char = CHARS[Math.floor(Math.random() * CHARS.length)];
+        const x = i * FONT_SIZE;
+        const y = columns[i] * FONT_SIZE;
+
+        // Head character is darker
+        ctx.fillStyle = RAIN_HEAD_COLOR;
+        ctx.fillText(char, x, y);
+
+        // Trail characters lighter
+        if (columns[i] > 1) {
+          ctx.fillStyle = RAIN_COLOR;
+          const trailChar = CHARS[Math.floor(Math.random() * CHARS.length)];
+          ctx.fillText(trailChar, x, y - FONT_SIZE);
+        }
+
+        // Reset or advance
+        if (y > h && Math.random() > 0.975) {
+          columns[i] = 0;
+        }
+        columns[i]++;
+      }
+
+      rafRef.current = requestAnimationFrame(draw);
+    };
+
+    // Fill initial white
+    ctx.fillStyle = "#ffffff";
+    ctx.fillRect(0, 0, canvas.offsetWidth, canvas.offsetHeight);
+
+    rafRef.current = requestAnimationFrame(draw);
+
+    return () => {
+      window.removeEventListener("resize", resize);
+      cancelAnimationFrame(rafRef.current);
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="absolute inset-0 w-full h-full"
+      style={{ display: "block" }}
+    />
+  );
+}
+
+/* ── Reveal Mask (follows cursor) ──────────────────────────────────── */
+
+function RevealMask() {
+  const maskRef = useRef<HTMLDivElement>(null);
+
+  const handleMouseMove = useCallback((e: MouseEvent) => {
+    const el = maskRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    el.style.setProperty("--mx", `${x}px`);
+    el.style.setProperty("--my", `${y}px`);
+    el.style.setProperty("--reveal-opacity", "1");
+  }, []);
+
+  const handleMouseLeave = useCallback(() => {
+    const el = maskRef.current;
+    if (!el) return;
+    el.style.setProperty("--reveal-opacity", "0");
+  }, []);
+
+  useEffect(() => {
+    const el = maskRef.current;
+    if (!el) return;
+    const parent = el.parentElement;
+    if (!parent) return;
+    parent.addEventListener("mousemove", handleMouseMove);
+    parent.addEventListener("mouseleave", handleMouseLeave);
+    return () => {
+      parent.removeEventListener("mousemove", handleMouseMove);
+      parent.removeEventListener("mouseleave", handleMouseLeave);
+    };
+  }, [handleMouseMove, handleMouseLeave]);
+
+  return (
+    <div
+      ref={maskRef}
+      className="reveal-mask"
+      style={
+        {
+          "--mx": "50%",
+          "--my": "50%",
+          "--reveal-opacity": "0",
+        } as React.CSSProperties
+      }
+    />
+  );
+}
+
+/* ── Downloads Section ─────────────────────────────────────────────── */
 
 export function Downloads() {
   return (
     <section
       id="install"
-      className="relative overflow-hidden bg-white py-48 text-dark"
+      className="relative overflow-hidden py-32 text-dark"
     >
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(240,185,11,0.16),transparent_40%),radial-gradient(circle_at_bottom_right,rgba(11,53,241,0.1),transparent_40%)]" />
-      <div className="relative z-10 mx-auto grid max-w-7xl grid-cols-1 gap-16 px-6 md:px-12 lg:grid-cols-12">
-        <div className="lg:col-span-4">
-          <p className="mb-4 font-mono text-xs uppercase tracking-[0.2em] text-brand">
-            Distribution
+      {/* Code rain background */}
+      <CodeRainBackground />
+
+      {/* White overlay with cursor reveal hole */}
+      <RevealMask />
+
+      {/* Content */}
+      <div className="relative z-10 mx-auto max-w-4xl px-6 md:px-12">
+        {/* Header */}
+        <div className="text-center mb-16">
+          <p className="mb-3 font-mono text-xs uppercase tracking-[0.2em] text-brand">
+            Install
           </p>
-          <h2 className="text-5xl font-black uppercase tracking-tighter md:text-7xl">
-            Release-backed install paths.
+          <h2 className="text-3xl font-black uppercase tracking-tighter md:text-5xl">
+            Get Milady
           </h2>
-          <p className="mt-6 max-w-xl text-base leading-8 text-dark/70">
-            Desktop buttons are generated from GitHub release assets instead of
-            hardcoded placeholders. Eliza Cloud and remote self-hosting now sit
-            alongside the download flow so users can either run local or attach
-            to a hosted backend from the same frontend.
+          <p className="mx-auto mt-4 max-w-lg text-sm leading-7 text-dark/60">
+            Download the desktop app or bootstrap via terminal.
+            All artifacts pulled from GitHub Releases.
           </p>
-          <div className="mt-8 border border-dark/10 bg-black px-5 py-4 font-mono text-sm text-white">
-            <div className="text-[10px] uppercase tracking-[0.2em] text-white/50">
-              Current channel
+        </div>
+
+        {/* Download buttons — compact row */}
+        <div className="flex flex-wrap justify-center gap-3 mb-16">
+          {releaseData.release.downloads.map((download) => (
+            <a
+              key={download.id}
+              href={download.url}
+              target="_blank"
+              rel="noreferrer"
+              className="group flex items-center gap-2.5 border border-dark/10 bg-white px-5 py-3 font-mono text-sm transition-all duration-200 hover:border-dark hover:bg-black hover:text-white"
+            >
+              <PlatformIcon id={download.id} />
+              <span className="font-bold uppercase tracking-wide">
+                {platformShortLabel(download.id)}
+              </span>
+              <span className="text-[10px] text-dark/40 group-hover:text-white/40">
+                {download.sizeLabel}
+              </span>
+            </a>
+          ))}
+        </div>
+
+        {/* Install commands */}
+        <div className="grid gap-4 md:grid-cols-2 mb-12">
+          <div className="bg-black rounded-lg p-5 text-white">
+            <div className="flex items-center justify-between mb-3">
+              <span className="font-mono text-[11px] uppercase tracking-[0.15em] text-white/70 font-bold">
+                macOS / Linux / WSL
+              </span>
             </div>
-            <div className="mt-2 text-lg font-bold uppercase tracking-[0.08em]">
-              {releaseData.release.prerelease ? "Canary" : "Stable"} •{" "}
-              {releaseData.release.tagName}
+            <pre className="overflow-x-auto text-xs text-green-400 leading-relaxed">
+              <code>{shellCommand}</code>
+            </pre>
+          </div>
+
+          <div className="bg-black rounded-lg p-5 text-white">
+            <div className="flex items-center justify-between mb-3">
+              <span className="font-mono text-[11px] uppercase tracking-[0.15em] text-white/70 font-bold">
+                Windows PowerShell
+              </span>
             </div>
-            <div className="mt-1 text-[11px] uppercase tracking-[0.18em] text-white/50">
-              Published {releaseData.release.publishedAtLabel}
-            </div>
+            <pre className="overflow-x-auto text-xs text-blue-400 leading-relaxed">
+              <code>{powershellCommand}</code>
+            </pre>
           </div>
         </div>
 
-        <div className="space-y-6 lg:col-span-8">
-          <div className="grid gap-4 md:grid-cols-2">
-            {releaseData.release.downloads.map((download) => (
-              <a
-                key={download.id}
-                href={download.url}
-                target="_blank"
-                rel="noreferrer"
-                className="group border border-dark/10 bg-white p-6 transition-colors duration-300 hover:border-dark hover:bg-black hover:text-white"
-              >
-                <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-dark/45 group-hover:text-white/45">
-                  {download.note}
-                </div>
-                <div className="mt-3 text-2xl font-black uppercase tracking-tight">
-                  {download.label}
-                </div>
-                <div className="mt-3 break-all font-mono text-xs text-dark/60 group-hover:text-white/60">
-                  {download.fileName}
-                </div>
-                <div className="mt-5 flex items-center justify-between font-mono text-[10px] uppercase tracking-[0.18em] text-dark/45 group-hover:text-white/45">
-                  <span>{download.sizeLabel}</span>
-                  <span>Download</span>
-                </div>
-              </a>
-            ))}
-          </div>
-
-          <div className="grid gap-6 md:grid-cols-2">
-            <CommandCard
-              eyebrow="macOS / Linux / WSL"
-              title="Shell bootstrap"
-              description="Copies the current install.sh from the Pages root."
-              code={shellCommand}
-            />
-            <CommandCard
-              eyebrow="Windows PowerShell"
-              title="PowerShell bootstrap"
-              description="Uses the same script currently shipped on the Pages site."
-              code={powershellCommand}
-            />
-          </div>
-
-          <div className="grid gap-6 md:grid-cols-2">
-            <InfoCard
-              eyebrow="Managed hosting"
-              title="Eliza Cloud"
-              body="Create managed Eliza Cloud instances at elizacloud.ai and connect the frontend to provisioned backend containers."
-              href={ELIZA_CLOUD_LOGIN_URL}
-              action="Open cloud"
-            />
-            <InfoCard
-              eyebrow="Self-hosted"
-              title="Remote backend"
-              body="Run Milady on your own box, expose it securely, then connect from onboarding with the backend address and MILADY_API_TOKEN."
-              href="https://github.com/milady-ai/milady#remote-backend-deployment"
-              action="Read setup"
-            />
-          </div>
-
-          <div className="grid gap-6 md:grid-cols-2">
-            <InfoCard
-              eyebrow="GitHub Releases"
-              title="Release page"
-              body="Open the full asset list, release notes, and changelog for the currently selected release."
-              href={releaseData.release.url}
-              action="Open release"
-            />
-            <InfoCard
-              eyebrow="Network path"
-              title="Tailscale attach"
-              body="Keep a remote Milady backend private with Tailscale serve or funnel, then connect from the Milady frontend with the same access key."
-              href="https://github.com/milady-ai/milady#tailscale"
-              action="View flow"
-            />
-          </div>
-
-          <div className="grid gap-6 md:grid-cols-2">
-            {releaseData.release.checksum ? (
-              <CommandCard
-                eyebrow="Verification"
-                title="Checksum verification"
-                description={`Downloads ${releaseData.release.checksum.fileName} from the selected release.`}
-                code={checksumCommand}
-              />
-            ) : (
-              <InfoCard
-                eyebrow="Verification"
-                title="Checksums unavailable"
-                body="This release did not publish a SHA256 checksum file, so verification stays on the release page."
-                href={releaseData.release.url}
-                action="Inspect assets"
-              />
-            )}
-            <InfoCard
-              eyebrow="Install surface"
-              title="Pages root scripts"
-              body="The deploy workflow copies install.sh and install.ps1 into the Pages artifact so the website and bootstrap commands stay in sync."
-              href={releaseData.scripts.shell.url}
-              action="Open install.sh"
-            />
-          </div>
+        {/* Footer info */}
+        <div className="flex flex-wrap items-center justify-center gap-6 text-center font-mono text-[11px] uppercase tracking-[0.15em] text-dark/40">
+          <span>
+            {releaseData.release.prerelease ? "Canary" : "Stable"} •{" "}
+            {releaseData.release.tagName}
+          </span>
+          <span>•</span>
+          <span>Published {releaseData.release.publishedAtLabel}</span>
+          <span>•</span>
+          <a
+            href={releaseData.release.url}
+            target="_blank"
+            rel="noreferrer"
+            className="text-brand hover:underline"
+          >
+            All release assets →
+          </a>
         </div>
       </div>
     </section>
-  );
-}
-
-function CommandCard({
-  eyebrow,
-  title,
-  description,
-  code,
-}: {
-  eyebrow: string;
-  title: string;
-  description: string;
-  code: string;
-}) {
-  return (
-    <div className="border border-dark/10 bg-black p-6 text-white">
-      <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-white/45">
-        {eyebrow}
-      </div>
-      <div className="mt-3 text-2xl font-black uppercase tracking-tight">
-        {title}
-      </div>
-      <p className="mt-3 text-sm leading-7 text-white/70">{description}</p>
-      <pre className="mt-5 overflow-x-auto border border-white/10 bg-white/[0.03] p-4 text-xs text-white">
-        <code>{code}</code>
-      </pre>
-    </div>
-  );
-}
-
-function InfoCard({
-  eyebrow,
-  title,
-  body,
-  href,
-  action,
-}: {
-  eyebrow: string;
-  title: string;
-  body: string;
-  href: string;
-  action: string;
-}) {
-  return (
-    <a
-      href={href}
-      target="_blank"
-      rel="noreferrer"
-      className="group border border-dark/10 bg-white p-6 transition-colors duration-300 hover:border-dark hover:bg-black hover:text-white"
-    >
-      <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-dark/45 group-hover:text-white/45">
-        {eyebrow}
-      </div>
-      <div className="mt-3 text-2xl font-black uppercase tracking-tight">
-        {title}
-      </div>
-      <p className="mt-3 text-sm leading-7 text-dark/70 group-hover:text-white/70">
-        {body}
-      </p>
-      <div className="mt-5 font-mono text-[10px] uppercase tracking-[0.18em] text-brand">
-        {action}
-      </div>
-    </a>
   );
 }

--- a/apps/homepage/src/components/Hero.tsx
+++ b/apps/homepage/src/components/Hero.tsx
@@ -1,9 +1,6 @@
 import { motion, type Variants } from "framer-motion";
 import { releaseData } from "../generated/release-data";
 
-const ELIZA_CLOUD_LOGIN_URL =
-  "https://elizacloud.ai/login?returnTo=%2Fdashboard%2Fmilady";
-
 const heroDownloads = releaseData.release.downloads.slice(0, 4);
 const releaseChannelLabel = releaseData.release.prerelease
   ? "Latest published canary"
@@ -88,9 +85,9 @@ export function HeroForeground() {
   };
 
   return (
-    <section className="absolute inset-0 flex flex-col items-center justify-end px-6 md:px-12 pointer-events-none overflow-hidden pb-32">
+    <section className="absolute inset-0 flex flex-col items-center justify-end px-6 md:px-12 pointer-events-none overflow-hidden pb-12">
       <motion.div
-        className="relative z-10 w-full flex flex-col items-center gap-8 translate-y-8"
+        className="relative z-10 w-full flex flex-col items-center gap-6"
         initial="hidden"
         animate="visible"
         variants={{
@@ -99,129 +96,84 @@ export function HeroForeground() {
           },
         }}
       >
-        <motion.div
-          variants={itemVariants}
-          className="w-full max-w-3xl text-center pointer-events-auto"
-        >
-          <p className="mb-4 font-mono text-[11px] uppercase tracking-[0.24em] text-white/45">
-            Desktop releases, CLI bootstrap, no hardcoded fake links
-          </p>
-          <h2 className="text-3xl font-black uppercase tracking-tighter text-white md:text-5xl">
-            GitHub release downloads, deployed into the real homepage.
-          </h2>
-          <p className="mx-auto mt-4 max-w-2xl text-sm leading-7 text-white/70 md:text-base">
-            Run Milady locally, or point the same frontend at Eliza Cloud or a
-            remote self-hosted backend. Signed desktop artifacts still ship
-            straight from GitHub Releases.
-          </p>
-          <p className="mt-4 font-mono text-[11px] uppercase tracking-[0.2em] text-brand">
-            {releaseChannelLabel} • {releaseData.release.tagName} •{" "}
-            {releaseData.release.publishedAtLabel}
-          </p>
-        </motion.div>
-
+        {/* ── Download Dock Bar ─────────────────────────────────────── */}
         <motion.div
           id="download"
           variants={itemVariants}
-          className="grid w-full max-w-5xl grid-cols-1 gap-3 pointer-events-auto md:grid-cols-2 xl:grid-cols-3"
+          className="pointer-events-auto flex flex-col items-center gap-3"
         >
-          {heroDownloads.map((download, index) => (
+          <div className="hero-dock">
+            <p className="hero-dock-title">Run locally. Swap providers. Own your runtime.</p>
+            <div className="hero-dock-icons">
+            {heroDownloads.map((download) => (
+              <a
+                key={download.id}
+                href={download.url}
+                target="_blank"
+                rel="noreferrer"
+                className="hero-dock-item group"
+                title={`${download.label} — ${download.sizeLabel}`}
+              >
+                <div className="hero-dock-icon">
+                  <DownloadIcon platform={download.id} />
+                </div>
+                <span className="hero-dock-label">
+                  {download.id.includes("arm64")
+                    ? "Mac M1+"
+                    : download.id.includes("x64") && download.id.includes("macos")
+                      ? "Mac Intel"
+                      : download.id.includes("windows")
+                        ? "Windows"
+                        : download.id.includes("linux")
+                          ? "Linux"
+                          : download.label.split("(")[0].trim()}
+                </span>
+                <span className="hero-dock-tooltip">
+                  {download.label}<br />{download.sizeLabel}
+                </span>
+              </a>
+            ))}
+
+            {/* Divider */}
+            <div className="hero-dock-divider" />
+
             <a
-              key={download.id}
-              href={download.url}
+              href="#install"
+              className="hero-dock-item group"
+              title="Install Scripts — Shell + PowerShell"
+            >
+              <div className="hero-dock-icon">
+                <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><path d="M21 2H3a1 1 0 00-1 1v18a1 1 0 001 1h18a1 1 0 001-1V3a1 1 0 00-1-1zm-1 18H4V4h16v16zM7 15l4-4-4-4 1.5-1.5L14 11l-5.5 5.5L7 15zm5 2h5v-1.5h-5V17z" /></svg>
+              </div>
+              <span className="hero-dock-label">Scripts</span>
+              <span className="hero-dock-tooltip">Install Scripts<br />Shell + PowerShell</span>
+            </a>
+
+            <a
+              href={releaseData.release.url}
               target="_blank"
               rel="noreferrer"
-              className={`group relative flex items-center gap-3 border px-4 py-4 font-mono transition-colors duration-300 ${
-                index === 0
-                  ? "border-brand bg-brand text-dark hover:border-white hover:bg-white"
-                  : "border-white/20 bg-black/80 text-white backdrop-blur-md hover:border-white hover:bg-white hover:text-dark"
-              }`}
+              className="hero-dock-item group"
+              title={`All Release Assets — ${releaseData.release.tagName}`}
             >
-              <DownloadIcon platform={download.id} />
-              <div className="min-w-0 flex-1">
-                <div className="text-[10px] uppercase tracking-[0.2em] opacity-60">
-                  {download.note}
-                </div>
-                <div className="mt-1 truncate text-sm font-bold uppercase tracking-[0.08em]">
-                  {download.label}
-                </div>
-                <div className="mt-1 truncate text-[10px] opacity-60">
-                  {download.fileName}
-                </div>
+              <div className="hero-dock-icon">
+                <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.009-.866-.013-1.7-2.782.603-3.369-1.342-3.369-1.342-.454-1.155-1.11-1.462-1.11-1.462-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.115 2.504.337 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z" /></svg>
               </div>
-              <div className="text-right text-[10px] uppercase tracking-[0.2em] opacity-60">
-                {download.sizeLabel}
-              </div>
+              <span className="hero-dock-label">GitHub</span>
+              <span className="hero-dock-tooltip">All Releases<br />{releaseData.release.tagName}</span>
             </a>
-          ))}
 
-          <a
-            href="#install"
-            className="group relative flex items-center justify-between gap-3 border border-white/20 bg-black/80 px-4 py-4 font-mono text-white backdrop-blur-md transition-colors duration-300 hover:border-white hover:bg-white hover:text-dark"
-          >
-            <div>
-              <div className="text-[10px] uppercase tracking-[0.2em] opacity-60">
-                Bootstrap
+            <div
+              className="hero-dock-item is-disabled"
+              title="iOS + Android — Coming Soon"
+            >
+              <div className="hero-dock-icon">
+                <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><path d="M17 1.01L7 1c-1.1 0-2 .9-2 2v18c0 1.1.9 2 2 2h10c1.1 0 2-.9 2-2V3c0-1.1-.9-1.99-2-1.99zM17 19H7V5h10v14z" /></svg>
               </div>
-              <div className="mt-1 text-sm font-bold uppercase tracking-[0.08em]">
-                Install Scripts
-              </div>
+              <span className="hero-dock-label">Mobile</span>
+              <span className="hero-dock-tooltip">iOS + Android<br />Coming Soon</span>
             </div>
-            <span className="text-[10px] uppercase tracking-[0.2em] opacity-60">
-              Shell + PowerShell
-            </span>
-          </a>
-
-          <a
-            href={ELIZA_CLOUD_LOGIN_URL}
-            target="_blank"
-            rel="noreferrer"
-            className="group relative flex items-center justify-between gap-3 border border-white/20 bg-black/80 px-4 py-4 font-mono text-white backdrop-blur-md transition-colors duration-300 hover:border-white hover:bg-white hover:text-dark"
-          >
-            <div>
-              <div className="text-[10px] uppercase tracking-[0.2em] opacity-60">
-                Managed
-              </div>
-              <div className="mt-1 text-sm font-bold uppercase tracking-[0.08em]">
-                Eliza Cloud
-              </div>
-            </div>
-            <span className="text-[10px] uppercase tracking-[0.2em] opacity-60">
-              elizacloud.ai
-            </span>
-          </a>
-
-          <a
-            href={releaseData.release.url}
-            target="_blank"
-            rel="noreferrer"
-            className="group relative flex items-center justify-between gap-3 border border-white/20 bg-black/80 px-4 py-4 font-mono text-white backdrop-blur-md transition-colors duration-300 hover:border-white hover:bg-white hover:text-dark"
-          >
-            <div>
-              <div className="text-[10px] uppercase tracking-[0.2em] opacity-60">
-                GitHub
-              </div>
-              <div className="mt-1 text-sm font-bold uppercase tracking-[0.08em]">
-                All Release Assets
-              </div>
-            </div>
-            <span className="text-[10px] uppercase tracking-[0.2em] opacity-60">
-              {releaseData.release.tagName}
-            </span>
-          </a>
-
-          <div className="group relative flex items-center justify-between gap-3 border border-white/10 bg-white/5 px-4 py-4 font-mono text-white/75 backdrop-blur-md">
-            <div>
-              <div className="text-[10px] uppercase tracking-[0.2em] opacity-60">
-                Self-host
-              </div>
-              <div className="mt-1 text-sm font-bold uppercase tracking-[0.08em]">
-                Remote Backend
-              </div>
-            </div>
-            <span className="text-[10px] uppercase tracking-[0.2em] opacity-60">
-              URL + access key
-            </span>
+            </div>{/* end hero-dock-icons */}
           </div>
         </motion.div>
       </motion.div>
@@ -231,10 +183,10 @@ export function HeroForeground() {
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ delay: 1, duration: 1 }}
-        className="absolute bottom-8 left-1/2 -translate-x-1/2 flex flex-col items-center gap-4 text-white/30 font-mono text-[10px] tracking-widest uppercase pointer-events-auto"
+        className="mt-6 flex flex-col items-center gap-3 text-white/30 font-mono text-[10px] tracking-widest uppercase pointer-events-auto"
       >
-        <span>Scroll For Install Details</span>
-        <div className="w-[1px] h-8 bg-gradient-to-b from-white/30 to-transparent" />
+        <span>Scroll For Details</span>
+        <div className="w-[1px] h-6 bg-gradient-to-b from-white/30 to-transparent" />
       </motion.div>
     </section>
   );

--- a/apps/homepage/src/styles.css
+++ b/apps/homepage/src/styles.css
@@ -103,3 +103,165 @@ body {
 }
 
 /* Peekaboo — all animation driven by inline styles in Comparison.tsx */
+
+/* ── Hero Download Dock ──────────────────────────────────────────── */
+
+.hero-dock {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 48px 16px;
+  border-radius: 28px;
+  background: rgba(120, 120, 130, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  backdrop-filter: blur(32px) saturate(140%);
+  -webkit-backdrop-filter: blur(32px) saturate(140%);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.hero-dock-title {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.5);
+  letter-spacing: 0.06em;
+  text-align: center;
+  margin: 0;
+}
+
+.hero-dock-icons {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+@media (max-width: 640px) {
+  .hero-dock {
+    padding: 10px 14px;
+    gap: 6px;
+    transform: scale(0.75);
+    transform-origin: center bottom;
+  }
+}
+
+.hero-dock-item {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 4px;
+  cursor: pointer;
+  text-decoration: none;
+  color: white;
+  transition: transform 0.2s ease;
+}
+
+.hero-dock-item:hover {
+  transform: translateY(-6px) scale(1.1);
+}
+
+.hero-dock-item:active {
+  transform: translateY(-2px) scale(0.95);
+}
+
+.hero-dock-item.is-disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.hero-dock-item.is-disabled:hover {
+  transform: none;
+}
+
+.hero-dock-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.hero-dock-item:hover .hero-dock-icon {
+  background: rgba(255, 255, 255, 0.18);
+  border-color: rgba(255, 255, 255, 0.25);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+}
+
+.hero-dock-label {
+  font-size: 9px;
+  font-weight: 500;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.6);
+  max-width: 56px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Tooltip on hover */
+.hero-dock-tooltip {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 6px 10px;
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(12px);
+  color: white;
+  font-size: 10px;
+  line-height: 1.4;
+  text-align: center;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+}
+
+.hero-dock-item:hover .hero-dock-tooltip {
+  opacity: 1;
+}
+
+/* ── Reveal Mask (cursor spotlight) ───────────────────────────────── */
+
+.reveal-mask {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  background: white;
+  transition: mask-image 0.05s ease;
+  mask-image: radial-gradient(
+    circle 120px at var(--mx) var(--my),
+    transparent 0%,
+    transparent 40%,
+    black 70%
+  );
+  -webkit-mask-image: radial-gradient(
+    circle 120px at var(--mx) var(--my),
+    transparent 0%,
+    transparent 40%,
+    black 70%
+  );
+  opacity: var(--reveal-opacity, 0);
+  pointer-events: none;
+}
+
+/* When cursor is not hovering, show full white */
+.reveal-mask[style*="--reveal-opacity: 0"] {
+  mask-image: none;
+  -webkit-mask-image: none;
+  opacity: 1;
+}
+
+.hero-dock-divider {
+  width: 1px;
+  height: 32px;
+  background: rgba(255, 255, 255, 0.15);
+  margin: 0 4px;
+  flex-shrink: 0;
+}


### PR DESCRIPTION
## Summary
- **Hero dock bar**: Replace download card grid with macOS-style pill-shaped dock (frosted glass, icon grid, hover tooltips, mobile scaling)
- **Downloads section**: Simplified centered layout with compact platform buttons + clean terminal command blocks
- **Code rain reveal**: Cursor-following mask reveals MILADY code rain background on the Downloads section
- **VRM idle animation**: Fix by pulling actual GLB from Git LFS (was LFS pointer)

## Test plan
- [ ] Hero section: verify dock bar displays all platforms, hover shows tooltips
- [ ] Resize narrow: dock scales down on mobile
- [ ] Downloads section: move cursor to reveal code rain background
- [ ] VRM character: verify idle animation plays (not T-pose)

🤖 Generated with [Claude Code](https://claude.com/claude-code)