### PR TITLE
fix: include topics in character draft load/save

### DIFF
--- a/packages/app-core/src/actions/character.ts
+++ b/packages/app-core/src/actions/character.ts
@@ -35,6 +35,7 @@ export async function loadCharacter(
         : (character.bio ?? ""),
       system: character.system ?? "",
       adjectives: character.adjectives ?? [],
+      topics: character.topics ?? [],
       style: {
         all: character.style?.all ?? [],
         chat: character.style?.chat ?? [],
@@ -76,6 +77,9 @@ export function prepareDraftForSave(
     (s) => s.trim().length > 0,
   );
   if (adjectives.length > 0) result.adjectives = adjectives;
+
+  const topics = (draft.topics ?? []).filter((s) => s.trim().length > 0);
+  if (topics.length > 0) result.topics = topics;
 
   const postExamples = (draft.postExamples ?? []).filter(
     (s) => s.trim().length > 0,


### PR DESCRIPTION
## Summary
- Adds `topics` field to character draft loading in `loadCharacter()` so existing topics are preserved when editing
- Adds `topics` filtering and inclusion in `prepareDraftForSave()` so topics are sent to the backend on save

Previously, topics were silently dropped during character editing — they wouldn't load into the draft and wouldn't be included in the save payload.

## Test plan
- [ ] Open character editor, verify topics appear in the Topics card
- [ ] Edit topics, save character, reload — confirm topics persist
- [ ] Save a character with empty topics — verify they're omitted from payload (no 422)

🤖 Generated with [Claude Code](https://claude.com/claude-code)