### PR TITLE
fix: connectors panel + dark mode nav tab visibility

### DIFF
--- a/apps/app/src/components/Header.tsx
+++ b/apps/app/src/components/Header.tsx
@@ -294,7 +294,7 @@ export function Header({ mobileLeft, transparent = false }: HeaderProps) {
                     key={group.label}
                     className={`inline-flex items-center justify-center gap-0 xl:gap-1.5 shrink-0 px-2.5 md:px-3 xl:px-4 py-2 text-[12px] bg-transparent border border-transparent cursor-pointer transition-all duration-300 rounded-full ${
                       isActive
-                        ? "text-accent-fg dark:text-txt-strong font-bold bg-accent dark:bg-accent/15 shadow-[0_0_15px_rgba(var(--accent),0.28)] border-accent/50 dark:border-accent/40 ring-1 ring-inset ring-white/18 dark:ring-accent/25"
+                        ? "text-accent font-bold bg-accent/15 shadow-[0_0_15px_rgba(var(--accent),0.18)] border-accent/40 ring-1 ring-inset ring-accent/20"
                         : "text-muted hover:text-txt hover:bg-bg-hover hover:border-border/50"
                     }`}
                     onClick={() => setTab(primaryTab)}
@@ -351,7 +351,7 @@ export function Header({ mobileLeft, transparent = false }: HeaderProps) {
                         type="button"
                         className={`w-full flex items-center gap-3 px-3 py-3.5 border rounded-xl text-[14px] font-medium transition-all duration-300 cursor-pointer min-h-[48px] ${
                           isActive
-                            ? "border-accent/50 bg-accent text-accent-fg shadow-[0_0_15px_rgba(var(--accent),0.24)] ring-1 ring-inset ring-white/18"
+                            ? "border-accent/40 bg-accent/15 text-accent shadow-[0_0_15px_rgba(var(--accent),0.18)] ring-1 ring-inset ring-accent/20"
                             : "border-transparent bg-transparent text-txt hover:border-border/50 hover:bg-bg-hover"
                         }`}
                         style={{ animationDelay: `${index * 50}ms` }}

--- a/apps/app/test/app/header-status.test.tsx
+++ b/apps/app/test/app/header-status.test.tsx
@@ -129,7 +129,7 @@ describe("header status", () => {
     expect(controls?.length).toBeGreaterThan(0);
   });
 
-  it("uses dark-mode readable classes for the active native tab", async () => {
+  it("uses accent classes for the active native tab", async () => {
     let tree: TestRenderer.ReactTestRenderer | undefined;
     await act(async () => {
       tree = TestRenderer.create(React.createElement(Header));
@@ -143,11 +143,7 @@ describe("header status", () => {
         typeof node.props.className === "string",
     );
 
-    expect(String(activeTabButton?.props.className)).toContain(
-      "dark:text-txt-strong",
-    );
-    expect(String(activeTabButton?.props.className)).toContain(
-      "dark:bg-accent/15",
-    );
+    expect(String(activeTabButton?.props.className)).toContain("text-accent");
+    expect(String(activeTabButton?.props.className)).toContain("bg-accent/15");
   });
 });

--- a/packages/app-core/src/components/PluginsView.tsx
+++ b/packages/app-core/src/components/PluginsView.tsx
@@ -2114,7 +2114,10 @@ function PluginListView({ label, mode = "all", inModal }: PluginListViewProps) {
                 data-testid="connectors-settings-content"
                 className="space-y-4"
               >
-                {visiblePlugins.map((plugin) => {
+                {(desktopConnectorLayout
+                  ? visiblePlugins.filter((p) => p.id === connectorSelectedId)
+                  : visiblePlugins
+                ).map((plugin) => {
                   const hasParams =
                     (plugin.parameters?.length ?? 0) > 0 &&
                     plugin.id !== "__ui-showcase__";

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -8009,6 +8009,7 @@ async function handleRequest(
         post?: string[];
       };
     if (body.adjectives) agent.adjectives = body.adjectives as string[];
+    if (body.topics) agent.topics = body.topics as string[];
     if (body.postExamples) agent.postExamples = body.postExamples as string[];
     if (body.messageExamples) {
       // Normalise to the {examples: [{name, content}]} format that @elizaos/core expects.

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -46,6 +46,8 @@ export type AgentConfig = {
   style?: { all?: string[]; chat?: string[]; post?: string[] };
   /** Personality adjectives. Set during onboarding from the chosen style preset. */
   adjectives?: string[];
+  /** Conversation topics the agent is knowledgeable about. */
+  topics?: string[];
   /** Example social media posts demonstrating the agent's voice. */
   postExamples?: string[];
   /** Example social media posts in Chinese (zh-CN) demonstrating the agent's voice. */


### PR DESCRIPTION
## Summary

Based on #985 by @miladybsc with CI fixes applied.

- **Nav tab styling unified** — replaced separate `text-accent-fg dark:text-txt-strong` / `bg-accent dark:bg-accent/15` with single `text-accent bg-accent/15` that works in both light and dark mode
- **Connectors panel fixed** — desktop layout now filters to only show the selected connector instead of rendering all plugins simultaneously
- **CI fixes** — added `topics` to `AgentConfig` type (TS error from server.ts change), updated header test to match new unified accent classes

Supersedes #985.

## Test plan
- [x] `bun run check` — typecheck + lint pass
- [x] `header-status.test.tsx` — 3/3 tests pass
- [ ] Manual: verify active nav tab is readable in both light and dark mode
- [ ] Manual: open connectors panel, select a connector — only selected one should show

Co-Authored-By: Cayden Tan <cayden0207@Caydens-MacBook-Pro.local>

🤖 Generated with [Claude Code](https://claude.com/claude-code)