### PR TITLE
fix: remove stale xterm.css subpath export

### DIFF
--- a/packages/app-core/package.json
+++ b/packages/app-core/package.json
@@ -28,7 +28,6 @@
     "./providers": "./src/providers/index.ts",
     "./actions": "./src/actions/index.ts",
     "./styles/base.css": "./src/styles/base.css",
-    "./styles/xterm.css": "./src/styles/xterm.css",
     "./styles/anime.css": "./src/styles/anime.css",
     "./styles/onboarding-game.css": "./src/styles/onboarding-game.css",
     "./styles/styles.css": "./src/styles/styles.css"


### PR DESCRIPTION
## Summary

Removes the dangling `"./styles/xterm.css"` subpath export from `packages/app-core/package.json`. The file was deleted in the LIFO removal (#992) but the export entry was missed — any consumer importing `@milady/app-core/styles/xterm.css` would fail module resolution.

## Test plan
- [x] `bun run check` — typecheck + lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)