### PR TITLE
feat: lazy-load Three.js, reuse nightly artifacts, dedup npm publish

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -145,6 +145,15 @@ jobs:
       - name: Run tests
         run: bun run test
 
+      - name: Upload build artifacts for publish
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-dist
+          path: |
+            dist/
+            package.json
+          retention-days: 1
+
       - name: Validate package
         run: |
           PACK_OUTPUT=$(npm pack --dry-run 2>&1)
@@ -163,10 +172,7 @@ jobs:
           echo "Pack summary: $SIZE_LINE"
 
   # ── Publish to npm ──────────────────────────────────────────────────────
-  # Note: This job does a full checkout + rebuild rather than reusing
-  # build-and-test artifacts because npm publish requires the complete
-  # package tree (all `files` entries from package.json), and
-  # setup-node with registry-url configures .npmrc for authentication.
+  # Reuses build artifacts from build-and-test to avoid redundant rebuilds.
   publish-npm:
     name: Publish to npm (nightly)
     needs: [check-commits, build-and-test]
@@ -198,26 +204,13 @@ jobs:
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
           restore-keys: bun-${{ runner.os }}-
 
-      - name: Install dependencies
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: nightly-dist
+
+      - name: Install dependencies (for npm publish file resolution)
         run: bun install --frozen-lockfile --ignore-scripts
-
-      - name: Run repository postinstall patches
-        run: bun run postinstall
-
-      - name: Set nightly version
-        run: |
-          node -e "
-            const fs = require('fs');
-            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-            pkg.version = '${{ needs.build-and-test.outputs.nightly_version }}';
-            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
-          "
-
-      - name: Build
-        run: |
-          bunx tsdown
-          node --import tsx scripts/write-build-info.ts
-          echo '{"type":"module"}' > dist/package.json
 
       - name: Publish with nightly dist-tag
         run: npm publish --tag nightly --access public

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -36,32 +36,15 @@ env:
   CI: "true"
 
 jobs:
-  publish:
-    name: Publish to npm
+  detect-meta:
+    name: Determine version and dist-tag
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 15
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      dist_tag: ${{ steps.meta.outputs.dist_tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          check-latest: false
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3.9"
-
-      - name: Cache Bun install
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-${{ runner.os }}-
 
       - name: Determine version and dist-tag
         id: meta
@@ -94,66 +77,29 @@ jobs:
           echo "Version: $VERSION"
           echo "Dist-tag: $DIST_TAG"
 
-      - name: Install dependencies
-        run: |
-          # Use --ignore-scripts to skip postinstall (submodule init) since we don't need plugins for npm publish
-          # Retry up to 3 times to handle flaky network issues
-          for attempt in 1 2 3; do
-            echo "Attempt $attempt of 3..."
-            if bun install --frozen-lockfile --ignore-scripts; then
-              echo "Dependencies installed successfully"
-              exit 0
-            fi
-            echo "Attempt $attempt failed, waiting 10s before retry..."
-            sleep 10
-          done
-          echo "All attempts failed"
-          exit 1
+  publish:
+    name: Publish
+    needs: detect-meta
+    uses: ./.github/workflows/reusable-npm-publish.yml
+    with:
+      version: ${{ needs.detect-meta.outputs.version }}
+      dist_tag: ${{ needs.detect-meta.outputs.dist_tag }}
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Set version in package.json
-        run: |
-          node -e "
-            const fs = require('fs');
-            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-            pkg.version = '${{ steps.meta.outputs.version }}';
-            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
-          "
-          echo "Publishing version: $(node -p "require('./package.json').version")"
-
-      - name: Build
-        run: |
-          bunx tsdown
-          node --import tsx scripts/write-build-info.ts
-          echo '{"type":"module"}' > dist/package.json
-
-      - name: Validate package
-        run: |
-          PACK_OUTPUT=$(npm pack --dry-run 2>&1)
-          echo "$PACK_OUTPUT"
-
-          # Verify critical files are included in the package
-          for required in "milady.mjs" "dist/index.js" "package.json"; do
-            if ! echo "$PACK_OUTPUT" | grep -q "$required"; then
-              echo "::error::Required file '$required' missing from package contents"
-              exit 1
-            fi
-          done
-
-          echo "Package validation passed — all required files present"
-
-      - name: Publish to npm
-        run: npm publish --tag ${{ steps.meta.outputs.dist_tag }} --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
+  verify:
+    name: Verify publish
+    needs: [detect-meta, publish]
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
       - name: Verify publish
         run: |
           sleep 5  # Give the registry a moment to propagate
-          PUBLISHED=$(npm view miladyai@${{ steps.meta.outputs.dist_tag }} version 2>/dev/null || echo "")
-          EXPECTED="${{ steps.meta.outputs.version }}"
+          PUBLISHED=$(npm view miladyai@${{ needs.detect-meta.outputs.dist_tag }} version 2>/dev/null || echo "")
+          EXPECTED="${{ needs.detect-meta.outputs.version }}"
 
           if [[ "$PUBLISHED" == "$EXPECTED" ]]; then
-            echo "Verified: miladyai@${{ steps.meta.outputs.dist_tag }} → $PUBLISHED"
+            echo "Verified: miladyai@${{ needs.detect-meta.outputs.dist_tag }} → $PUBLISHED"
           else
             echo "::warning::Published version ($PUBLISHED) does not match expected ($EXPECTED). Registry may still be propagating."
           fi
@@ -165,10 +111,10 @@ jobs:
           echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
           echo "|-------|-------|" >> $GITHUB_STEP_SUMMARY
           echo "| Package | milady |" >> $GITHUB_STEP_SUMMARY
-          echo "| Version | \`${{ steps.meta.outputs.version }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| Dist-tag | \`${{ steps.meta.outputs.dist_tag }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Version | \`${{ needs.detect-meta.outputs.version }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Dist-tag | \`${{ needs.detect-meta.outputs.dist_tag }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Install" >> $GITHUB_STEP_SUMMARY
           echo '```bash' >> $GITHUB_STEP_SUMMARY
-          echo "npm install -g miladyai@${{ steps.meta.outputs.dist_tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "npm install -g miladyai@${{ needs.detect-meta.outputs.dist_tag }}" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/reusable-npm-publish.yml
+++ b/.github/workflows/reusable-npm-publish.yml
@@ -1,0 +1,85 @@
+name: Reusable npm publish
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+      dist_tag:
+        required: true
+        type: string
+      run_postinstall:
+        required: false
+        type: boolean
+        default: false
+      run_validation:
+        required: false
+        type: boolean
+        default: true
+    secrets:
+      NPM_TOKEN:
+        required: true
+
+jobs:
+  publish:
+    name: Publish to npm (${{ inputs.dist_tag }})
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          check-latest: false
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.9"
+
+      - name: Cache Bun install
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Run repository postinstall patches
+        if: inputs.run_postinstall
+        run: bun run postinstall
+
+      - name: Set version in package.json
+        run: node scripts/set-package-version.mjs
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+
+      - name: Build
+        run: |
+          bunx tsdown
+          node --import tsx scripts/write-build-info.ts
+          echo '{"type":"module"}' > dist/package.json
+
+      - name: Validate package
+        if: inputs.run_validation
+        run: |
+          PACK_OUTPUT=$(npm pack --dry-run 2>&1)
+          echo "$PACK_OUTPUT"
+          for required in "milady.mjs" "dist/index.js" "package.json"; do
+            if ! echo "$PACK_OUTPUT" | grep -q "$required"; then
+              echo "::error::Required file '$required' missing from package contents"
+              exit 1
+            fi
+          done
+
+      - name: Publish
+        run: npm publish --tag ${{ inputs.dist_tag }} --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/apps/app/src/components/companion/CompanionSceneHost.tsx
+++ b/apps/app/src/components/companion/CompanionSceneHost.tsx
@@ -1,5 +1,45 @@
-export {
-  CompanionSceneHost,
-  SharedCompanionScene,
-  useSharedCompanionScene,
-} from "@milady/app-core/components";
+import type { ReactNode } from "react";
+import { lazy, Suspense } from "react";
+
+// The hook has no 3D dependencies — safe to import statically from the barrel.
+export { useSharedCompanionScene } from "@milady/app-core/components";
+
+// Lazy-load the heavy 3D scene components.  CompanionSceneHost (in app-core)
+// statically imports VrmStage → VrmViewer → VrmEngine → three, so deferring
+// this import keeps three/@pixiv/three-vrm/@sparkjsdev/spark out of the
+// initial bundle.
+const LazyCompanionSceneHost = lazy(() =>
+  import("@milady/app-core/components/CompanionSceneHost").then((m) => ({
+    default: m.CompanionSceneHost,
+  })),
+);
+
+const LazySharedCompanionScene = lazy(() =>
+  import("@milady/app-core/components/CompanionSceneHost").then((m) => ({
+    default: m.SharedCompanionScene,
+  })),
+);
+
+export function CompanionSceneHost(props: {
+  active: boolean;
+  interactive?: boolean;
+  children?: ReactNode;
+}) {
+  return (
+    <Suspense fallback={null}>
+      <LazyCompanionSceneHost {...props} />
+    </Suspense>
+  );
+}
+
+export function SharedCompanionScene(props: {
+  active: boolean;
+  interactive?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <Suspense fallback={null}>
+      <LazySharedCompanionScene {...props} />
+    </Suspense>
+  );
+}

--- a/apps/app/src/components/companion/VrmStage.tsx
+++ b/apps/app/src/components/companion/VrmStage.tsx
@@ -1,2 +1,27 @@
-export type { VrmStageAvatarEntry } from "@milady/app-core/components";
-export { VrmStage } from "@milady/app-core/components";
+import type { ComponentProps } from "react";
+import { lazy, Suspense } from "react";
+
+// Re-export the type — it's just a type, no runtime cost.
+export type { VrmStageAvatarEntry } from "@milady/app-core/components/VrmStage";
+
+// Lazy-load VrmStage to defer three/@pixiv/three-vrm/@sparkjsdev/spark.
+const LazyVrmStage = lazy(() =>
+  import("@milady/app-core/components/VrmStage").then((m) => ({
+    default: m.VrmStage,
+  })),
+);
+
+// Extract props from the inner memoized component that the lazy wrapper wraps.
+// React.LazyExoticComponent<T> erases prop info, so we reach through using the
+// module's VrmStage type directly (type-only import, no runtime cost).
+type VrmStageProps = ComponentProps<
+  typeof import("@milady/app-core/components/VrmStage").VrmStage
+>;
+
+export function VrmStage(props: VrmStageProps) {
+  return (
+    <Suspense fallback={null}>
+      <LazyVrmStage {...props} />
+    </Suspense>
+  );
+}

--- a/packages/app-core/package.json
+++ b/packages/app-core/package.json
@@ -18,6 +18,9 @@
     "./bridge/electrobun-runtime": "./src/bridge/electrobun-runtime.ts",
     "./state": "./src/state/index.ts",
     "./components": "./src/components/index.ts",
+    "./components/ChatAvatar": "./src/components/ChatAvatar.tsx",
+    "./components/CompanionSceneHost": "./src/components/CompanionSceneHost.tsx",
+    "./components/VrmStage": "./src/components/VrmStage.tsx",
     "./components/*": "./src/components/*",
     "./utils": "./src/utils/index.ts",
     "./voice": "./src/voice/index.ts",
@@ -28,7 +31,6 @@
     "./providers": "./src/providers/index.ts",
     "./actions": "./src/actions/index.ts",
     "./styles/base.css": "./src/styles/base.css",
-    "./styles/xterm.css": "./src/styles/xterm.css",
     "./styles/anime.css": "./src/styles/anime.css",
     "./styles/onboarding-game.css": "./src/styles/onboarding-game.css",
     "./styles/styles.css": "./src/styles/styles.css"

--- a/packages/app-core/src/components/CompanionSceneHost.tsx
+++ b/packages/app-core/src/components/CompanionSceneHost.tsx
@@ -7,18 +7,17 @@ import {
 } from "@milady/app-core/state";
 import { resolveAppAssetUrl } from "@milady/app-core/utils";
 import {
-  createContext,
   memo,
   type ReactNode,
   type PointerEvent as ReactPointerEvent,
   type WheelEvent as ReactWheelEvent,
   useCallback,
-  useContext,
   useEffect,
   useMemo,
   useRef,
 } from "react";
 import type { VrmEngine } from "./avatar/VrmEngine";
+import { SharedCompanionSceneContext } from "./shared-companion-scene-context";
 import { VrmStage } from "./VrmStage";
 
 const COMPANION_ZOOM_WHEEL_SENSITIVITY = 1 / 720;
@@ -40,7 +39,8 @@ const NON_TEXT_INPUT_TYPES = new Set([
   "submit",
 ]);
 
-const SharedCompanionSceneContext = createContext(false);
+// SharedCompanionSceneContext is imported from ./shared-companion-scene-context
+// to keep the hook importable without pulling in the 3D stack.
 
 type TouchPoint = {
   x: number;
@@ -472,9 +472,8 @@ function CompanionSceneSurface({
 
 export const CompanionSceneHost = memo(CompanionSceneSurface);
 
-export function useSharedCompanionScene(): boolean {
-  return useContext(SharedCompanionSceneContext);
-}
+// Re-export the hook so existing imports from this module keep working.
+export { useSharedCompanionScene } from "./shared-companion-scene-context";
 
 export function SharedCompanionScene({
   active,

--- a/packages/app-core/src/components/index.ts
+++ b/packages/app-core/src/components/index.ts
@@ -2,14 +2,20 @@ export * from "./ApiKeyConfig";
 export * from "./AppsPageView";
 export * from "./AppsView";
 export * from "./AvatarLoader";
-export * from "./avatar/VrmEngine";
-export * from "./avatar/VrmViewer";
+// VrmEngine and VrmViewer are intentionally excluded from this barrel.
+// They pull in three / @pixiv/three-vrm / @sparkjsdev/spark and are only
+// consumed internally by VrmStage and CompanionSceneHost.  Keeping them
+// out of the barrel lets consumers lazy-load the 3D scene.
 export * from "./BugReportModal";
-export * from "./ChatAvatar";
+// ChatAvatar is intentionally excluded from this barrel — it imports
+// VrmViewer which pulls in three.  Import directly from "./ChatAvatar".
 export * from "./CloudSourceControls";
 export * from "./CodingAgentSettingsSection";
 export * from "./CommandPalette";
-export * from "./CompanionSceneHost";
+// CompanionSceneHost is intentionally excluded from this barrel — it imports
+// VrmStage which pulls in the heavy 3D stack.  Import directly from
+// "./CompanionSceneHost" or use the hook from "./shared-companion-scene-context".
+export { useSharedCompanionScene } from "./shared-companion-scene-context";
 export * from "./ConfigPageView";
 export * from "./ConfigSaveFooter";
 export * from "./ConfirmModal";
@@ -53,5 +59,7 @@ export * from "./ui-badges";
 export * from "./ui-switch";
 export * from "./VectorBrowserView";
 export * from "./VoiceConfigView";
-export * from "./VrmStage";
+// VrmStage is intentionally excluded from this barrel for the same reason
+// as VrmEngine/VrmViewer — it statically imports the heavy 3D stack.
+// Import directly from "./VrmStage" when needed.
 export * from "./WhatsAppQrOverlay";

--- a/packages/app-core/src/components/shared-companion-scene-context.ts
+++ b/packages/app-core/src/components/shared-companion-scene-context.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared context for the companion scene.
+ *
+ * Extracted into its own module so consumers can import
+ * `useSharedCompanionScene` without pulling in the heavy 3D stack
+ * (three / @pixiv/three-vrm / @sparkjsdev/spark) that lives in
+ * CompanionSceneHost.
+ */
+import { createContext, useContext } from "react";
+
+export const SharedCompanionSceneContext = createContext(false);
+
+export function useSharedCompanionScene(): boolean {
+  return useContext(SharedCompanionSceneContext);
+}

--- a/scripts/set-package-version.mjs
+++ b/scripts/set-package-version.mjs
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+
+const version = process.env.RELEASE_VERSION;
+if (!version) {
+  console.error("RELEASE_VERSION environment variable is required");
+  process.exit(1);
+}
+
+const pkg = JSON.parse(readFileSync("package.json", "utf8"));
+pkg.version = version;
+writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");
+console.log(`Set package version to ${version}`);


### PR DESCRIPTION
## Summary

Addresses the final 4 build/release findings. 10 files changed, 3 new files created.

### 1. Three.js lazy loading (bundle size)

Three.js (~1.7MB), @pixiv/three-vrm, and @sparkjsdev/spark are no longer in the initial page load:

- **`CompanionSceneHost`** and **`SharedCompanionScene`** wrapped with `React.lazy()` in the app-level barrel — 3D stack only loads when the companion view mounts
- **`useSharedCompanionScene`** extracted to a separate module (`shared-companion-scene-context.ts`) — hook can be imported without triggering the 3D import chain
- **VrmEngine, VrmViewer, VrmStage, CompanionSceneHost** removed from the `@milady/app-core/components` barrel — no longer pulled in by unrelated component imports
- Works with existing `manualChunks: { "vendor-3d": [...] }` config

### 2. Nightly artifact reuse (~3min saved per nightly)

- `build-and-test` job now uploads `dist/` + `package.json` as artifact
- `publish-npm` job downloads the artifact instead of doing full `bun install` + `postinstall` + `tsdown` rebuild
- Only a lightweight `bun install --ignore-scripts` remains (for `npm publish` file resolution)

### 3. Deduplicate npm publish logic

- New `reusable-npm-publish.yml` (`workflow_call`) with inputs for version, dist_tag, run_postinstall, run_validation
- New `scripts/set-package-version.mjs` (replaces 3 copy-pasted inline Node scripts)
- `publish-npm.yml` refactored into detect-meta → publish (via reusable) → verify

### 4. app-core build step (no action needed)

Research concluded the current raw-TypeScript-exports pattern is correct for a Vite monorepo. Vite caches transforms after first import, so ongoing dev is fast. A tsup build step would add complexity (watch process, source map config, dual export paths) without measurable benefit. The real cold-start win comes from #1 (lazy loading removes the heaviest modules from the import graph entirely).

### Also
- Removed stale `./styles/xterm.css` subpath export from app-core/package.json

## Test plan
- [x] `bun run check` — typecheck + lint pass
- [x] `bun run test` — 881 tests pass (40 files, 0 failures)
- [ ] Manual: verify companion view loads correctly (3D chunk loaded on demand)
- [ ] Manual: verify nightly workflow uploads/downloads artifact correctly
- [ ] Manual: verify `publish-npm.yml` calls reusable workflow successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)