### PR TITLE
fix(release): guard orchestrator pin for postinstall patch

### DIFF
--- a/scripts/release-check.test.ts
+++ b/scripts/release-check.test.ts
@@ -4,6 +4,7 @@ import {
   bundlesDependency,
   findLocalPackHotspots,
   hasLifecycleScriptReferencingMissingFile,
+  isExactVersionSpecifier,
   isPackPathCoveredByFilesList,
   shouldSkipExactPackDryRun,
 } from "./release-check";
@@ -83,6 +84,19 @@ describe("release-check package guards", () => {
         "@elizaos/plugin-agent-orchestrator",
       ),
     ).toBe(true);
+  });
+
+  it("accepts only exact dependency versions for orchestrator release pins", () => {
+    expect(isExactVersionSpecifier("0.3.14")).toBe(true);
+    expect(isExactVersionSpecifier("2.0.0-alpha.1")).toBe(true);
+    expect(isExactVersionSpecifier("1.2.3+build.4")).toBe(true);
+
+    expect(isExactVersionSpecifier(undefined)).toBe(false);
+    expect(isExactVersionSpecifier("next")).toBe(false);
+    expect(isExactVersionSpecifier("latest")).toBe(false);
+    expect(isExactVersionSpecifier("^0.3.14")).toBe(false);
+    expect(isExactVersionSpecifier("~0.3.14")).toBe(false);
+    expect(isExactVersionSpecifier("workspace:*")).toBe(false);
   });
 
   it("flags lifecycle hooks that reference missing files", () => {

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -80,6 +80,7 @@ const localPackHotspotPaths = [
 type RootPackageJson = {
   bundleDependencies?: string[];
   bundledDependencies?: string[];
+  dependencies?: Record<string, string>;
   files?: string[];
   scripts?: Record<string, string>;
 };
@@ -146,6 +147,18 @@ export function bundlesDependency(
     ...(pkg.bundledDependencies ?? []),
   ];
   return bundled.includes(dependencyName);
+}
+
+export function isExactVersionSpecifier(
+  versionSpecifier: string | undefined,
+): boolean {
+  if (typeof versionSpecifier !== "string") {
+    return false;
+  }
+
+  return /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(
+    versionSpecifier,
+  );
 }
 
 export function hasLifecycleScriptReferencingMissingFile(
@@ -222,6 +235,15 @@ function assertBundledAgentOrchestratorInstallFix() {
   if (!bundlesDependency(rootPackage, orchestratorPackageName)) {
     console.error(
       "release-check: package.json must bundle @elizaos/plugin-agent-orchestrator until the upstream tarball stops shipping a broken postinstall hook.",
+    );
+    process.exit(1);
+  }
+
+  const orchestratorVersion =
+    rootPackage.dependencies?.[orchestratorPackageName];
+  if (!isExactVersionSpecifier(orchestratorVersion)) {
+    console.error(
+      "release-check: package.json must pin @elizaos/plugin-agent-orchestrator to an exact version until the upstream tarball stops shipping a broken postinstall hook.",
     );
     process.exit(1);
   }


### PR DESCRIPTION
## Summary
- require `@elizaos/plugin-agent-orchestrator` to stay pinned to an exact version in `release-check`
- fail release validation if the dependency drifts back to floating tags or ranges
- add regression tests for accepted and rejected version specifiers

## Testing
- `bunx vitest run scripts/release-check.test.ts`
- `bunx vitest run scripts/lib/patch-bun-exports.test.ts`
- `bun run check`

Fixes #930