### PR TITLE
workflows: add release testbox warmups

### DIFF
--- a/.github/workflows/android-release-build-aab-testbox.yml
+++ b/.github/workflows/android-release-build-aab-testbox.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Begin Testbox
-        uses: useblacksmith/begin-testbox@v2
+        uses: useblacksmith/begin-testbox@d0e04585c26905fdd92c94a09c159544c7ee1b67 # v2
         with:
           testbox_id: ${{ inputs.testbox_id }}
 
@@ -45,7 +45,7 @@ jobs:
           MAJOR=$(echo "$VERSION_NAME" | cut -d. -f1)
           MINOR=$(echo "$VERSION_NAME" | cut -d. -f2 | cut -d- -f1)
           PATCH=$(echo "$VERSION_NAME" | cut -d. -f3 | cut -d- -f1)
-          PRE=$(echo "$VERSION_NAME" | grep -oP '(?<=\\.).*\\d+$' || echo "0")
+          PRE=$(echo "$VERSION_NAME" | grep -oP '(?<=\.)\d+$' || echo "0")
           VERSION_CODE=$(( MAJOR * 1000000 + MINOR * 10000 + PATCH * 100 + PRE ))
           echo "name=$VERSION_NAME" >> "$GITHUB_OUTPUT"
           echo "code=$VERSION_CODE" >> "$GITHUB_OUTPUT"
@@ -54,20 +54,13 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      - name: Decode keystore
-        run: |
-          echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > /tmp/milady-upload.jks
-        env:
-          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
-
       - name: Run Testbox
-        uses: useblacksmith/run-testbox@v2
+        uses: useblacksmith/run-testbox@5ca05834db1d3813554d1dd109e5f2087a8d7cbc # v2
         if: always()
         env:
           MILADY_VERSION_NAME: ${{ steps.version.outputs.name }}
           MILADY_VERSION_CODE: ${{ steps.version.outputs.code }}
-          MILADY_KEYSTORE_PATH: /tmp/milady-upload.jks
-          MILADY_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-          MILADY_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
-          MILADY_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
-          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+
+      - name: Clean up temporary keystore material
+        if: always()
+        run: rm -f /tmp/milady-upload.jks

--- a/.github/workflows/release-electrobun-build-linux-x64-testbox.yml
+++ b/.github/workflows/release-electrobun-build-linux-x64-testbox.yml
@@ -22,7 +22,7 @@ jobs:
         shell: bash -euo pipefail {0}
     steps:
       - name: Begin Testbox
-        uses: useblacksmith/begin-testbox@v2
+        uses: useblacksmith/begin-testbox@d0e04585c26905fdd92c94a09c159544c7ee1b67 # v2
         with:
           testbox_id: ${{ inputs.testbox_id }}
 
@@ -131,7 +131,7 @@ jobs:
           restore-keys: electrobun-core-linux-x64-
 
       - name: Run Testbox
-        uses: useblacksmith/run-testbox@v2
+        uses: useblacksmith/run-testbox@5ca05834db1d3813554d1dd109e5f2087a8d7cbc # v2
         if: always()
         env:
           ELECTROBUN_BUILD_ENV: stable

--- a/.github/workflows/release-electrobun-build-windows-x64-testbox.yml
+++ b/.github/workflows/release-electrobun-build-windows-x64-testbox.yml
@@ -22,7 +22,7 @@ jobs:
         shell: bash -euo pipefail {0}
     steps:
       - name: Begin Testbox
-        uses: useblacksmith/begin-testbox@v2
+        uses: useblacksmith/begin-testbox@d0e04585c26905fdd92c94a09c159544c7ee1b67 # v2
         with:
           testbox_id: ${{ inputs.testbox_id }}
 
@@ -234,7 +234,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Testbox
-        uses: useblacksmith/run-testbox@v2
+        uses: useblacksmith/run-testbox@5ca05834db1d3813554d1dd109e5f2087a8d7cbc # v2
         if: always()
         env:
           ELECTROBUN_BUILD_ENV: stable


### PR DESCRIPTION
This PR will be reviewed by an AI agent. Provide clear context to help it assess your changes.

Aesthetic/UI changes that don't improve agent capability are out of scope and will be rejected.

## Category
- [ ] Bug fix
- [ ] Security fix
- [ ] Performance improvement
- [ ] New feature
- [ ] Documentation
- [ ] Test coverage
- [x] Other

## What
Add manual-only Blacksmith testbox warmup workflows for release builds on supported platforms:
- Android release AAB
- Electrobun Linux x64 release
- Electrobun Windows x64 release

## Why
- Allow Blacksmith warmups that mirror release-build setup without changing existing CI/CD triggers.
- Keep release validation additive and explicit rather than folding testbox logic into the current release workflows.
- Avoid unsafe Apple testbox workflows until Blacksmith exposes macOS runner parity.

## How
- Added three standalone `workflow_dispatch` workflows under `.github/workflows/`.
- Kept them manual-only with no `push`, `pull_request`, `release`, or tag triggers.
- Preserved the existing release workflows unchanged.
- Split Electrobun into explicit Linux and Windows warmups instead of trying to reuse the matrix release job directly.

## Testing
- Validated all three workflow files parse via Ruby YAML load.
- Pushed branch `codex/release-testboxes-90f1`.
- Attempted `blacksmith testbox warmup ... --ref codex/release-testboxes-90f1` for all three workflows.
- Warmup dispatches currently fail with GitHub Actions `404 Not Found` because `workflow_dispatch` only works after the workflow files exist on the default branch (`develop`).