### PR TITLE
chore(ci): harden Electrobun release workflow

### DIFF
--- a/.github/workflows/release-electrobun.yml
+++ b/.github/workflows/release-electrobun.yml
@@ -104,8 +104,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: bun-electrobun-${{ matrix.platform.artifact-name }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-electrobun-${{ matrix.platform.artifact-name }}-
+          key: bun-electrobun-validate-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-electrobun-validate-
 
       - name: Install root dependencies
         run: bun install --frozen-lockfile --ignore-scripts
@@ -127,21 +127,8 @@ jobs:
           echo '{"type":"module"}' > dist/package.json
           node --import tsx scripts/write-build-info.ts
 
-      - name: Build renderer (vite)
-        run: bunx vite build
-        working-directory: apps/app
-
       - name: Release readiness checks
         run: bun run release:check
-
-      - name: Upload arch-neutral build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: electrobun-shared-build
-          path: |
-            dist/
-            apps/app/dist/
-          retention-days: 1
 
   build:
     name: Build ${{ matrix.platform.name }}
@@ -188,8 +175,16 @@ jobs:
         with:
           bun-version: ${{ env.BUN_VERSION }}
 
+      - name: Restore Bun install cache (Windows)
+        if: matrix.platform.os == 'windows'
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-electrobun-${{ matrix.platform.artifact-name }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-electrobun-${{ matrix.platform.artifact-name }}-
 
       - name: Cache Bun install
+        if: matrix.platform.os != 'windows'
         uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
@@ -209,10 +204,8 @@ jobs:
             bun install --frozen-lockfile --ignore-scripts
           fi
 
-      - name: Download arch-neutral build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: electrobun-shared-build
+      - name: Run repository postinstall patches
+        run: bun run postinstall
 
       - name: Cache Whisper models and binaries
         if: matrix.platform.os == 'macos' || matrix.platform.os == 'linux'
@@ -230,49 +223,13 @@ jobs:
         env:
           RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
 
-      # dist/ and apps/app/dist/ are downloaded from the shared build artifact
-      # (built once in validate-release, arch-neutral JS/CSS/HTML).
-
-      # Copy the vite-built frontend into the Electrobun renderer directory.
-      # The bun entry point (src/index.ts) resolves the renderer at
-      # ../renderer/index.html relative to itself, which maps to
-      # apps/app/electrobun/renderer/ at build time and
-      # Resources/app/renderer/ in the packaged bundle.
-      # Without this step the renderer directory is absent from the package
-      # and the window opens to a file-not-found error.
-      - name: Stage renderer for Electrobun bundle
-        run: |
-          rm -rf apps/app/electrobun/renderer
-          cp -r apps/app/dist apps/app/electrobun/renderer
-
-      # macOS: compile Objective-C++ native effects dylib
-      - name: Build native macOS effects dylib
-        if: matrix.platform.os == 'macos'
-        run: |
-          if [ "${{ matrix.platform.artifact-name }}" = "macos-x64" ]; then
-            arch -x86_64 bun run build:native-effects
-          else
-            bun run build:native-effects
-          fi
-        working-directory: apps/app/electrobun
-
-      # Build the webview bridge preload (direct Electrobun RPC bridge injected into the webview)
-      - name: Build webview bridge preload
-        run: bun run build:preload
-        working-directory: apps/app/electrobun
-
-      # Build whisper.cpp binary for on-device speech recognition (macOS/Linux only)
-      # Skipped on Windows (no make) — STT falls back to swabbleAudioChunkPush mode.
-      # macOS Intel: keep the whisper build on an explicit x64 path.
-      - name: Build whisper.cpp (on-device STT)
-        if: matrix.platform.os == 'macos' || matrix.platform.os == 'linux'
+      - name: Stage desktop bundle inputs
         run: |
           if [ "${{ matrix.platform.os }}" = "macos" ] && [ "${{ matrix.platform.artifact-name }}" = "macos-x64" ]; then
-            arch -x86_64 bun run build:whisper
+            MILADY_DESKTOP_COMMAND_PREFIX="arch -x86_64" node scripts/desktop-build.mjs stage --variant=base --build-whisper
           else
-            bun run build:whisper
+            node scripts/desktop-build.mjs stage --variant=base --build-whisper
           fi
-        working-directory: apps/app/electrobun
 
       # Import the Developer ID certificate into a temporary keychain.
       # Requires CSC_LINK (base64-encoded .p12) + CSC_KEY_PASSWORD.
@@ -344,66 +301,13 @@ jobs:
         run: |
           wrapper_dir="$RUNNER_TEMP/milady-notary-bin"
           mkdir -p "$wrapper_dir"
+          cp apps/app/electrobun/scripts/hdiutil-wrapper.sh "$wrapper_dir/hdiutil"
           cp apps/app/electrobun/scripts/xcrun-wrapper.sh "$wrapper_dir/xcrun"
           cp apps/app/electrobun/scripts/zip-wrapper.sh "$wrapper_dir/zip"
+          chmod +x "$wrapper_dir/hdiutil"
           chmod +x "$wrapper_dir/xcrun"
           chmod +x "$wrapper_dir/zip"
           echo "$wrapper_dir" >> "$GITHUB_PATH"
-
-      # Install electrobun globally so the binary is in PATH at ~/.bun/bin/electrobun
-      # (no @ in path, avoiding the GNU tar user@host misinterpretation on Windows)
-      # Copy the runtime package closure that the built server bundle still imports
-      # by bare specifier, plus the installed @elizaos/* and @milady/plugin-* set.
-      # agent.ts sets NODE_PATH to milady-dist/node_modules, which resolves to these copies.
-      # macOS Intel: keep the x64 node_modules copy on an explicit x64 path.
-      - name: Bundle backend node_modules into dist/
-        run: |
-          if [ "${{ matrix.platform.os }}" = "macos" ] && [ "${{ matrix.platform.artifact-name }}" = "macos-x64" ]; then
-            arch -x86_64 node --import tsx scripts/copy-runtime-node-modules.ts --scan-dir dist --target-dist dist
-          else
-            node --import tsx scripts/copy-runtime-node-modules.ts --scan-dir dist --target-dist dist
-          fi
-
-      - name: Install electrobun CLI
-        # macOS Intel: keep the global electrobun install on an explicit x64 path.
-        run: |
-          ELECTROBUN_VERSION="$(node -p "require('./apps/app/electrobun/package.json').dependencies.electrobun.replace(/^[^0-9]*/, '')")"
-          echo "Installing electrobun@$ELECTROBUN_VERSION"
-          echo "ELECTROBUN_VERSION=$ELECTROBUN_VERSION" >> "$GITHUB_ENV"
-          if [ "${{ matrix.platform.os }}" = "macos" ] && [ "${{ matrix.platform.artifact-name }}" = "macos-x64" ]; then
-            arch -x86_64 bun install -g "electrobun@$ELECTROBUN_VERSION"
-          else
-            bun install -g "electrobun@$ELECTROBUN_VERSION"
-          fi
-
-      - name: Materialize local electrobun package for build
-        run: |
-          node -e "
-            const fs = require('node:fs');
-            const path = require('node:path');
-            const { execSync } = require('node:child_process');
-            // electrobun is installed globally — resolve from global node_modules
-            let src;
-            try {
-              src = fs.realpathSync('node_modules/electrobun');
-            } catch {
-              // Not in workspace node_modules — find from global install
-              const globalDir = execSync('bun pm -g bin', { encoding: 'utf8' }).trim();
-              const globalModules = path.resolve(globalDir, '..', 'install', 'global', 'node_modules', 'electrobun');
-              if (fs.existsSync(globalModules)) {
-                src = fs.realpathSync(globalModules);
-              } else {
-                // Fallback: resolve via require
-                const pkgPath = require.resolve('electrobun/package.json');
-                src = path.dirname(pkgPath);
-              }
-            }
-            const dest = path.resolve('apps/app/electrobun/node_modules/electrobun');
-            fs.rmSync(dest, { recursive: true, force: true });
-            fs.mkdirSync(path.dirname(dest), { recursive: true });
-            fs.cpSync(src, dest, { recursive: true });
-            console.log('Materialized local electrobun package:', dest, '<-', src);
-          "
 
       - name: Cache local electrobun core downloads
         uses: actions/cache@v4
@@ -416,45 +320,69 @@ jobs:
         if: matrix.platform.os == 'windows'
         shell: pwsh
         run: |
-          $globalNodeModules = Join-Path $env:USERPROFILE ".bun\install\global\node_modules"
-          $electrobunDir = Join-Path $globalNodeModules "electrobun"
-          $globalRceditDir = Join-Path $globalNodeModules "rcedit"
-          $globalRceditExe = Join-Path $globalRceditDir "bin\rcedit-x64.exe"
-
-          if (-not (Test-Path $globalRceditExe)) {
-            Write-Host "Installing global rcedit helper..."
-            bun install -g "rcedit@4.0.1"
-          }
-
-          $resolvedRceditPackageJson = node -e @'
-            const { createRequire } = require("node:module");
-            const path = require("node:path");
-            const electrobunDir = process.argv[1];
+          $electrobunDir = Join-Path $PWD "apps/app/electrobun/node_modules/electrobun"
+          $resolvedElectrobunDir = node -e @'
+            const fs = require("node:fs");
+            const packageDir = process.argv[1];
             try {
-              const req = createRequire(path.join(electrobunDir, "package.json"));
-              process.stdout.write(req.resolve("rcedit/package.json"));
+              process.stdout.write(fs.realpathSync(packageDir));
             } catch (error) {
-              process.stdout.write("");
+              process.stdout.write(packageDir);
             }
           '@ $electrobunDir
+          if ($null -eq $resolvedElectrobunDir) {
+            $resolvedElectrobunDir = $electrobunDir
+          } elseif ($resolvedElectrobunDir -is [array]) {
+            $resolvedElectrobunDir = ($resolvedElectrobunDir -join "")
+          }
+          $resolvedElectrobunDir = "$resolvedElectrobunDir".Trim()
+          if ([string]::IsNullOrWhiteSpace($resolvedElectrobunDir)) {
+            $resolvedElectrobunDir = $electrobunDir
+          }
+          Write-Host "Resolved electrobun package dir: $resolvedElectrobunDir"
 
-          $resolvedRceditPackageJson = $resolvedRceditPackageJson.Trim()
+          function Resolve-RceditPackageJson([string]$packageDir) {
+            $resolvedPath = node -e @'
+              const { createRequire } = require("node:module");
+              const path = require("node:path");
+              const packageDir = process.argv[1];
+              try {
+                const req = createRequire(path.join(packageDir, "package.json"));
+                process.stdout.write(req.resolve("rcedit/package.json"));
+              } catch (error) {
+                process.stdout.write("");
+              }
+            '@ $packageDir
+
+            if ($null -eq $resolvedPath) {
+              return ""
+            }
+            if ($resolvedPath -is [array]) {
+              $resolvedPath = ($resolvedPath -join "")
+            }
+
+            return "$resolvedPath".Trim()
+          }
+
+          $resolvedRceditPackageJson = Resolve-RceditPackageJson $resolvedElectrobunDir
           if ([string]::IsNullOrWhiteSpace($resolvedRceditPackageJson)) {
-            Write-Warning "Electrobun could not resolve rcedit/package.json; seeding a local copy under the electrobun package."
-            $resolvedRceditDir = Join-Path $electrobunDir "node_modules\rcedit"
+            Write-Warning "Electrobun could not resolve rcedit/package.json; installing a local copy under the electrobun package."
+            $resolvedRceditDir = Join-Path $resolvedElectrobunDir "node_modules\rcedit"
           } else {
             $resolvedRceditDir = Split-Path -Parent $resolvedRceditPackageJson
           }
           $resolvedRceditExe = Join-Path $resolvedRceditDir "bin\rcedit-x64.exe"
 
           if (-not (Test-Path $resolvedRceditExe)) {
-            Write-Warning "Electrobun resolved rcedit without a bundled binary at $resolvedRceditExe; copying known-good package into place."
-            $resolvedNodeModulesDir = Split-Path -Parent $resolvedRceditDir
-            New-Item -ItemType Directory -Force -Path $resolvedNodeModulesDir | Out-Null
-            if (Test-Path $resolvedRceditDir) {
-              Remove-Item -Recurse -Force $resolvedRceditDir
+            Write-Host "Installing local rcedit helper under Electrobun..."
+            npm install --prefix $resolvedElectrobunDir --no-save --no-package-lock --ignore-scripts --fund=false --audit=false "rcedit@4.0.1"
+            $resolvedRceditPackageJson = Resolve-RceditPackageJson $resolvedElectrobunDir
+            if ([string]::IsNullOrWhiteSpace($resolvedRceditPackageJson)) {
+              $resolvedRceditDir = Join-Path $resolvedElectrobunDir "node_modules\rcedit"
+            } else {
+              $resolvedRceditDir = Split-Path -Parent $resolvedRceditPackageJson
             }
-            Copy-Item -Recurse -Force $globalRceditDir $resolvedNodeModulesDir
+            $resolvedRceditExe = Join-Path $resolvedRceditDir "bin\rcedit-x64.exe"
           }
 
           if (-not (Test-Path $resolvedRceditExe)) {
@@ -475,9 +403,28 @@ jobs:
         if: matrix.platform.os == 'windows'
         shell: pwsh
         run: |
-          $electrobunDir = Join-Path $env:USERPROFILE ".bun\install\global\node_modules\electrobun"
-          $cacheDir     = Join-Path $electrobunDir ".cache"
-          $binDir       = Join-Path $electrobunDir "bin"
+          $electrobunDir = Join-Path $PWD "apps/app/electrobun/node_modules/electrobun"
+          $resolvedElectrobunDir = node -e @'
+            const fs = require("node:fs");
+            const packageDir = process.argv[1];
+            try {
+              process.stdout.write(fs.realpathSync(packageDir));
+            } catch (error) {
+              process.stdout.write(packageDir);
+            }
+          '@ $electrobunDir
+          if ($null -eq $resolvedElectrobunDir) {
+            $resolvedElectrobunDir = $electrobunDir
+          } elseif ($resolvedElectrobunDir -is [array]) {
+            $resolvedElectrobunDir = ($resolvedElectrobunDir -join "")
+          }
+          $resolvedElectrobunDir = "$resolvedElectrobunDir".Trim()
+          if ([string]::IsNullOrWhiteSpace($resolvedElectrobunDir)) {
+            $resolvedElectrobunDir = $electrobunDir
+          }
+          Write-Host "Resolved electrobun package dir: $resolvedElectrobunDir"
+          $cacheDir     = Join-Path $resolvedElectrobunDir ".cache"
+          $binDir       = Join-Path $resolvedElectrobunDir "bin"
           $cliBinary    = Join-Path $cacheDir "electrobun.exe"
           $binBinary    = Join-Path $binDir "electrobun.exe"
 
@@ -486,7 +433,7 @@ jobs:
             exit 0
           }
 
-          $version      = (Get-Content (Join-Path $electrobunDir "package.json") | ConvertFrom-Json).version
+          $version      = (Get-Content (Join-Path $resolvedElectrobunDir "package.json") | ConvertFrom-Json).version
           $assetName    = "electrobun-cli-win-x64.tar.gz"
           $releaseApiUrl = "https://api.github.com/repos/blackboardsh/electrobun/releases/tags/v$version"
           $headers = @{
@@ -539,14 +486,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Electrobun app
-        # macOS Intel: keep the packaged app build on an explicit x64 path.
         run: |
           if [ "${{ matrix.platform.os }}" = "macos" ] && [ "${{ matrix.platform.artifact-name }}" = "macos-x64" ]; then
-            arch -x86_64 electrobun build --env=${{ needs.prepare.outputs.env }}
+            MILADY_DESKTOP_COMMAND_PREFIX="arch -x86_64" node scripts/desktop-build.mjs package --env=${{ needs.prepare.outputs.env }}
           else
-            electrobun build --env=${{ needs.prepare.outputs.env }}
+            node scripts/desktop-build.mjs package --env=${{ needs.prepare.outputs.env }}
           fi
-        working-directory: apps/app/electrobun
         env:
           # Electrobun reads these env vars directly. The workflow derives the
           # signing identity from CSC_LINK/CSC_KEY_PASSWORD during keychain setup
@@ -556,45 +501,9 @@ jobs:
           ELECTROBUN_APPLEIDPASS: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           ELECTROBUN_TEAMID: ${{ secrets.APPLE_TEAM_ID }}
           ELECTROBUN_SKIP_CODESIGN: ${{ steps.macos-keychain.outputs.skip_codesign }}
+          ELECTROBUN_REAL_HDIUTIL: /usr/bin/hdiutil
           ELECTROBUN_REAL_XCRUN: /usr/bin/xcrun
           ELECTROBUN_REAL_ZIP: /usr/bin/zip
-
-      # Inject version.json into the packaged Resources directory.
-      # The bun entry getVersionInfo() reads ../Resources/version.json and
-      # throws if absent, killing the process before main() runs.
-      # Electrobun does not generate this file for us, so write it from the
-      # release metadata after the packaged bundle exists.
-      - name: Inject version.json into bundle (Windows)
-        if: matrix.platform.os == 'windows'
-        shell: pwsh
-        run: |
-          $version = (Get-Content apps/app/electrobun/package.json | ConvertFrom-Json).version
-          $envName = "${{ needs.prepare.outputs.env }}"
-          $buildRoot = "apps/app/electrobun/build"
-
-          Get-ChildItem -Path $buildRoot -Recurse -Directory -Filter "Resources" | ForEach-Object {
-            $versionJson = @{
-              identifier = "com.miladyai.milady"
-              channel = $envName
-              name = "milady"
-              version = $version
-            } | ConvertTo-Json -Compress
-            $dest = Join-Path $_.FullName "version.json"
-            Write-Host "Writing $dest"
-            Set-Content -Path $dest -Value $versionJson -Encoding utf8
-          }
-
-      - name: Inject version.json into bundle (macOS / Linux)
-        if: matrix.platform.os != 'windows'
-        run: |
-          VERSION="$(node -p "require('./apps/app/electrobun/package.json').version")"
-          ENV_NAME="${{ needs.prepare.outputs.env }}"
-          find apps/app/electrobun/build -type d -name "Resources" | while read -r res_dir; do
-            dest="$res_dir/version.json"
-            printf '{"identifier":"com.miladyai.milady","channel":"%s","name":"milady","version":"%s"}' \
-              "$ENV_NAME" "$VERSION" > "$dest"
-            echo "Wrote $dest"
-          done
 
       - name: List build output
         run: |
@@ -640,6 +549,10 @@ jobs:
         if: matrix.platform.os == 'windows'
         shell: pwsh
         env:
+          # GitHub's Windows runner crashes Bun inside node-llama-cpp during
+          # packaged smoke startup; disable local embeddings for this smoke path
+          # so we only validate launcher/bootstrap behavior here.
+          MILADY_DISABLE_LOCAL_EMBEDDINGS: "1"
           MILADY_TEST_WINDOWS_LAUNCHER_DIR: ${{ runner.temp }}\milady-windows-ui-launcher
           MILADY_TEST_WINDOWS_LAUNCHER_PATH_FILE: ${{ runner.temp }}\milady-windows-ui-launcher.txt
         run: |
@@ -664,6 +577,8 @@ jobs:
 
       - name: Run Windows packaged renderer bootstrap check
         if: matrix.platform.os == 'windows'
+        env:
+          MILADY_DISABLE_LOCAL_EMBEDDINGS: "1"
         run: |
           cd apps/app
           bunx playwright test --config playwright.electrobun.packaged.config.ts test/electrobun-packaged/electrobun-windows-startup.e2e.spec.ts

--- a/apps/app/electrobun/electrobun.config.ts
+++ b/apps/app/electrobun/electrobun.config.ts
@@ -12,8 +12,9 @@ export default {
     exitOnLastWindowClosed: false,
   },
   scripts: {
-    // Sign native code inside milady-dist/node_modules on the inner app bundle
-    // before Electrobun runs the platform signing/notarization flow.
+    // Rebuild the direct macOS launcher, sign nested runtime binaries, then
+    // sign the rebuilt launcher on the inner app bundle before Electrobun runs
+    // its normal platform signing flow.
     postBuild: "scripts/postwrap-sign-runtime-macos.ts",
     // Capture wrapper-bundle binary metadata after the self-extractor is created.
     postWrap: "scripts/postwrap-diagnostics.ts",
@@ -57,6 +58,8 @@ export default {
     mac: {
       bundleWGPU: true,
       codesign: process.env.ELECTROBUN_SKIP_CODESIGN !== "1",
+      // Keep Electrobun's app notarization enabled so updater tarballs ship a
+      // notarized inner app bundle before the DMG staging script runs.
       notarize: process.env.ELECTROBUN_SKIP_CODESIGN !== "1",
       defaultRenderer: "native",
       icons: "assets/appIcon.iconset",

--- a/apps/app/electrobun/scripts/postwrap-sign-runtime-macos.ts
+++ b/apps/app/electrobun/scripts/postwrap-sign-runtime-macos.ts
@@ -2,6 +2,7 @@
 
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -10,6 +11,7 @@ type ExecFileSyncFn = typeof execFileSync;
 
 const NATIVE_EXTENSIONS = new Set([".bare", ".dylib", ".node", ".so"]);
 const KNOWN_NATIVE_HELPERS = new Set(["spawn-helper"]);
+const SUPPORTED_LAUNCHER_ARCHES = new Set(["arm64", "x86_64"]);
 const CODESIGN_MAX_ATTEMPTS = 4;
 const CODESIGN_RETRY_DELAY_MS = 5_000;
 const WINDOWS_ABS_PATH_RE = /^[A-Za-z]:[\\/]/;
@@ -71,7 +73,9 @@ function normalizeBundleStem(value: string): string {
   return value.toLowerCase().replace(/[^a-z0-9]/g, "");
 }
 
-function resolveBuildBundlePath(env: NodeJS.ProcessEnv): string | null {
+export function resolveBuildBundlePath(
+  env: NodeJS.ProcessEnv = process.env,
+): string | null {
   const buildDir = env.ELECTROBUN_BUILD_DIR?.trim();
   if (!buildDir || env.ELECTROBUN_OS !== "macos") {
     return null;
@@ -111,6 +115,50 @@ function resolveBuildBundlePath(env: NodeJS.ProcessEnv): string | null {
   throw new Error(
     `runtime-sign: multiple app bundles found in ${resolvedBuildDir}: ${bundleCandidates.join(", ")}`,
   );
+}
+
+export function resolveDirectLauncherSourcePath(
+  scriptPath = fileURLToPath(import.meta.url),
+): string {
+  return path.join(path.dirname(scriptPath), "macos-direct-launcher.c");
+}
+
+export function parseLauncherArchitectures(output: string): string[] {
+  const architectures = output
+    .split(/\s+/)
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  if (architectures.length === 0) {
+    throw new Error("runtime-sign: failed to determine launcher architecture");
+  }
+
+  for (const architecture of architectures) {
+    if (!SUPPORTED_LAUNCHER_ARCHES.has(architecture)) {
+      throw new Error(
+        `runtime-sign: unsupported launcher architecture: ${architecture}`,
+      );
+    }
+  }
+
+  return architectures;
+}
+
+export function buildDirectLauncherCompileArgs(
+  sourcePath: string,
+  outputPath: string,
+  architectures: string[],
+): string[] {
+  return [
+    "-O2",
+    "-Wall",
+    "-Wextra",
+    ...architectures.flatMap((architecture) => ["-arch", architecture]),
+    "-mmacosx-version-min=11.0",
+    sourcePath,
+    "-o",
+    outputPath,
+  ];
 }
 
 export function resolveRuntimeNodeModulesPath(
@@ -193,6 +241,17 @@ function formatExecSyncFailure(error: unknown): string {
   return String(error);
 }
 
+function execText(
+  command: string,
+  args: string[],
+  execFile: ExecFileSyncFn = execFileSync,
+): string {
+  return execFile(command, args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
 function sleepMs(ms: number): void {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
@@ -259,10 +318,7 @@ function signRuntimeFile(
   developerId: string,
   execFile: ExecFileSyncFn = execFileSync,
 ): boolean {
-  const fileDescription = execFileSync("file", ["-b", filePath], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
-  }).trim();
+  const fileDescription = execText("file", ["-b", filePath], execFile);
   const machOKind = classifyMachOKind(fileDescription);
   if (!machOKind) {
     return false;
@@ -296,6 +352,95 @@ function signRuntimeFile(
   }
 
   return true;
+}
+
+export function installDirectLauncher(
+  buildBundlePath: string,
+  execFile: ExecFileSyncFn = execFileSync,
+): string {
+  const launcherPath = joinPortable(
+    buildBundlePath,
+    "Contents",
+    "MacOS",
+    "launcher",
+  );
+  const sourcePath = resolveDirectLauncherSourcePath();
+
+  if (!fs.existsSync(sourcePath)) {
+    throw new Error(
+      `runtime-sign: direct launcher source not found: ${sourcePath}`,
+    );
+  }
+  if (!fs.existsSync(launcherPath)) {
+    throw new Error(`runtime-sign: launcher not found at ${launcherPath}`);
+  }
+
+  const architectures = parseLauncherArchitectures(
+    execText("lipo", ["-archs", launcherPath], execFile),
+  );
+  const tempRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), "milady-direct-launcher-"),
+  );
+  const tempLauncherPath = path.join(tempRoot, "launcher");
+
+  try {
+    execFile(
+      "/usr/bin/clang",
+      buildDirectLauncherCompileArgs(
+        sourcePath,
+        tempLauncherPath,
+        architectures,
+      ),
+      {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    fs.copyFileSync(tempLauncherPath, launcherPath);
+    fs.chmodSync(launcherPath, 0o755);
+  } finally {
+    fs.rmSync(tempRoot, { force: true, recursive: true });
+  }
+
+  console.log(
+    `[runtime-sign] rebuilt direct launcher at ${launcherPath} (${architectures.join(", ")})`,
+  );
+  return launcherPath;
+}
+
+type SignBuildBundleArtifactsDeps = {
+  collectNativeCandidates?: typeof collectNativeCandidates;
+  installDirectLauncher?: typeof installDirectLauncher;
+  signRuntimeFile?: typeof signRuntimeFile;
+};
+
+export function signBuildBundleArtifacts(
+  buildBundlePath: string,
+  runtimeNodeModulesPath: string,
+  developerId: string,
+  deps: SignBuildBundleArtifactsDeps = {},
+): number {
+  const installLauncher = deps.installDirectLauncher ?? installDirectLauncher;
+  const collectCandidates =
+    deps.collectNativeCandidates ?? collectNativeCandidates;
+  const signFile = deps.signRuntimeFile ?? signRuntimeFile;
+
+  const launcherPath = installLauncher(buildBundlePath);
+
+  let signedCount = 0;
+  for (const candidate of collectCandidates(runtimeNodeModulesPath)) {
+    if (signFile(candidate, developerId)) {
+      signedCount += 1;
+    }
+  }
+
+  if (!signFile(launcherPath, developerId)) {
+    throw new Error(
+      `runtime-sign: failed to sign rebuilt launcher at ${launcherPath}`,
+    );
+  }
+
+  return signedCount;
 }
 
 function shouldRun(env: NodeJS.ProcessEnv = process.env): boolean {
@@ -332,10 +477,20 @@ function main(): void {
     );
   }
 
-  let signedCount = 0;
-  for (const candidate of collectNativeCandidates(runtimeNodeModulesPath)) {
-    if (signRuntimeFile(candidate, developerId)) {
-      signedCount += 1;
+  const buildBundlePath = resolveBuildBundlePath();
+  let signedCount: number;
+  if (buildBundlePath) {
+    signedCount = signBuildBundleArtifacts(
+      buildBundlePath,
+      runtimeNodeModulesPath,
+      developerId,
+    );
+  } else {
+    signedCount = 0;
+    for (const candidate of collectNativeCandidates(runtimeNodeModulesPath)) {
+      if (signRuntimeFile(candidate, developerId)) {
+        signedCount += 1;
+      }
     }
   }
 

--- a/apps/app/electrobun/scripts/stage-macos-release-artifacts.sh
+++ b/apps/app/electrobun/scripts/stage-macos-release-artifacts.sh
@@ -75,7 +75,6 @@ LAUNCHER_PATH="$STAGED_APP_PATH/Contents/MacOS/launcher"
 WGPU_PATH="$STAGED_APP_PATH/Contents/MacOS/libwebgpu_dawn.dylib"
 VERSION_JSON_PATH="$STAGED_APP_PATH/Contents/Resources/version.json"
 RUNTIME_DIR="$STAGED_APP_PATH/Contents/Resources/app/milady-dist"
-DIRECT_LAUNCHER_SOURCE="$SCRIPT_DIR/macos-direct-launcher.c"
 
 for required_path in "$LAUNCHER_PATH" "$WGPU_PATH" "$VERSION_JSON_PATH" "$RUNTIME_DIR"; do
   if [[ ! -e "$required_path" ]]; then
@@ -84,65 +83,11 @@ for required_path in "$LAUNCHER_PATH" "$WGPU_PATH" "$VERSION_JSON_PATH" "$RUNTIM
   fi
 done
 
-if [[ ! -f "$DIRECT_LAUNCHER_SOURCE" ]]; then
-  echo "stage-macos-release-artifacts: direct launcher source not found: $DIRECT_LAUNCHER_SOURCE"
-  exit 1
-fi
-
-entitlement_args=()
-if [[ "$SKIP_SIGNATURE_CHECK" != "1" && -n "${ELECTROBUN_DEVELOPER_ID:-}" ]]; then
-  TMP_ENTITLEMENTS_PATH="$TMP_ROOT/staged-entitlements.plist"
-  if ! codesign -d --entitlements :- "$STAGED_APP_PATH" >"$TMP_ENTITLEMENTS_PATH" 2>/dev/null; then
-    echo "stage-macos-release-artifacts: failed to extract entitlements from staged app bundle"
-    exit 1
-  fi
-  if [[ ! -s "$TMP_ENTITLEMENTS_PATH" ]]; then
-    echo "stage-macos-release-artifacts: extracted entitlements were empty"
-    exit 1
-  fi
-  entitlement_args=(--entitlements "$TMP_ENTITLEMENTS_PATH")
-fi
-
-TMP_LAUNCHER_PATH="$TMP_ROOT/direct-launcher"
-LAUNCHER_ARCHES="$(lipo -archs "$LAUNCHER_PATH" 2>/dev/null || true)"
-if [[ -z "$LAUNCHER_ARCHES" ]]; then
-  echo "stage-macos-release-artifacts: failed to determine launcher architecture for $LAUNCHER_PATH"
-  exit 1
-fi
-
-clang_arch_args=()
-for arch in $LAUNCHER_ARCHES; do
-  case "$arch" in
-    arm64|x86_64)
-      clang_arch_args+=(-arch "$arch")
-      ;;
-    *)
-      echo "stage-macos-release-artifacts: unsupported launcher architecture: $arch"
-      exit 1
-      ;;
-  esac
-done
-
-/usr/bin/clang \
-  -O2 \
-  -Wall \
-  -Wextra \
-  "${clang_arch_args[@]}" \
-  -mmacosx-version-min=11.0 \
-  "$DIRECT_LAUNCHER_SOURCE" \
-  -o "$TMP_LAUNCHER_PATH"
-install -m 0755 "$TMP_LAUNCHER_PATH" "$LAUNCHER_PATH"
-
 echo "Staged app bundle: $STAGED_APP_PATH"
 if [[ "$SKIP_SIGNATURE_CHECK" != "1" && -n "${ELECTROBUN_DEVELOPER_ID:-}" ]]; then
-  # The extracted updater app bundle is already correctly signed/notarized by
-  # electrobun. Re-sign only what changed and keep the original entitlements so
-  # we do not rewrite valid nested signatures with a blanket --deep pass.
-  if ! codesign --force --timestamp --sign "$ELECTROBUN_DEVELOPER_ID" --options runtime "${entitlement_args[@]}" "$LAUNCHER_PATH"; then
-    echo "stage-macos-release-artifacts: launcher runtime signing failed, retrying without hardened runtime" >&2
-    codesign --force --timestamp --sign "$ELECTROBUN_DEVELOPER_ID" "${entitlement_args[@]}" "$LAUNCHER_PATH"
-  fi
-  codesign --force --timestamp --sign "$ELECTROBUN_DEVELOPER_ID" --options runtime "${entitlement_args[@]}" "$STAGED_APP_PATH"
+  # The updater tarball app bundle should already be signed by Electrobun's
+  # build pipeline. Verify the copied app, then only sign/notarize the DMG we
+  # create from it here.
   codesign --verify --deep --strict --verbose=2 "$STAGED_APP_PATH"
 else
   echo "Skipping staged app signature verification (unsigned/local build)."

--- a/apps/app/electrobun/src/__tests__/postwrap-sign-runtime-macos.test.ts
+++ b/apps/app/electrobun/src/__tests__/postwrap-sign-runtime-macos.test.ts
@@ -6,10 +6,14 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildCodesignArgs,
+  buildDirectLauncherCompileArgs,
   classifyMachOKind,
   isRetryableCodesignFailure,
+  parseLauncherArchitectures,
+  resolveBuildBundlePath,
   resolveRuntimeNodeModulesPath,
   shouldConsiderForCodesign,
+  signBuildBundleArtifacts,
 } from "../../scripts/postwrap-sign-runtime-macos";
 
 describe("classifyMachOKind", () => {
@@ -77,6 +81,22 @@ describe("isRetryableCodesignFailure", () => {
 });
 
 describe("resolveRuntimeNodeModulesPath", () => {
+  it("resolves the matching build bundle from ELECTROBUN_BUILD_DIR", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "postwrap-sign-"));
+    const stableBundle = path.join(tempDir, "Milady.app");
+    const canaryBundle = path.join(tempDir, "Milady canary.app");
+    fs.mkdirSync(stableBundle, { recursive: true });
+    fs.mkdirSync(canaryBundle, { recursive: true });
+
+    expect(
+      resolveBuildBundlePath({
+        ELECTROBUN_BUILD_DIR: tempDir,
+        ELECTROBUN_OS: "macos",
+        ELECTROBUN_APP_NAME: "Milady-canary",
+      }),
+    ).toBe(canaryBundle);
+  });
+
   it("accepts an explicit runtime node_modules path", () => {
     expect(
       resolveRuntimeNodeModulesPath(
@@ -181,6 +201,79 @@ describe("resolveRuntimeNodeModulesPath", () => {
     expect(resolveRuntimeNodeModulesPath(["/tmp/dist/node_modules"], {})).toBe(
       "/tmp/dist/node_modules",
     );
+  });
+});
+
+describe("parseLauncherArchitectures", () => {
+  it("preserves the packaged launcher architecture list", () => {
+    expect(parseLauncherArchitectures("x86_64 arm64")).toEqual([
+      "x86_64",
+      "arm64",
+    ]);
+  });
+
+  it("rejects unsupported launcher architectures", () => {
+    expect(() => parseLauncherArchitectures("arm64 ppc64")).toThrow(
+      "runtime-sign: unsupported launcher architecture: ppc64",
+    );
+  });
+});
+
+describe("buildDirectLauncherCompileArgs", () => {
+  it("builds clang args for every packaged launcher architecture", () => {
+    expect(
+      buildDirectLauncherCompileArgs(
+        "/tmp/macos-direct-launcher.c",
+        "/tmp/out/launcher",
+        ["arm64", "x86_64"],
+      ),
+    ).toEqual([
+      "-O2",
+      "-Wall",
+      "-Wextra",
+      "-arch",
+      "arm64",
+      "-arch",
+      "x86_64",
+      "-mmacosx-version-min=11.0",
+      "/tmp/macos-direct-launcher.c",
+      "-o",
+      "/tmp/out/launcher",
+    ]);
+  });
+});
+
+describe("signBuildBundleArtifacts", () => {
+  it("rebuilds the launcher before nested runtime signing and signs it last", () => {
+    const calls: string[] = [];
+
+    const signedCount = signBuildBundleArtifacts(
+      "/tmp/Milady.app",
+      "/tmp/Milady.app/Contents/Resources/app/milady-dist/node_modules",
+      "Developer ID Application: Test",
+      {
+        installDirectLauncher: (bundlePath) => {
+          calls.push(`install:${bundlePath}`);
+          return `${bundlePath}/Contents/MacOS/launcher`;
+        },
+        collectNativeCandidates: (runtimeNodeModulesPath) => {
+          calls.push(`collect:${runtimeNodeModulesPath}`);
+          return ["/tmp/addon.node"];
+        },
+        signRuntimeFile: (filePath, developerId) => {
+          calls.push(`sign:${filePath}:${developerId}`);
+          return true;
+        },
+      },
+    );
+
+    expect(signedCount).toBe(1);
+    expect(calls).toEqual([
+      "install:/tmp/Milady.app",
+      "collect:/tmp/Milady.app/Contents/Resources/app/milady-dist/node_modules",
+      "sign:/tmp/addon.node:Developer ID Application: Test",
+      "sign:/tmp/Milady.app/Contents/MacOS/launcher:Developer ID Application: Test",
+    ]);
   });
 });
 

--- a/apps/app/electrobun/src/__tests__/stage-macos-release-artifacts.test.ts
+++ b/apps/app/electrobun/src/__tests__/stage-macos-release-artifacts.test.ts
@@ -9,18 +9,25 @@ const STAGE_MACOS_RELEASE_ARTIFACTS_PATH = path.resolve(
 );
 
 describe("stage-macos-release-artifacts.sh", () => {
-  it("rebuilds the direct launcher using the packaged launcher architecture", () => {
+  it("stages the signed app without rebuilding or re-signing it", () => {
     const script = fs.readFileSync(STAGE_MACOS_RELEASE_ARTIFACTS_PATH, "utf8");
 
+    expect(script).toContain('ditto "$APP_BUNDLE_PATH" "$STAGED_APP_PATH"');
     expect(script).toContain(
-      'LAUNCHER_ARCHES="$(lipo -archs "$LAUNCHER_PATH" 2>/dev/null || true)"',
+      'codesign --verify --deep --strict --verbose=2 "$STAGED_APP_PATH"',
     );
-    expect(script).toContain("clang_arch_args=()");
-    expect(script).toContain('clang_arch_args+=(-arch "$arch")');
+    expect(script).not.toContain(
+      'DIRECT_LAUNCHER_SOURCE="$SCRIPT_DIR/macos-direct-launcher.c"',
+    );
+    expect(script).not.toContain(
+      'codesign -d --entitlements :- "$STAGED_APP_PATH"',
+    );
+    expect(script).not.toContain("/usr/bin/clang \\");
+    expect(script).not.toContain(
+      'install -m 0755 "$TMP_LAUNCHER_PATH" "$LAUNCHER_PATH"',
+    );
     expect(script).toContain(
-      'echo "stage-macos-release-artifacts: unsupported launcher architecture: $arch"',
+      'codesign --force --timestamp --sign "$ELECTROBUN_DEVELOPER_ID" "$TEMP_DMG_PATH"',
     );
-    // biome-ignore lint/suspicious/noTemplateCurlyInString: bash variable expansion in shell script assertion
-    expect(script).toContain('"${clang_arch_args[@]}"');
   });
 });

--- a/scripts/copy-runtime-node-modules.test.ts
+++ b/scripts/copy-runtime-node-modules.test.ts
@@ -5,17 +5,20 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
+  finalizeRuntimePackageDir,
   getRuntimeDependencies,
   getRuntimeDependencyEntries,
   inferVersionFromBunEntryPath,
   isExactVersionSpecifier,
   isPackageCompatibleWithCurrentPlatform,
+  matchesRuntimePackageNameHint,
   matchesRuntimeVariant,
   normalizeResolvedPackage,
   selectCopyTargetNodeModules,
   selectResolvedCandidate,
   shouldCopyPackageEntry,
   shouldKeepPackageRelativePath,
+  shouldRefreshTopLevelPackageCopy,
   shouldSkipPackagedDependency,
   stripPackagedCronCliRegistration,
 } from "./copy-runtime-node-modules";
@@ -185,6 +188,54 @@ describe("packaged dependency overrides", () => {
   });
 });
 
+describe("finalizeRuntimePackageDir", () => {
+  it("prunes cached package payloads and patches cron's CLI import", () => {
+    const otherPlatform =
+      ["darwin", "linux", "win32"].find(
+        (value) => value !== process.platform,
+      ) ?? "darwin";
+    const packageDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "runtime-package-finalize-test-"),
+    );
+    const currentVariantDir = path.join(
+      packageDir,
+      "prebuilds",
+      `${process.platform}-${process.arch}`,
+    );
+    const otherVariantDir = path.join(
+      packageDir,
+      "prebuilds",
+      `${otherPlatform}-${process.arch}`,
+    );
+    const cronEntryPath = path.join(packageDir, "dist", "index.js");
+
+    fs.mkdirSync(currentVariantDir, { recursive: true });
+    fs.mkdirSync(otherVariantDir, { recursive: true });
+    fs.mkdirSync(path.dirname(cronEntryPath), { recursive: true });
+    fs.writeFileSync(
+      path.join(packageDir, "package.json"),
+      JSON.stringify({ name: "@elizaos/plugin-cron", version: "1.0.0" }),
+    );
+    fs.writeFileSync(path.join(currentVariantDir, "kept.node"), "");
+    fs.writeFileSync(path.join(otherVariantDir, "pruned.node"), "");
+    fs.writeFileSync(
+      cronEntryPath,
+      [
+        'import { defineCliCommand, registerCliCommand } from "@elizaos/plugin-cli";',
+        'registerCliCommand(defineCliCommand("cron", "Cron", () => {}));',
+      ].join("\n"),
+    );
+
+    finalizeRuntimePackageDir(packageDir);
+
+    expect(fs.existsSync(path.join(currentVariantDir, "kept.node"))).toBe(true);
+    expect(fs.existsSync(otherVariantDir)).toBe(false);
+    expect(fs.readFileSync(cronEntryPath, "utf8")).toContain(
+      "const defineCliCommand = () => null;",
+    );
+  });
+});
+
 describe("isExactVersionSpecifier", () => {
   it("detects exact semver pins", () => {
     expect(isExactVersionSpecifier("1.3.2")).toBe(true);
@@ -290,6 +341,19 @@ describe("selectCopyTargetNodeModules", () => {
     );
   });
 
+  it("always hoists tslib so helper copies do not explode the bundle tree", () => {
+    expect(
+      selectCopyTargetNodeModules({
+        name: "tslib",
+        requesterDestDir: "/tmp/app/dist/node_modules/@smithy/util-utf8",
+        rootDestDir: "/tmp/app/dist",
+        targetNodeModules: "/tmp/app/dist/node_modules",
+        topLevelVersions: new Map([["tslib", "2.7.0"]]),
+        resolvedVersion: "2.8.1",
+      }),
+    ).toBe("/tmp/app/dist/node_modules");
+  });
+
   it("always hoists @elizaos/core to the top level once present", () => {
     expect(
       selectCopyTargetNodeModules({
@@ -301,6 +365,27 @@ describe("selectCopyTargetNodeModules", () => {
         resolvedVersion: "2.0.0-alpha.3",
       }),
     ).toBe("/tmp/app/dist/node_modules");
+  });
+});
+
+describe("shouldRefreshTopLevelPackageCopy", () => {
+  it("upgrades the hoisted tslib copy when a newer helper version appears", () => {
+    expect(shouldRefreshTopLevelPackageCopy("tslib", "2.7.0", "2.8.1")).toBe(
+      true,
+    );
+    expect(shouldRefreshTopLevelPackageCopy("tslib", "2.8.1", "2.7.0")).toBe(
+      false,
+    );
+  });
+
+  it("does not force-refresh unrelated packages", () => {
+    expect(
+      shouldRefreshTopLevelPackageCopy(
+        "discord-api-types",
+        "0.37.120",
+        "0.38.40",
+      ),
+    ).toBe(false);
   });
 });
 
@@ -421,6 +506,30 @@ describe("matchesRuntimeVariant", () => {
     );
     expect(matchesRuntimeVariant("musl_arm64", "darwin", "arm64")).toBe(false);
     expect(matchesRuntimeVariant("win32-x64", "darwin", "arm64")).toBe(false);
+  });
+});
+
+describe("matchesRuntimePackageNameHint", () => {
+  it("skips package names that clearly target a foreign platform", () => {
+    expect(
+      matchesRuntimePackageNameHint("@esbuild/openbsd-x64", "darwin", "arm64"),
+    ).toBe(false);
+    expect(
+      matchesRuntimePackageNameHint(
+        "@rollup/rollup-linux-x64-gnu",
+        "darwin",
+        "arm64",
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps generic package names and the active platform variant", () => {
+    expect(
+      matchesRuntimePackageNameHint("@aws-sdk/util-utf8", "darwin", "arm64"),
+    ).toBe(true);
+    expect(
+      matchesRuntimePackageNameHint("@esbuild/darwin-arm64", "darwin", "arm64"),
+    ).toBe(true);
   });
 });
 

--- a/scripts/copy-runtime-node-modules.ts
+++ b/scripts/copy-runtime-node-modules.ts
@@ -254,6 +254,24 @@ export function matchesRuntimeVariant(
   return true;
 }
 
+export function matchesRuntimePackageNameHint(
+  packageName: string,
+  targetOS = process.platform,
+  targetArch = process.arch,
+): boolean {
+  const packageBaseName = packageName.split("/").pop() ?? packageName;
+  const constraints = getRuntimeVariantConstraints(packageBaseName);
+
+  // Only treat the package name as a platform hint when it actually carries
+  // an OS token like linux/win32/darwin/openbsd. Generic package names that
+  // happen to contain an arch token should not be filtered here.
+  if (!constraints.os) {
+    return true;
+  }
+
+  return matchesRuntimeVariant(packageBaseName, targetOS, targetArch);
+}
+
 export function shouldKeepPackageRelativePath(
   relativePath: string,
   targetOS = process.platform,
@@ -343,8 +361,7 @@ function copyPackageDir(
     dereference: true,
     filter: shouldCopyPackageEntry,
   });
-  pruneCopiedPackageDir(dest);
-  patchCopiedPackageRuntimeSurface(name, dest);
+  finalizeRuntimePackageDir(dest, name);
   return true;
 }
 
@@ -385,6 +402,30 @@ function patchCopiedPackageRuntimeSurface(
   const rewritten = stripPackagedCronCliRegistration(original);
   if (rewritten !== original) {
     fs.writeFileSync(cronEntryPath, rewritten);
+  }
+}
+
+export function finalizeRuntimePackageDir(
+  packageDir: string,
+  packageName: string | null = null,
+): void {
+  // Keep cached package roots trimmed to the same platform-specific payload
+  // we actually ship so repeated packaging runs do not balloon tmp usage.
+  pruneCopiedPackageDir(packageDir);
+
+  let resolvedPackageName = packageName;
+  if (!resolvedPackageName) {
+    try {
+      resolvedPackageName =
+        readJson<{ name?: string }>(path.join(packageDir, "package.json"))
+          .name ?? null;
+    } catch {
+      resolvedPackageName = null;
+    }
+  }
+
+  if (resolvedPackageName) {
+    patchCopiedPackageRuntimeSurface(resolvedPackageName, packageDir);
   }
 }
 
@@ -465,6 +506,7 @@ function fetchPublishedPackage(
   const packageRoot = path.join(cacheDir, "package");
   const manifestPath = path.join(packageRoot, "package.json");
   if (fs.existsSync(manifestPath)) {
+    finalizeRuntimePackageDir(packageRoot, name);
     const resolved = { sourceDir: packageRoot, packageJsonPath: manifestPath };
     registryPackageIndex.set(key, resolved);
     return resolved;
@@ -474,6 +516,7 @@ function fetchPublishedPackage(
   fs.mkdirSync(cacheDir, { recursive: true });
 
   try {
+    let tarballPath: string | null = null;
     const tarballName = execFileSync(
       "npm",
       ["pack", `${name}@${version}`, "--silent"],
@@ -488,13 +531,19 @@ function fetchPublishedPackage(
       .pop();
 
     if (!tarballName) return null;
+    tarballPath = path.join(cacheDir, tarballName);
 
-    execFileSync("tar", ["-xzf", tarballName, "-C", cacheDir], {
-      cwd: cacheDir,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    try {
+      execFileSync("tar", ["-xzf", tarballName, "-C", cacheDir], {
+        cwd: cacheDir,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } finally {
+      fs.rmSync(tarballPath, { force: true });
+    }
 
     if (!fs.existsSync(manifestPath)) return null;
+    finalizeRuntimePackageDir(packageRoot, name);
 
     const resolved = { sourceDir: packageRoot, packageJsonPath: manifestPath };
     registryPackageIndex.set(key, resolved);
@@ -520,6 +569,7 @@ function materializeTrackedWorkspacePackage(
   const packageRoot = path.join(cacheDir, relative);
   const manifestPath = path.join(packageRoot, "package.json");
   if (fs.existsSync(manifestPath)) {
+    finalizeRuntimePackageDir(packageRoot);
     const resolved = { sourceDir: packageRoot, packageJsonPath: manifestPath };
     trackedPackageIndex.set(relative, resolved);
     return resolved;
@@ -544,6 +594,7 @@ function materializeTrackedWorkspacePackage(
     });
 
     if (!fs.existsSync(manifestPath)) return null;
+    finalizeRuntimePackageDir(packageRoot);
 
     const resolved = { sourceDir: packageRoot, packageJsonPath: manifestPath };
     trackedPackageIndex.set(relative, resolved);
@@ -797,6 +848,49 @@ export function getRuntimeDependencies(pkgPath: string): string[] {
   return getRuntimeDependencyEntries(pkgPath).map((entry) => entry.name);
 }
 
+function compareLooseSemverVersions(left: string, right: string): number {
+  const leftMatch = left.match(/^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/);
+  const rightMatch = right.match(/^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/);
+  if (!leftMatch || !rightMatch) {
+    return left.localeCompare(right, undefined, {
+      numeric: true,
+      sensitivity: "base",
+    });
+  }
+
+  const leftParts = leftMatch.slice(1).map((part) => Number(part));
+  const rightParts = rightMatch.slice(1).map((part) => Number(part));
+
+  for (let index = 0; index < leftParts.length; index += 1) {
+    if (leftParts[index] === rightParts[index]) {
+      continue;
+    }
+    return leftParts[index] < rightParts[index] ? -1 : 1;
+  }
+
+  return 0;
+}
+
+function shouldAlwaysHoistPackage(name: string): boolean {
+  return ALWAYS_HOISTED_PACKAGES.has(name) || name === "tslib";
+}
+
+export function shouldRefreshTopLevelPackageCopy(
+  name: string,
+  currentVersion: string | null | undefined,
+  nextVersion: string | null | undefined,
+): boolean {
+  if (name !== "tslib" || !nextVersion) {
+    return false;
+  }
+
+  if (!currentVersion) {
+    return true;
+  }
+
+  return compareLooseSemverVersions(currentVersion, nextVersion) < 0;
+}
+
 type CopyTargetOptions = {
   name: string;
   requesterDestDir: string;
@@ -818,7 +912,7 @@ export function selectCopyTargetNodeModules({
     return targetNodeModules;
   }
 
-  if (ALWAYS_HOISTED_PACKAGES.has(name) && topLevelVersions.has(name)) {
+  if (shouldAlwaysHoistPackage(name) && topLevelVersions.has(name)) {
     return targetNodeModules;
   }
 
@@ -915,6 +1009,11 @@ function main(): void {
 
     const { name, spec, requesterDir, requesterDestDir } = request;
     if (!name || DEP_SKIP.has(name)) continue;
+    if (!matchesRuntimePackageNameHint(name)) {
+      missingAlwaysBundled.delete(name);
+      missingDiscovered.delete(name);
+      continue;
+    }
 
     const resolved = resolvePackage(name, spec, requesterDir);
     if (!resolved) {
@@ -942,6 +1041,16 @@ function main(): void {
       resolvedVersion,
     });
     const destination = packagePath(name, copyTargetNodeModules);
+    if (
+      copyTargetNodeModules === targetNodeModules &&
+      shouldRefreshTopLevelPackageCopy(
+        name,
+        topLevelVersions.get(name),
+        resolvedVersion,
+      )
+    ) {
+      copiedDestinations.delete(destination);
+    }
 
     if (copiedDestinations.has(destination)) {
       missingAlwaysBundled.delete(name);

--- a/scripts/desktop-build-script.test.ts
+++ b/scripts/desktop-build-script.test.ts
@@ -1,0 +1,72 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const SCRIPT_PATH = path.resolve(import.meta.dirname, "desktop-build.mjs");
+
+describe("desktop-build.mjs", () => {
+  it("stages the desktop runtime, renderer, preload, and native inputs", () => {
+    const script = fs.readFileSync(SCRIPT_PATH, "utf8");
+
+    expect(script).toContain('runPackageBinary("tsdown", [],');
+    expect(script).toContain("scripts/write-build-info.ts");
+    expect(script).toContain("scripts/copy-runtime-node-modules.ts");
+    expect(script).toContain("--exclude-optional-pack");
+    expect(script).toContain(
+      'runBun(["install", "--frozen-lockfile", "--ignore-scripts"], {',
+    );
+    expect(script).toContain(
+      "Ensuring Electrobun workspace dependencies are installed",
+    );
+    expect(script).toContain('runPackageBinary("vite", ["build"],');
+    expect(script).toContain('runBun(["run", "build:preload"]');
+    expect(script).toContain('runBun(["run", "build:native-effects"]');
+    expect(script).toContain('runBun(["run", "build:whisper"]');
+  });
+
+  it("supports prefixed child commands and electrobun package fallback", () => {
+    const script = fs.readFileSync(SCRIPT_PATH, "utf8");
+
+    expect(script).toContain("PROFILE_EXCLUDED_OPTIONAL_PACKS");
+    expect(script).toContain("function getProfileExcludedOptionalPacks(");
+    expect(script).toContain("MILADY_DESKTOP_COMMAND_PREFIX");
+    expect(script).toContain("function buildInvocation(");
+    expect(script).toContain("function getRepeatedArgValues(");
+    expect(script).toContain('const direct = which("electrobun")');
+    expect(script).toContain(
+      'runPackageBinary("electrobun", commandArgs, options);',
+    );
+    expect(script).toContain('case "stage":');
+    expect(script).toContain('case "package":');
+    expect(script).toContain('case "build":');
+    expect(script).toContain('case "run":');
+  });
+
+  it("packages through the electrobun workspace build script", () => {
+    const script = fs.readFileSync(SCRIPT_PATH, "utf8");
+
+    expect(script).toContain('const packageArgs = ["run", "build"]');
+    expect(script).toContain('packageArgs.push("--", `--env=${buildEnv}`);');
+    expect(script).toContain("runBun(packageArgs, {");
+  });
+
+  it("can stage a direct macOS release app from the Electrobun build output", () => {
+    const script = fs.readFileSync(SCRIPT_PATH, "utf8");
+
+    expect(script).toContain(
+      'const stageMacosReleaseApp = getBooleanArg(args, "stage-macos-release-app");',
+    );
+    expect(script).toContain(
+      'if (stageMacosReleaseApp && process.platform === "darwin") {',
+    );
+    expect(script).toContain(
+      "apps/app/electrobun/scripts/stage-macos-release-artifacts.sh",
+    );
+    expect(script).not.toContain('MILADY_ELECTROBUN_NOTARIZE: "0"');
+    expect(script).toContain("MILADY_STAGE_MACOS_SKIP_DMG");
+    expect(script).toContain(
+      "--stage-macos-release-app        Stage a direct macOS .app + DMG from the Electrobun build output",
+    );
+  });
+});

--- a/scripts/desktop-build.mjs
+++ b/scripts/desktop-build.mjs
@@ -1,0 +1,375 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const ROOT = process.cwd();
+const APP_DIR = path.join(ROOT, "apps", "app");
+const ELECTROBUN_DIR = path.join(APP_DIR, "electrobun");
+const DIST_PACKAGE_JSON = path.join(ROOT, "dist", "package.json");
+const PROFILE_EXCLUDED_OPTIONAL_PACKS = {
+  full: [],
+  "no-streaming": ["streaming"],
+};
+const COMMAND_PREFIX = (process.env.MILADY_DESKTOP_COMMAND_PREFIX ?? "")
+  .trim()
+  .split(/\s+/)
+  .filter(Boolean);
+
+const argv = process.argv.slice(2);
+const command = argv[0] && !argv[0].startsWith("--") ? argv[0] : "build";
+const flagStart = command === "build" && argv[0]?.startsWith("--") ? 0 : 1;
+const args = argv.slice(flagStart);
+
+const buildProfile =
+  getArgValue(args, "profile") ?? process.env.MILADY_DESKTOP_PROFILE ?? "full";
+const variant =
+  getArgValue(args, "variant") ?? process.env.VITE_APP_VARIANT ?? "base";
+const buildEnv = getArgValue(args, "env") ?? process.env.BUILD_ENV ?? "";
+const buildWhisper = getBooleanArg(args, "build-whisper");
+const stageMacosReleaseApp = getBooleanArg(args, "stage-macos-release-app");
+const excludedOptionalPacks = [
+  ...new Set([
+    ...getProfileExcludedOptionalPacks(buildProfile),
+    ...getRepeatedArgValues(args, "exclude-optional-pack"),
+  ]),
+];
+
+function fail(message, code = 1) {
+  console.error(`[desktop-build] ${message}`);
+  process.exit(code);
+}
+
+function getProfileExcludedOptionalPacks(profile) {
+  const packs = PROFILE_EXCLUDED_OPTIONAL_PACKS[profile];
+  if (!packs) {
+    fail(
+      `Unknown desktop build profile: ${profile}. Available profiles: ${Object.keys(PROFILE_EXCLUDED_OPTIONAL_PACKS).join(", ")}`,
+    );
+  }
+  return packs;
+}
+
+function which(commandName) {
+  const pathEnv = process.env.PATH ?? "";
+  if (!pathEnv) return null;
+
+  const isWindows = process.platform === "win32";
+  const exts = isWindows
+    ? (process.env.PATHEXT?.split(";").filter(Boolean) ?? [
+        ".EXE",
+        ".CMD",
+        ".BAT",
+        ".COM",
+      ])
+    : [""];
+
+  for (const dir of pathEnv.split(path.delimiter).filter(Boolean)) {
+    for (const ext of exts) {
+      const suffix = isWindows && ext && !commandName.endsWith(ext) ? ext : "";
+      const candidate = path.join(dir, `${commandName}${suffix}`);
+      if (fs.existsSync(candidate)) {
+        return candidate;
+      }
+    }
+  }
+
+  return null;
+}
+
+function getArgValue(argvItems, name) {
+  const exact = `--${name}`;
+  const prefixed = `--${name}=`;
+  const index = argvItems.indexOf(exact);
+  if (index >= 0) {
+    const value = argvItems[index + 1];
+    return value && !value.startsWith("--") ? value : null;
+  }
+
+  const inline = argvItems.find((item) => item.startsWith(prefixed));
+  return inline ? inline.slice(prefixed.length) : null;
+}
+
+function getBooleanArg(argvItems, name) {
+  const value = getArgValue(argvItems, name);
+  if (value !== null) {
+    return ["1", "true", "yes", "on"].includes(value.toLowerCase());
+  }
+  return argvItems.includes(`--${name}`);
+}
+
+function getRepeatedArgValues(argvItems, name) {
+  const values = [];
+  const exact = `--${name}`;
+  const prefixed = `--${name}=`;
+
+  for (let i = 0; i < argvItems.length; i += 1) {
+    const item = argvItems[i];
+    if (item === exact) {
+      const value = argvItems[i + 1];
+      if (value && !value.startsWith("--")) {
+        values.push(value);
+        i += 1;
+      }
+      continue;
+    }
+
+    if (item.startsWith(prefixed)) {
+      values.push(item.slice(prefixed.length));
+    }
+  }
+
+  return values;
+}
+
+function buildInvocation(binary, binaryArgs = []) {
+  if (COMMAND_PREFIX.length === 0) {
+    return { command: binary, args: binaryArgs };
+  }
+
+  return {
+    command: COMMAND_PREFIX[0],
+    args: [...COMMAND_PREFIX.slice(1), binary, ...binaryArgs],
+  };
+}
+
+function run(commandName, commandArgs, options = {}) {
+  const { cwd = ROOT, env = process.env, label } = options;
+  const invocation = buildInvocation(commandName, commandArgs);
+  const rendered = [invocation.command, ...invocation.args].join(" ");
+  console.log(`[desktop-build] ${label ?? rendered}`);
+
+  const result = spawnSync(invocation.command, invocation.args, {
+    cwd,
+    env,
+    stdio: "inherit",
+  });
+
+  if (result.status !== 0) {
+    fail(
+      `${rendered} failed with exit code ${result.status ?? 1}`,
+      result.status ?? 1,
+    );
+  }
+}
+
+function runBun(commandArgs, options = {}) {
+  const bun = which("bun");
+  if (!bun) {
+    fail('Could not find "bun" in PATH.');
+  }
+  run(bun, commandArgs, options);
+}
+
+function runNode(commandArgs, options = {}) {
+  const node = which("node") ?? process.execPath;
+  run(node, commandArgs, options);
+}
+
+function runPackageBinary(binary, binaryArgs, options = {}) {
+  const bunx = which("bunx");
+  if (bunx) {
+    run(bunx, [binary, ...binaryArgs], options);
+    return;
+  }
+
+  const npx = which("npx");
+  if (npx) {
+    run(npx, [binary, ...binaryArgs], options);
+    return;
+  }
+
+  fail(`Could not find bunx or npx to run ${binary}.`);
+}
+
+function runElectrobun(commandArgs, options = {}) {
+  const direct = which("electrobun");
+  if (direct) {
+    run(direct, commandArgs, options);
+    return;
+  }
+
+  runPackageBinary("electrobun", commandArgs, options);
+}
+
+function ensureAppDirs() {
+  for (const dir of [APP_DIR, ELECTROBUN_DIR]) {
+    if (!fs.existsSync(dir)) {
+      fail(`Expected directory not found: ${dir}`);
+    }
+  }
+}
+
+function writeDistPackageJson() {
+  fs.mkdirSync(path.dirname(DIST_PACKAGE_JSON), { recursive: true });
+  fs.writeFileSync(DIST_PACKAGE_JSON, '{"type":"module"}\n');
+}
+
+function stageDesktopBuild() {
+  ensureAppDirs();
+
+  runPackageBinary("tsdown", [], {
+    cwd: ROOT,
+    label: "Building core runtime bundle with tsdown",
+  });
+  writeDistPackageJson();
+
+  runNode(["--import", "tsx", "scripts/write-build-info.ts"], {
+    cwd: ROOT,
+    label: "Writing build metadata",
+  });
+
+  runNode(
+    [
+      "--import",
+      "tsx",
+      "scripts/copy-runtime-node-modules.ts",
+      "--scan-dir",
+      "dist",
+      "--target-dist",
+      "dist",
+      ...excludedOptionalPacks.flatMap((pack) => [
+        "--exclude-optional-pack",
+        pack,
+      ]),
+    ],
+    {
+      cwd: ROOT,
+      label:
+        excludedOptionalPacks.length > 0
+          ? `Bundling runtime node_modules into dist (profile=${buildProfile}, excluding: ${excludedOptionalPacks.join(", ")})`
+          : `Bundling runtime node_modules into dist (profile=${buildProfile})`,
+    },
+  );
+
+  runBun(["install", "--frozen-lockfile", "--ignore-scripts"], {
+    cwd: APP_DIR,
+    label: "Ensuring app workspace dependencies are installed",
+  });
+
+  runBun(["install", "--frozen-lockfile", "--ignore-scripts"], {
+    cwd: ELECTROBUN_DIR,
+    label: "Ensuring Electrobun workspace dependencies are installed",
+  });
+
+  runPackageBinary("vite", ["build"], {
+    cwd: APP_DIR,
+    env: { ...process.env, VITE_APP_VARIANT: variant },
+    label: `Building renderer bundle (VITE_APP_VARIANT=${variant})`,
+  });
+
+  runBun(["run", "build:preload"], {
+    cwd: ELECTROBUN_DIR,
+    label: "Building Electrobun preload bridge",
+  });
+
+  if (process.platform === "darwin") {
+    runBun(["run", "build:native-effects"], {
+      cwd: ELECTROBUN_DIR,
+      label: "Building native macOS effects dylib",
+    });
+  }
+
+  if (
+    buildWhisper &&
+    (process.platform === "darwin" || process.platform === "linux")
+  ) {
+    runBun(["run", "build:whisper"], {
+      cwd: ELECTROBUN_DIR,
+      label: "Building whisper.cpp native binary",
+    });
+  }
+}
+
+function packageDesktopBuild() {
+  ensureAppDirs();
+  const packageArgs = ["run", "build"];
+  if (buildEnv) {
+    packageArgs.push("--", `--env=${buildEnv}`);
+  }
+
+  const packageEnv = {
+    ...process.env,
+  };
+
+  runBun(packageArgs, {
+    cwd: ELECTROBUN_DIR,
+    env: packageEnv,
+    label: buildEnv
+      ? `Packaging Electrobun app (env=${buildEnv})`
+      : "Packaging Electrobun app",
+  });
+
+  if (stageMacosReleaseApp && process.platform === "darwin") {
+    run(
+      "bash",
+      ["apps/app/electrobun/scripts/stage-macos-release-artifacts.sh"],
+      {
+        cwd: ROOT,
+        env: {
+          ...packageEnv,
+          ELECTROBUN_SKIP_CODESIGN: process.env.ELECTROBUN_SKIP_CODESIGN ?? "1",
+          MILADY_STAGE_MACOS_SKIP_DMG:
+            process.env.MILADY_STAGE_MACOS_SKIP_DMG ?? "1",
+        },
+        label: "Staging direct macOS release app",
+      },
+    );
+  }
+}
+
+function runDesktopBuild() {
+  const electrobunArgs = ["run"];
+  runElectrobun(electrobunArgs, {
+    cwd: ELECTROBUN_DIR,
+    label: "Launching packaged Electrobun app",
+  });
+}
+
+function printUsage() {
+  console.log(`Usage: node scripts/desktop-build.mjs <command> [options]
+
+Commands:
+  stage    Build runtime/assets/preload inputs for desktop packaging
+  package  Run electrobun build against the staged desktop inputs
+  build    Run stage + package
+  run      Run stage + package + electrobun run
+
+Options:
+  --profile <full|no-streaming>    Optional desktop packaging profile (default: full)
+  --variant <base|companion|full>  Renderer build variant (default: base)
+  --env <channel>                  Electrobun build env (e.g. canary, stable)
+  --build-whisper                  Build whisper.cpp on macOS/Linux during stage
+  --stage-macos-release-app        Stage a direct macOS .app + DMG from the Electrobun build output
+  --exclude-optional-pack <name>   Exclude a manifest-classified optional capability pack during staging
+
+Environment:
+  MILADY_DESKTOP_COMMAND_PREFIX    Prefix every spawned command, e.g. "arch -x86_64"
+`);
+}
+
+switch (command) {
+  case "stage":
+    stageDesktopBuild();
+    break;
+  case "package":
+    packageDesktopBuild();
+    break;
+  case "build":
+    stageDesktopBuild();
+    packageDesktopBuild();
+    break;
+  case "run":
+    stageDesktopBuild();
+    packageDesktopBuild();
+    runDesktopBuild();
+    break;
+  case "help":
+  case "--help":
+  case "-h":
+    printUsage();
+    break;
+  default:
+    fail(`Unknown command: ${command}`);
+}

--- a/scripts/electrobun-release-workflow-drift.test.ts
+++ b/scripts/electrobun-release-workflow-drift.test.ts
@@ -15,6 +15,10 @@ const MACOS_STAGE_SCRIPT_PATH = path.join(
   ROOT,
   "apps/app/electrobun/scripts/stage-macos-release-artifacts.sh",
 );
+const MACOS_POSTBUILD_SIGN_SCRIPT_PATH = path.join(
+  ROOT,
+  "apps/app/electrobun/scripts/postwrap-sign-runtime-macos.ts",
+);
 const MACOS_EFFECTS_BUILD_SCRIPT_PATH = path.join(
   ROOT,
   "apps/app/electrobun/scripts/build-macos-effects.sh",
@@ -33,30 +37,30 @@ const WINDOWS_PACKAGED_TEST_PATH = path.join(
 );
 
 describe("Electrobun release workflow drift", () => {
-  it("stages the built renderer before packaging", () => {
+  it("uses the shared desktop-build script to stage bundle inputs before packaging", () => {
     const workflow = fs.readFileSync(WORKFLOW_PATH, "utf8");
 
-    expect(workflow).toContain("name: Build renderer (vite)");
-    expect(workflow).toContain("name: Stage renderer for Electrobun bundle");
+    expect(workflow).toContain("name: Stage desktop bundle inputs");
     expect(workflow).toContain(
-      "cp -r apps/app/dist apps/app/electrobun/renderer",
+      "node scripts/desktop-build.mjs stage --variant=base --build-whisper",
     );
   });
 
-  it("injects version.json into packaged bundles after the build step", () => {
+  it("relies on Electrobun's built-in version.json generation", () => {
     const workflow = fs.readFileSync(WORKFLOW_PATH, "utf8");
-    const buildIndex = workflow.indexOf("name: Build Electrobun app");
-    const windowsIndex = workflow.indexOf(
+
+    expect(workflow).not.toContain(
       "name: Inject version.json into bundle (Windows)",
     );
-    const unixIndex = workflow.indexOf(
+    expect(workflow).not.toContain(
       "name: Inject version.json into bundle (macOS / Linux)",
     );
-
-    expect(buildIndex).toBeGreaterThan(-1);
-    expect(windowsIndex).toBeGreaterThan(buildIndex);
-    expect(unixIndex).toBeGreaterThan(buildIndex);
-    expect(workflow).toContain('"identifier":"com.miladyai.milady"');
+    expect(workflow).not.toContain(
+      'Get-ChildItem -Path $buildRoot -Recurse -Directory -Filter "Resources"',
+    );
+    expect(workflow).not.toContain(
+      'find apps/app/electrobun/build -type d -name "Resources"',
+    );
   });
 
   it("builds the Intel macOS artifact on the real Intel runner", () => {
@@ -69,10 +73,11 @@ describe("Electrobun release workflow drift", () => {
     expect(workflow).toContain(
       "arch -x86_64 bun install --frozen-lockfile --ignore-scripts",
     );
-    // tsdown and vite are now built once in validate-release and shared as artifacts
-    expect(workflow).toContain("arch -x86_64 bun run build:whisper");
     expect(workflow).toContain(
-      `arch -x86_64 electrobun build --env=\${{ needs.prepare.outputs.env }}`,
+      'MILADY_DESKTOP_COMMAND_PREFIX="arch -x86_64" node scripts/desktop-build.mjs stage --variant=base --build-whisper',
+    );
+    expect(workflow).toContain(
+      'MILADY_DESKTOP_COMMAND_PREFIX="arch -x86_64" node scripts/desktop-build.mjs package --env=${{ needs.prepare.outputs.env }}',
     );
     expect(workflow).not.toContain("arch -x86_64 bun install --ignore-scripts");
     expect(workflow).not.toContain(
@@ -99,6 +104,28 @@ describe("Electrobun release workflow drift", () => {
     expect(workflow).toContain("needs: [prepare, validate-release]");
   });
 
+  it("uses a non-matrix cache key in validate-release", () => {
+    const workflow = fs.readFileSync(WORKFLOW_PATH, "utf8");
+    const validateSection = workflow.slice(
+      workflow.indexOf("name: Validate Release Inputs"),
+      workflow.indexOf("  build:"),
+    );
+
+    expect(validateSection).toContain(
+      "key: bun-electrobun-validate-${{ hashFiles('bun.lock') }}",
+    );
+    expect(validateSection).toContain("restore-keys: bun-electrobun-validate-");
+    expect(validateSection).not.toContain("matrix.platform.artifact-name");
+  });
+
+  it("restores the Bun cache without saving it on Windows build jobs", () => {
+    const workflow = fs.readFileSync(WORKFLOW_PATH, "utf8");
+
+    expect(workflow).toContain("name: Restore Bun install cache (Windows)");
+    expect(workflow).toContain("if: matrix.platform.os == 'windows'");
+    expect(workflow).toContain("uses: actions/cache/restore@v4");
+  });
+
   it("verifies the Windows electrobun tarball digest before extraction", () => {
     const workflow = fs.readFileSync(WORKFLOW_PATH, "utf8");
 
@@ -113,28 +140,49 @@ describe("Electrobun release workflow drift", () => {
     );
     expect(workflow).toContain("electrobun CLI checksum mismatch");
     expect(workflow).toContain("Verified electrobun CLI SHA256:");
+    expect(workflow).toContain(
+      "process.stdout.write(fs.realpathSync(packageDir));",
+    );
+    expect(workflow).toContain(
+      'Write-Host "Resolved electrobun package dir: $resolvedElectrobunDir"',
+    );
+    expect(workflow).toContain(
+      '$cacheDir     = Join-Path $resolvedElectrobunDir ".cache"',
+    );
+    expect(workflow).toContain(
+      "Installing local rcedit helper under Electrobun...",
+    );
+    expect(workflow).toContain(
+      'npm install --prefix $resolvedElectrobunDir --no-save --no-package-lock --ignore-scripts --fund=false --audit=false "rcedit@4.0.1"',
+    );
+    expect(workflow).toContain(
+      '$resolvedRceditDir = Join-Path $resolvedElectrobunDir "node_modules\\rcedit"',
+    );
+    expect(workflow).not.toContain('bun install -g "rcedit@4.0.1"');
   });
 
-  it("materializes a local electrobun package before packaging", () => {
+  it("stages the desktop bundle before restoring local electrobun caches", () => {
     const workflow = fs.readFileSync(WORKFLOW_PATH, "utf8");
+    const stageIndex = workflow.indexOf("name: Stage desktop bundle inputs");
+    const cacheIndex = workflow.indexOf(
+      "name: Cache local electrobun core downloads",
+    );
 
-    expect(workflow).toContain(
-      "name: Materialize local electrobun package for build",
-    );
-    expect(workflow).toContain(
-      "src = fs.realpathSync('node_modules/electrobun');",
-    );
-    expect(workflow).toContain(
-      "const dest = path.resolve('apps/app/electrobun/node_modules/electrobun');",
-    );
-    expect(workflow).toContain("fs.cpSync(src, dest, { recursive: true });");
+    expect(stageIndex).toBeGreaterThan(-1);
+    expect(cacheIndex).toBeGreaterThan(stageIndex);
     expect(workflow).toContain("name: Cache local electrobun core downloads");
     expect(workflow).toContain(
       "path: apps/app/electrobun/node_modules/electrobun/.cache",
     );
+    expect(workflow).not.toContain(
+      "name: Materialize local electrobun package for build",
+    );
+    expect(workflow).not.toContain(
+      'bun install -g "electrobun@$ELECTROBUN_VERSION"',
+    );
   });
 
-  it("caches whisper models for release builds and avoids repeated renderer reinstalls", () => {
+  it("caches whisper models for release builds and avoids workflow-local staging drift", () => {
     const workflow = fs.readFileSync(WORKFLOW_PATH, "utf8");
 
     expect(workflow).toContain("name: Cache Whisper models and binaries");
@@ -142,10 +190,12 @@ describe("Electrobun release workflow drift", () => {
     expect(workflow).toContain(
       "restore-keys: whisper-$" + "{{ matrix.platform.artifact-name }}-",
     );
-    // Vite build is now shared via artifact from validate-release
+    expect(workflow).toContain("name: Stage desktop bundle inputs");
     expect(workflow).toContain(
-      "# dist/ and apps/app/dist/ are downloaded from the shared build artifact",
+      "apps/app/electrobun/scripts/hdiutil-wrapper.sh",
     );
+    expect(workflow).toContain("ELECTROBUN_REAL_HDIUTIL: /usr/bin/hdiutil");
+    expect(workflow).not.toContain("MILADY_ELECTROBUN_NOTARIZE: 0");
   });
 
   it("keeps updater transport files off the public GitHub release asset list", () => {
@@ -166,48 +216,58 @@ describe("Electrobun release workflow drift", () => {
     expect(workflow).toContain("update-channel/");
   });
 
-  it("treats the staged macOS app as an intermediate signed bundle, not a notarized final artifact", () => {
+  it("treats the staged macOS app as a copied signed bundle and only signs the DMG", () => {
     const stageScript = fs.readFileSync(MACOS_STAGE_SCRIPT_PATH, "utf8");
 
+    expect(stageScript).toContain("Electrobun's");
     expect(stageScript).toContain(
-      "electrobun. Re-sign only what changed and keep the original entitlements",
-    );
-    expect(stageScript).toContain(
-      'codesign -d --entitlements :- "$STAGED_APP_PATH"',
-    );
-    expect(stageScript).toContain(
-      `--options runtime "\${entitlement_args[@]}" "$LAUNCHER_PATH"`,
-    );
-    expect(stageScript).toContain(
-      `--options runtime "\${entitlement_args[@]}" "$STAGED_APP_PATH"`,
+      'ditto "$APP_BUNDLE_PATH" "$STAGED_APP_PATH"',
     );
     expect(stageScript).toContain(
       'codesign --verify --deep --strict --verbose=2 "$STAGED_APP_PATH"',
     );
-    expect(stageScript).toContain("command_status=$?");
-    expect(stageScript).not.toContain(
-      'codesign --force --deep --timestamp --sign "$ELECTROBUN_DEVELOPER_ID" "$STAGED_APP_PATH"',
+    expect(stageScript).toContain("command_status=0");
+    expect(stageScript).toContain(
+      'codesign --force --timestamp --sign "$ELECTROBUN_DEVELOPER_ID" "$TEMP_DMG_PATH"',
     );
     expect(stageScript).not.toContain(
-      'spctl -a -vv --type exec "$STAGED_APP_PATH"',
+      'codesign -d --entitlements :- "$STAGED_APP_PATH"',
+    );
+    expect(stageScript).not.toContain(
+      'codesign --force --timestamp --sign "$ELECTROBUN_DEVELOPER_ID" --options runtime "${entitlement_args[@]}" "$STAGED_APP_PATH"',
     );
     expect(stageScript).toContain("xcrun notarytool submit \\");
     expect(stageScript).toContain('xcrun stapler staple "$TEMP_DMG_PATH"');
   });
 
-  it("rebuilds the staged macOS direct launcher with the packaged launcher architecture", () => {
-    const stageScript = fs.readFileSync(MACOS_STAGE_SCRIPT_PATH, "utf8");
+  it("rebuilds the direct launcher in the macOS postBuild hook", () => {
+    const postBuildScript = fs.readFileSync(
+      MACOS_POSTBUILD_SIGN_SCRIPT_PATH,
+      "utf8",
+    );
 
-    expect(stageScript).toContain(
-      'LAUNCHER_ARCHES="$(lipo -archs "$LAUNCHER_PATH" 2>/dev/null || true)"',
+    expect(postBuildScript).toContain(
+      'return path.join(path.dirname(scriptPath), "macos-direct-launcher.c");',
     );
-    expect(stageScript).toContain("clang_arch_args=()");
-    expect(stageScript).toContain('clang_arch_args+=(-arch "$arch")');
-    expect(stageScript).toContain(
-      'echo "stage-macos-release-artifacts: unsupported launcher architecture: $arch"',
+    expect(postBuildScript).toContain(
+      "const architectures = parseLauncherArchitectures(",
     );
-    // biome-ignore lint/suspicious/noTemplateCurlyInString: bash variable expansion in shell script assertion
-    expect(stageScript).toContain('"${clang_arch_args[@]}"');
+    expect(postBuildScript).toContain(
+      'execText("lipo", ["-archs", launcherPath]',
+    );
+    expect(postBuildScript).toContain('"/usr/bin/clang"');
+    expect(postBuildScript).toContain(
+      "runtime-sign: unsupported launcher architecture:",
+    );
+    expect(postBuildScript).toContain(
+      "const launcherPath = installLauncher(buildBundlePath);",
+    );
+    expect(postBuildScript).toContain(
+      "if (!signFile(launcherPath, developerId)) {",
+    );
+    expect(postBuildScript).toContain(
+      "[runtime-sign] rebuilt direct launcher at",
+    );
   });
 
   it("pins the native macOS effects build to C++17", () => {
@@ -274,6 +334,7 @@ describe("Electrobun release workflow drift", () => {
       "MILADY_TEST_WINDOWS_LAUNCHER_PATH_FILE: $" +
         "{{ runner.temp }}\\milady-windows-ui-launcher.txt",
     );
+    expect(workflow).toContain('MILADY_DISABLE_LOCAL_EMBEDDINGS: "1"');
     expect(workflow).toContain(
       'Add-Content -Path $env:GITHUB_ENV -Value "MILADY_TEST_WINDOWS_LAUNCHER_PATH=$launcherPath"',
     );
@@ -320,6 +381,7 @@ describe("Electrobun release workflow drift", () => {
     expect(workflow).toContain(
       "bunx playwright test --config playwright.electrobun.packaged.config.ts test/electrobun-packaged/electrobun-windows-startup.e2e.spec.ts",
     );
+    expect(workflow).toContain('MILADY_DISABLE_LOCAL_EMBEDDINGS: "1"');
     expect(workflow).not.toContain(
       "name: Install Playwright Chromium (Windows)",
     );

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -26,18 +26,19 @@ const requiredWorkflowSnippets = [
   "bun-version: $" + "{{ env.BUN_VERSION }}",
   "name: Release readiness checks",
   "run: bun run release:check",
+  "key: bun-electrobun-validate-${{ hashFiles('bun.lock') }}",
+  "restore-keys: bun-electrobun-validate-",
   "name: Ensure avatar assets",
   "node scripts/ensure-avatars.mjs",
   "Install quiet macOS packaging wrappers",
+  "apps/app/electrobun/scripts/hdiutil-wrapper.sh",
   "apps/app/electrobun/scripts/xcrun-wrapper.sh",
   "apps/app/electrobun/scripts/zip-wrapper.sh",
+  "ELECTROBUN_REAL_HDIUTIL: /usr/bin/hdiutil",
   "ELECTROBUN_REAL_XCRUN: /usr/bin/xcrun",
   "ELECTROBUN_REAL_ZIP: /usr/bin/zip",
-  "Stage renderer for Electrobun bundle",
-  "cp -r apps/app/dist apps/app/electrobun/renderer",
-  "Inject version.json into bundle (Windows)",
-  "Inject version.json into bundle (macOS / Linux)",
-  '"identifier":"com.miladyai.milady"',
+  "Stage desktop bundle inputs",
+  "node scripts/desktop-build.mjs stage --variant=base --build-whisper",
   "Stage standard macOS release app",
   "apps/app/electrobun/scripts/stage-macos-release-artifacts.sh",
   "retry_stapler_validate()",
@@ -61,15 +62,30 @@ const requiredWorkflowSnippets = [
   "$expectedHash = $asset.digest.Substring(7).ToLowerInvariant()",
   "$actualHash = (Get-FileHash -Path $tarPath -Algorithm SHA256).Hash.ToLowerInvariant()",
   "electrobun CLI checksum mismatch",
-  "name: Materialize local electrobun package for build",
-  "src = fs.realpathSync('node_modules/electrobun');",
-  "const dest = path.resolve('apps/app/electrobun/node_modules/electrobun');",
-  "fs.cpSync(src, dest, { recursive: true });",
+  "process.stdout.write(fs.realpathSync(packageDir));",
+  'Write-Host "Resolved electrobun package dir: $resolvedElectrobunDir"',
+  '$cacheDir     = Join-Path $resolvedElectrobunDir ".cache"',
+  "name: Restore Bun install cache (Windows)",
+  "uses: actions/cache/restore@v4",
+  "Installing local rcedit helper under Electrobun...",
+  'npm install --prefix $resolvedElectrobunDir --no-save --no-package-lock --ignore-scripts --fund=false --audit=false "rcedit@4.0.1"',
+  '$resolvedRceditDir = Join-Path $resolvedElectrobunDir "node_modules\\rcedit"',
+  "node scripts/desktop-build.mjs package --env=${{ needs.prepare.outputs.env }}",
+  'MILADY_DISABLE_LOCAL_EMBEDDINGS: "1"',
+  'Join-Path $PWD "apps/app/electrobun/node_modules/electrobun"',
+  "function Resolve-RceditPackageJson([string]$packageDir)",
 ];
-const forbiddenWorkflowSnippets = [' -name "*.exe" -o \\'];
+const forbiddenWorkflowSnippets = [
+  ' -name "*.exe" -o \\',
+  "Inject version.json into bundle (Windows)",
+  "Inject version.json into bundle (macOS / Linux)",
+  'bun install -g "rcedit@4.0.1"',
+  "MILADY_ELECTROBUN_NOTARIZE: 0",
+];
 const requiredElectrobunConfigSnippets = [
   'postBuild: "scripts/postwrap-sign-runtime-macos.ts"',
   'postWrap: "scripts/postwrap-diagnostics.ts"',
+  'notarize: process.env.ELECTROBUN_SKIP_CODESIGN !== "1"',
 ];
 const localPackHotspotPaths = [
   "dist/node_modules",
@@ -347,6 +363,44 @@ function assertElectrobunConfigHasPostWrapSigner() {
   }
 }
 
+function assertMacPostBuildHookLooksCorrect() {
+  const script = readFileSync(
+    "apps/app/electrobun/scripts/postwrap-sign-runtime-macos.ts",
+    "utf8",
+  );
+  const requiredSnippets = [
+    'return path.join(path.dirname(scriptPath), "macos-direct-launcher.c");',
+    "export function parseLauncherArchitectures",
+    "runtime-sign: unsupported launcher architecture:",
+    "export function buildDirectLauncherCompileArgs",
+    'execText("lipo", ["-archs", launcherPath], execFile)',
+    "export function installDirectLauncher",
+    "export function signBuildBundleArtifacts",
+    "const launcherPath = installLauncher(buildBundlePath);",
+    "if (!signFile(launcherPath, developerId)) {",
+    "[runtime-sign] rebuilt direct launcher at",
+  ];
+  const missing = requiredSnippets.filter(
+    (snippet) => !script.includes(snippet),
+  );
+  const requiredPatterns = [
+    /buildDirectLauncherCompileArgs\(\s*sourcePath,\s*tempLauncherPath,\s*architectures,\s*\)/m,
+  ];
+  const missingPatterns = requiredPatterns
+    .filter((pattern) => !pattern.test(script))
+    .map((pattern) => pattern.toString());
+
+  if (missing.length > 0 || missingPatterns.length > 0) {
+    console.error(
+      "release-check: macOS postBuild signer is missing launcher rebuild wiring:",
+    );
+    for (const snippet of [...missing, ...missingPatterns]) {
+      console.error(`  - ${snippet}`);
+    }
+    process.exit(1);
+  }
+}
+
 function assertMacArtifactStagerLooksCorrect() {
   const script = readFileSync(
     "apps/app/electrobun/scripts/stage-macos-release-artifacts.sh",
@@ -355,14 +409,10 @@ function assertMacArtifactStagerLooksCorrect() {
   const requiredSnippets = [
     'find "$ARTIFACTS_DIR" -maxdepth 1 -type f -name "*-macos-*.app.tar.zst"',
     "no macOS updater tarball found",
-    'DIRECT_LAUNCHER_SOURCE="$SCRIPT_DIR/macos-direct-launcher.c"',
-    'codesign -d --entitlements :- "$STAGED_APP_PATH"',
-    "/usr/bin/clang \\",
-    'install -m 0755 "$TMP_LAUNCHER_PATH" "$LAUNCHER_PATH"',
-    `--options runtime "\${entitlement_args[@]}" "$LAUNCHER_PATH"`,
-    `--options runtime "\${entitlement_args[@]}" "$STAGED_APP_PATH"`,
+    'ditto "$APP_BUNDLE_PATH" "$STAGED_APP_PATH"',
     'codesign --verify --deep --strict --verbose=2 "$STAGED_APP_PATH"',
     "hdiutil create \\",
+    'codesign --force --timestamp --sign "$ELECTROBUN_DEVELOPER_ID" "$TEMP_DMG_PATH"',
     "retry_command 3 20 xcrun notarytool submit \\",
     'retry_command 5 15 xcrun stapler staple "$TEMP_DMG_PATH"',
     'mv "$TEMP_DMG_PATH" "$FINAL_DMG_PATH"',
@@ -382,7 +432,10 @@ function assertMacArtifactStagerLooksCorrect() {
   }
 
   const forbiddenSnippets = [
-    'codesign --force --deep --timestamp --sign "$ELECTROBUN_DEVELOPER_ID" "$STAGED_APP_PATH"',
+    'DIRECT_LAUNCHER_SOURCE="$SCRIPT_DIR/macos-direct-launcher.c"',
+    'codesign -d --entitlements :- "$STAGED_APP_PATH"',
+    "/usr/bin/clang \\",
+    'install -m 0755 "$TMP_LAUNCHER_PATH" "$LAUNCHER_PATH"',
     "exit_code=$?",
   ];
   const forbidden = forbiddenSnippets.filter((snippet) =>
@@ -505,6 +558,7 @@ function assertMacSmokeScriptLaunchesPackagedLauncherDirectly() {
 function main() {
   assertReleaseWorkflowHasNotaryWrapper();
   assertElectrobunConfigHasPostWrapSigner();
+  assertMacPostBuildHookLooksCorrect();
   assertMacArtifactStagerLooksCorrect();
   assertWindowsSmokeScriptHasLeadingParamBlock();
   assertMacSmokeScriptLaunchesPackagedLauncherDirectly();


### PR DESCRIPTION
## Summary
- harden the Electrobun release workflow and release checks around local package materialization, rcedit resolution, Windows cache handling, and macOS post-build signing/staging
- add/refresh the release-focused regression coverage for the postBuild signer, artifact stager, workflow drift checks, runtime node_modules copy logic, and desktop build script
- keep the release guard robust to formatter-induced line wrapping in the macOS launcher rebuild check

## Testing
- bunx vitest run apps/app/electrobun/src/__tests__/postwrap-sign-runtime-macos.test.ts apps/app/electrobun/src/__tests__/stage-macos-release-artifacts.test.ts scripts/copy-runtime-node-modules.test.ts scripts/desktop-build-script.test.ts scripts/electrobun-release-workflow-drift.test.ts scripts/release-check.test.ts
- bun run release:check
- bun run typecheck
- bun run lint
- bun run pre-review:local

## Notes
- bun run lint still reports the existing branch-baseline Biome warnings/internal panics in unrelated files, but exits 0 for this branch state and pre-review approved it
- this branch was split out of the recovered stash so the wallet/app fixes could land separately in #1009