### PR TITLE
fix: resolve 18 bugs from Test Milady 0.88 QA report

### DIFF
--- a/apps/app/plugins/talkmode/src/web.ts
+++ b/apps/app/plugins/talkmode/src/web.ts
@@ -194,12 +194,14 @@ export class TalkModeWeb extends WebPlugin {
       const utterance = new SpeechSynthesisUtterance(text);
       this.currentUtterance = utterance;
 
+      // Always set language — fallback to en-US if directive doesn't specify.
+      // Without this, the browser uses the system locale, which may read
+      // numbers in the wrong language (e.g., Chinese on a Chinese-locale system).
+      utterance.lang = options.directive?.language || "en-US";
+
       // Apply directive settings if available
       if (options.directive?.speed) {
         utterance.rate = options.directive.speed;
-      }
-      if (options.directive?.language) {
-        utterance.lang = options.directive.language;
       }
 
       utterance.onend = () => {

--- a/packages/app-core/src/api/client.ts
+++ b/packages/app-core/src/api/client.ts
@@ -2316,21 +2316,31 @@ export class MiladyClient {
     pairingEnabled: boolean;
     expiresAt: number | null;
   }> {
-    try {
-      return await this.fetch("/api/auth/status");
-    } catch (err: unknown) {
-      const status = (err as Error & { status?: number })?.status;
-      if (status === 401) {
-        // Server requires auth
-        return { required: true, pairingEnabled: false, expiresAt: null };
+    // Retry with exponential backoff — the server may not be ready during boot.
+    const maxRetries = 3;
+    const baseBackoffMs = 1000;
+    let lastErr: unknown;
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        return await this.fetch("/api/auth/status");
+      } catch (err: unknown) {
+        const status = (err as Error & { status?: number })?.status;
+        if (status === 401) {
+          return { required: true, pairingEnabled: false, expiresAt: null };
+        }
+        if (status === 404) {
+          return { required: false, pairingEnabled: false, expiresAt: null };
+        }
+        lastErr = err;
+        const kind = (err as Error & { kind?: string })?.kind;
+        if (kind === "timeout" && attempt < maxRetries) {
+          await new Promise((r) => setTimeout(r, baseBackoffMs * 2 ** attempt));
+          continue;
+        }
+        if (attempt >= maxRetries) break;
       }
-      if (status === 404) {
-        // npm-installed server without auth routes — no auth required
-        return { required: false, pairingEnabled: false, expiresAt: null };
-      }
-      // Other errors (500, network) — re-throw so caller can handle
-      throw err;
     }
+    throw lastErr;
   }
 
   async pair(code: string): Promise<{ token: string }> {

--- a/packages/app-core/src/components/ConfigPageView.tsx
+++ b/packages/app-core/src/components/ConfigPageView.tsx
@@ -468,18 +468,19 @@ export function ConfigPageView({ embedded = false }: { embedded?: boolean }) {
   }, []);
 
   /* ── RPC provider selection state ──────────────────────────────────── */
+  const initialRpc = resolveInitialWalletRpcSelections(walletConfig);
   const [selectedEvmRpc, setSelectedEvmRpc] =
-    useState<WalletRpcSelections["evm"]>("eliza-cloud");
+    useState<WalletRpcSelections["evm"]>(initialRpc.evm);
   const [selectedBscRpc, setSelectedBscRpc] =
-    useState<WalletRpcSelections["bsc"]>("eliza-cloud");
+    useState<WalletRpcSelections["bsc"]>(initialRpc.bsc);
   const [selectedSolanaRpc, setSelectedSolanaRpc] =
-    useState<WalletRpcSelections["solana"]>("eliza-cloud");
+    useState<WalletRpcSelections["solana"]>(initialRpc.solana);
 
   useEffect(() => {
-    const initialSelections = resolveInitialWalletRpcSelections(walletConfig);
-    setSelectedEvmRpc(initialSelections.evm);
-    setSelectedBscRpc(initialSelections.bsc);
-    setSelectedSolanaRpc(initialSelections.solana);
+    const selections = resolveInitialWalletRpcSelections(walletConfig);
+    setSelectedEvmRpc(selections.evm);
+    setSelectedBscRpc(selections.bsc);
+    setSelectedSolanaRpc(selections.solana);
   }, [walletConfig]);
 
   const handleWalletSaveAll = useCallback(() => {

--- a/packages/app-core/src/components/PluginsView.tsx
+++ b/packages/app-core/src/components/PluginsView.tsx
@@ -1949,6 +1949,8 @@ function PluginListView({ label, mode = "all", inModal }: PluginListViewProps) {
       setConnectorSelectedId(pluginId);
       setConnectorExpandedIds((prev) => {
         if (desktopConnectorLayout) {
+          // Accordion: toggle off if already open, otherwise open this one only
+          if (prev.has(pluginId)) return new Set();
           return new Set([pluginId]);
         }
         const next = new Set(prev);
@@ -2725,6 +2727,10 @@ function PluginListView({ label, mode = "all", inModal }: PluginListViewProps) {
             <div className="relative flex-1 min-w-[220px]">
               <Input
                 type="text"
+                name="plugin-search"
+                autoComplete="off"
+                data-1p-ignore
+                data-lpignore="true"
                 className="w-full bg-card/60 backdrop-blur-md shadow-inner pr-8 h-9 rounded-xl focus-visible:ring-accent border-border/40"
                 placeholder={searchPlaceholder}
                 value={pluginSearch}

--- a/packages/app-core/src/components/shared/ShellHeaderControls.tsx
+++ b/packages/app-core/src/components/shared/ShellHeaderControls.tsx
@@ -120,7 +120,7 @@ export function ShellHeaderControls({
     >
       <div className="flex shrink-0 items-center">
         <fieldset
-          className="inline-flex items-center gap-0.5 rounded-xl border border-border/60 bg-transparent p-0.5 shadow-sm dark:border-border/70 dark:bg-transparent"
+          className="inline-flex items-center gap-0.5 rounded-xl border border-border/60 bg-transparent p-0.5 shadow-sm dark:border-border dark:bg-transparent"
           data-testid="ui-shell-toggle"
           aria-label="Switch shell view"
         >

--- a/packages/app-core/src/config/config-field.tsx
+++ b/packages/app-core/src/config/config-field.tsx
@@ -98,17 +98,14 @@ function PasswordFieldInner({ fp: props }: { fp: FieldRenderProps }) {
 
   const [visible, setVisible] = useState(false);
   const [busy, setBusy] = useState(false);
+  const [fieldValue, setFieldValue] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
   const onReveal = props.onReveal;
 
   const handleToggle = useCallback(async () => {
-    const input = inputRef.current;
-    if (!input) return;
-
     if (visible) {
-      // Currently showing -- hide it
+      // Hide — just toggle visibility, value stays in React state
       setVisible(false);
-      input.value = "";
       return;
     }
 
@@ -119,13 +116,14 @@ function PasswordFieldInner({ fp: props }: { fp: FieldRenderProps }) {
       setBusy(false);
       if (realValue != null) {
         setVisible(true);
-        input.value = realValue;
+        setFieldValue(realValue);
+        props.onChange(realValue);
       }
     } else {
       // Fallback: just toggle type (shows whatever is in the input)
       setVisible(true);
     }
-  }, [visible, onReveal]);
+  }, [visible, onReveal, props]);
 
   return (
     <div className="flex">
@@ -133,11 +131,12 @@ function PasswordFieldInner({ fp: props }: { fp: FieldRenderProps }) {
         ref={inputRef}
         className="flex-1 px-3 py-2 border border-[var(--border)] border-r-0 bg-[var(--card)] text-[13px] font-[var(--mono)] transition-all focus:border-[var(--accent)] focus:outline-none focus:ring-1 focus:ring-[var(--accent)] box-border h-[36px] rounded-l-sm placeholder:text-[var(--muted)] placeholder:opacity-60"
         type={visible ? "text" : "password"}
-        defaultValue=""
+        value={fieldValue}
         placeholder={placeholder}
         data-config-key={props.key}
         data-field-type="password"
         onChange={(e) => {
+          setFieldValue(e.target.value);
           props.onChange(e.target.value);
           fireAction(props, "change");
         }}

--- a/packages/app-core/src/state/AppContext.tsx
+++ b/packages/app-core/src/state/AppContext.tsx
@@ -926,6 +926,8 @@ export function AppProvider({ children }: { children: ReactNode }) {
 
   // --- Refs for timers ---
   const actionNoticeTimer = useRef<number | null>(null);
+  /** Session-scoped set of notice texts that have been shown with once=true. */
+  const shownOnceNotices = useRef<Set<string>>(new Set());
   const elizaCloudPollInterval = useRef<number | null>(null);
   const elizaCloudLoginPollTimer = useRef<number | null>(null);
   const prevAgentStateRef = useRef<string | null>(null);
@@ -989,7 +991,10 @@ export function AppProvider({ children }: { children: ReactNode }) {
       text: string,
       tone: "info" | "success" | "error" = "info",
       ttlMs = 2800,
+      once = false,
     ) => {
+      if (once && shownOnceNotices.current.has(text)) return;
+      if (once) shownOnceNotices.current.add(text);
       setActionNoticeState({ tone, text });
       if (actionNoticeTimer.current != null) {
         window.clearTimeout(actionNoticeTimer.current);
@@ -3092,6 +3097,24 @@ export function AppProvider({ children }: { children: ReactNode }) {
         conversationMessagesRef.current.length > 0
       )
         return;
+
+      // Clean up empty conversations: if the previous conversation has only
+      // system/greeting messages and no user messages, delete it silently.
+      const prevId = activeConversationId;
+      if (prevId && prevId !== id) {
+        const prevMessages = conversationMessagesRef.current;
+        const hasUserMessage = prevMessages.some((m) => m.role === "user");
+        if (!hasUserMessage && prevMessages.length <= 1) {
+          void client.deleteConversation(prevId).catch(() => {});
+          setConversations((prev) => prev.filter((c) => c.id !== prevId));
+          setUnreadConversations((prev) => {
+            const next = new Set(prev);
+            next.delete(prevId);
+            return next;
+          });
+        }
+      }
+
       const previousActive = activeConversationId;
       setActiveConversationId(id);
       activeConversationIdRef.current = id;

--- a/packages/autonomous/src/api/server.ts
+++ b/packages/autonomous/src/api/server.ts
@@ -13070,11 +13070,20 @@ async function handleRequest(
     const pending = state.conversationRestorePromise;
     if (!pending) return;
     try {
-      await pending;
+      const timeout = new Promise<void>((_, reject) =>
+        setTimeout(
+          () =>
+            reject(
+              new Error("Conversation restore timed out after 5000ms"),
+            ),
+          5000,
+        ),
+      );
+      await Promise.race([pending, timeout]);
     } catch {
-      // Restore failures are logged at the source. Routes should continue with
-      // the best available in-memory state instead of surfacing the restore
-      // implementation detail as an API error.
+      // Restore failures (including timeout) are logged at the source.
+      // Routes should continue with the best available in-memory state
+      // instead of surfacing the restore implementation detail as an API error.
     }
   };
 

--- a/packages/autonomous/src/cloud/validate-url.ts
+++ b/packages/autonomous/src/cloud/validate-url.ts
@@ -149,6 +149,11 @@ export async function validateCloudBaseUrl(
     return `Cloud base URL "${rawUrl}" points to a blocked local hostname.`;
   }
 
+  // Dev-mode bypass: skip IP-range blocking but keep URL format checks above.
+  if (process.env.NODE_ENV === "development" || process.env.MILADY_DEV) {
+    return null;
+  }
+
   if (isBlockedIp(hostname)) {
     return `Cloud base URL "${rawUrl}" points to a blocked address.`;
   }

--- a/packages/autonomous/src/runtime/trajectory-persistence.ts
+++ b/packages/autonomous/src/runtime/trajectory-persistence.ts
@@ -767,6 +767,25 @@ async function ensureTrajectoriesTable(
       // ignore when column already exists
     }
 
+    // Best-effort forward migration: add scenario_id column + index
+    // (referenced by upstream elizaOS core or external plugins).
+    try {
+      await executeRawSql(
+        runtime,
+        `ALTER TABLE trajectories ADD COLUMN scenario_id TEXT`,
+      );
+    } catch {
+      // ignore when column already exists
+    }
+    try {
+      await executeRawSql(
+        runtime,
+        `CREATE INDEX IF NOT EXISTS idx_trajectories_scenario_id ON trajectories(scenario_id)`,
+      );
+    } catch {
+      // ignore if index creation fails
+    }
+
     if (needsRecreate) {
       console.warn(
         "[trajectory-persistence] Recreated trajectories table with updated schema",

--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -21,8 +21,8 @@ const buttonVariants = cva(
       },
       size: {
         default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
+        sm: "h-9 rounded-md px-3 py-1.5",
+        lg: "h-11 rounded-md px-8 py-2.5",
         icon: "h-10 w-10",
       },
     },

--- a/src/plugins/telegram-enhanced/service.ts
+++ b/src/plugins/telegram-enhanced/service.ts
@@ -22,11 +22,21 @@ export class TelegramEnhancedService extends (TelegramService as any) {
     (TelegramService as any).serviceType;
 
   static async start(runtime: unknown) {
-    // biome-ignore lint/suspicious/noExplicitAny: untyped external module returns unknown shape
-    const service = (await (TelegramService as any).start(runtime)) as Record<
-      string,
-      unknown
-    >;
+    let service: Record<string, unknown>;
+    try {
+      // biome-ignore lint/suspicious/noExplicitAny: untyped external module returns unknown shape
+      service = (await (TelegramService as any).start(runtime)) as Record<
+        string,
+        unknown
+      >;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(
+        `[telegram-enhanced] Failed to initialize Telegram plugin: ${msg}. ` +
+          "Check bot token and Telegram config.",
+      );
+      return null;
+    }
     if (service?.bot) {
       // biome-ignore lint/suspicious/noExplicitAny: EnhancedTelegramMessageManager extends untyped base class
       service.messageManager = new (EnhancedTelegramMessageManager as any)(

--- a/src/runtime/embedding-manager.ts
+++ b/src/runtime/embedding-manager.ts
@@ -77,6 +77,8 @@ export class MiladyEmbeddingManager {
   private inFlightCount = 0;
   /** Serialized unload promise — prevents generateEmbedding from using resources being disposed. */
   private unloading: Promise<void> | null = null;
+  /** Promise-based drain for dispose() to wait on in-flight calls. */
+  private drainResolve: (() => void) | null = null;
   /** Only write dimension metadata on the very first init (not idle re-inits). */
   private dimensionCheckDone = false;
 
@@ -97,14 +99,16 @@ export class MiladyEmbeddingManager {
       throw new Error("[milady] EmbeddingManager has been disposed");
     }
 
-    if (this.unloading) await this.unloading;
-
-    await this.ensureInitialized();
-
+    // Increment BEFORE any async operations to close TOCTOU window:
+    // dispose() checks inFlightCount, so we must be counted before awaiting.
     this.inFlightCount += 1;
     this.lastUsedAt = Date.now();
 
     try {
+      if (this.unloading) await this.unloading;
+
+      await this.ensureInitialized();
+
       if (!this.embeddingContext) {
         throw new Error("[milady] Embedding context not available after init");
       }
@@ -127,12 +131,23 @@ export class MiladyEmbeddingManager {
       return new Array(this.dimensions).fill(0);
     } finally {
       this.inFlightCount -= 1;
+      if (this.inFlightCount === 0 && this.drainResolve) {
+        this.drainResolve();
+      }
     }
   }
 
   async dispose(): Promise<void> {
     if (this.disposed) return;
     this.disposed = true;
+    // Wait for in-flight generateEmbedding() calls to finish (max 5s).
+    if (this.inFlightCount > 0) {
+      const drainPromise = new Promise<void>((resolve) => {
+        this.drainResolve = resolve;
+      });
+      const timeout = new Promise<void>((resolve) => setTimeout(resolve, 5000));
+      await Promise.race([drainPromise, timeout]);
+    }
     await this.releaseResources();
   }
 


### PR DESCRIPTION
## Summary

- **18 bugs** from the [Test Milady 0.88 QA report](https://www.notion.so/Test-Milady-0-88-325f1f07d80580de8919e6b26c5abc43) across 13 files
- Based on latest `upstream/develop`

### Critical Fixes
- **Password field toggle**: Convert to controlled React state — hide/show no longer erases bot tokens and API keys
- **Embedding disposal race**: Close TOCTOU window by moving `inFlightCount` before async ops; add promise-based drain in `dispose()`

### Conversation & Chat
- Add 5s timeout to conversation restore to prevent indefinite hangs
- Auto-delete empty conversations (no user messages) on navigation away

### UI/Visual
- Add explicit `py-*` to `sm`/`lg` button size variants for consistent hit targets
- Improve dark mode border visibility on shell header toggle
- Fix connector section collapse: allow toggling off in desktop accordion mode
- Add `autoComplete=off` and anti-autofill attrs to connector search input

### Config
- Initialize RPC provider selections from `walletConfig` at mount instead of hardcoded `"eliza-cloud"` defaults

### Backend
- Add `scenario_id` column + index migration to trajectories table (upstream compat)
- Retry auth status check with exponential backoff during boot
- Wrap Telegram plugin init with try-catch to prevent cascading errors

### i18n & UX
- Add `once` flag to `setActionNotice` for one-time error hints
- Set TTS `utterance.lang` explicitly to prevent system locale fallback
- Add dev-mode bypass for cloud URL IP blocking (after format checks, before DNS)

## Test plan

- [ ] Run `bun run check` — no new lint errors introduced
- [ ] Manual QA: toggle password show/hide on bot token field — value preserved
- [ ] Manual QA: click "New Chat", navigate away without typing — empty chat removed
- [ ] Manual QA: verify dark mode header toggle visibility
- [ ] Manual QA: connector section expand/collapse on desktop
- [ ] Manual QA: Settings page shows correct RPC provider after onboarding
- [ ] Manual QA: dev mode onboarding completes without blocked-address errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)