### PR TITLE
fix(security): rate limit, audit log, and delay for wallet key export

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -1,1 +1,23 @@
+// Re-export the full upstream server API.
 export * from "@elizaos/autonomous/api/server";
+
+// Override the wallet export rejection function with the hardened version
+// that adds rate limiting, audit logging, and a forced confirmation delay.
+import { resolveWalletExportRejection as upstreamResolveWalletExportRejection } from "@elizaos/autonomous/api/server";
+import { createHardenedExportGuard } from "./wallet-export-guard";
+
+const _hardenedGuard = createHardenedExportGuard(
+  upstreamResolveWalletExportRejection,
+);
+
+/**
+ * Hardened wallet export rejection function.
+ *
+ * Wraps the upstream token validation with per-IP rate limiting (1 per 10 min),
+ * audit logging (IP + UA), and a 10s confirmation delay via single-use nonces.
+ */
+export function resolveWalletExportRejection(
+  ...args: Parameters<typeof upstreamResolveWalletExportRejection>
+): ReturnType<typeof upstreamResolveWalletExportRejection> {
+  return _hardenedGuard(...args);
+}

--- a/src/api/wallet-export-guard.test.ts
+++ b/src/api/wallet-export-guard.test.ts
@@ -6,10 +6,7 @@ import {
   getWalletExportAuditLog,
 } from "./wallet-export-guard";
 
-function mockReq(
-  ip = "192.168.1.1",
-  ua = "test-agent",
-): http.IncomingMessage {
+function mockReq(ip = "192.168.1.1", ua = "test-agent"): http.IncomingMessage {
   return {
     headers: { "user-agent": ua },
     socket: { remoteAddress: ip },
@@ -193,13 +190,15 @@ describe("wallet-export-guard", () => {
     const log = getWalletExportAuditLog();
     expect(log.length).toBeGreaterThanOrEqual(2);
 
-    const rejected = log.find((e) => e.ip === "10.0.0.4" && e.outcome === "rejected");
+    const rejected = log.find(
+      (e) => e.ip === "10.0.0.4" && e.outcome === "rejected",
+    );
     expect(rejected).toBeDefined();
     expect(rejected!.userAgent).toBe("AuditTestAgent");
     expect(rejected!.timestamp).toMatch(/^\d{4}-/);
   });
 
-  it("reads X-Forwarded-For for IP when present", () => {
+  it("ignores X-Forwarded-For and uses socket.remoteAddress", () => {
     const guard = createHardenedExportGuard(alwaysAllow);
     const req = {
       headers: {
@@ -213,6 +212,25 @@ describe("wallet-export-guard", () => {
 
     const log = getWalletExportAuditLog();
     const latest = log[log.length - 1];
-    expect(latest.ip).toBe("203.0.113.50");
+    // XFF is untrusted — must use socket address
+    expect(latest.ip).toBe("127.0.0.1");
+  });
+
+  it("rejects nonce issuance when per-IP nonce cap is reached", () => {
+    const guard = createHardenedExportGuard(alwaysAllow);
+    const req = mockReq("10.0.0.50");
+
+    // Issue 3 nonces (the cap)
+    for (let i = 0; i < 3; i++) {
+      const result = guard(req, { confirm: true, requestNonce: true });
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe(403);
+    }
+
+    // 4th should be rejected with 429
+    const result = guard(req, { confirm: true, requestNonce: true });
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(429);
+    expect(result!.reason).toContain("Too many pending");
   });
 });

--- a/src/api/wallet-export-guard.ts
+++ b/src/api/wallet-export-guard.ts
@@ -11,6 +11,7 @@
  * keys without leaving an audit trail and hitting rate limits.
  */
 
+import crypto from "node:crypto";
 import type http from "node:http";
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -58,11 +59,12 @@ if (typeof sweepTimer === "object" && "unref" in sweepTimer) {
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
+/**
+ * Get client IP from the socket directly. X-Forwarded-For is not trusted
+ * because this is a local server — trusting XFF would let attackers spoof
+ * IPs to bypass rate limits and nonce IP binding.
+ */
 function getClientIp(req: http.IncomingMessage): string {
-  const forwarded = req.headers["x-forwarded-for"];
-  if (typeof forwarded === "string") {
-    return forwarded.split(",")[0].trim();
-  }
   return req.socket?.remoteAddress ?? "unknown";
 }
 
@@ -91,14 +93,7 @@ function recordAudit(entry: WalletExportAuditEntry): void {
   }
 
   const logLine = `[wallet-export-audit] ${entry.outcome} ip=${entry.ip} ua="${entry.userAgent}"${entry.reason ? ` reason="${entry.reason}"` : ""}`;
-
-  if (entry.outcome === "allowed") {
-    // Use console.warn so it's visible in production logs (logger may
-    // be suppressed at info level in packaged builds).
-    console.warn(logLine);
-  } else {
-    console.warn(logLine);
-  }
+  console.warn(logLine);
 }
 
 /** Read-only snapshot of the audit log for diagnostics endpoints. */
@@ -116,21 +111,16 @@ export function _resetForTesting(): void {
 // ── Confirmation delay ───────────────────────────────────────────────────────
 
 const EXPORT_DELAY_MS = 10_000; // 10 seconds
+const MAX_PENDING_NONCES_PER_IP = 3;
 
 /**
  * Issue a time-limited export nonce.  The client must wait at least
  * EXPORT_DELAY_MS before submitting the actual export request with this nonce.
  */
-const pendingExportNonces = new Map<
-  string,
-  { issuedAt: number; ip: string }
->();
+const pendingExportNonces = new Map<string, { issuedAt: number; ip: string }>();
 const NONCE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
-function issueExportNonce(ip: string): string {
-  const nonce = `wxn_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
-  pendingExportNonces.set(nonce, { issuedAt: Date.now(), ip });
-
+function issueExportNonce(ip: string): string | null {
   // Sweep expired nonces
   const now = Date.now();
   for (const [key, value] of pendingExportNonces) {
@@ -138,6 +128,19 @@ function issueExportNonce(ip: string): string {
       pendingExportNonces.delete(key);
     }
   }
+
+  // Cap pending nonces per IP to prevent unbounded growth from repeated
+  // requestNonce calls (which are rate-limit-exempt).
+  let countForIp = 0;
+  for (const entry of pendingExportNonces.values()) {
+    if (entry.ip === ip) countForIp++;
+  }
+  if (countForIp >= MAX_PENDING_NONCES_PER_IP) {
+    return null;
+  }
+
+  const nonce = `wxn_${crypto.randomBytes(16).toString("hex")}`;
+  pendingExportNonces.set(nonce, { issuedAt: Date.now(), ip });
 
   return nonce;
 }
@@ -221,6 +224,19 @@ export function createHardenedExportGuard(
     // 2. Nonce/delay flow — nonce requests are always allowed (no rate limit)
     if (body.requestNonce) {
       const nonce = issueExportNonce(ip);
+      if (!nonce) {
+        recordAudit({
+          timestamp: new Date().toISOString(),
+          ip,
+          userAgent: ua,
+          outcome: "rejected",
+          reason: "Too many pending nonces for this IP",
+        });
+        return {
+          status: 429,
+          reason: `Too many pending export requests. Complete or wait for existing nonces to expire.`,
+        };
+      }
       recordAudit({
         timestamp: new Date().toISOString(),
         ip,
@@ -271,9 +287,7 @@ export function createHardenedExportGuard(
     if (rateLimitEntry) {
       const elapsed = Date.now() - rateLimitEntry.lastExportAt;
       if (elapsed < RATE_LIMIT_WINDOW_MS) {
-        const retryAfter = Math.ceil(
-          (RATE_LIMIT_WINDOW_MS - elapsed) / 1000,
-        );
+        const retryAfter = Math.ceil((RATE_LIMIT_WINDOW_MS - elapsed) / 1000);
         recordAudit({
           timestamp: new Date().toISOString(),
           ip,


### PR DESCRIPTION
## Summary
- `/api/wallet/export` exports raw private keys with only a token check — no rate limiting, no audit trail, no confirmation delay. A compromised session = instant key extraction.
- Adds `createHardenedExportGuard()` that wraps the upstream validation with:
  - **10s mandatory confirmation delay**: two-phase nonce flow — request nonce, wait 10s, submit nonce
  - **1-per-10min rate limit** per IP on successful exports
  - **Audit log** with IP, User-Agent, timestamp for every attempt (allowed/rejected/rate-limited)
  - **IP-bound single-use nonces** to prevent replay from different clients

## Test plan
- [x] 12 unit tests covering all guard behaviors (all passing)
- [ ] Upstream rejection still works (invalid token → 403)
- [ ] Nonce issuance returns countdown JSON
- [ ] Export rejected before 10s delay
- [ ] Export allowed after 10s delay
- [ ] Rate limited after successful export
- [ ] Rate limit clears after 10 minutes
- [ ] Nonce rejected from different IP
- [ ] Expired/invalid nonce rejected
- [ ] Nonce consumed after single use
- [ ] Audit log records all outcomes with IP + UA

🤖 Generated with [Claude Code](https://claude.com/claude-code)