### PR TITLE
feat: cloud control plane dashboard for homepage

### DIFF
--- a/apps/homepage/apps/homepage/src/generated/release-data.ts
+++ b/apps/homepage/apps/homepage/src/generated/release-data.ts
@@ -1,0 +1,57 @@
+export const releaseData = {
+  generatedAt: "2026-03-18T10:48:47.497Z",
+  scripts: {
+    shell: {
+      url: "https://milady.ai/install.sh",
+      command: "curl -fsSL https://milady.ai/install.sh | bash",
+    },
+    powershell: {
+      url: "https://milady.ai/install.ps1",
+      command: "irm https://milady.ai/install.ps1 | iex",
+    },
+  },
+  release: {
+    tagName: "v2.0.0-alpha.87",
+    publishedAtLabel: "Mar 15, 2026",
+    prerelease: true,
+    url: "https://github.com/milady-ai/milady/releases/tag/v2.0.0-alpha.87",
+    downloads: [
+      {
+        id: "macos-arm64",
+        label: "macOS (Apple Silicon)",
+        fileName: "canary-macos-arm64-Milady-canary.dmg",
+        url: "https://github.com/milady-ai/milady/releases/download/v2.0.0-alpha.87/canary-macos-arm64-Milady-canary.dmg",
+        sizeLabel: "567.5 MB",
+        note: "DMG installer",
+      },
+      {
+        id: "macos-x64",
+        label: "macOS (Intel)",
+        fileName: "canary-macos-x64-Milady-canary.dmg",
+        url: "https://github.com/milady-ai/milady/releases/download/v2.0.0-alpha.87/canary-macos-x64-Milady-canary.dmg",
+        sizeLabel: "579.9 MB",
+        note: "DMG installer",
+      },
+      {
+        id: "windows-x64",
+        label: "Windows",
+        fileName: "Milady-Setup-canary.exe",
+        url: "https://github.com/milady-ai/milady/releases/download/v2.0.0-alpha.87/Milady-Setup-canary.exe",
+        sizeLabel: "415.0 KB",
+        note: "Release asset",
+      },
+      {
+        id: "linux-x64",
+        label: "Linux",
+        fileName: "canary-linux-x64-Milady-canary-Setup.tar.gz",
+        url: "https://github.com/milady-ai/milady/releases/download/v2.0.0-alpha.87/canary-linux-x64-Milady-canary-Setup.tar.gz",
+        sizeLabel: "637.0 MB",
+        note: "tar.gz package",
+      },
+    ],
+    checksum: {
+      fileName: "SHA256SUMS.txt",
+      url: "https://github.com/milady-ai/milady/releases/download/v2.0.0-alpha.87/SHA256SUMS.txt",
+    },
+  },
+} as const;

--- a/apps/homepage/package.json
+++ b/apps/homepage/package.json
@@ -11,12 +11,13 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@tailwindcss/typography": "^0.5.19",
     "@pixiv/three-vrm": "^3.5.0",
     "@react-three/fiber": "^9.5.0",
+    "@tailwindcss/typography": "^0.5.19",
     "framer-motion": "^12.34.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-router-dom": "^7.13.1",
     "three": "^0.183.2"
   },
   "devDependencies": {

--- a/apps/homepage/src/App.tsx
+++ b/apps/homepage/src/App.tsx
@@ -3,10 +3,9 @@ import { DownloadIcons } from "./components/DownloadIcons";
 import { Features } from "./components/Features";
 import { Footer } from "./components/Footer";
 import { HeroBackground } from "./components/Hero";
-import { Nav } from "./components/Nav";
 import { Privacy } from "./components/Privacy";
 
-export function App() {
+export function Homepage() {
   return (
     <div
       id="top"
@@ -22,11 +21,8 @@ export function App() {
           <HeroBackground />
         </div>
 
-        {/* LAYER 2: Foreground UI (Nav, Download Icons) */}
+        {/* LAYER 2: Foreground UI (Download Icons) */}
         <div className="absolute top-0 left-0 right-0 z-30 pointer-events-none">
-          <div className="pointer-events-auto">
-            <Nav />
-          </div>
           <div className="w-full min-h-screen flex items-end justify-center pb-6 sm:pb-10 px-4 pointer-events-auto">
             <DownloadIcons />
           </div>

--- a/apps/homepage/src/__tests__/agent-provider.test.tsx
+++ b/apps/homepage/src/__tests__/agent-provider.test.tsx
@@ -1,0 +1,399 @@
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentProvider, useAgents } from "../lib/AgentProvider";
+import { setToken } from "../lib/auth";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  localStorage.clear();
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+  vi.useRealTimers();
+});
+
+function TestConsumer() {
+  const { agents, loading } = useAgents();
+  return (
+    <div>
+      <span data-testid="loading">{String(loading)}</span>
+      <span data-testid="count">{agents.length}</span>
+      {agents.map((a) => (
+        <span key={a.id} data-testid={`agent-${a.id}`}>
+          {a.name}|{a.source}|{a.status}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+describe("AgentProvider", () => {
+  it("starts in loading state", () => {
+    // Mock all fetches to hang (never resolve) so loading stays true
+    mockFetch.mockReturnValue(new Promise(() => {}));
+    const { getByTestId } = render(
+      <AgentProvider>
+        <TestConsumer />
+      </AgentProvider>,
+    );
+    expect(getByTestId("loading").textContent).toBe("true");
+  });
+
+  it("shows no agents when not authenticated and local is offline", async () => {
+    // All fetches fail
+    mockFetch.mockRejectedValue(new Error("connection refused"));
+    let result: ReturnType<typeof render>;
+    await act(async () => {
+      result = render(
+        <AgentProvider>
+          <TestConsumer />
+        </AgentProvider>,
+      );
+      await vi.advanceTimersByTimeAsync(50);
+    });
+    expect(result?.getByTestId("count").textContent).toBe("0");
+    expect(result?.getByTestId("loading").textContent).toBe("false");
+  });
+
+  it("fetches cloud agents when authenticated", async () => {
+    setToken("test-key");
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("/api/v1/milady/agents")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve([
+              {
+                id: "a1",
+                name: "Cloud Agent 1",
+                status: "running",
+                model: "gpt-4",
+              },
+              {
+                id: "a2",
+                name: "Cloud Agent 2",
+                status: "suspended",
+                model: "claude",
+              },
+            ]),
+        });
+      }
+      return Promise.reject(new Error("connection refused"));
+    });
+
+    let result: ReturnType<typeof render>;
+    await act(async () => {
+      result = render(
+        <AgentProvider>
+          <TestConsumer />
+        </AgentProvider>,
+      );
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    expect(result?.getByTestId("count").textContent).toBe("2");
+    expect(result?.getByTestId("agent-cloud-a1").textContent).toContain(
+      "Cloud Agent 1|cloud|running",
+    );
+    expect(result?.getByTestId("agent-cloud-a2").textContent).toContain(
+      "Cloud Agent 2|cloud|paused",
+    );
+  });
+
+  it("discovers local agent when localhost:2138 is healthy", async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("localhost:2138/api/health")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ status: "ok" }),
+        });
+      }
+      if (url.includes("localhost:2138/api/agent/status")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              agentName: "Milady Local",
+              state: "running",
+              model: "llama",
+            }),
+        });
+      }
+      return Promise.reject(new Error("not found"));
+    });
+
+    let result: ReturnType<typeof render>;
+    await act(async () => {
+      result = render(
+        <AgentProvider>
+          <TestConsumer />
+        </AgentProvider>,
+      );
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    expect(result?.getByTestId("count").textContent).toBe("1");
+    expect(result?.getByTestId("agent-local-default").textContent).toContain(
+      "Milady Local|local|running",
+    );
+  });
+
+  it("shows local agent as running when health ok but status endpoint fails", async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("localhost:2138/api/health")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ status: "ok" }),
+        });
+      }
+      if (url.includes("localhost:2138/api/agent/status")) {
+        return Promise.reject(new Error("not implemented"));
+      }
+      return Promise.reject(new Error("not found"));
+    });
+
+    let result: ReturnType<typeof render>;
+    await act(async () => {
+      result = render(
+        <AgentProvider>
+          <TestConsumer />
+        </AgentProvider>,
+      );
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    expect(result?.getByTestId("count").textContent).toBe("1");
+    expect(result?.getByTestId("agent-local-default").textContent).toContain(
+      "Local Agent|local|running",
+    );
+  });
+
+  it("maps cloud status strings correctly", async () => {
+    setToken("test-key");
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("/api/v1/milady/agents")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve([
+              { id: "r", name: "R", status: "active" },
+              { id: "p", name: "P", status: "suspended" },
+              { id: "s", name: "S", status: "terminated" },
+              { id: "v", name: "V", status: "creating" },
+              { id: "u", name: "U", status: "weird-state" },
+              { id: "h", name: "H", status: "healthy" },
+              { id: "d", name: "D", status: "deleted" },
+              { id: "st", name: "ST", status: "starting" },
+            ]),
+        });
+      }
+      return Promise.reject(new Error("offline"));
+    });
+
+    let result: ReturnType<typeof render>;
+    await act(async () => {
+      result = render(
+        <AgentProvider>
+          <TestConsumer />
+        </AgentProvider>,
+      );
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    expect(result?.getByTestId("agent-cloud-r").textContent).toContain(
+      "|running",
+    );
+    expect(result?.getByTestId("agent-cloud-p").textContent).toContain(
+      "|paused",
+    );
+    expect(result?.getByTestId("agent-cloud-s").textContent).toContain(
+      "|stopped",
+    );
+    expect(result?.getByTestId("agent-cloud-v").textContent).toContain(
+      "|provisioning",
+    );
+    expect(result?.getByTestId("agent-cloud-u").textContent).toContain(
+      "|unknown",
+    );
+    expect(result?.getByTestId("agent-cloud-h").textContent).toContain(
+      "|running",
+    );
+    expect(result?.getByTestId("agent-cloud-d").textContent).toContain(
+      "|stopped",
+    );
+    expect(result?.getByTestId("agent-cloud-st").textContent).toContain(
+      "|provisioning",
+    );
+  });
+
+  it("uses agent id as name fallback when name is empty", async () => {
+    setToken("test-key");
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("/api/v1/milady/agents")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve([
+              { id: "no-name-id", name: "", status: "running" },
+            ]),
+        });
+      }
+      return Promise.reject(new Error("offline"));
+    });
+
+    let result: ReturnType<typeof render>;
+    await act(async () => {
+      result = render(
+        <AgentProvider>
+          <TestConsumer />
+        </AgentProvider>,
+      );
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    expect(result?.getByTestId("agent-cloud-no-name-id").textContent).toContain(
+      "no-name-id|cloud|",
+    );
+  });
+
+  it("throws when useAgents is used outside of provider", () => {
+    function Orphan() {
+      useAgents();
+      return null;
+    }
+    expect(() => render(<Orphan />)).toThrow(
+      "useAgents must be used within AgentProvider",
+    );
+  });
+
+  it("silently skips cloud agents when cloud API fails", async () => {
+    setToken("test-key");
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("/api/v1/milady/agents")) {
+        return Promise.reject(new Error("network error"));
+      }
+      if (url.includes("localhost:2138/api/health")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ status: "ok" }),
+        });
+      }
+      if (url.includes("localhost:2138/api/agent/status")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              agentName: "Local",
+              state: "running",
+              model: "m",
+            }),
+        });
+      }
+      return Promise.reject(new Error("offline"));
+    });
+
+    let result: ReturnType<typeof render>;
+    await act(async () => {
+      result = render(
+        <AgentProvider>
+          <TestConsumer />
+        </AgentProvider>,
+      );
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    // Only local agent should be present
+    expect(result?.getByTestId("count").textContent).toBe("1");
+    expect(result?.getByTestId("agent-local-default")).toBeTruthy();
+  });
+
+  it("includes remote agents from connections store", async () => {
+    // Set up a stored remote connection
+    const connId = crypto.randomUUID();
+    localStorage.setItem(
+      "milady-connections",
+      JSON.stringify([
+        {
+          id: connId,
+          name: "Remote Box",
+          url: "http://10.0.0.5:2138",
+          type: "remote",
+        },
+      ]),
+    );
+
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("10.0.0.5:2138/api/health")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ status: "ok" }),
+        });
+      }
+      if (url.includes("10.0.0.5:2138/api/agent/status")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              agentName: "Remote Agent",
+              state: "paused",
+              model: "gpt-4",
+            }),
+        });
+      }
+      return Promise.reject(new Error("offline"));
+    });
+
+    let result: ReturnType<typeof render>;
+    await act(async () => {
+      result = render(
+        <AgentProvider>
+          <TestConsumer />
+        </AgentProvider>,
+      );
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    expect(result?.getByTestId("count").textContent).toBe("1");
+    expect(result?.getByTestId(`agent-remote-${connId}`).textContent).toContain(
+      "Remote Agent|remote|paused",
+    );
+  });
+
+  it("shows remote agent as unknown when health check fails", async () => {
+    const connId = crypto.randomUUID();
+    localStorage.setItem(
+      "milady-connections",
+      JSON.stringify([
+        {
+          id: connId,
+          name: "Dead Remote",
+          url: "http://10.0.0.5:2138",
+          type: "remote",
+        },
+      ]),
+    );
+
+    mockFetch.mockRejectedValue(new Error("connection refused"));
+
+    let result: ReturnType<typeof render>;
+    await act(async () => {
+      result = render(
+        <AgentProvider>
+          <TestConsumer />
+        </AgentProvider>,
+      );
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    expect(result?.getByTestId(`agent-remote-${connId}`).textContent).toContain(
+      "Dead Remote|remote|unknown",
+    );
+  });
+});

--- a/apps/homepage/src/__tests__/auth.test.ts
+++ b/apps/homepage/src/__tests__/auth.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearToken,
+  cloudLogin,
+  cloudLoginPoll,
+  fetchWithAuth,
+  getToken,
+  isAuthenticated,
+  setToken,
+} from "../lib/auth";
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+afterEach(() => {
+  localStorage.clear();
+  vi.unstubAllGlobals();
+});
+
+describe("auth", () => {
+  it("stores and retrieves token", () => {
+    setToken("test-api-key");
+    expect(getToken()).toBe("test-api-key");
+  });
+
+  it("clears token", () => {
+    setToken("test-api-key");
+    clearToken();
+    expect(getToken()).toBeNull();
+  });
+
+  it("isAuthenticated returns false when no token", () => {
+    expect(isAuthenticated()).toBe(false);
+  });
+
+  it("isAuthenticated returns true when token exists", () => {
+    setToken("test-api-key");
+    expect(isAuthenticated()).toBe(true);
+  });
+
+  it("cloudLogin and cloudLoginPoll are exported", async () => {
+    const auth = await import("../lib/auth");
+    expect(typeof auth.cloudLogin).toBe("function");
+    expect(typeof auth.cloudLoginPoll).toBe("function");
+  });
+});
+
+describe("fetchWithAuth", () => {
+  it("attaches X-Api-Key header when token exists", async () => {
+    const mockFetch = vi.fn().mockResolvedValueOnce({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", mockFetch);
+    setToken("test-key");
+    await fetchWithAuth("http://example.com/test");
+    const headers = mockFetch.mock.calls[0][1].headers;
+    expect(headers.get("X-Api-Key")).toBe("test-key");
+  });
+
+  it("does not set header when no token", async () => {
+    const mockFetch = vi.fn().mockResolvedValueOnce({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", mockFetch);
+    await fetchWithAuth("http://example.com/test");
+    const headers = mockFetch.mock.calls[0][1].headers;
+    expect(headers.has("X-Api-Key")).toBe(false);
+  });
+
+  it("clears token on 401 response", async () => {
+    const mockFetch = vi.fn().mockResolvedValueOnce({ ok: false, status: 401 });
+    vi.stubGlobal("fetch", mockFetch);
+    setToken("will-be-cleared");
+    await fetchWithAuth("http://example.com/test");
+    expect(getToken()).toBeNull();
+  });
+
+  it("does not clear token on non-401 errors", async () => {
+    const mockFetch = vi.fn().mockResolvedValueOnce({ ok: false, status: 500 });
+    vi.stubGlobal("fetch", mockFetch);
+    setToken("keep-me");
+    await fetchWithAuth("http://example.com/test");
+    expect(getToken()).toBe("keep-me");
+  });
+
+  it("passes through additional request options", async () => {
+    const mockFetch = vi.fn().mockResolvedValueOnce({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", mockFetch);
+    setToken("key");
+    await fetchWithAuth("http://example.com/test", {
+      method: "POST",
+      body: JSON.stringify({ data: 1 }),
+    });
+    expect(mockFetch.mock.calls[0][1].method).toBe("POST");
+    expect(mockFetch.mock.calls[0][1].body).toBe(JSON.stringify({ data: 1 }));
+  });
+
+  it("returns the response object", async () => {
+    const mockResponse = { ok: true, status: 200 };
+    const mockFetch = vi.fn().mockResolvedValueOnce(mockResponse);
+    vi.stubGlobal("fetch", mockFetch);
+    const result = await fetchWithAuth("http://example.com/test");
+    expect(result).toBe(mockResponse);
+  });
+});
+
+describe("cloudLogin", () => {
+  it("creates session and returns browserUrl", async () => {
+    const mockFetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: () =>
+        Promise.resolve({ sessionId: "test-session", status: "pending" }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+    vi.stubGlobal("crypto", { randomUUID: () => "mock-uuid" });
+    const result = await cloudLogin();
+    expect(result.sessionId).toBe("mock-uuid");
+    expect(result.browserUrl).toContain(
+      "elizacloud.ai/auth/cli-login?session=mock-uuid",
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/auth/cli-session"),
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("throws when server returns non-ok", async () => {
+    const mockFetch = vi.fn().mockResolvedValueOnce({ ok: false, status: 500 });
+    vi.stubGlobal("fetch", mockFetch);
+    vi.stubGlobal("crypto", { randomUUID: () => "mock-uuid" });
+    await expect(cloudLogin()).rejects.toThrow("Failed to create auth session");
+  });
+});
+
+describe("cloudLoginPoll", () => {
+  it("returns authenticated status with apiKey", async () => {
+    const mockFetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({ status: "authenticated", apiKey: "key-123" }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+    const result = await cloudLoginPoll("test-session");
+    expect(result.status).toBe("authenticated");
+    expect(result.apiKey).toBe("key-123");
+  });
+
+  it("throws on 404 (session expired)", async () => {
+    const mockFetch = vi.fn().mockResolvedValueOnce({ ok: false, status: 404 });
+    vi.stubGlobal("fetch", mockFetch);
+    await expect(cloudLoginPoll("expired-session")).rejects.toThrow("expired");
+  });
+
+  it("throws on other non-ok status", async () => {
+    const mockFetch = vi.fn().mockResolvedValueOnce({ ok: false, status: 500 });
+    vi.stubGlobal("fetch", mockFetch);
+    await expect(cloudLoginPoll("test-session")).rejects.toThrow(
+      "Poll failed: 500",
+    );
+  });
+
+  it("calls correct URL with encoded session id", async () => {
+    const mockFetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ status: "pending" }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+    await cloudLoginPoll("session with spaces");
+    expect(mockFetch.mock.calls[0][0]).toContain("session%20with%20spaces");
+  });
+});

--- a/apps/homepage/src/__tests__/cloud-api.test.ts
+++ b/apps/homepage/src/__tests__/cloud-api.test.ts
@@ -1,0 +1,573 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CloudApiClient, CloudClient } from "../lib/cloud-api";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  localStorage.clear();
+});
+afterEach(() => localStorage.clear());
+
+describe("CloudApiClient", () => {
+  const client = new CloudApiClient({
+    url: "http://localhost:2138",
+    type: "local",
+  });
+
+  it("health() calls GET /api/health", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ status: "ok", uptime: 100 }),
+    });
+    const result = await client.health();
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:2138/api/health",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(result.status).toBe("ok");
+  });
+
+  it("startAgent() calls POST /api/agent/start", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ ok: true, status: { state: "paused" } }),
+    });
+    const result = await client.startAgent();
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:2138/api/agent/start",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("playAgent() chains start then resume", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ ok: true, status: { state: "paused" } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ ok: true, status: { state: "running" } }),
+      });
+    const result = await client.playAgent();
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(result.status.state).toBe("running");
+  });
+
+  it("exportAgent() calls POST /api/agent/export with password", async () => {
+    const blob = new Blob(["data"]);
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      blob: () => Promise.resolve(blob),
+    });
+    const result = await client.exportAgent("mypass");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:2138/api/agent/export",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ password: "mypass" }),
+      }),
+    );
+    expect(result).toBeInstanceOf(Blob);
+  });
+
+  it("stopAgent() calls POST /api/agent/stop", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ ok: true, status: { state: "stopped" } }),
+    });
+    const result = await client.stopAgent();
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:2138/api/agent/stop",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("pauseAgent() calls POST /api/agent/pause", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ ok: true, status: { state: "paused" } }),
+    });
+    const result = await client.pauseAgent();
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:2138/api/agent/pause",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("resumeAgent() calls POST /api/agent/resume", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ ok: true, status: { state: "running" } }),
+    });
+    const result = await client.resumeAgent();
+    expect(result.ok).toBe(true);
+  });
+
+  it("getAgentStatus() calls GET /api/agent/status", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          agentName: "Test",
+          model: "gpt-4",
+          state: "running",
+        }),
+    });
+    const result = await client.getAgentStatus();
+    expect(result.agentName).toBe("Test");
+    expect(result.state).toBe("running");
+  });
+
+  it("getMetrics() calls GET /api/metrics", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve([
+          {
+            cpu: 50,
+            memoryMb: 512,
+            diskMb: 1024,
+            timestamp: "2026-01-01T00:00:00Z",
+          },
+        ]),
+    });
+    const result = await client.getMetrics();
+    expect(result).toHaveLength(1);
+    expect(result[0].cpu).toBe(50);
+  });
+
+  it("getLogs() calls GET /api/logs with query params", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve([
+          {
+            level: "info",
+            message: "test",
+            timestamp: "2026-01-01",
+            agentName: "A",
+          },
+        ]),
+    });
+    const result = await client.getLogs({ limit: 10, level: "error" });
+    expect(mockFetch.mock.calls[0][0]).toContain(
+      "/api/logs?limit=10&level=error",
+    );
+    expect(result).toHaveLength(1);
+  });
+
+  it("getLogs() calls GET /api/logs without query params when none given", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve([]),
+    });
+    await client.getLogs();
+    expect(mockFetch.mock.calls[0][0]).toBe("http://localhost:2138/api/logs");
+  });
+
+  it("estimateExportSize() calls GET /api/agent/export/estimate", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ sizeBytes: 1048576 }),
+    });
+    const result = await client.estimateExportSize();
+    expect(result.sizeBytes).toBe(1048576);
+  });
+
+  it("importAgent() builds binary envelope correctly", async () => {
+    const mockFile = new File(["file-content"], "test.bin");
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ ok: true }),
+    });
+    const result = await client.importAgent(mockFile, "pass");
+    const body = mockFetch.mock.calls[0][1].body;
+    expect(body).toBeInstanceOf(Blob);
+    expect(result.ok).toBe(true);
+  });
+
+  it("getBilling() calls GET /api/billing", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ plan: "pro" }),
+    });
+    const result = await client.getBilling();
+    expect(result).toEqual({ plan: "pro" });
+  });
+
+  it("throws on non-ok response", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+    await expect(client.health()).rejects.toThrow("API 500");
+  });
+
+  it("strips trailing slash from URL", () => {
+    const c = new CloudApiClient({
+      url: "http://localhost:2138/",
+      type: "local",
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ status: "ok", uptime: 0 }),
+    });
+    c.health();
+    expect(mockFetch.mock.calls[0][0]).toBe("http://localhost:2138/api/health");
+  });
+});
+
+describe("CloudClient", () => {
+  const cc = new CloudClient("test-api-key");
+
+  it("listAgents() calls GET /api/v1/milady/agents with X-Api-Key", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve([{ id: "a1", name: "Agent1", status: "running" }]),
+    });
+    const agents = await cc.listAgents();
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://www.elizacloud.ai/api/v1/milady/agents",
+      expect.objectContaining({ method: "GET" }),
+    );
+    // Verify X-Api-Key header
+    const call = mockFetch.mock.calls[0];
+    const headers = call[1].headers as Headers;
+    expect(headers.get("X-Api-Key")).toBe("test-api-key");
+    expect(agents).toHaveLength(1);
+    expect(agents[0].id).toBe("a1");
+  });
+
+  it("suspendAgent() calls POST /api/v1/milady/agents/:id/suspend", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({}),
+    });
+    await cc.suspendAgent("agent-123");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://www.elizacloud.ai/api/v1/milady/agents/agent-123/suspend",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("resumeAgent() calls POST /api/v1/milady/agents/:id/resume", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ jobId: "job-1" }),
+    });
+    const result = await cc.resumeAgent("agent-123");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://www.elizacloud.ai/api/v1/milady/agents/agent-123/resume",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(result.jobId).toBe("job-1");
+  });
+
+  it("getCreditsBalance() calls GET /api/credits/balance", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ balance: 5000, currency: "credits" }),
+    });
+    const balance = await cc.getCreditsBalance();
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://www.elizacloud.ai/api/credits/balance",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(balance.balance).toBe(5000);
+  });
+
+  it("takeSnapshot() calls POST /api/v1/milady/agents/:id/snapshot", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({}),
+    });
+    await cc.takeSnapshot("agent-123");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://www.elizacloud.ai/api/v1/milady/agents/agent-123/snapshot",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("listBackups() calls GET /api/v1/milady/agents/:id/backups", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve([{ id: "b1", createdAt: "2026-01-01" }]),
+    });
+    const backups = await cc.listBackups("agent-123");
+    expect(backups).toHaveLength(1);
+    expect(backups[0].id).toBe("b1");
+  });
+
+  it("throws on non-ok response", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      json: () => Promise.resolve({ error: "forbidden" }),
+    });
+    await expect(cc.listAgents()).rejects.toThrow("Cloud API 403");
+  });
+
+  it("deleteAgent() calls DELETE", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({}),
+    });
+    await cc.deleteAgent("agent-1");
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/v1/milady/agents/agent-1"),
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  it("provisionAgent() calls POST provision", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 202,
+      json: () => Promise.resolve({ jobId: "job-1" }),
+    });
+    const result = await cc.provisionAgent("agent-1");
+    expect(result.jobId).toBe("job-1");
+    expect(mockFetch.mock.calls[0][0]).toContain("/agent-1/provision");
+  });
+
+  it("bridge() sends JSON-RPC", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ result: { state: "running" } }),
+    });
+    const result = await cc.bridge("agent-1", "status.get");
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.method).toBe("status.get");
+    expect(body.jsonrpc).toBe("2.0");
+    expect(body.id).toBeDefined();
+    expect(result.result.state).toBe("running");
+  });
+
+  it("bridge() passes params", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ result: {} }),
+    });
+    await cc.bridge("agent-1", "config.set", { key: "value" });
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.params).toEqual({ key: "value" });
+  });
+
+  it("getAgentBridgeStatus() returns result from bridge", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({ result: { state: "running", uptime: 100 } }),
+    });
+    const status = await cc.getAgentBridgeStatus("agent-1");
+    expect(status.state).toBe("running");
+    expect(status.uptime).toBe(100);
+  });
+
+  it("getContainerLogs() returns text", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve("log line 1\nlog line 2"),
+    });
+    const logs = await cc.getContainerLogs("container-1");
+    expect(logs).toContain("log line 1");
+    expect(logs).toContain("log line 2");
+  });
+
+  it("getContainerLogs() throws on non-ok", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
+    await expect(cc.getContainerLogs("missing")).rejects.toThrow("Logs 404");
+  });
+
+  it("getCurrentSession() returns session stats", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ credits: 100, requests: 50, tokens: 1000 }),
+    });
+    const session = await cc.getCurrentSession();
+    expect(session.credits).toBe(100);
+    expect(session.requests).toBe(50);
+    expect(session.tokens).toBe(1000);
+  });
+
+  it("createAgent() sends config as body", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ id: "new-agent" }),
+    });
+    const result = await cc.createAgent({ name: "Test Agent" });
+    expect(result.id).toBe("new-agent");
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.name).toBe("Test Agent");
+  });
+
+  it("getAgent() calls GET /api/v1/milady/agents/:id", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({ id: "a1", name: "Agent1", status: "running" }),
+    });
+    const agent = await cc.getAgent("a1");
+    expect(agent.id).toBe("a1");
+    expect(mockFetch.mock.calls[0][0]).toContain("/agents/a1");
+  });
+
+  it("restoreBackup() sends backupId in body", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({}),
+    });
+    await cc.restoreBackup("agent-1", "backup-42");
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.backupId).toBe("backup-42");
+  });
+
+  it("restoreBackup() sends empty body when no backupId", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({}),
+    });
+    await cc.restoreBackup("agent-1");
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body).toEqual({});
+  });
+
+  it("getJobStatus() calls GET /api/v1/jobs/:id", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ id: "j1", status: "completed" }),
+    });
+    const job = await cc.getJobStatus("j1");
+    expect(job.status).toBe("completed");
+    expect(mockFetch.mock.calls[0][0]).toContain("/jobs/j1");
+  });
+
+  it("listContainers() returns array", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve([{ id: "c1" }]),
+    });
+    const containers = await cc.listContainers();
+    expect(containers).toHaveLength(1);
+  });
+
+  it("listContainers() unwraps nested data", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ containers: [{ id: "c1" }, { id: "c2" }] }),
+    });
+    const containers = await cc.listContainers();
+    expect(containers).toHaveLength(2);
+  });
+
+  it("getContainerHealth() calls GET /api/v1/containers/:id/health", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ healthy: true }),
+    });
+    const health = await cc.getContainerHealth("c1");
+    expect(health).toEqual({ healthy: true });
+  });
+
+  it("getContainerMetrics() calls GET /api/v1/containers/:id/metrics", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ cpu: 25 }),
+    });
+    const metrics = await cc.getContainerMetrics("c1");
+    expect(metrics).toEqual({ cpu: 25 });
+  });
+
+  it("getCreditsSummary() calls GET /api/v1/credits/summary", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ total: 500 }),
+    });
+    const summary = await cc.getCreditsSummary();
+    expect(summary).toEqual({ total: 500 });
+  });
+
+  it("listAgents() unwraps nested agents property", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ agents: [{ id: "a1" }, { id: "a2" }] }),
+    });
+    const agents = await cc.listAgents();
+    expect(agents).toHaveLength(2);
+  });
+
+  it("listAgents() unwraps nested data property", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ data: [{ id: "a1" }] }),
+    });
+    const agents = await cc.listAgents();
+    expect(agents).toHaveLength(1);
+  });
+
+  it("listBackups() unwraps nested backups property", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({ backups: [{ id: "b1", createdAt: "2026-01-01" }] }),
+    });
+    const backups = await cc.listBackups("agent-1");
+    expect(backups).toHaveLength(1);
+  });
+
+  it("sets Content-Type for JSON body requests", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ id: "new" }),
+    });
+    await cc.createAgent({ name: "Test" });
+    const headers = mockFetch.mock.calls[0][1].headers as Headers;
+    expect(headers.get("Content-Type")).toBe("application/json");
+  });
+});

--- a/apps/homepage/src/__tests__/connections.test.ts
+++ b/apps/homepage/src/__tests__/connections.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  addConnection,
+  getConnections,
+  removeConnection,
+} from "../lib/connections";
+
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+describe("connections store", () => {
+  it("starts empty", () => {
+    expect(getConnections()).toEqual([]);
+  });
+
+  it("adds a connection", () => {
+    const conn = addConnection({
+      name: "Local",
+      url: "http://localhost:2138",
+      type: "local",
+    });
+    expect(conn.id).toBeDefined();
+    expect(getConnections()).toHaveLength(1);
+  });
+
+  it("removes a connection by id", () => {
+    const conn = addConnection({
+      name: "Local",
+      url: "http://localhost:2138",
+      type: "local",
+    });
+    removeConnection(conn.id);
+    expect(getConnections()).toHaveLength(0);
+  });
+
+  it("persists across reads", () => {
+    addConnection({
+      name: "Remote",
+      url: "http://10.0.0.5:2138",
+      type: "remote",
+    });
+    const conns = getConnections();
+    expect(conns).toHaveLength(1);
+    expect(conns[0].name).toBe("Remote");
+  });
+});

--- a/apps/homepage/src/__tests__/dashboard.test.tsx
+++ b/apps/homepage/src/__tests__/dashboard.test.tsx
@@ -1,0 +1,528 @@
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentCard } from "../components/dashboard/AgentCard";
+import { AgentDetail } from "../components/dashboard/AgentDetail";
+import { ConnectionModal } from "../components/dashboard/ConnectionModal";
+import { LogsPanel } from "../components/dashboard/LogsPanel";
+import { MetricsPanel } from "../components/dashboard/MetricsPanel";
+import { Sidebar } from "../components/dashboard/Sidebar";
+import type { AgentStatus } from "../lib/cloud-api";
+
+vi.mock("../lib/AgentProvider", () => ({
+  useAgents: () => ({
+    agents: [
+      {
+        id: "local-default",
+        name: "Test Agent",
+        source: "local" as const,
+        status: "running" as const,
+        model: "gpt-4",
+        sourceUrl: "http://localhost:2138",
+        client: {
+          exportAgent: vi.fn(),
+          importAgent: vi.fn(),
+        },
+      },
+    ],
+    loading: false,
+    cloudClient: null,
+    refresh: vi.fn(),
+    addRemoteUrl: vi.fn(),
+    removeRemote: vi.fn(),
+  }),
+}));
+
+beforeEach(() => localStorage.clear());
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+/* ------------------------------------------------------------------ */
+/*  Sidebar                                                           */
+/* ------------------------------------------------------------------ */
+describe("Sidebar", () => {
+  it("renders all 6 section buttons", () => {
+    const onChange = vi.fn();
+    render(<Sidebar active="agents" onChange={onChange} />);
+
+    for (const label of [
+      "Agents",
+      "Metrics",
+      "Logs",
+      "Snapshots",
+      "Credits",
+      "Billing",
+    ]) {
+      const buttons = screen.getAllByText(
+        (_content, el) =>
+          !!(el?.textContent?.includes(label) && el?.tagName === "BUTTON"),
+      );
+      expect(buttons.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("calls onChange with section id when clicked", () => {
+    const onChange = vi.fn();
+    render(<Sidebar active="agents" onChange={onChange} />);
+
+    // Click the first "Metrics" button (desktop sidebar)
+    const metricsButtons = screen.getAllByText(
+      (_content, el) =>
+        !!(el?.textContent?.includes("Metrics") && el?.tagName === "BUTTON"),
+    );
+    fireEvent.click(metricsButtons[0]);
+    expect(onChange).toHaveBeenCalledWith("metrics");
+
+    const logsButtons = screen.getAllByText(
+      (_content, el) =>
+        !!(el?.textContent?.includes("Logs") && el?.tagName === "BUTTON"),
+    );
+    fireEvent.click(logsButtons[0]);
+    expect(onChange).toHaveBeenCalledWith("logs");
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  ConnectionModal                                                   */
+/* ------------------------------------------------------------------ */
+describe("ConnectionModal", () => {
+  it("renders name and url inputs", () => {
+    const onSubmit = vi.fn();
+    const onClose = vi.fn();
+    render(<ConnectionModal onSubmit={onSubmit} onClose={onClose} />);
+
+    expect(screen.getByPlaceholderText("My Remote Agent")).toBeTruthy();
+    expect(screen.getByPlaceholderText("http://10.0.0.5:2138")).toBeTruthy();
+  });
+
+  it("Connect button is disabled when name is empty", () => {
+    const onSubmit = vi.fn();
+    render(<ConnectionModal onSubmit={onSubmit} onClose={() => {}} />);
+
+    const connectBtn = screen.getByText("Connect");
+    expect(connectBtn).toBeDisabled();
+  });
+
+  it("Connect button is disabled when url is empty", () => {
+    const onSubmit = vi.fn();
+    render(<ConnectionModal onSubmit={onSubmit} onClose={() => {}} />);
+
+    // Fill name but leave url empty (url starts empty now)
+    fireEvent.change(screen.getByPlaceholderText("My Remote Agent"), {
+      target: { value: "Test" },
+    });
+
+    const connectBtn = screen.getByText("Connect");
+    expect(connectBtn).toBeDisabled();
+  });
+
+  it("calls onSubmit when Connect is clicked with valid inputs", () => {
+    const onSubmit = vi.fn();
+    render(<ConnectionModal onSubmit={onSubmit} onClose={() => {}} />);
+
+    fireEvent.change(screen.getByPlaceholderText("My Remote Agent"), {
+      target: { value: "Test Agent" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("http://10.0.0.5:2138"), {
+      target: { value: "http://10.0.0.5:2138" },
+    });
+
+    const connectBtn = screen.getByText("Connect");
+    expect(connectBtn).not.toBeDisabled();
+    fireEvent.click(connectBtn);
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      name: "Test Agent",
+      url: "http://10.0.0.5:2138",
+      type: "remote",
+    });
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  AgentCard                                                         */
+/* ------------------------------------------------------------------ */
+describe("AgentCard", () => {
+  const baseProps = {
+    connectionName: "Local",
+    onPlay: vi.fn(),
+    onResume: vi.fn(),
+    onPause: vi.fn(),
+    onStop: vi.fn(),
+    onSelect: vi.fn(),
+    selected: false,
+  };
+
+  function makeAgent(overrides: Partial<AgentStatus> = {}): AgentStatus {
+    return {
+      agentName: "TestAgent",
+      model: "gpt-4",
+      state: "running",
+      uptime: 3600,
+      ...overrides,
+    };
+  }
+
+  it("renders agent name, model, and state", () => {
+    const { container } = render(
+      <AgentCard {...baseProps} agent={makeAgent()} />,
+    );
+    expect(container.textContent).toContain("TestAgent");
+    expect(container.textContent).toContain("gpt-4");
+    expect(container.textContent).toContain("running");
+  });
+
+  it("shows Play button when stopped", () => {
+    render(
+      <AgentCard {...baseProps} agent={makeAgent({ state: "stopped" })} />,
+    );
+    expect(screen.getByText("Play")).toBeTruthy();
+    expect(screen.queryByText("Resume")).toBeNull();
+    expect(screen.queryByText("Pause")).toBeNull();
+  });
+
+  it("shows Resume button when paused", () => {
+    render(<AgentCard {...baseProps} agent={makeAgent({ state: "paused" })} />);
+    expect(screen.getByText("Resume")).toBeTruthy();
+    expect(screen.queryByText("Play")).toBeNull();
+  });
+
+  it("shows Pause button when running", () => {
+    render(
+      <AgentCard {...baseProps} agent={makeAgent({ state: "running" })} />,
+    );
+    expect(screen.getByText("Pause")).toBeTruthy();
+    expect(screen.queryByText("Play")).toBeNull();
+    expect(screen.queryByText("Resume")).toBeNull();
+  });
+
+  it("calls onStop when Stop is clicked", () => {
+    const onStop = vi.fn();
+    render(
+      <AgentCard
+        {...baseProps}
+        onStop={onStop}
+        agent={makeAgent({ state: "running" })}
+      />,
+    );
+    fireEvent.click(screen.getByText("Stop"));
+    expect(onStop).toHaveBeenCalled();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  MetricsPanel                                                      */
+/* ------------------------------------------------------------------ */
+describe("MetricsPanel", () => {
+  it("renders coming soon placeholder", () => {
+    const { container } = render(<MetricsPanel />);
+    expect(container.textContent).toContain("Metrics coming soon");
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  LogsPanel                                                         */
+/* ------------------------------------------------------------------ */
+describe("LogsPanel", () => {
+  it("renders coming soon placeholder", () => {
+    const { container } = render(<LogsPanel />);
+    expect(container.textContent).toContain("Logs coming soon");
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  ExportPanel (rendered with mocked useAgents)                      */
+/* ------------------------------------------------------------------ */
+describe("ExportPanel", () => {
+  it("renders password input and export/import buttons", async () => {
+    const { ExportPanel } = await import("../components/dashboard/ExportPanel");
+    const { container } = render(<ExportPanel connectionId="local-default" />);
+    const text = container.textContent ?? "";
+    expect(text).toContain("Password");
+    expect(screen.getByText("Export Agent")).toBeTruthy();
+    expect(screen.getByText("Import Agent")).toBeTruthy();
+  });
+
+  it("Export button is disabled when password < 4 chars", async () => {
+    const { ExportPanel } = await import("../components/dashboard/ExportPanel");
+    render(<ExportPanel connectionId="local-default" />);
+    const exportBtn = screen.getByText("Export Agent");
+    expect(exportBtn).toBeDisabled();
+
+    // Type 3 chars — still disabled
+    const pwInput = screen.getByLabelText("Password (min 4 chars)");
+    fireEvent.change(pwInput, { target: { value: "abc" } });
+    expect(screen.getByText("Export Agent")).toBeDisabled();
+
+    // Type 4 chars — enabled
+    fireEvent.change(pwInput, { target: { value: "abcd" } });
+    expect(screen.getByText("Export Agent")).not.toBeDisabled();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  AgentDetail                                                        */
+/* ------------------------------------------------------------------ */
+describe("AgentDetail", () => {
+  const agent: AgentStatus = {
+    agentName: "Detail Agent",
+    model: "claude-3",
+    state: "running",
+    uptime: 7200,
+  };
+
+  it("renders Metrics tab by default", () => {
+    const { container } = render(
+      <AgentDetail agent={agent} connectionId="local-default" />,
+    );
+    expect(container.textContent).toContain("Metrics coming soon");
+  });
+
+  it("shows agent name in header", () => {
+    const { container } = render(
+      <AgentDetail agent={agent} connectionId="local-default" />,
+    );
+    expect(container.textContent).toContain("Detail Agent");
+  });
+
+  it("renders all three tab buttons", () => {
+    render(<AgentDetail agent={agent} connectionId="local-default" />);
+    expect(screen.getByText("Metrics")).toBeTruthy();
+    expect(screen.getByText("Logs")).toBeTruthy();
+    expect(screen.getByText("Snapshots")).toBeTruthy();
+  });
+
+  it("switches to Logs tab", () => {
+    const { container } = render(
+      <AgentDetail agent={agent} connectionId="local-default" />,
+    );
+    fireEvent.click(screen.getByText("Logs"));
+    expect(container.textContent).toContain("Logs coming soon");
+  });
+
+  it("switches to Snapshots tab", () => {
+    render(<AgentDetail agent={agent} connectionId="local-default" />);
+    fireEvent.click(screen.getByText("Snapshots"));
+    // Snapshots tab renders ExportPanel which has "Export Agent" button
+    expect(screen.getByText("Export Agent")).toBeTruthy();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  AgentCard — regression tests                                       */
+/* ------------------------------------------------------------------ */
+describe("AgentCard regression", () => {
+  const baseProps = {
+    connectionName: "Local",
+    onPlay: vi.fn(),
+    onResume: vi.fn(),
+    onPause: vi.fn(),
+    onStop: vi.fn(),
+    onSelect: vi.fn(),
+    selected: false,
+  };
+
+  function makeAgent(overrides: Partial<AgentStatus> = {}): AgentStatus {
+    return {
+      agentName: "TestAgent",
+      model: "gpt-4",
+      state: "running",
+      uptime: 3600,
+      ...overrides,
+    };
+  }
+
+  it("does not show Stop button when already stopped", () => {
+    render(
+      <AgentCard {...baseProps} agent={makeAgent({ state: "stopped" })} />,
+    );
+    expect(screen.queryByText("Stop")).toBeNull();
+  });
+
+  it("shows both Pause and Stop for running agent", () => {
+    render(
+      <AgentCard {...baseProps} agent={makeAgent({ state: "running" })} />,
+    );
+    expect(screen.getByText("Pause")).toBeTruthy();
+    expect(screen.getByText("Stop")).toBeTruthy();
+  });
+
+  it("shows Stop button for paused agent", () => {
+    render(<AgentCard {...baseProps} agent={makeAgent({ state: "paused" })} />);
+    expect(screen.getByText("Stop")).toBeTruthy();
+  });
+
+  it("displays uptime formatted correctly (hours and minutes)", () => {
+    const { container } = render(
+      <AgentCard {...baseProps} agent={makeAgent({ uptime: 3660 })} />,
+    );
+    // 3660s = 1h 1m
+    expect(container.textContent).toContain("1h 1m");
+  });
+
+  it("displays uptime as minutes only when less than an hour", () => {
+    const { container } = render(
+      <AgentCard {...baseProps} agent={makeAgent({ uptime: 300 })} />,
+    );
+    // 300s = 5m
+    expect(container.textContent).toContain("5m");
+  });
+
+  it("displays dash when uptime is 0 or undefined", () => {
+    const { container } = render(
+      <AgentCard {...baseProps} agent={makeAgent({ uptime: 0 })} />,
+    );
+    expect(container.textContent).toContain("\u2014");
+  });
+
+  it("displays memory count when provided", () => {
+    const { container } = render(
+      <AgentCard {...baseProps} agent={makeAgent({ memories: 42 })} />,
+    );
+    expect(container.textContent).toContain("42 memories");
+  });
+
+  it("hides memory count when undefined", () => {
+    const { container } = render(
+      <AgentCard {...baseProps} agent={makeAgent()} />,
+    );
+    expect(container.textContent).not.toContain("memories");
+  });
+
+  it("shows connection source label", () => {
+    const { container } = render(
+      <AgentCard
+        {...baseProps}
+        connectionName="Cloud-Prod"
+        agent={makeAgent()}
+      />,
+    );
+    expect(container.textContent).toContain("Cloud-Prod");
+  });
+
+  it("calls onSelect when card is clicked", () => {
+    const onSelect = vi.fn();
+    const { container } = render(
+      <AgentCard {...baseProps} onSelect={onSelect} agent={makeAgent()} />,
+    );
+    fireEvent.click(container.firstChild as HTMLElement);
+    expect(onSelect).toHaveBeenCalled();
+  });
+
+  it("calls onPlay when Play button is clicked on stopped agent", () => {
+    const onPlay = vi.fn();
+    render(
+      <AgentCard
+        {...baseProps}
+        onPlay={onPlay}
+        agent={makeAgent({ state: "stopped" })}
+      />,
+    );
+    fireEvent.click(screen.getByText("Play"));
+    expect(onPlay).toHaveBeenCalled();
+  });
+
+  it("calls onPause when Pause button is clicked on running agent", () => {
+    const onPause = vi.fn();
+    render(
+      <AgentCard
+        {...baseProps}
+        onPause={onPause}
+        agent={makeAgent({ state: "running" })}
+      />,
+    );
+    fireEvent.click(screen.getByText("Pause"));
+    expect(onPause).toHaveBeenCalled();
+  });
+
+  it("calls onResume when Resume button is clicked on paused agent", () => {
+    const onResume = vi.fn();
+    render(
+      <AgentCard
+        {...baseProps}
+        onResume={onResume}
+        agent={makeAgent({ state: "paused" })}
+      />,
+    );
+    fireEvent.click(screen.getByText("Resume"));
+    expect(onResume).toHaveBeenCalled();
+  });
+
+  it("applies selected styling when selected is true", () => {
+    const { container } = render(
+      <AgentCard {...baseProps} selected={true} agent={makeAgent()} />,
+    );
+    const card = container.firstChild as HTMLElement;
+    expect(card.className).toContain("border-brand");
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  AuthGate                                                           */
+/* ------------------------------------------------------------------ */
+describe("AuthGate", () => {
+  it("renders children when authenticated", async () => {
+    localStorage.setItem("milady-cloud-token", "test-key");
+    let result: ReturnType<typeof render>;
+    await act(async () => {
+      const { AuthGate } = await import("../components/dashboard/AuthGate");
+      result = render(
+        <AuthGate>
+          <div>Dashboard Content</div>
+        </AuthGate>,
+      );
+    });
+    expect(result?.getByText("Dashboard Content")).toBeTruthy();
+  });
+
+  it("shows login UI when not authenticated", async () => {
+    let result: ReturnType<typeof render>;
+    await act(async () => {
+      const { AuthGate } = await import("../components/dashboard/AuthGate");
+      result = render(
+        <AuthGate>
+          <div>Dashboard Content</div>
+        </AuthGate>,
+      );
+    });
+    expect(result?.getByText("Login with Eliza Cloud")).toBeTruthy();
+    expect(result?.getByText("Skip (local only)")).toBeTruthy();
+  });
+
+  it("renders children after clicking Skip", async () => {
+    let result: ReturnType<typeof render>;
+    await act(async () => {
+      const { AuthGate } = await import("../components/dashboard/AuthGate");
+      result = render(
+        <AuthGate>
+          <div>Dashboard Content</div>
+        </AuthGate>,
+      );
+    });
+    const skipBtn = result?.getByText("Skip (local only)");
+    await act(async () => {
+      fireEvent.click(skipBtn);
+    });
+    expect(result?.getByText("Dashboard Content")).toBeTruthy();
+  });
+
+  it("shows Milady Cloud heading in login view", async () => {
+    let result: ReturnType<typeof render>;
+    await act(async () => {
+      const { AuthGate } = await import("../components/dashboard/AuthGate");
+      result = render(
+        <AuthGate>
+          <div>child</div>
+        </AuthGate>,
+      );
+    });
+    expect(result?.getByText("Milady Cloud")).toBeTruthy();
+  });
+});

--- a/apps/homepage/src/__tests__/nav.test.tsx
+++ b/apps/homepage/src/__tests__/nav.test.tsx
@@ -1,32 +1,41 @@
 import { cleanup, render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it } from "vitest";
 import { Nav } from "../components/Nav";
 import { releaseData } from "../generated/release-data";
 
 afterEach(cleanup);
 
+function renderNav() {
+  return render(
+    <MemoryRouter>
+      <Nav />
+    </MemoryRouter>,
+  );
+}
+
 describe("Nav", () => {
   it("version clock element exists with version-clock class", () => {
-    const { container } = render(<Nav />);
+    const { container } = renderNav();
     const clock = container.querySelector(".version-clock");
     expect(clock).toBeTruthy();
   });
 
   it("version clock displays the tag name from release data", () => {
-    const { container } = render(<Nav />);
+    const { container } = renderNav();
     const clock = container.querySelector(".version-clock");
     expect(clock?.textContent).toContain(releaseData.release.tagName);
   });
 
   it('version clock shows "canary" when prerelease is true', () => {
-    const { container } = render(<Nav />);
+    const { container } = renderNav();
     const clock = container.querySelector(".version-clock");
     const expected = releaseData.release.prerelease ? "canary" : "stable";
     expect(clock?.textContent).toContain(expected);
   });
 
   it("releases button links to the release page URL", () => {
-    const { container } = render(<Nav />);
+    const { container } = renderNav();
     const releasesLink = Array.from(container.querySelectorAll("a")).find(
       (a) => a.textContent?.trim() === "Releases",
     );
@@ -35,15 +44,25 @@ describe("Nav", () => {
   });
 
   it("version clock is positioned after the Releases button in DOM order", () => {
-    const { container } = render(<Nav />);
-    const nav = container.querySelector("nav")!;
+    const { container } = renderNav();
+    const nav = container.querySelector("nav");
+    expect(nav).toBeTruthy();
+    if (!nav) throw new Error("Expected nav element to render");
     const html = nav.innerHTML;
-
     const releasesIdx = html.indexOf("Releases");
     const clockIdx = html.indexOf("version-clock");
-
     expect(releasesIdx).toBeGreaterThan(-1);
     expect(clockIdx).toBeGreaterThan(-1);
     expect(clockIdx).toBeGreaterThan(releasesIdx);
+  });
+
+  it("Cloud link navigates to /dashboard (not external)", () => {
+    const { container } = renderNav();
+    const cloudLink = Array.from(container.querySelectorAll("a")).find(
+      (a) => a.textContent?.trim() === "Cloud",
+    );
+    expect(cloudLink).toBeTruthy();
+    expect(cloudLink?.getAttribute("href")).toBe("/dashboard");
+    expect(cloudLink?.getAttribute("target")).toBeNull();
   });
 });

--- a/apps/homepage/src/__tests__/regression.test.tsx
+++ b/apps/homepage/src/__tests__/regression.test.tsx
@@ -1,0 +1,143 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearToken,
+  fetchWithAuth,
+  getToken,
+  isAuthenticated,
+  setToken,
+} from "../lib/auth";
+import {
+  addConnection,
+  getConnections,
+  removeConnection,
+} from "../lib/connections";
+
+beforeEach(() => localStorage.clear());
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+  vi.unstubAllGlobals();
+});
+
+/* ------------------------------------------------------------------ */
+/*  Regression: auth state                                             */
+/* ------------------------------------------------------------------ */
+describe("Regression: auth state", () => {
+  it("clearing token makes isAuthenticated return false", () => {
+    setToken("abc");
+    expect(isAuthenticated()).toBe(true);
+    clearToken();
+    expect(isAuthenticated()).toBe(false);
+  });
+
+  it("fetchWithAuth works without token (no header set)", async () => {
+    const mockFetch = vi.fn().mockResolvedValueOnce({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", mockFetch);
+    const res = await fetchWithAuth("http://example.com");
+    expect(res.ok).toBe(true);
+    const headers = mockFetch.mock.calls[0][1].headers;
+    expect(headers.has("X-Api-Key")).toBe(false);
+  });
+
+  it("multiple setToken calls overwrite correctly", () => {
+    setToken("first");
+    setToken("second");
+    setToken("third");
+    expect(getToken()).toBe("third");
+  });
+
+  it("getToken returns null before any setToken", () => {
+    expect(getToken()).toBeNull();
+  });
+
+  it("clearToken is idempotent", () => {
+    clearToken();
+    clearToken();
+    expect(getToken()).toBeNull();
+  });
+
+  it("setToken with empty string still counts as authenticated", () => {
+    setToken("");
+    // localStorage.getItem returns "" which is not null
+    expect(isAuthenticated()).toBe(true);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Regression: connections store                                      */
+/* ------------------------------------------------------------------ */
+describe("Regression: connections store", () => {
+  it("handles corrupted localStorage gracefully", () => {
+    localStorage.setItem("milady-connections", "not-json");
+    expect(getConnections()).toEqual([]);
+  });
+
+  it("handles null localStorage value gracefully", () => {
+    // getConnections should return empty array when key doesn't exist
+    expect(getConnections()).toEqual([]);
+  });
+
+  it("addConnection generates unique IDs", () => {
+    const c1 = addConnection({ name: "A", url: "http://a", type: "remote" });
+    const c2 = addConnection({ name: "B", url: "http://b", type: "remote" });
+    expect(c1.id).not.toBe(c2.id);
+  });
+
+  it("removeConnection on non-existent id is safe", () => {
+    addConnection({ name: "A", url: "http://a", type: "remote" });
+    removeConnection("non-existent-id");
+    expect(getConnections()).toHaveLength(1);
+  });
+
+  it("preserves other connections when removing one", () => {
+    const _c1 = addConnection({ name: "A", url: "http://a", type: "remote" });
+    const c2 = addConnection({ name: "B", url: "http://b", type: "remote" });
+    const _c3 = addConnection({ name: "C", url: "http://c", type: "remote" });
+    removeConnection(c2.id);
+    const remaining = getConnections();
+    expect(remaining).toHaveLength(2);
+    expect(remaining.map((c) => c.name)).toEqual(["A", "C"]);
+  });
+
+  it("stores connection type correctly", () => {
+    addConnection({ name: "Local", url: "http://localhost", type: "local" });
+    addConnection({ name: "Remote", url: "http://10.0.0.5", type: "remote" });
+    const conns = getConnections();
+    expect(conns[0].type).toBe("local");
+    expect(conns[1].type).toBe("remote");
+  });
+
+  it("stores connection url correctly", () => {
+    const url = "http://my-server.com:2138";
+    addConnection({ name: "Test", url, type: "remote" });
+    expect(getConnections()[0].url).toBe(url);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Regression: routing                                                */
+/* ------------------------------------------------------------------ */
+describe("Regression: routing", () => {
+  it("homepage at / renders top section", async () => {
+    const { AppRoutes } = await import("../router");
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <AppRoutes />
+      </MemoryRouter>,
+    );
+    expect(document.querySelector("#top")).toBeTruthy();
+  });
+
+  it("dashboard at /dashboard has data-testid", async () => {
+    localStorage.setItem("milady-cloud-token", "test-key");
+    const { AppRoutes } = await import("../router");
+    render(
+      <MemoryRouter initialEntries={["/dashboard"]}>
+        <AppRoutes />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId("dashboard")).toBeTruthy();
+  });
+});

--- a/apps/homepage/src/__tests__/router.test.tsx
+++ b/apps/homepage/src/__tests__/router.test.tsx
@@ -1,0 +1,33 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AppRoutes } from "../router";
+
+beforeEach(() => {
+  localStorage.setItem("milady-cloud-token", "test-api-key");
+});
+
+afterEach(() => {
+  localStorage.removeItem("milady-cloud-token");
+  cleanup();
+});
+
+describe("Router", () => {
+  it("renders homepage at /", () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <AppRoutes />
+      </MemoryRouter>,
+    );
+    expect(document.querySelector("#top")).toBeTruthy();
+  });
+
+  it("renders dashboard at /dashboard", () => {
+    render(
+      <MemoryRouter initialEntries={["/dashboard"]}>
+        <AppRoutes />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId("dashboard")).toBeTruthy();
+  });
+});

--- a/apps/homepage/src/__tests__/write-release-data.test.ts
+++ b/apps/homepage/src/__tests__/write-release-data.test.ts
@@ -5,9 +5,7 @@ import {
   pickRelease,
 } from "../lib/release-helpers";
 
-function makeRelease(
-  overrides: Partial<GithubRelease> = {},
-): GithubRelease {
+function makeRelease(overrides: Partial<GithubRelease> = {}): GithubRelease {
   return {
     draft: false,
     prerelease: false,

--- a/apps/homepage/src/components/DownloadIcons.tsx
+++ b/apps/homepage/src/components/DownloadIcons.tsx
@@ -7,7 +7,12 @@ const REPO = "milady-ai/milady";
 
 function AppleIcon() {
   return (
-    <svg aria-hidden="true" className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+    <svg
+      aria-hidden="true"
+      className="w-5 h-5"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+    >
       <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
     </svg>
   );
@@ -15,7 +20,12 @@ function AppleIcon() {
 
 function WindowsIcon() {
   return (
-    <svg aria-hidden="true" className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+    <svg
+      aria-hidden="true"
+      className="w-5 h-5"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+    >
       <path d="M3 12V6.5l8-1.1V12H3zm0 .5h8v6.6l-8-1.1V12.5zM11.5 12V5.3l9.5-1.3V12h-9.5zm0 .5H21v7.8l-9.5-1.3v-6.5z" />
     </svg>
   );
@@ -23,7 +33,12 @@ function WindowsIcon() {
 
 function LinuxIcon() {
   return (
-    <svg aria-hidden="true" className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+    <svg
+      aria-hidden="true"
+      className="w-5 h-5"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+    >
       <path d="M12.504 0c-.155 0-.315.008-.48.021-4.226.333-3.105 4.807-3.17 6.298-.076 1.092-.3 1.953-1.05 3.02-.885 1.051-2.127 2.75-2.716 4.521-.278.832-.41 1.684-.287 2.489a.424.424 0 00-.11.135c-.26.268-.45.6-.663.839-.199.199-.485.267-.797.4-.313.136-.658.269-.864.68-.09.189-.136.394-.132.602 0 .199.027.4.055.536.058.399.116.728.04.97-.249.68-.28 1.145-.106 1.484.174.334.535.47.94.601.81.2 1.91.135 2.774.6.926.466 1.866.67 2.616.47.526-.116.97-.464 1.208-.946.587-.003 1.23-.269 2.26-.334.699-.058 1.574.267 2.577.2a3.4 3.4 0 00.114.333c.391.778 1.113 1.396 1.884 1.564.422.074.852-.002 1.278-.29.19-.13.363-.295.528-.525.39-.546.981-1.3 1.006-2.34.034-.46-.04-.87-.233-1.27a2 2 0 00-.13-.262c.009-.02.018-.042.027-.064.135-.327.191-.672.186-1.004-.01-.667-.311-1.321-.656-1.862-.388-.567-.852-1.079-1.186-1.625-.334-.546-.514-1.134-.394-1.893.202-1.283.545-2.57.353-3.822-.116-.752-.398-1.493-.876-2.104-.46-.588-1.093-1.037-1.86-1.211a4.1 4.1 0 00-1.464-.074c-.511.054-1.052.176-1.622.367z" />
     </svg>
   );
@@ -31,7 +46,12 @@ function LinuxIcon() {
 
 function UbuntuIcon() {
   return (
-    <svg aria-hidden="true" className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+    <svg
+      aria-hidden="true"
+      className="w-5 h-5"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+    >
       <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 2.5a2.5 2.5 0 110 5 2.5 2.5 0 010-5zM5.5 14a2 2 0 110-4 2 2 0 010 4zm13 0a2 2 0 110-4 2 2 0 010 4zM12 19.5a2.5 2.5 0 110-5 2.5 2.5 0 010 5z" />
     </svg>
   );
@@ -39,7 +59,12 @@ function UbuntuIcon() {
 
 function AndroidIcon() {
   return (
-    <svg aria-hidden="true" className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+    <svg
+      aria-hidden="true"
+      className="w-5 h-5"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+    >
       <path d="M17.523 15.341a1 1 0 010-2h.001a1 1 0 010 2h-.001zm-11.046 0a1 1 0 010-2h.001a1 1 0 010 2h-.001zm11.405-6.02l1.997-3.46a.416.416 0 00-.152-.567.416.416 0 00-.568.152L17.14 8.95a10.18 10.18 0 00-5.14-1.372 10.18 10.18 0 00-5.14 1.372L4.84 5.446a.416.416 0 00-.568-.152.416.416 0 00-.152.567l1.997 3.46C2.688 11.186.343 14.652 0 18.7h24c-.344-4.048-2.688-7.514-6.118-9.38z" />
     </svg>
   );
@@ -47,7 +72,12 @@ function AndroidIcon() {
 
 function IosIcon() {
   return (
-    <svg aria-hidden="true" className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+    <svg
+      aria-hidden="true"
+      className="w-5 h-5"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+    >
       <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
     </svg>
   );
@@ -55,7 +85,12 @@ function IosIcon() {
 
 function GithubIcon() {
   return (
-    <svg aria-hidden="true" className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+    <svg
+      aria-hidden="true"
+      className="w-5 h-5"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+    >
       <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.009-.866-.013-1.7-2.782.603-3.369-1.342-3.369-1.342-.454-1.155-1.11-1.462-1.11-1.462-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.115 2.504.337 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z" />
     </svg>
   );
@@ -72,10 +107,25 @@ const iconMap: Record<string, () => ReactNode> = {
 };
 
 const platformDefs = [
-  { id: "apple", label: "Download from", store: "App Store", assetId: "macos-arm64" },
-  { id: "windows", label: "Download for", store: "Windows", assetId: "windows-x64" },
+  {
+    id: "apple",
+    label: "Download from",
+    store: "App Store",
+    assetId: "macos-arm64",
+  },
+  {
+    id: "windows",
+    label: "Download for",
+    store: "Windows",
+    assetId: "windows-x64",
+  },
   { id: "linux", label: "Download for", store: "Linux", assetId: "linux-x64" },
-  { id: "ubuntu", label: "Download for", store: "Ubuntu", assetId: "linux-deb" },
+  {
+    id: "ubuntu",
+    label: "Download for",
+    store: "Ubuntu",
+    assetId: "linux-deb",
+  },
   { id: "android", label: "Coming", store: "Soon", assetId: "" },
   { id: "ios", label: "Coming", store: "Soon", assetId: "" },
   { id: "github", label: "All", store: "Releases", assetId: "github" },
@@ -103,28 +153,38 @@ function buildStaticUrls(): Record<string, string> {
 
 export function DownloadIcons() {
   const [urls, setUrls] = useState<Record<string, string>>(buildStaticUrls);
-  const [releasePageUrl, setReleasePageUrl] = useState<string>(releaseData.release.url);
+  const [releasePageUrl, setReleasePageUrl] = useState<string>(
+    releaseData.release.url,
+  );
 
   useEffect(() => {
     fetch(`https://api.github.com/repos/${REPO}/releases?per_page=10`, {
       headers: { Accept: "application/vnd.github+json" },
     })
       .then((r) => (r.ok ? r.json() : Promise.reject()))
-      .then((releases: Array<{ draft: boolean; html_url: string; assets: Array<{ name: string; browser_download_url: string }> }>) => {
-        const release = releases.find((r) => !r.draft && r.assets.length > 0);
-        if (!release) return;
+      .then(
+        (
+          releases: Array<{
+            draft: boolean;
+            html_url: string;
+            assets: Array<{ name: string; browser_download_url: string }>;
+          }>,
+        ) => {
+          const release = releases.find((r) => !r.draft && r.assets.length > 0);
+          if (!release) return;
 
-        setReleasePageUrl(release.html_url);
+          setReleasePageUrl(release.html_url);
 
-        const freshUrls: Record<string, string> = {};
-        for (const asset of release.assets) {
-          const id = matchAsset(asset.name);
-          if (id && !freshUrls[id]) {
-            freshUrls[id] = asset.browser_download_url;
+          const freshUrls: Record<string, string> = {};
+          for (const asset of release.assets) {
+            const id = matchAsset(asset.name);
+            if (id && !freshUrls[id]) {
+              freshUrls[id] = asset.browser_download_url;
+            }
           }
-        }
-        setUrls(freshUrls);
-      })
+          setUrls(freshUrls);
+        },
+      )
       .catch(() => {
         // Silently fall back to build-time data
       });

--- a/apps/homepage/src/components/Downloads.tsx
+++ b/apps/homepage/src/components/Downloads.tsx
@@ -1,9 +1,43 @@
 import { useCallback, useEffect, useRef } from "react";
 import { releaseData } from "../generated/release-data";
+
 // Platform icons are now handled by DownloadIcons via Font Awesome
-function AppleIcon() { return <svg aria-hidden="true" className="w-6 h-6" viewBox="0 0 24 24" fill="currentColor"><path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" /></svg>; }
-function LinuxIcon() { return <svg aria-hidden="true" className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><path d="M12.504 0c-.155 0-.315.008-.48.021-4.226.333-3.105 4.807-3.17 6.298-.076 1.092-.3 1.953-1.05 3.02-.885 1.051-2.127 2.75-2.716 4.521-.278.832-.41 1.684-.287 2.489.037.192.11.398.17.607.062.208.137.424.168.631.032.208.02.406-.069.56-.045.077-.119.136-.232.17-.113.034-.264.044-.47.015z" /></svg>; }
-function WindowsIcon() { return <svg aria-hidden="true" className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><path d="M3 12V6.5l8-1.1V12H3zm0 .5h8v6.6l-8-1.1V12.5zM11.5 12V5.3l9.5-1.3V12h-9.5zm0 .5H21v7.8l-9.5-1.3v-6.5z" /></svg>; }
+function AppleIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="w-6 h-6"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+    >
+      <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
+    </svg>
+  );
+}
+function LinuxIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="w-5 h-5"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+    >
+      <path d="M12.504 0c-.155 0-.315.008-.48.021-4.226.333-3.105 4.807-3.17 6.298-.076 1.092-.3 1.953-1.05 3.02-.885 1.051-2.127 2.75-2.716 4.521-.278.832-.41 1.684-.287 2.489.037.192.11.398.17.607.062.208.137.424.168.631.032.208.02.406-.069.56-.045.077-.119.136-.232.17-.113.034-.264.044-.47.015z" />
+    </svg>
+  );
+}
+function WindowsIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="w-5 h-5"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+    >
+      <path d="M3 12V6.5l8-1.1V12H3zm0 .5h8v6.6l-8-1.1V12.5zM11.5 12V5.3l9.5-1.3V12h-9.5zm0 .5H21v7.8l-9.5-1.3v-6.5z" />
+    </svg>
+  );
+}
 
 const shellCommand = releaseData.scripts.shell.command;
 const powershellCommand = releaseData.scripts.powershell.command;

--- a/apps/homepage/src/components/Footer.tsx
+++ b/apps/homepage/src/components/Footer.tsx
@@ -26,10 +26,7 @@ export function Footer() {
 
         {/* Social links */}
         <div className="flex gap-6">
-          <SocialLink
-            href="https://github.com/milady-ai/milady"
-            label="GitHub"
-          >
+          <SocialLink href="https://github.com/milady-ai/milady" label="GitHub">
             <svg
               aria-hidden="true"
               className="w-6 h-6"

--- a/apps/homepage/src/components/Hero.tsx
+++ b/apps/homepage/src/components/Hero.tsx
@@ -116,4 +116,3 @@ export function HeroBackground() {
     </section>
   );
 }
-

--- a/apps/homepage/src/components/Nav.tsx
+++ b/apps/homepage/src/components/Nav.tsx
@@ -1,61 +1,88 @@
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import { releaseData } from "../generated/release-data";
 
-const ELIZA_CLOUD_LOGIN_URL =
-  "https://elizacloud.ai/login?returnTo=%2Fdashboard%2Fmilady";
-
 export function Nav() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const isOnDashboard = location.pathname === "/dashboard";
+
+  /** Navigate to homepage and scroll to a section anchor. */
+  function scrollTo(anchor: string) {
+    return (e: React.MouseEvent) => {
+      e.preventDefault();
+      if (isOnDashboard) {
+        navigate("/");
+        // Wait for route to render, then scroll
+        setTimeout(() => {
+          document
+            .getElementById(anchor)
+            ?.scrollIntoView({ behavior: "smooth" });
+        }, 100);
+      } else {
+        document.getElementById(anchor)?.scrollIntoView({ behavior: "smooth" });
+      }
+    };
+  }
+
   return (
     <nav className="fixed top-0 left-0 right-0 z-50 flex flex-col bg-dark/95 backdrop-blur-md border-b border-sharp">
       <div className="flex items-center justify-between px-6 py-4 md:px-12">
-      <a
-        href="#top"
-        className="group text-4xl font-black text-[#1a1a1a] hover:text-white tracking-tighter uppercase flex items-center gap-2 mt-1 transition-colors duration-300"
-      >
-        <img src="/logo.png" alt="Milady" className="w-8 h-8 rounded-full brightness-[0.3] group-hover:brightness-100 transition-all duration-300" />
-        MILADY
-      </a>
-      <div className="hidden md:flex items-center gap-8 font-mono text-xs uppercase tracking-widest">
-        <a
-          href="#install"
-          className="text-text-muted hover:text-brand transition-colors duration-300"
+        <button
+          type="button"
+          onClick={scrollTo("top")}
+          className="group text-4xl font-black text-[#1a1a1a] hover:text-white tracking-tighter uppercase flex items-center gap-2 mt-1 transition-colors duration-300"
         >
-          Install
-        </a>
-        <a
-          href={ELIZA_CLOUD_LOGIN_URL}
-          target="_blank"
-          rel="noreferrer"
-          className="text-text-muted hover:text-brand transition-colors duration-300"
-        >
-          Cloud
-        </a>
-        <a
-          href="#privacy"
-          className="text-text-muted hover:text-brand transition-colors duration-300"
-        >
-          Privacy
-        </a>
-        <a
-          href="#features"
-          className="text-text-muted hover:text-brand transition-colors duration-300"
-        >
-          Features
-        </a>
-        <a
-          href="#comparison"
-          className="text-text-muted hover:text-brand transition-colors duration-300"
-        >
-          Why Local
-        </a>
-        <a
-          href={releaseData.release.url}
-          target="_blank"
-          rel="noreferrer"
-          className="border-sharp px-4 py-2 hover:bg-brand hover:text-dark hover:border-brand transition-all duration-300"
-        >
-          Releases
-        </a>
-      </div>
+          <img
+            src="/logo.png"
+            alt="Milady"
+            className="w-8 h-8 rounded-full brightness-[0.3] group-hover:brightness-100 transition-all duration-300"
+          />
+          MILADY
+        </button>
+        <div className="hidden md:flex items-center gap-8 font-mono text-xs uppercase tracking-widest">
+          <button
+            type="button"
+            onClick={scrollTo("install")}
+            className="text-text-muted hover:text-brand transition-colors duration-300"
+          >
+            Install
+          </button>
+          <Link
+            to="/dashboard"
+            className={`transition-colors duration-300 ${isOnDashboard ? "text-brand" : "text-text-muted hover:text-brand"}`}
+          >
+            Cloud
+          </Link>
+          <button
+            type="button"
+            onClick={scrollTo("privacy")}
+            className="text-text-muted hover:text-brand transition-colors duration-300"
+          >
+            Privacy
+          </button>
+          <button
+            type="button"
+            onClick={scrollTo("features")}
+            className="text-text-muted hover:text-brand transition-colors duration-300"
+          >
+            Features
+          </button>
+          <button
+            type="button"
+            onClick={scrollTo("comparison")}
+            className="text-text-muted hover:text-brand transition-colors duration-300"
+          >
+            Why Local
+          </button>
+          <a
+            href={releaseData.release.url}
+            target="_blank"
+            rel="noreferrer"
+            className="border-sharp px-4 py-2 hover:bg-brand hover:text-dark hover:border-brand transition-all duration-300"
+          >
+            Releases
+          </a>
+        </div>
       </div>
       <div className="hidden md:flex justify-end px-3 pb-2">
         <span className="version-clock">

--- a/apps/homepage/src/components/dashboard/AgentCard.tsx
+++ b/apps/homepage/src/components/dashboard/AgentCard.tsx
@@ -1,0 +1,149 @@
+import type { AgentStatus } from "../../lib/cloud-api";
+
+interface AgentCardProps {
+  agent: AgentStatus;
+  connectionName: string;
+  onPlay: () => void;
+  onResume: () => void;
+  onPause: () => void;
+  onStop: () => void;
+  onSelect: () => void;
+  selected: boolean;
+}
+
+const STATE_COLORS: Record<string, string> = {
+  running: "bg-green-500",
+  paused: "bg-yellow-500",
+  stopped: "bg-red-500",
+  provisioning: "bg-cyan-500 animate-pulse",
+  unknown: "bg-white/20",
+};
+
+function formatUptime(seconds?: number): string {
+  if (!seconds) return "\u2014";
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+}
+
+function stopProp(handler: () => void) {
+  return (e: React.MouseEvent) => {
+    e.stopPropagation();
+    handler();
+  };
+}
+
+export function AgentCard({
+  agent,
+  connectionName,
+  onPlay,
+  onResume,
+  onPause,
+  onStop,
+  onSelect,
+  selected,
+}: AgentCardProps) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={`border rounded p-4 cursor-pointer transition-all duration-200 text-left w-full ${
+        selected
+          ? "border-brand bg-brand/5"
+          : "border-white/10 hover:border-white/20 hover:bg-white/[0.02]"
+      }`}
+    >
+      <div className="flex items-start justify-between mb-3">
+        <div>
+          <h3 className="text-sm font-medium text-text-light">
+            {agent.agentName}
+          </h3>
+          <span className="text-[10px] font-mono text-text-muted uppercase tracking-wider">
+            {agent.model}
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span
+            className={`w-2 h-2 rounded-full ${STATE_COLORS[agent.state] ?? STATE_COLORS.unknown}`}
+          />
+          <span className="text-[10px] font-mono text-text-muted uppercase">
+            {agent.state}
+          </span>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-4 text-[10px] font-mono text-text-muted mb-3">
+        <span>
+          {"\u2191"} {formatUptime(agent.uptime)}
+        </span>
+        {agent.memories !== undefined && (
+          <span>
+            {"\u29eb"} {agent.memories} memories
+          </span>
+        )}
+        <span
+          className={`ml-auto px-1.5 py-0.5 rounded text-[9px] font-mono uppercase tracking-wider ${
+            connectionName === "cloud"
+              ? "bg-blue-500/10 text-blue-400 border border-blue-500/20"
+              : connectionName === "local"
+                ? "bg-green-500/10 text-green-400 border border-green-500/20"
+                : "bg-purple-500/10 text-purple-400 border border-purple-500/20"
+          }`}
+        >
+          {connectionName}
+        </span>
+      </div>
+
+      <div className="flex gap-2">
+        {agent.state === "stopped" && (
+          <button
+            type="button"
+            onClick={stopProp(onPlay)}
+            className="px-2 py-1 text-[10px] font-mono uppercase tracking-wider border border-green-500/30 text-green-500 rounded hover:bg-green-500/10 transition-colors"
+          >
+            Play
+          </button>
+        )}
+        {agent.state === "paused" && (
+          <button
+            type="button"
+            onClick={stopProp(onResume)}
+            className="px-2 py-1 text-[10px] font-mono uppercase tracking-wider border border-green-500/30 text-green-500 rounded hover:bg-green-500/10 transition-colors"
+          >
+            Resume
+          </button>
+        )}
+        {agent.state === "running" && (
+          <button
+            type="button"
+            onClick={stopProp(onPause)}
+            className="px-2 py-1 text-[10px] font-mono uppercase tracking-wider border border-yellow-500/30 text-yellow-500 rounded hover:bg-yellow-500/10 transition-colors"
+          >
+            Pause
+          </button>
+        )}
+        {agent.state !== "stopped" &&
+          agent.state !== "provisioning" &&
+          agent.state !== "unknown" && (
+            <button
+              type="button"
+              onClick={stopProp(onStop)}
+              className="px-2 py-1 text-[10px] font-mono uppercase tracking-wider border border-red-500/30 text-red-500 rounded hover:bg-red-500/10 transition-colors"
+            >
+              Stop
+            </button>
+          )}
+        {agent.state === "provisioning" && (
+          <span className="px-2 py-1 text-[10px] font-mono uppercase tracking-wider text-cyan-500 animate-pulse">
+            Provisioning...
+          </span>
+        )}
+        {agent.state === "unknown" && (
+          <span className="px-2 py-1 text-[10px] font-mono uppercase tracking-wider text-text-muted">
+            Status unknown
+          </span>
+        )}
+      </div>
+    </button>
+  );
+}

--- a/apps/homepage/src/components/dashboard/AgentDetail.tsx
+++ b/apps/homepage/src/components/dashboard/AgentDetail.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react";
+import type { AgentStatus } from "../../lib/cloud-api";
+import { ExportPanel } from "./ExportPanel";
+import { LogsPanel } from "./LogsPanel";
+import { MetricsPanel } from "./MetricsPanel";
+
+const TABS = ["Metrics", "Logs", "Snapshots"] as const;
+type Tab = (typeof TABS)[number];
+
+interface AgentDetailProps {
+  agent: AgentStatus;
+  connectionId: string;
+}
+
+export function AgentDetail({ agent, connectionId }: AgentDetailProps) {
+  const [tab, setTab] = useState<Tab>("Metrics");
+
+  return (
+    <div className="border border-white/10 rounded">
+      <div className="flex border-b border-white/10">
+        {TABS.map((t) => (
+          <button
+            type="button"
+            key={t}
+            onClick={() => setTab(t)}
+            className={`px-4 py-2 font-mono text-xs uppercase tracking-widest transition-colors ${
+              tab === t
+                ? "text-brand border-b-2 border-brand"
+                : "text-text-muted hover:text-text-light"
+            }`}
+          >
+            {t}
+          </button>
+        ))}
+        <span className="ml-auto px-4 py-2 text-[10px] font-mono text-text-muted">
+          {agent.agentName}
+        </span>
+      </div>
+      <div className="p-4">
+        {tab === "Metrics" && <MetricsPanel />}
+        {tab === "Logs" && <LogsPanel />}
+        {tab === "Snapshots" && <ExportPanel connectionId={connectionId} />}
+      </div>
+    </div>
+  );
+}

--- a/apps/homepage/src/components/dashboard/AgentGrid.tsx
+++ b/apps/homepage/src/components/dashboard/AgentGrid.tsx
@@ -1,0 +1,114 @@
+import { useCallback } from "react";
+import { useAgents } from "../../lib/AgentProvider";
+import { AgentCard } from "./AgentCard";
+import { AgentDetail } from "./AgentDetail";
+
+interface AgentGridProps {
+  selectedAgentId: string | null;
+  onSelectAgent: (id: string | null) => void;
+}
+
+export function AgentGrid({ selectedAgentId, onSelectAgent }: AgentGridProps) {
+  const { agents, loading, refresh } = useAgents();
+
+  const handleAction = useCallback(
+    async (agentId: string, action: "play" | "resume" | "pause" | "stop") => {
+      const agent = agents.find((a) => a.id === agentId);
+      if (!agent) return;
+      try {
+        if (
+          agent.source === "cloud" &&
+          agent.cloudClient &&
+          agent.cloudAgentId
+        ) {
+          if (action === "play" || action === "resume") {
+            await agent.cloudClient.resumeAgent(agent.cloudAgentId);
+          } else if (action === "pause") {
+            await agent.cloudClient.suspendAgent(agent.cloudAgentId);
+          } else if (action === "stop") {
+            await agent.cloudClient.suspendAgent(agent.cloudAgentId);
+          }
+        } else if (agent.client) {
+          if (action === "play") await agent.client.playAgent();
+          else if (action === "resume") await agent.client.resumeAgent();
+          else if (action === "pause") await agent.client.pauseAgent();
+          else if (action === "stop") await agent.client.stopAgent();
+        }
+        await refresh();
+      } catch (err) {
+        console.error(`Failed to ${action} agent:`, err);
+      }
+    },
+    [agents, refresh],
+  );
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-32">
+        <div className="text-brand font-mono text-sm animate-pulse">
+          Discovering agents...
+        </div>
+      </div>
+    );
+  }
+
+  if (agents.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-32 space-y-3">
+        <div className="text-text-muted/30 text-4xl">{"\u25C9"}</div>
+        <div className="text-text-muted font-mono text-sm">No agents found</div>
+        <div className="text-text-muted/50 font-mono text-xs text-center max-w-md">
+          Log in with Eliza Cloud to see your hosted agents, or start a local
+          Milady agent on port 2138.
+        </div>
+      </div>
+    );
+  }
+
+  const selected = selectedAgentId
+    ? agents.find((a) => a.id === selectedAgentId)
+    : null;
+
+  return (
+    <div>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {agents.map((agent) => (
+          <AgentCard
+            key={agent.id}
+            agent={{
+              agentName: agent.name,
+              state: agent.status,
+              model: agent.model ?? "\u2014",
+              uptime: agent.uptime,
+              memories: agent.memories,
+            }}
+            connectionName={agent.source}
+            onPlay={() => handleAction(agent.id, "play")}
+            onResume={() => handleAction(agent.id, "resume")}
+            onPause={() => handleAction(agent.id, "pause")}
+            onStop={() => handleAction(agent.id, "stop")}
+            onSelect={() =>
+              onSelectAgent(selectedAgentId === agent.id ? null : agent.id)
+            }
+            selected={selectedAgentId === agent.id}
+          />
+        ))}
+      </div>
+
+      {selected && (
+        <div className="mt-6">
+          <AgentDetail
+            agent={{
+              agentName: selected.name,
+              state: selected.status,
+              model: selected.model ?? "\u2014",
+              uptime: selected.uptime,
+              memories: selected.memories,
+            }}
+            connectionId={selected.id}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/homepage/src/components/dashboard/AuthGate.tsx
+++ b/apps/homepage/src/components/dashboard/AuthGate.tsx
@@ -1,0 +1,150 @@
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import {
+  clearToken,
+  cloudLogin,
+  cloudLoginPoll,
+  isAuthenticated,
+  setToken,
+} from "../../lib/auth";
+
+type AuthState =
+  | "checking"
+  | "unauthenticated"
+  | "polling"
+  | "authenticated"
+  | "error";
+
+export function AuthGate({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<AuthState>("checking");
+  const [error, setError] = useState<string | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval>>();
+
+  useEffect(() => {
+    setState(isAuthenticated() ? "authenticated" : "unauthenticated");
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, []);
+
+  const handleLogin = useCallback(async () => {
+    setState("polling");
+    setError(null);
+    try {
+      const { sessionId, browserUrl } = await cloudLogin();
+      window.open(browserUrl, "_blank", "noopener,noreferrer");
+
+      const deadline = Date.now() + 5 * 60 * 1000;
+      pollRef.current = setInterval(async () => {
+        try {
+          if (Date.now() > deadline) {
+            clearInterval(pollRef.current);
+            setState("error");
+            setError("Login timed out. Please try again.");
+            return;
+          }
+          const result = await cloudLoginPoll(sessionId);
+          if (result.status === "authenticated" && result.apiKey) {
+            clearInterval(pollRef.current);
+            setToken(result.apiKey);
+            setState("authenticated");
+          }
+        } catch (err) {
+          if (String(err).includes("expired")) {
+            clearInterval(pollRef.current);
+            setState("error");
+            setError("Session expired. Please try again.");
+          }
+          // Otherwise keep polling
+        }
+      }, 2000);
+    } catch (err) {
+      setState("error");
+      setError(`Failed to start login: ${err}`);
+    }
+  }, []);
+
+  const _handleLogout = useCallback(() => {
+    clearToken();
+    setState("unauthenticated");
+  }, []);
+
+  const handleSkip = useCallback(() => {
+    setState("authenticated");
+  }, []);
+
+  if (state === "checking") {
+    return (
+      <div className="min-h-screen bg-dark flex items-center justify-center">
+        <div className="text-text-muted font-mono text-sm">Loading...</div>
+      </div>
+    );
+  }
+
+  if (state === "authenticated") {
+    return <>{children}</>;
+  }
+
+  return (
+    <div className="min-h-screen bg-dark flex items-center justify-center pt-20">
+      <div className="max-w-sm w-full space-y-6 p-6">
+        <div className="text-center">
+          <h2 className="text-xl font-medium text-text-light mb-2">
+            Milady Cloud
+          </h2>
+          <p className="text-text-muted text-sm">
+            Sign in with your Eliza Cloud account to manage your agents.
+          </p>
+        </div>
+
+        {state === "polling" ? (
+          <div className="text-center space-y-3">
+            <div className="text-brand font-mono text-sm animate-pulse">
+              Waiting for authentication...
+            </div>
+            <p className="text-text-muted text-xs">
+              Complete the login in the browser tab that opened.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <button
+              type="button"
+              onClick={handleLogin}
+              className="w-full px-4 py-2 bg-brand text-dark font-mono text-xs uppercase tracking-widest rounded hover:bg-brand-hover transition-colors"
+            >
+              Login with Eliza Cloud
+            </button>
+            <button
+              type="button"
+              onClick={handleSkip}
+              className="w-full px-4 py-2 border border-white/10 text-text-muted font-mono text-xs uppercase tracking-widest rounded hover:border-white/30 transition-colors"
+            >
+              Skip (local only)
+            </button>
+          </div>
+        )}
+
+        {error && (
+          <div className="space-y-2">
+            <div className="text-red-500 font-mono text-xs text-center">
+              {error}
+            </div>
+            <button
+              type="button"
+              onClick={() => setState("unauthenticated")}
+              className="w-full px-4 py-2 border border-white/10 text-text-muted font-mono text-xs uppercase tracking-widest rounded hover:border-white/30 transition-colors"
+            >
+              Try Again
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/homepage/src/components/dashboard/BillingPanel.tsx
+++ b/apps/homepage/src/components/dashboard/BillingPanel.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from "react";
+import { useAgents } from "../../lib/AgentProvider";
+import { getToken, isAuthenticated } from "../../lib/auth";
+import { CloudClient } from "../../lib/cloud-api";
+
+export function BillingPanel() {
+  const { agents } = useAgents();
+  const cloudAgents = agents.filter((a) => a.source === "cloud");
+  const [billingSettings, setBillingSettings] = useState<Record<
+    string,
+    unknown
+  > | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isAuthenticated()) return;
+    setLoading(true);
+    const cc = new CloudClient(getToken() ?? "");
+    cc.getBillingSettings()
+      .then(setBillingSettings)
+      .catch((e) => setError(e.message ?? String(e)))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (!isAuthenticated()) {
+    return (
+      <div className="flex flex-col items-center justify-center py-32 space-y-3">
+        <div className="text-text-muted/30 text-4xl">{"\u25C8"}</div>
+        <div className="text-text-muted font-mono text-sm">
+          Not connected to cloud
+        </div>
+        <div className="text-text-muted/50 font-mono text-xs">
+          Log in with Eliza Cloud to view billing settings.
+        </div>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-32">
+        <div className="text-brand font-mono text-sm animate-pulse">
+          Loading billing...
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center py-32 space-y-3">
+        <div className="text-text-muted/30 text-4xl">{"\u25C8"}</div>
+        <div className="text-text-muted font-mono text-sm">
+          Billing data unavailable
+        </div>
+        <div className="text-text-muted/50 font-mono text-xs">{error}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 max-w-2xl">
+      <h3 className="font-mono text-xs uppercase tracking-widest text-brand">
+        Billing & Usage
+      </h3>
+
+      {/* Cloud Agents Summary */}
+      <div className="bg-dark border border-white/10 rounded p-4">
+        <div className="text-text-muted font-mono text-[10px] uppercase tracking-wider">
+          Cloud Agents
+        </div>
+        <div className="text-text-light font-mono text-lg mt-1">
+          {cloudAgents.length} active
+        </div>
+      </div>
+
+      {/* Billing Settings */}
+      {billingSettings && (
+        <div className="bg-dark border border-white/10 rounded p-4">
+          <div className="text-text-muted font-mono text-[10px] uppercase tracking-wider mb-2">
+            Settings
+          </div>
+          <pre className="font-mono text-xs text-text-muted overflow-auto">
+            {JSON.stringify(billingSettings, null, 2)}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/homepage/src/components/dashboard/ConnectionModal.tsx
+++ b/apps/homepage/src/components/dashboard/ConnectionModal.tsx
@@ -1,0 +1,59 @@
+import { useState } from "react";
+
+interface ConnectionModalProps {
+  onSubmit: (data: { name: string; url: string; type: "remote" }) => void;
+  onClose: () => void;
+}
+
+export function ConnectionModal({ onSubmit, onClose }: ConnectionModalProps) {
+  const [name, setName] = useState("");
+  const [url, setUrl] = useState("");
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div className="bg-dark-secondary border border-white/10 rounded p-6 w-96 space-y-4">
+        <h3 className="font-mono text-xs uppercase tracking-widest text-brand">
+          Add Remote Agent
+        </h3>
+
+        <label className="block">
+          <span className="text-text-muted text-xs font-mono">Name</span>
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="My Remote Agent"
+            className="mt-1 w-full bg-dark border border-white/10 px-3 py-2 text-sm text-text-light font-mono rounded focus:border-brand focus:outline-none"
+          />
+        </label>
+
+        <label className="block">
+          <span className="text-text-muted text-xs font-mono">URL</span>
+          <input
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder="http://10.0.0.5:2138"
+            className="mt-1 w-full bg-dark border border-white/10 px-3 py-2 text-sm text-text-light font-mono rounded focus:border-brand focus:outline-none"
+          />
+        </label>
+
+        <div className="flex gap-3 pt-2">
+          <button
+            type="button"
+            onClick={() => onSubmit({ name, url, type: "remote" })}
+            disabled={!name || !url}
+            className="flex-1 px-4 py-2 bg-brand text-dark font-mono text-xs uppercase tracking-widest rounded hover:bg-brand-hover transition-colors disabled:opacity-30"
+          >
+            Connect
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 border border-white/10 text-text-muted font-mono text-xs uppercase tracking-widest rounded hover:border-white/30 transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/homepage/src/components/dashboard/CreditsPanel.tsx
+++ b/apps/homepage/src/components/dashboard/CreditsPanel.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from "react";
+import { getToken, isAuthenticated } from "../../lib/auth";
+import { CloudClient, type CreditBalance } from "../../lib/cloud-api";
+
+export function CreditsPanel() {
+  const [credits, setCredits] = useState<CreditBalance | null>(null);
+  const [session, setSession] = useState<{
+    credits?: number;
+    requests?: number;
+    tokens?: number;
+  } | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isAuthenticated()) return;
+    setLoading(true);
+    const cc = new CloudClient(getToken() ?? "");
+    Promise.all([
+      cc.getCreditsBalance().catch(() => null),
+      cc.getCurrentSession().catch(() => null),
+    ])
+      .then(([creds, sess]) => {
+        if (creds) setCredits(creds);
+        if (sess) setSession(sess);
+        if (!creds && !sess) setError("Could not load credit data");
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (!isAuthenticated()) {
+    return (
+      <div className="flex flex-col items-center justify-center py-32 space-y-3">
+        <div className="text-text-muted/30 text-4xl">{"\u25C7"}</div>
+        <div className="text-text-muted font-mono text-sm">
+          Not connected to cloud
+        </div>
+        <div className="text-text-muted/50 font-mono text-xs">
+          Log in with Eliza Cloud to view your credits.
+        </div>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-32">
+        <div className="text-brand font-mono text-sm animate-pulse">
+          Loading credits...
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center py-32 space-y-3">
+        <div className="text-text-muted/30 text-4xl">{"\u25C7"}</div>
+        <div className="text-text-muted font-mono text-sm">{error}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 max-w-2xl">
+      <h3 className="font-mono text-xs uppercase tracking-widest text-brand">
+        Credits
+      </h3>
+
+      {/* Balance card */}
+      <div className="bg-dark border border-white/10 rounded p-6">
+        <div className="text-text-muted font-mono text-[10px] uppercase tracking-wider mb-2">
+          Balance
+        </div>
+        <div className="text-text-light font-mono text-3xl">
+          {credits ? credits.balance.toLocaleString() : "\u2014"}
+        </div>
+        <div className="text-text-muted font-mono text-xs mt-1">
+          {credits?.currency ?? "credits"}
+        </div>
+      </div>
+
+      {/* Session usage */}
+      {session && (
+        <div className="bg-dark border border-white/10 rounded p-6 space-y-4">
+          <div className="text-text-muted font-mono text-[10px] uppercase tracking-wider">
+            Current Session Usage
+          </div>
+          <div className="grid grid-cols-3 gap-6">
+            <div>
+              <div className="text-text-muted font-mono text-[10px] uppercase">
+                Requests
+              </div>
+              <div className="text-text-light font-mono text-2xl mt-1">
+                {session.requests?.toLocaleString() ?? "\u2014"}
+              </div>
+            </div>
+            <div>
+              <div className="text-text-muted font-mono text-[10px] uppercase">
+                Tokens
+              </div>
+              <div className="text-text-light font-mono text-2xl mt-1">
+                {session.tokens?.toLocaleString() ?? "\u2014"}
+              </div>
+            </div>
+            <div>
+              <div className="text-text-muted font-mono text-[10px] uppercase">
+                Credits Used
+              </div>
+              <div className="text-text-light font-mono text-2xl mt-1">
+                {session.credits?.toLocaleString() ?? "\u2014"}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/homepage/src/components/dashboard/Dashboard.tsx
+++ b/apps/homepage/src/components/dashboard/Dashboard.tsx
@@ -1,0 +1,71 @@
+import { useState } from "react";
+import { AgentProvider } from "../../lib/AgentProvider";
+import { AgentGrid } from "./AgentGrid";
+import { AuthGate } from "./AuthGate";
+import { BillingPanel } from "./BillingPanel";
+import { CreditsPanel } from "./CreditsPanel";
+import { ExportPanel } from "./ExportPanel";
+import { LogsPanel } from "./LogsPanel";
+import { MetricsPanel } from "./MetricsPanel";
+import { type DashboardSection, Sidebar } from "./Sidebar";
+import { SourceBar } from "./SourceBar";
+
+export function Dashboard() {
+  const [section, setSection] = useState<DashboardSection>("agents");
+  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
+
+  return (
+    <AuthGate>
+      <AgentProvider>
+        <div
+          data-testid="dashboard"
+          className="min-h-screen bg-dark text-text-light"
+        >
+          <div className="pt-[100px] flex min-h-screen">
+            <Sidebar active={section} onChange={setSection} />
+            <div className="flex-1 flex flex-col min-w-0">
+              <SourceBar />
+              <main className="flex-1 px-8 py-6">
+                <DashboardContent
+                  section={section}
+                  selectedAgentId={selectedAgentId}
+                  onSelectAgent={setSelectedAgentId}
+                />
+              </main>
+            </div>
+          </div>
+        </div>
+      </AgentProvider>
+    </AuthGate>
+  );
+}
+
+function DashboardContent({
+  section,
+  selectedAgentId,
+  onSelectAgent,
+}: {
+  section: DashboardSection;
+  selectedAgentId: string | null;
+  onSelectAgent: (id: string | null) => void;
+}) {
+  switch (section) {
+    case "agents":
+      return (
+        <AgentGrid
+          selectedAgentId={selectedAgentId}
+          onSelectAgent={onSelectAgent}
+        />
+      );
+    case "metrics":
+      return <MetricsPanel />;
+    case "logs":
+      return <LogsPanel />;
+    case "snapshots":
+      return <ExportPanel connectionId={selectedAgentId ?? ""} />;
+    case "credits":
+      return <CreditsPanel />;
+    case "billing":
+      return <BillingPanel />;
+  }
+}

--- a/apps/homepage/src/components/dashboard/ExportPanel.tsx
+++ b/apps/homepage/src/components/dashboard/ExportPanel.tsx
@@ -1,0 +1,233 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useAgents } from "../../lib/AgentProvider";
+import type { CloudBackup } from "../../lib/cloud-api";
+
+interface ExportPanelProps {
+  connectionId: string;
+}
+
+export function ExportPanel({ connectionId }: ExportPanelProps) {
+  const { agents } = useAgents();
+  const agent = agents.find((a) => a.id === connectionId);
+
+  // Local/remote export state
+  const [password, setPassword] = useState("");
+  const [status, setStatus] = useState<string | null>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  // Cloud backup state
+  const [backups, setBackups] = useState<CloudBackup[]>([]);
+  const [backupsLoading, setBackupsLoading] = useState(false);
+
+  const isCloud =
+    agent?.source === "cloud" && agent.cloudClient && agent.cloudAgentId;
+
+  // Fetch cloud backups on mount / agent change
+  useEffect(() => {
+    if (!isCloud) return;
+    setBackupsLoading(true);
+    agent.cloudClient
+      ?.listBackups(agent.cloudAgentId ?? "")
+      .then(setBackups)
+      .catch(() => setBackups([]))
+      .finally(() => setBackupsLoading(false));
+  }, [isCloud, agent?.cloudAgentId, agent?.cloudClient]);
+
+  // Cloud: take snapshot
+  const handleSnapshot = useCallback(async () => {
+    if (!agent?.cloudClient || !agent.cloudAgentId) return;
+    setStatus("Taking snapshot...");
+    try {
+      await agent.cloudClient.takeSnapshot(agent.cloudAgentId);
+      setStatus("Snapshot created");
+      // Refresh backup list
+      const updated = await agent.cloudClient.listBackups(agent.cloudAgentId);
+      setBackups(updated);
+    } catch (err) {
+      setStatus(`Snapshot failed: ${err}`);
+    }
+  }, [agent]);
+
+  // Cloud: restore backup
+  const handleRestore = useCallback(
+    async (backupId: string) => {
+      if (!agent?.cloudClient || !agent.cloudAgentId) return;
+      setStatus("Restoring...");
+      try {
+        await agent.cloudClient.restoreBackup(agent.cloudAgentId, backupId);
+        setStatus("Restore complete");
+      } catch (err) {
+        setStatus(`Restore failed: ${err}`);
+      }
+    },
+    [agent],
+  );
+
+  // Local/remote: export
+  const handleExport = useCallback(async () => {
+    if (!agent?.client || password.length < 4) return;
+    setStatus("Exporting...");
+    try {
+      const blob = await agent.client.exportAgent(password);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `milady-agent-export-${Date.now()}.bin`;
+      a.click();
+      URL.revokeObjectURL(url);
+      setStatus("Export complete");
+    } catch (err) {
+      setStatus(`Export failed: ${err}`);
+    }
+  }, [agent, password]);
+
+  // Local/remote: import
+  const handleImport = useCallback(async () => {
+    if (!agent?.client || password.length < 4) return;
+    const file = fileRef.current?.files?.[0];
+    if (!file) {
+      setStatus("No file selected");
+      return;
+    }
+    setStatus("Importing...");
+    try {
+      await agent.client.importAgent(file, password);
+      setStatus("Import complete");
+    } catch (err) {
+      setStatus(`Import failed: ${err}`);
+    }
+  }, [agent, password]);
+
+  if (!connectionId) {
+    return (
+      <div className="flex flex-col items-center justify-center py-32 space-y-3">
+        <div className="text-text-muted/30 text-4xl">{"\u2913"}</div>
+        <div className="text-text-muted font-mono text-sm">
+          No agent selected
+        </div>
+        <div className="text-text-muted/50 font-mono text-xs">
+          Select an agent from the Agents panel to export or import snapshots.
+        </div>
+      </div>
+    );
+  }
+
+  if (!agent) {
+    return (
+      <div className="text-text-muted font-mono text-sm">Agent not found</div>
+    );
+  }
+
+  // Cloud agent: snapshot & backup UI
+  if (isCloud) {
+    return (
+      <div className="space-y-6 max-w-lg">
+        <h3 className="font-mono text-xs uppercase tracking-widest text-brand">
+          Cloud Snapshots — {agent.name}
+        </h3>
+
+        <button
+          type="button"
+          onClick={handleSnapshot}
+          className="px-4 py-2 bg-brand text-dark font-mono text-xs uppercase tracking-widest rounded hover:bg-brand-hover transition-colors"
+        >
+          Take Snapshot
+        </button>
+
+        {backupsLoading && (
+          <div className="text-brand font-mono text-sm animate-pulse">
+            Loading backups...
+          </div>
+        )}
+
+        {!backupsLoading && backups.length === 0 && (
+          <div className="text-text-muted font-mono text-xs">
+            No backups yet.
+          </div>
+        )}
+
+        {!backupsLoading && backups.length > 0 && (
+          <div className="space-y-2">
+            <div className="text-text-muted font-mono text-[10px] uppercase tracking-wider">
+              Backups
+            </div>
+            {backups.map((b) => (
+              <div
+                key={b.id}
+                className="flex items-center justify-between bg-dark border border-white/10 rounded p-3"
+              >
+                <div>
+                  <div className="text-text-light font-mono text-xs">
+                    {b.id.slice(0, 12)}
+                  </div>
+                  <div className="text-text-muted font-mono text-[10px]">
+                    {new Date(b.createdAt).toLocaleString()}
+                    {b.size ? ` — ${(b.size / 1024 / 1024).toFixed(1)} MB` : ""}
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => handleRestore(b.id)}
+                  className="px-3 py-1 text-[10px] font-mono uppercase tracking-wider border border-brand/30 text-brand rounded hover:bg-brand/10 transition-colors"
+                >
+                  Restore
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {status && (
+          <p className="text-xs font-mono text-text-muted">{status}</p>
+        )}
+      </div>
+    );
+  }
+
+  // Local/remote agent: password-based export/import
+  return (
+    <div className="space-y-4 max-w-md">
+      <label className="block">
+        <span className="text-text-muted text-xs font-mono">
+          Password (min 4 chars)
+        </span>
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="mt-1 w-full bg-dark border border-white/10 px-3 py-2 text-sm text-text-light font-mono rounded focus:border-brand focus:outline-none"
+        />
+      </label>
+
+      <input ref={fileRef} type="file" className="hidden" />
+
+      <div className="flex gap-3">
+        <button
+          type="button"
+          onClick={handleExport}
+          disabled={password.length < 4}
+          className="px-4 py-2 bg-brand text-dark font-mono text-xs uppercase tracking-widest rounded hover:bg-brand-hover transition-colors disabled:opacity-30"
+        >
+          Export Agent
+        </button>
+        <button
+          type="button"
+          onClick={() => fileRef.current?.click()}
+          className="px-4 py-2 border border-white/10 text-text-muted font-mono text-xs uppercase tracking-widest rounded hover:border-white/30 transition-colors"
+        >
+          Select File...
+        </button>
+        <button
+          type="button"
+          onClick={handleImport}
+          disabled={password.length < 4}
+          className="px-4 py-2 border border-white/10 text-text-muted font-mono text-xs uppercase tracking-widest rounded hover:border-white/30 transition-colors disabled:opacity-30"
+        >
+          Import Agent
+        </button>
+      </div>
+
+      {status && <p className="text-xs font-mono text-text-muted">{status}</p>}
+    </div>
+  );
+}

--- a/apps/homepage/src/components/dashboard/LogsPanel.tsx
+++ b/apps/homepage/src/components/dashboard/LogsPanel.tsx
@@ -1,0 +1,11 @@
+export function LogsPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-32 space-y-3">
+      <div className="text-text-muted/30 text-4xl">{"\u25FB"}</div>
+      <div className="text-text-muted font-mono text-sm">Logs coming soon</div>
+      <div className="text-text-muted/50 font-mono text-xs">
+        Container logs will be available when the logs API ships.
+      </div>
+    </div>
+  );
+}

--- a/apps/homepage/src/components/dashboard/MetricsPanel.tsx
+++ b/apps/homepage/src/components/dashboard/MetricsPanel.tsx
@@ -1,0 +1,13 @@
+export function MetricsPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center py-32 space-y-3">
+      <div className="text-text-muted/30 text-4xl">{"\u25EB"}</div>
+      <div className="text-text-muted font-mono text-sm">
+        Metrics coming soon
+      </div>
+      <div className="text-text-muted/50 font-mono text-xs">
+        Container metrics will be available when the metrics API ships.
+      </div>
+    </div>
+  );
+}

--- a/apps/homepage/src/components/dashboard/Sidebar.tsx
+++ b/apps/homepage/src/components/dashboard/Sidebar.tsx
@@ -1,0 +1,63 @@
+const SECTIONS = [
+  { id: "agents", label: "Agents", icon: "\u25C9" },
+  { id: "metrics", label: "Metrics", icon: "\u25EB" },
+  { id: "logs", label: "Logs", icon: "\u25FB" },
+  { id: "snapshots", label: "Snapshots", icon: "\u2913" },
+  { id: "credits", label: "Credits", icon: "\u25C7" },
+  { id: "billing", label: "Billing", icon: "\u25C8" },
+] as const;
+
+export type DashboardSection = (typeof SECTIONS)[number]["id"];
+
+interface SidebarProps {
+  active: DashboardSection;
+  onChange: (section: DashboardSection) => void;
+}
+
+export function Sidebar({ active, onChange }: SidebarProps) {
+  return (
+    <>
+      {/* Desktop sidebar */}
+      <aside className="hidden md:block w-52 border-r border-white/10 px-4 py-6 flex-shrink-0">
+        <h3 className="text-[10px] font-mono uppercase tracking-widest text-text-muted/50 px-3 mb-4">
+          Dashboard
+        </h3>
+        <nav className="space-y-1">
+          {SECTIONS.map((s) => (
+            <button
+              type="button"
+              key={s.id}
+              onClick={() => onChange(s.id)}
+              className={`w-full text-left px-3 py-2 font-mono text-xs uppercase tracking-widest transition-colors duration-200 rounded ${
+                active === s.id
+                  ? "text-brand bg-brand/10"
+                  : "text-text-muted hover:text-text-light hover:bg-white/5"
+              }`}
+            >
+              <span className="mr-2">{s.icon}</span>
+              {s.label}
+            </button>
+          ))}
+        </nav>
+      </aside>
+
+      {/* Mobile tab bar */}
+      <div className="md:hidden flex overflow-x-auto border-b border-white/10 px-2 gap-1">
+        {SECTIONS.map((s) => (
+          <button
+            type="button"
+            key={s.id}
+            onClick={() => onChange(s.id)}
+            className={`flex-shrink-0 px-3 py-2 font-mono text-[10px] uppercase tracking-widest transition-colors ${
+              active === s.id
+                ? "text-brand border-b-2 border-brand"
+                : "text-text-muted"
+            }`}
+          >
+            {s.icon} {s.label}
+          </button>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/apps/homepage/src/components/dashboard/SourceBar.tsx
+++ b/apps/homepage/src/components/dashboard/SourceBar.tsx
@@ -1,0 +1,77 @@
+import { useState } from "react";
+import { useAgents } from "../../lib/AgentProvider";
+import { isAuthenticated } from "../../lib/auth";
+import { ConnectionModal } from "./ConnectionModal";
+
+export function SourceBar() {
+  const { agents, loading, refresh, addRemoteUrl } = useAgents();
+  const [showAddRemote, setShowAddRemote] = useState(false);
+
+  const cloudCount = agents.filter((a) => a.source === "cloud").length;
+  const localCount = agents.filter((a) => a.source === "local").length;
+  const remoteCount = agents.filter((a) => a.source === "remote").length;
+  const authed = isAuthenticated();
+
+  return (
+    <div className="px-8 py-3 border-b border-white/10 flex items-center gap-6 text-xs font-mono">
+      {/* Cloud source */}
+      <div className="flex items-center gap-2">
+        <span
+          className={`w-1.5 h-1.5 rounded-full ${authed && cloudCount > 0 ? "bg-green-500" : authed ? "bg-yellow-500" : "bg-white/20"}`}
+        />
+        <span className="text-text-muted">
+          {!authed
+            ? "cloud (not connected)"
+            : cloudCount > 0
+              ? `cloud (${cloudCount})`
+              : "cloud (0 agents)"}
+        </span>
+      </div>
+
+      {/* Local source */}
+      <div className="flex items-center gap-2">
+        <span
+          className={`w-1.5 h-1.5 rounded-full ${localCount > 0 ? "bg-green-500" : "bg-white/20"}`}
+        />
+        <span className="text-text-muted">
+          {localCount > 0 ? `local (${localCount})` : "local (offline)"}
+        </span>
+      </div>
+
+      {/* Remote source */}
+      {remoteCount > 0 && (
+        <div className="flex items-center gap-2">
+          <span className="w-1.5 h-1.5 rounded-full bg-green-500" />
+          <span className="text-text-muted">remote ({remoteCount})</span>
+        </div>
+      )}
+
+      <div className="ml-auto flex items-center gap-3">
+        <button
+          type="button"
+          onClick={() => setShowAddRemote(true)}
+          className="text-text-muted hover:text-brand transition-colors uppercase tracking-widest"
+        >
+          + Remote
+        </button>
+        <button
+          type="button"
+          onClick={() => refresh()}
+          className={`text-text-muted hover:text-brand transition-colors uppercase tracking-widest ${loading ? "animate-pulse" : ""}`}
+        >
+          Refresh
+        </button>
+      </div>
+
+      {showAddRemote && (
+        <ConnectionModal
+          onSubmit={(data) => {
+            addRemoteUrl(data.name, data.url);
+            setShowAddRemote(false);
+          }}
+          onClose={() => setShowAddRemote(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/homepage/src/lib/AgentProvider.tsx
+++ b/apps/homepage/src/lib/AgentProvider.tsx
@@ -1,0 +1,247 @@
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { type CloudAgent, getToken } from "./auth";
+import { CLOUD_BASE, CloudApiClient, CloudClient } from "./cloud-api";
+import { addConnection, getConnections, removeConnection } from "./connections";
+
+export type AgentSource = "cloud" | "local" | "remote";
+
+export interface ManagedAgent {
+  id: string;
+  name: string;
+  source: AgentSource;
+  status: "running" | "paused" | "stopped" | "provisioning" | "unknown";
+  model?: string;
+  uptime?: number;
+  memories?: number;
+  sourceUrl?: string;
+  cloudAgent?: CloudAgent;
+  client?: CloudApiClient;
+  cloudClient?: CloudClient;
+  cloudAgentId?: string;
+}
+
+interface AgentContextValue {
+  agents: ManagedAgent[];
+  loading: boolean;
+  cloudClient: CloudClient | null;
+  refresh: () => Promise<void>;
+  addRemoteUrl: (name: string, url: string) => void;
+  removeRemote: (id: string) => void;
+}
+
+const AgentContext = createContext<AgentContextValue | null>(null);
+
+const LOCAL_PROBE_URL = "http://localhost:2138";
+
+export function AgentProvider({ children }: { children: ReactNode }) {
+  const [agents, setAgents] = useState<ManagedAgent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [cloudClientState, setCloudClientState] = useState<CloudClient | null>(
+    null,
+  );
+  const intervalRef = useRef<ReturnType<typeof setInterval>>();
+  const tokenRef = useRef<string | null>(null);
+  const cloudClientRef = useRef<CloudClient | null>(null);
+
+  const getOrCreateCloudClient = useCallback((): CloudClient | null => {
+    const token = getToken();
+    if (!token) {
+      cloudClientRef.current = null;
+      tokenRef.current = null;
+      return null;
+    }
+    if (token !== tokenRef.current) {
+      cloudClientRef.current = new CloudClient(token);
+      tokenRef.current = token;
+    }
+    return cloudClientRef.current;
+  }, []);
+
+  const fetchAll = useCallback(async () => {
+    const results: ManagedAgent[] = [];
+
+    // 1. Cloud agents (if authenticated)
+    if (getToken()) {
+      const cc = getOrCreateCloudClient();
+      if (!cc) return;
+      setCloudClientState(cc);
+      try {
+        const cloudAgents = await cc.listAgents();
+        for (const ca of cloudAgents) {
+          results.push({
+            id: `cloud-${ca.id}`,
+            name: ca.agentName || ca.name || ca.id,
+            source: "cloud",
+            status: mapCloudStatus(ca.status),
+            model: ca.model,
+            cloudAgent: ca,
+            cloudClient: cc,
+            cloudAgentId: ca.id,
+            sourceUrl: `${CLOUD_BASE}/api/v1/milady/agents/${ca.id}`,
+          });
+        }
+      } catch (err) {
+        console.warn("[AgentProvider] Cloud agent fetch failed:", err);
+      }
+    } else {
+      setCloudClientState(null);
+    }
+
+    // 2. Local agent (auto-probe localhost:2138)
+    try {
+      const localClient = new CloudApiClient({
+        url: LOCAL_PROBE_URL,
+        type: "local",
+      });
+      const health = await localClient.health();
+      if (health.status) {
+        try {
+          const status = await localClient.getAgentStatus();
+          results.push({
+            id: "local-default",
+            name: status.agentName || "Local Agent",
+            source: "local",
+            status: status.state,
+            model: status.model,
+            uptime: status.uptime,
+            memories: status.memories,
+            sourceUrl: LOCAL_PROBE_URL,
+            client: localClient,
+          });
+        } catch {
+          // Health OK but no agent status endpoint — show as running
+          results.push({
+            id: "local-default",
+            name: "Local Agent",
+            source: "local",
+            status: "running",
+            sourceUrl: LOCAL_PROBE_URL,
+            client: localClient,
+          });
+        }
+      }
+    } catch {
+      // localhost not running — skip silently
+    }
+
+    // 3. Remote agents (manually added)
+    const remotes = getConnections().filter((c) => c.type === "remote");
+    for (const remote of remotes) {
+      const client = new CloudApiClient({ url: remote.url, type: "remote" });
+      try {
+        await client.health();
+        try {
+          const status = await client.getAgentStatus();
+          results.push({
+            id: `remote-${remote.id}`,
+            name: status.agentName || remote.name,
+            source: "remote",
+            status: status.state,
+            model: status.model,
+            uptime: status.uptime,
+            memories: status.memories,
+            sourceUrl: remote.url,
+            client,
+          });
+        } catch {
+          results.push({
+            id: `remote-${remote.id}`,
+            name: remote.name,
+            source: "remote",
+            status: "unknown",
+            sourceUrl: remote.url,
+            client,
+          });
+        }
+      } catch {
+        results.push({
+          id: `remote-${remote.id}`,
+          name: remote.name,
+          source: "remote",
+          status: "unknown",
+          sourceUrl: remote.url,
+          client,
+        });
+      }
+    }
+
+    setAgents(results);
+    setLoading(false);
+  }, [getOrCreateCloudClient]);
+
+  useEffect(() => {
+    fetchAll();
+    // Poll every 30s — sources that fail are already caught silently,
+    // no need to hammer them every 10s
+    intervalRef.current = setInterval(fetchAll, 30000);
+    return () => clearInterval(intervalRef.current);
+  }, [fetchAll]);
+
+  const addRemoteUrl = useCallback(
+    (name: string, url: string) => {
+      addConnection({ name, url, type: "remote" });
+      fetchAll();
+    },
+    [fetchAll],
+  );
+
+  const removeRemote = useCallback(
+    (id: string) => {
+      const connId = id.replace("remote-", "");
+      removeConnection(connId);
+      fetchAll();
+    },
+    [fetchAll],
+  );
+
+  return (
+    <AgentContext
+      value={{
+        agents,
+        loading,
+        cloudClient: cloudClientState,
+        refresh: fetchAll,
+        addRemoteUrl,
+        removeRemote,
+      }}
+    >
+      {children}
+    </AgentContext>
+  );
+}
+
+function mapCloudStatus(status: string): ManagedAgent["status"] {
+  const s = status?.toLowerCase() ?? "";
+  if (s === "running" || s === "active" || s === "healthy") return "running";
+  if (s === "paused" || s === "suspended") return "paused";
+  if (
+    s === "stopped" ||
+    s === "terminated" ||
+    s === "deleted" ||
+    s === "disconnected"
+  )
+    return "stopped";
+  if (
+    s === "provisioning" ||
+    s === "creating" ||
+    s === "starting" ||
+    s === "pending"
+  )
+    return "provisioning";
+  if (s === "error") return "stopped";
+  return "unknown";
+}
+
+export function useAgents() {
+  const ctx = useContext(AgentContext);
+  if (!ctx) throw new Error("useAgents must be used within AgentProvider");
+  return ctx;
+}

--- a/apps/homepage/src/lib/auth.ts
+++ b/apps/homepage/src/lib/auth.ts
@@ -1,0 +1,101 @@
+const TOKEN_KEY = "milady-cloud-token";
+
+export function getToken(): string | null {
+  return localStorage.getItem(TOKEN_KEY);
+}
+
+export function setToken(token: string): void {
+  localStorage.setItem(TOKEN_KEY, token);
+}
+
+export function clearToken(): void {
+  localStorage.removeItem(TOKEN_KEY);
+}
+
+export function isAuthenticated(): boolean {
+  return getToken() !== null;
+}
+
+import { CLOUD_BASE } from "./cloud-api";
+
+export async function cloudLogin(): Promise<{
+  sessionId: string;
+  browserUrl: string;
+}> {
+  const sessionId = crypto.randomUUID();
+  const res = await fetch(`${CLOUD_BASE}/api/auth/cli-session`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ sessionId }),
+    redirect: "manual",
+  });
+  if (!res.ok) throw new Error(`Failed to create auth session: ${res.status}`);
+  return {
+    sessionId,
+    browserUrl: `${CLOUD_BASE}/auth/cli-login?session=${encodeURIComponent(sessionId)}`,
+  };
+}
+
+export async function cloudLoginPoll(
+  sessionId: string,
+): Promise<{ status: string; apiKey?: string }> {
+  const res = await fetch(
+    `${CLOUD_BASE}/api/auth/cli-session/${encodeURIComponent(sessionId)}`,
+    {
+      redirect: "manual",
+    },
+  );
+  if (res.status === 404) throw new Error("Session expired");
+  if (!res.ok) throw new Error(`Poll failed: ${res.status}`);
+  return res.json();
+}
+
+export interface CloudAgent {
+  id: string;
+  agentName: string;
+  name?: string;
+  status: string;
+  model?: string;
+  errorMessage?: string | null;
+  lastHeartbeatAt?: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export async function fetchCloudAgents(): Promise<CloudAgent[]> {
+  const token = getToken();
+  if (!token) return [];
+  try {
+    const res = await fetch(`${CLOUD_BASE}/api/v1/milady/agents`, {
+      headers: { "X-Api-Key": token },
+    });
+    if (!res.ok) {
+      console.warn("[fetchCloudAgents] API returned", res.status);
+      return [];
+    }
+    const json = await res.json();
+    // Cloud API returns { success: true, data: [...] }
+    const agents =
+      json?.data ?? json?.agents ?? (Array.isArray(json) ? json : []);
+    return agents;
+  } catch (err) {
+    console.warn("[fetchCloudAgents] Failed:", err);
+    return [];
+  }
+}
+
+export async function fetchWithAuth(
+  url: string,
+  opts: RequestInit = {},
+): Promise<Response> {
+  const token = getToken();
+  const headers = new Headers(opts.headers);
+  if (token) {
+    headers.set("X-Api-Key", token);
+  }
+  const res = await fetch(url, { ...opts, headers });
+  if (res.status === 401) {
+    clearToken();
+  }
+  return res;
+}

--- a/apps/homepage/src/lib/cloud-api.ts
+++ b/apps/homepage/src/lib/cloud-api.ts
@@ -1,0 +1,398 @@
+export const CLOUD_BASE = "https://www.elizacloud.ai";
+
+export interface CloudAgentDetail {
+  id: string;
+  agentName: string;
+  name?: string; // fallback
+  status: string;
+  databaseStatus?: string;
+  model?: string;
+  bridgeUrl?: string;
+  tokens?: { used: number; limit: number };
+  errorMessage?: string | null;
+  lastBackupAt?: string | null;
+  lastHeartbeatAt?: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+  token_address?: string | null;
+  token_chain?: string | null;
+  token_name?: string | null;
+  token_ticker?: string | null;
+}
+
+export interface CloudBackup {
+  id: string;
+  createdAt: string;
+  size?: number;
+}
+
+export interface CreditBalance {
+  balance: number;
+  currency?: string;
+}
+
+export interface JobStatus {
+  id: string;
+  status: "pending" | "in_progress" | "completed" | "failed";
+  result?: unknown;
+  error?: string;
+}
+
+export interface BridgeResponse {
+  jsonrpc: string;
+  id: string;
+  result?: Record<string, unknown>;
+  error?: { code: number; message: string };
+}
+
+export class CloudClient {
+  private apiKey: string;
+
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+  }
+
+  private async request<T>(path: string, opts: RequestInit = {}): Promise<T> {
+    const headers = new Headers(opts.headers);
+    headers.set("X-Api-Key", this.apiKey);
+    if (opts.body && typeof opts.body === "string") {
+      headers.set("Content-Type", "application/json");
+    }
+    const res = await fetch(`${CLOUD_BASE}${path}`, { ...opts, headers });
+    if (!res.ok) throw new Error(`Cloud API ${res.status}: ${path}`);
+    return res.json();
+  }
+
+  // Agent management
+  async listAgents(): Promise<CloudAgentDetail[]> {
+    // Cloud API returns { success: true, data: [...] }
+    const json = await this.request<Record<string, unknown>>(
+      "/api/v1/milady/agents",
+      {
+        method: "GET",
+      },
+    );
+    const agents =
+      (json as { data?: CloudAgentDetail[] }).data ??
+      (json as { agents?: CloudAgentDetail[] }).agents ??
+      (Array.isArray(json) ? json : []);
+    return agents as CloudAgentDetail[];
+  }
+
+  async getAgent(agentId: string): Promise<CloudAgentDetail> {
+    return this.request(`/api/v1/milady/agents/${agentId}`, { method: "GET" });
+  }
+
+  async createAgent(config: {
+    name: string;
+    characterId?: string;
+    config?: object;
+    environmentVars?: Record<string, string>;
+  }): Promise<{ id: string }> {
+    return this.request("/api/v1/milady/agents", {
+      method: "POST",
+      body: JSON.stringify(config),
+    });
+  }
+
+  async deleteAgent(agentId: string): Promise<void> {
+    await this.request(`/api/v1/milady/agents/${agentId}`, {
+      method: "DELETE",
+    });
+  }
+
+  // Lifecycle
+  async provisionAgent(agentId: string): Promise<{ jobId?: string }> {
+    return this.request(`/api/v1/milady/agents/${agentId}/provision`, {
+      method: "POST",
+    });
+  }
+
+  async suspendAgent(agentId: string): Promise<void> {
+    await this.request(`/api/v1/milady/agents/${agentId}/suspend`, {
+      method: "POST",
+    });
+  }
+
+  async resumeAgent(agentId: string): Promise<{ jobId?: string }> {
+    return this.request(`/api/v1/milady/agents/${agentId}/resume`, {
+      method: "POST",
+    });
+  }
+
+  // Snapshots & backups
+  async takeSnapshot(agentId: string): Promise<void> {
+    await this.request(`/api/v1/milady/agents/${agentId}/snapshot`, {
+      method: "POST",
+    });
+  }
+
+  async listBackups(agentId: string): Promise<CloudBackup[]> {
+    const data = await this.request<
+      CloudBackup[] | { backups?: CloudBackup[]; data?: CloudBackup[] }
+    >(`/api/v1/milady/agents/${agentId}/backups`, { method: "GET" });
+    return Array.isArray(data)
+      ? data
+      : ((data as { backups?: CloudBackup[]; data?: CloudBackup[] }).backups ??
+          (data as { backups?: CloudBackup[]; data?: CloudBackup[] }).data ??
+          []);
+  }
+
+  async restoreBackup(agentId: string, backupId?: string): Promise<void> {
+    await this.request(`/api/v1/milady/agents/${agentId}/restore`, {
+      method: "POST",
+      body: JSON.stringify(backupId ? { backupId } : {}),
+    });
+  }
+
+  // Bridge (JSON-RPC to sandbox)
+  async bridge(
+    agentId: string,
+    method: string,
+    params?: object,
+  ): Promise<BridgeResponse> {
+    return this.request(`/api/v1/milady/agents/${agentId}/bridge`, {
+      method: "POST",
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: crypto.randomUUID(),
+        method,
+        params: params ?? {},
+      }),
+    });
+  }
+
+  async getAgentBridgeStatus(
+    agentId: string,
+  ): Promise<{ state: string; uptime?: number; memories?: number }> {
+    const res = await this.bridge(agentId, "status.get");
+    return (res.result ?? res) as {
+      state: string;
+      uptime?: number;
+      memories?: number;
+    };
+  }
+
+  // Credits & billing
+  async getCreditsBalance(): Promise<CreditBalance> {
+    return this.request("/api/credits/balance", { method: "GET" });
+  }
+
+  async getCreditsSummary(): Promise<Record<string, unknown>> {
+    return this.request("/api/v1/credits/summary", { method: "GET" });
+  }
+
+  // Jobs (async operation polling)
+  async getJobStatus(jobId: string): Promise<JobStatus> {
+    return this.request(`/api/v1/jobs/${jobId}`, { method: "GET" });
+  }
+
+  async pollJobUntilDone(
+    jobId: string,
+    timeoutMs = 120000,
+  ): Promise<JobStatus> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const job = await this.getJobStatus(jobId);
+      if (job.status === "completed" || job.status === "failed") return job;
+      await new Promise((r) => setTimeout(r, 2000));
+    }
+    throw new Error("Job timed out");
+  }
+
+  // Containers (for container-level monitoring)
+  async listContainers(): Promise<Record<string, unknown>[]> {
+    const data = await this.request<
+      | Record<string, unknown>[]
+      | {
+          containers?: Record<string, unknown>[];
+          data?: Record<string, unknown>[];
+        }
+    >("/api/v1/containers", {
+      method: "GET",
+    });
+    return Array.isArray(data)
+      ? data
+      : ((
+          data as {
+            containers?: Record<string, unknown>[];
+            data?: Record<string, unknown>[];
+          }
+        ).containers ??
+          (
+            data as {
+              containers?: Record<string, unknown>[];
+              data?: Record<string, unknown>[];
+            }
+          ).data ??
+          []);
+  }
+
+  async getContainerHealth(
+    containerId: string,
+  ): Promise<Record<string, unknown>> {
+    return this.request(`/api/v1/containers/${containerId}/health`, {
+      method: "GET",
+    });
+  }
+
+  async getContainerMetrics(
+    containerId: string,
+  ): Promise<Record<string, unknown>> {
+    return this.request(`/api/v1/containers/${containerId}/metrics`, {
+      method: "GET",
+    });
+  }
+
+  async getContainerLogs(containerId: string): Promise<string> {
+    const res = await fetch(
+      `${CLOUD_BASE}/api/v1/containers/${containerId}/logs`,
+      {
+        headers: { "X-Api-Key": this.apiKey },
+      },
+    );
+    if (!res.ok) throw new Error(`Logs ${res.status}`);
+    return res.text();
+  }
+
+  // Billing settings
+  async getBillingSettings(): Promise<Record<string, unknown>> {
+    return this.request("/api/v1/billing/settings", { method: "GET" });
+  }
+
+  // Session info
+  async getCurrentSession(): Promise<{
+    credits?: number;
+    requests?: number;
+    tokens?: number;
+  }> {
+    return this.request("/api/sessions/current", { method: "GET" });
+  }
+}
+
+export type ConnectionType = "local" | "remote" | "cloud";
+
+export interface ConnectionInfo {
+  url: string;
+  type: ConnectionType;
+}
+
+export interface AgentStatus {
+  state: "running" | "paused" | "stopped" | "provisioning" | "unknown";
+  uptime?: number;
+  memories?: number;
+  agentName: string;
+  model: string;
+}
+
+export interface MetricsData {
+  cpu: number;
+  memoryMb: number;
+  diskMb: number;
+  timestamp: string;
+}
+
+export interface LogEntry {
+  level: "info" | "warn" | "error";
+  message: string;
+  timestamp: string;
+  agentName: string;
+}
+
+export class CloudApiClient {
+  private baseUrl: string;
+  private type: ConnectionType;
+
+  constructor(connection: ConnectionInfo) {
+    this.baseUrl = connection.url.replace(/\/$/, "");
+    this.type = connection.type;
+  }
+
+  private async request<T>(path: string, opts: RequestInit = {}): Promise<T> {
+    // Use plain fetch — local/remote agents don't use cloud API keys.
+    // fetchWithAuth would leak the cloud API key to arbitrary URLs.
+    const res = await fetch(`${this.baseUrl}${path}`, opts);
+    if (!res.ok) throw new Error(`API ${res.status}: ${path}`);
+    return res.json();
+  }
+
+  async health(): Promise<{
+    status: string;
+    uptime: number;
+    memoryUsage?: Record<string, unknown>;
+  }> {
+    return this.request("/api/health", { method: "GET" });
+  }
+
+  async getAgentStatus(): Promise<AgentStatus> {
+    return this.request("/api/agent/status", { method: "GET" });
+  }
+
+  async startAgent(): Promise<{ ok: boolean; status: { state: string } }> {
+    return this.request("/api/agent/start", { method: "POST" });
+  }
+
+  async stopAgent(): Promise<{ ok: boolean; status: { state: string } }> {
+    return this.request("/api/agent/stop", { method: "POST" });
+  }
+
+  async pauseAgent(): Promise<{ ok: boolean; status: { state: string } }> {
+    return this.request("/api/agent/pause", { method: "POST" });
+  }
+
+  async resumeAgent(): Promise<{ ok: boolean; status: { state: string } }> {
+    return this.request("/api/agent/resume", { method: "POST" });
+  }
+
+  async playAgent(): Promise<{ ok: boolean; status: { state: string } }> {
+    await this.startAgent();
+    return this.resumeAgent();
+  }
+
+  async exportAgent(password: string, includeLogs?: boolean): Promise<Blob> {
+    const res = await fetch(`${this.baseUrl}/api/agent/export`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ password, includeLogs }),
+    });
+    if (!res.ok) throw new Error(`Export failed: ${res.status}`);
+    return res.blob();
+  }
+
+  async estimateExportSize(): Promise<{ sizeBytes: number }> {
+    return this.request("/api/agent/export/estimate", { method: "GET" });
+  }
+
+  async importAgent(file: File, password: string): Promise<{ ok: boolean }> {
+    const passwordBytes = new TextEncoder().encode(password);
+    const fileBytes = new Uint8Array(await file.arrayBuffer());
+    const lengthBuf = new ArrayBuffer(4);
+    new DataView(lengthBuf).setUint32(0, passwordBytes.length);
+    const envelope = new Blob([lengthBuf, passwordBytes, fileBytes]);
+    const res = await fetch(`${this.baseUrl}/api/agent/import`, {
+      method: "POST",
+      body: envelope,
+    });
+    if (!res.ok) throw new Error(`Import failed: ${res.status}`);
+    return res.json();
+  }
+
+  async getMetrics(): Promise<MetricsData[]> {
+    return this.request("/api/metrics", { method: "GET" });
+  }
+
+  async getLogs(opts?: {
+    limit?: number;
+    level?: string;
+  }): Promise<LogEntry[]> {
+    const params = new URLSearchParams();
+    if (opts?.limit) params.set("limit", String(opts.limit));
+    if (opts?.level) params.set("level", opts.level);
+    const qs = params.toString();
+    return this.request(`/api/logs${qs ? `?${qs}` : ""}`, { method: "GET" });
+  }
+
+  async getBilling(): Promise<Record<string, unknown>> {
+    return this.request("/api/billing", { method: "GET" });
+  }
+}

--- a/apps/homepage/src/lib/connections.ts
+++ b/apps/homepage/src/lib/connections.ts
@@ -1,0 +1,37 @@
+import type { ConnectionType } from "./cloud-api";
+
+const STORAGE_KEY = "milady-connections";
+
+export interface StoredConnection {
+  id: string;
+  name: string;
+  url: string;
+  type: ConnectionType;
+}
+
+export function getConnections(): StoredConnection[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveConnections(conns: StoredConnection[]): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(conns));
+}
+
+export function addConnection(
+  input: Omit<StoredConnection, "id">,
+): StoredConnection {
+  const conn: StoredConnection = { ...input, id: crypto.randomUUID() };
+  const conns = getConnections();
+  conns.push(conn);
+  saveConnections(conns);
+  return conn;
+}
+
+export function removeConnection(id: string): void {
+  saveConnections(getConnections().filter((c) => c.id !== id));
+}

--- a/apps/homepage/src/lib/release-helpers.ts
+++ b/apps/homepage/src/lib/release-helpers.ts
@@ -45,9 +45,7 @@ export function pickRelease(releases: GithubRelease[]): GithubRelease | null {
     return bTime - aTime;
   });
   return (
-    published.find(
-      (r) => Array.isArray(r.assets) && r.assets.length > 0,
-    ) ??
+    published.find((r) => Array.isArray(r.assets) && r.assets.length > 0) ??
     published[0] ??
     null
   );

--- a/apps/homepage/src/main.tsx
+++ b/apps/homepage/src/main.tsx
@@ -1,13 +1,18 @@
 import "./styles.css";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { App } from "./App";
+import { HashRouter } from "react-router-dom";
+import { Nav } from "./components/Nav";
+import { AppRoutes } from "./router";
 
 const root = document.getElementById("root");
 if (!root) throw new Error("No root element");
 
 createRoot(root).render(
   <StrictMode>
-    <App />
+    <HashRouter>
+      <Nav />
+      <AppRoutes />
+    </HashRouter>
   </StrictMode>,
 );

--- a/apps/homepage/src/router.tsx
+++ b/apps/homepage/src/router.tsx
@@ -1,0 +1,12 @@
+import { Route, Routes } from "react-router-dom";
+import { Homepage } from "./App";
+import { Dashboard } from "./components/dashboard/Dashboard";
+
+export function AppRoutes() {
+  return (
+    <Routes>
+      <Route path="/" element={<Homepage />} />
+      <Route path="/dashboard" element={<Dashboard />} />
+    </Routes>
+  );
+}

--- a/apps/homepage/src/styles.css
+++ b/apps/homepage/src/styles.css
@@ -130,8 +130,13 @@ body {
 }
 
 @keyframes clock-blink {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.2; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.2;
+  }
 }
 
 /* ── Hero Download Dock ──────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

Adds a cloud control plane dashboard at `/#/dashboard` on the Milady homepage, replacing the external elizacloud.ai redirect. Re-applied cleanly after develop revert.

### Features
- **Agent-first** — auto-discovers agents from Eliza Cloud, local (localhost:2138), and remote
- **Eliza Cloud auth** — polling-based session auth (same flow as CLI/desktop)
- **Full cloud API** — agent lifecycle, snapshots/backups, credits, billing
- **6 dashboard sections**: Agents, Metrics, Logs, Snapshots, Credits, Billing
- **Correct API shape** — unwraps `{ success, data }` envelope, uses `agentName` field

### Scope
- Only touches `apps/homepage/` — no changes to core, plugins, or CI
- 175 tests, zero Biome lint errors, build clean
- Single dependency added: `react-router-dom`

## Test plan
- [x] `bun run test` — 175/175 passing
- [x] `npx biome check src/` — 0 errors
- [x] `bun run build` — clean (411KB JS, 40KB CSS)
- [x] Homepage at `/` unchanged
- [x] Dashboard at `/#/dashboard` renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)