### PR TITLE
fix: add PyPI API token fallback for first publish

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -145,6 +145,9 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: packaging/pypi/dist/
+          # Falls back to API token when OIDC trusted publishing is not
+          # configured (e.g. first publish before the project exists on PyPI).
+          password: ${{ secrets.PYPI_API_TOKEN }}
 
   # ── Homebrew ───────────────────────────────────────────────────────────
   update-homebrew:


### PR DESCRIPTION
## Summary

- The `milady` package doesn't exist on PyPI yet, so OIDC trusted publishing fails with `invalid-publisher`
- Added `PYPI_API_TOKEN` secret fallback to the publish workflow so the first release can go through
- `PYPI_API_TOKEN` secret has been configured on the repo
- Once the project exists on PyPI, a trusted publisher can be registered and the token becomes optional

## Changed files

| File | Change |
|------|--------|
| `.github/workflows/publish-packages.yml` | Add `password: ${{ secrets.PYPI_API_TOKEN }}` fallback |

🤖 Generated with [Claude Code](https://claude.com/claude-code)