### PR TITLE
fix: remove MILADY_DISABLE_LOCAL_EMBEDDINGS from release-check drift guard

### DIFF
--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -72,7 +72,6 @@ const requiredWorkflowSnippets = [
   "node scripts/desktop-build.mjs package --env=$" +
     "{{ needs.prepare.outputs.env }}",
   "MILADY_ELECTROBUN_NOTARIZE: 0",
-  'MILADY_DISABLE_LOCAL_EMBEDDINGS: "1"',
   'Join-Path $PWD "apps/app/electrobun/node_modules/electrobun"',
   "if ($null -eq $resolvedRceditPackageJson)",
   '$resolvedRceditPackageJson = "$resolvedRceditPackageJson".Trim()',


### PR DESCRIPTION
## Summary

`release-check.ts` asserts that `MILADY_DISABLE_LOCAL_EMBEDDINGS: "1"` exists in the release workflow. This was removed in #1040 because `agent.ts` now sets it automatically on Windows. The release-check drift guard needs to match.

Blocks the Electrobun release workflow (step: Validate Release Inputs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)