### PR TITLE
fix: retry apt-get on transient 503 during debian package build

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -279,8 +279,12 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y debhelper devscripts fakeroot
+          for attempt in 1 2 3; do
+            sudo apt-get update && \
+            sudo apt-get install -y debhelper devscripts fakeroot && break
+            echo "apt-get attempt $attempt failed, retrying in 10s..."
+            sleep 10
+          done
 
       - name: Build .deb package
         run: |


### PR DESCRIPTION
## Summary

Ubuntu's apt mirror on CI runners intermittently returns `503 Service Unavailable`, causing the Debian package build to fail. This has happened on multiple consecutive releases.

Adds a 3-attempt retry loop around `apt-get update && apt-get install` with 10s backoff between attempts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)