### PR TITLE
fix: resolve Windows Electrobun smoke test health check timeout

### DIFF
--- a/.github/workflows/release-electrobun.yml
+++ b/.github/workflows/release-electrobun.yml
@@ -580,9 +580,10 @@ jobs:
         if: matrix.platform.os == 'windows'
         shell: pwsh
         env:
-          # agent.ts now sets MILADY_DISABLE_LOCAL_EMBEDDINGS=1 on Windows
-          # automatically, so the smoke test validates the same code path
-          # real users hit.
+          # agent.ts sets MILADY_DISABLE_LOCAL_EMBEDDINGS=1 on Windows
+          # automatically; we also set it here so the ENTIRE process tree
+          # (including the PowerShell parent and any subprocesses) inherits it.
+          MILADY_DISABLE_LOCAL_EMBEDDINGS: "1"
           MILADY_TEST_WINDOWS_LAUNCHER_DIR: ${{ runner.temp }}\milady-windows-ui-launcher
           MILADY_TEST_WINDOWS_LAUNCHER_PATH_FILE: ${{ runner.temp }}\milady-windows-ui-launcher.txt
         run: |

--- a/apps/app/electrobun/scripts/smoke-test-windows.ps1
+++ b/apps/app/electrobun/scripts/smoke-test-windows.ps1
@@ -97,7 +97,7 @@ function Get-ObservedBackendPorts([int]$DefaultPort) {
     if (
       $line -match 'Runtime started -- agent: .* port: ([0-9]+), pid:' -or
       $line -match 'Server bound to dynamic port ([0-9]+)' -or
-      $line -match 'Waiting for health endpoint at http://localhost:([0-9]+)/api/health'
+      $line -match 'Waiting for health endpoint at http://(?:localhost|127\.0\.0\.1):([0-9]+)/api/health'
     ) {
       $observedPort = [int]$Matches[1]
       if (-not $ports.Contains($observedPort)) {
@@ -247,7 +247,20 @@ try {
           break
         }
       } catch {
-        # ignore and continue checking other observed ports
+        # Log the actual error periodically so we can diagnose connection issues
+        $elapsed = [int]((Get-Date) - $deadline.AddSeconds(-$TimeoutSeconds)).TotalSeconds
+        if ($elapsed % 30 -lt 3) {
+          Write-Host "Health check attempt on port ${port} failed ($elapsed s): $($_.Exception.Message)"
+        }
+        # Fallback: try curl.exe which handles Windows networking differently
+        try {
+          $curlResult = & curl.exe -s -o NUL -w "%{http_code}" "http://127.0.0.1:${port}/api/health" --connect-timeout 2 2>$null
+          if ($curlResult -eq "200") {
+            $healthy = $true
+            Write-Host "Backend health check passed on port $port (via curl)."
+            break
+          }
+        } catch {}
       }
     }
 

--- a/scripts/electrobun-release-workflow-drift.test.ts
+++ b/scripts/electrobun-release-workflow-drift.test.ts
@@ -304,9 +304,9 @@ describe("Electrobun release workflow drift", () => {
       "MILADY_TEST_WINDOWS_LAUNCHER_PATH_FILE: $" +
         "{{ runner.temp }}\\milady-windows-ui-launcher.txt",
     );
-    // agent.ts now sets MILADY_DISABLE_LOCAL_EMBEDDINGS=1 on Windows
-    // automatically, so the workflow no longer needs the env var override.
-    expect(workflow).not.toContain('MILADY_DISABLE_LOCAL_EMBEDDINGS: "1"');
+    // agent.ts sets MILADY_DISABLE_LOCAL_EMBEDDINGS=1 on Windows automatically;
+    // the workflow also sets it so the entire process tree inherits it.
+    expect(workflow).toContain('MILADY_DISABLE_LOCAL_EMBEDDINGS: "1"');
     expect(workflow).toContain(
       'Add-Content -Path $env:GITHUB_ENV -Value "MILADY_TEST_WINDOWS_LAUNCHER_PATH=$launcherPath"',
     );
@@ -353,7 +353,7 @@ describe("Electrobun release workflow drift", () => {
     expect(workflow).toContain(
       "bunx playwright test --config playwright.electrobun.packaged.config.ts test/electrobun-packaged/electrobun-windows-startup.e2e.spec.ts",
     );
-    expect(workflow).not.toContain('MILADY_DISABLE_LOCAL_EMBEDDINGS: "1"');
+    expect(workflow).toContain('MILADY_DISABLE_LOCAL_EMBEDDINGS: "1"');
     expect(workflow).not.toContain(
       "name: Install Playwright Chromium (Windows)",
     );

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -72,6 +72,7 @@ const requiredWorkflowSnippets = [
   "node scripts/desktop-build.mjs package --env=$" +
     "{{ needs.prepare.outputs.env }}",
   "MILADY_ELECTROBUN_NOTARIZE: 0",
+  'MILADY_DISABLE_LOCAL_EMBEDDINGS: "1"',
   'Join-Path $PWD "apps/app/electrobun/node_modules/electrobun"',
   "if ($null -eq $resolvedRceditPackageJson)",
   '$resolvedRceditPackageJson = "$resolvedRceditPackageJson".Trim()',
@@ -460,7 +461,7 @@ function assertWindowsSmokeScriptHasLeadingParamBlock() {
     "Find-Launcher $selfExtractionRoot",
     "Started extracted launcher:",
     "Runtime started -- agent: .* port:",
-    "Waiting for health endpoint at http://localhost:",
+    "Waiting for health endpoint at http://(?:localhost|127\\.0\\.0\\.1):",
   ];
   const missingSnippets = requiredSnippets.filter(
     (snippet) => !script.includes(snippet),


### PR DESCRIPTION
## Summary

- **Add diagnostic logging** to the Windows smoke test health check catch block — errors were silently swallowed, making it impossible to diagnose why `Invoke-WebRequest` fails on CI
- **Add `curl.exe` fallback** for health checks — `Invoke-WebRequest` has known issues on some Windows CI environments; `curl.exe` (built into Windows 10+) handles networking differently
- **Fix `Get-ObservedBackendPorts` regex** — matched only `http://localhost:` but the server logs `http://127.0.0.1:`, so dynamic port fallback was never discovered
- **Restore `MILADY_DISABLE_LOCAL_EMBEDDINGS: "1"`** as a workflow env var on the smoke test step so the entire process tree inherits it (not just the child spawned by `agent.ts`)

## Test plan

- [x] `npx vitest run scripts/electrobun-release-workflow-drift.test.ts` — 20/20 passing
- [x] `npx vitest run scripts/coverage-policy-drift.test.ts` — 9/9 passing
- [x] `bun run release:check` — all assertions pass
- [ ] Trigger Electrobun release workflow and verify Windows smoke test logs show diagnostic output
- [ ] Verify health check passes (or at minimum, the failure reason is now visible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)