### PR TITLE
fix(homepage): harden hosted auth flow + CORS same-host patch for pairing

### DIFF
--- a/apps/homepage/src/__tests__/agent-provider-hosted.test.tsx
+++ b/apps/homepage/src/__tests__/agent-provider-hosted.test.tsx
@@ -1,0 +1,93 @@
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+describe("AgentProvider hosted fallback", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    localStorage.clear();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+    vi.useRealTimers();
+    vi.doUnmock("../lib/runtime-config");
+  });
+
+  it("does not show public sandbox agents on hosted auth failure", async () => {
+    vi.doMock("../lib/runtime-config", async () => {
+      const actual = await vi.importActual<
+        typeof import("../lib/runtime-config")
+      >("../lib/runtime-config");
+      return {
+        ...actual,
+        CLOUD_BASE: "https://www.dev.elizacloud.ai",
+        isHostedRuntime: () => true,
+        shouldAllowPublicSandboxDiscoveryFallback: () => false,
+      };
+    });
+
+    const { AgentProvider, useAgents } = await import("../lib/AgentProvider");
+    const { setToken } = await import("../lib/auth");
+
+    function TestConsumer() {
+      const { agents, loading } = useAgents();
+      return (
+        <div>
+          <span data-testid="loading">{String(loading)}</span>
+          <span data-testid="count">{agents.length}</span>
+        </div>
+      );
+    }
+
+    setToken("stale-key");
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("/api/v1/milady/agents")) {
+        return Promise.resolve({
+          ok: false,
+          status: 500,
+          json: () => Promise.resolve({ error: "Invalid or expired API key" }),
+          text: () => Promise.resolve("Invalid or expired API key"),
+        });
+      }
+      if (url.includes("sandboxes.waifu.fun/agents")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve([
+              {
+                id: "public-1",
+                agent_name: "everyone-agent",
+                web_ui_port: 3000,
+              },
+            ]),
+        });
+      }
+      return Promise.reject(new Error("offline"));
+    });
+
+    let result: ReturnType<typeof render>;
+    await act(async () => {
+      result = render(
+        <AgentProvider>
+          <TestConsumer />
+        </AgentProvider>,
+      );
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    expect(result?.getByTestId("count").textContent).toBe("0");
+    expect(result?.getByTestId("loading").textContent).toBe("false");
+    expect(
+      mockFetch.mock.calls.some((call) =>
+        String(call[0]).includes("sandboxes.waifu.fun/agents"),
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/homepage/src/__tests__/auth.test.ts
+++ b/apps/homepage/src/__tests__/auth.test.ts
@@ -8,6 +8,10 @@ import {
   isAuthenticated,
   setToken,
 } from "../lib/auth";
+import {
+  getCloudTokenStorageKey,
+  LEGACY_CLOUD_TOKEN_STORAGE_KEY,
+} from "../lib/runtime-config";
 
 beforeEach(() => {
   localStorage.clear();
@@ -22,6 +26,14 @@ describe("auth", () => {
   it("stores and retrieves token", () => {
     setToken("test-api-key");
     expect(getToken()).toBe("test-api-key");
+  });
+
+  it("stores token under a cloud-scoped storage key", () => {
+    setToken("test-api-key");
+    expect(localStorage.getItem(getCloudTokenStorageKey())).toBe(
+      "test-api-key",
+    );
+    expect(localStorage.getItem(LEGACY_CLOUD_TOKEN_STORAGE_KEY)).toBeNull();
   });
 
   it("clears token", () => {

--- a/apps/homepage/src/__tests__/cloud-api.test.ts
+++ b/apps/homepage/src/__tests__/cloud-api.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getToken, setToken } from "../lib/auth";
 import { CloudApiClient, CloudClient } from "../lib/cloud-api";
 
 const mockFetch = vi.fn();
@@ -394,6 +395,19 @@ describe("CloudClient", () => {
       json: () => Promise.resolve({ error: "forbidden" }),
     });
     await expect(cc.listAgents()).rejects.toThrow("Cloud API 403");
+  });
+
+  it("clears stored token when backend returns auth failure", async () => {
+    setToken("stale-key");
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ error: "Invalid or expired API key" }),
+      text: () => Promise.resolve("Invalid or expired API key"),
+    });
+
+    await expect(cc.listAgents()).rejects.toThrow("Invalid or expired API key");
+    expect(getToken()).toBeNull();
   });
 
   it("deleteAgent() calls DELETE", async () => {

--- a/apps/homepage/src/__tests__/dashboard.test.tsx
+++ b/apps/homepage/src/__tests__/dashboard.test.tsx
@@ -9,9 +9,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AgentCard } from "../components/dashboard/AgentCard";
 import { AgentDetail } from "../components/dashboard/AgentDetail";
 import { ConnectionModal } from "../components/dashboard/ConnectionModal";
+import { CreateAgentForm } from "../components/dashboard/CreateAgentForm";
 import { LogsPanel } from "../components/dashboard/LogsPanel";
 import { MetricsPanel } from "../components/dashboard/MetricsPanel";
 import { Sidebar } from "../components/dashboard/Sidebar";
+import * as auth from "../lib/auth";
 import type { AgentStatus } from "../lib/cloud-api";
 
 vi.mock("../lib/AgentProvider", () => ({
@@ -42,6 +44,7 @@ beforeEach(() => localStorage.clear());
 afterEach(() => {
   cleanup();
   localStorage.clear();
+  vi.useRealTimers();
 });
 
 /* ------------------------------------------------------------------ */
@@ -242,27 +245,20 @@ describe("LogsPanel", () => {
 /*  ExportPanel                                                       */
 /* ------------------------------------------------------------------ */
 describe("ExportPanel", () => {
-  it("renders password input and export/import buttons", async () => {
+  it("renders snapshot actions and empty state", async () => {
     const { ExportPanel } = await import("../components/dashboard/ExportPanel");
     const { container } = render(<ExportPanel connectionId="local-default" />);
     const text = container.textContent ?? "";
-    expect(text).toContain("Password");
-    expect(screen.getByText("Export Agent")).toBeTruthy();
-    expect(screen.getByText("Import Agent")).toBeTruthy();
+    expect(text).toContain("Cloud Snapshots");
+    expect(screen.getByText("Take Snapshot")).toBeTruthy();
+    expect(screen.getByText("No backups yet.")).toBeTruthy();
   });
 
-  it("Export button is disabled when password < 4 chars", async () => {
+  it("shows the snapshot action as enabled", async () => {
     const { ExportPanel } = await import("../components/dashboard/ExportPanel");
     render(<ExportPanel connectionId="local-default" />);
-    const exportBtn = screen.getByText("Export Agent");
-    expect(exportBtn).toBeDisabled();
-
-    const pwInput = screen.getByLabelText("Password (min 4 chars)");
-    fireEvent.change(pwInput, { target: { value: "abc" } });
-    expect(screen.getByText("Export Agent")).toBeDisabled();
-
-    fireEvent.change(pwInput, { target: { value: "abcd" } });
-    expect(screen.getByText("Export Agent")).not.toBeDisabled();
+    const snapshotBtn = screen.getByText("Take Snapshot");
+    expect(snapshotBtn).not.toBeDisabled();
   });
 });
 
@@ -347,7 +343,7 @@ describe("AgentDetail", () => {
       />,
     );
     fireEvent.click(screen.getByText("Snapshots"));
-    expect(screen.getByText("Export Agent")).toBeTruthy();
+    expect(screen.getByText("Take Snapshot")).toBeTruthy();
   });
 });
 
@@ -530,5 +526,53 @@ describe("AuthGate", () => {
     });
     expect(result?.queryByText("Sign in with Eliza Cloud")).toBeNull();
     expect(result?.getByText("child")).toBeTruthy();
+  });
+});
+
+describe("CreateAgentForm", () => {
+  it("shows a Sign In button for unauthenticated users", () => {
+    vi.spyOn(auth, "isAuthenticated").mockReturnValue(false);
+
+    render(<CreateAgentForm onCreated={vi.fn()} onCancel={vi.fn()} />);
+
+    expect(screen.getByText("Sign In")).toBeTruthy();
+    expect(screen.queryByLabelText("Agent Name")).toBeNull();
+  });
+
+  it("reuses the cloud sign-in flow and completes auth polling", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(auth, "isAuthenticated").mockReturnValue(false);
+    const loginSpy = vi.spyOn(auth, "cloudLogin").mockResolvedValue({
+      sessionId: "test-session",
+      browserUrl: "https://cloud.example/auth",
+    });
+    const pollSpy = vi.spyOn(auth, "cloudLoginPoll").mockResolvedValue({
+      status: "authenticated",
+      apiKey: "test-key",
+    });
+    const openSpy = vi
+      .spyOn(window, "open")
+      .mockImplementation(() => ({ closed: false }) as Window);
+
+    render(<CreateAgentForm onCreated={vi.fn()} onCancel={vi.fn()} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Sign In"));
+      await Promise.resolve();
+    });
+
+    expect(loginSpy).toHaveBeenCalledTimes(1);
+    expect(openSpy).toHaveBeenCalledWith(
+      "https://cloud.example/auth",
+      "_blank",
+      "noopener,noreferrer",
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(pollSpy).toHaveBeenCalledWith("test-session");
+    expect(auth.getToken()).toBe("test-key");
   });
 });

--- a/apps/homepage/src/__tests__/open-web-ui.test.ts
+++ b/apps/homepage/src/__tests__/open-web-ui.test.ts
@@ -101,9 +101,9 @@ describe("open-web-ui", () => {
       expect(popup.location.href).toBeTruthy();
     });
 
-    // Should rewrite waifu.fun → milady.ai in the redirect URL
-    expect(popup.location.href).toContain("milady.ai");
+    // Pairing redirect URL stays as waifu.fun (milady.ai /pair is a static
+    // file that doesn't understand cloud tokens, waifu.fun routes to the agent)
+    expect(popup.location.href).toContain("waifu.fun");
     expect(popup.location.href).toContain("token=pair-token");
-    expect(popup.location.href).not.toContain("waifu.fun");
   });
 });

--- a/apps/homepage/src/__tests__/open-web-ui.test.ts
+++ b/apps/homepage/src/__tests__/open-web-ui.test.ts
@@ -101,9 +101,8 @@ describe("open-web-ui", () => {
       expect(popup.location.href).toBeTruthy();
     });
 
-    // Pairing redirect URL stays as waifu.fun (milady.ai /pair is a static
-    // file that doesn't understand cloud tokens, waifu.fun routes to the agent)
-    expect(popup.location.href).toContain("waifu.fun");
+    // Pairing redirect URL is rewritten to milady.ai (canonical domain)
+    expect(popup.location.href).toContain("milady.ai");
     expect(popup.location.href).toContain("token=pair-token");
   });
 });

--- a/apps/homepage/src/__tests__/open-web-ui.test.ts
+++ b/apps/homepage/src/__tests__/open-web-ui.test.ts
@@ -8,28 +8,28 @@ afterEach(() => {
 });
 
 describe("open-web-ui", () => {
-  it("preserves waifu.fun URLs when domain matches", () => {
+  it("rewrites waifu.fun URLs to milady.ai", () => {
     const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
 
     openWebUIDirect("https://agent-123.waifu.fun");
 
-    // URL may be normalized (trailing slash) by the URL constructor
     const url = (openSpy.mock.calls[0]?.[0] as string) ?? "";
-    expect(url.startsWith("https://agent-123.waifu.fun")).toBe(true);
-    expect(url).not.toContain("milady.ai");
+    expect(url).toContain("agent-123.milady.ai");
+    expect(url).not.toContain("waifu.fun");
   });
 
-  it("appends api token to URL when provided", () => {
+  it("appends api token to rewritten URL when provided", () => {
     const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
 
     openWebUIDirect("https://agent-123.waifu.fun", "milady_abc123");
 
     const url = (openSpy.mock.calls[0]?.[0] as string) ?? "";
-    expect(url).toContain("agent-123.waifu.fun");
+    expect(url).toContain("agent-123.milady.ai");
     expect(url).toContain("token=milady_abc123");
+    expect(url).not.toContain("waifu.fun");
   });
 
-  it("preserves pairing redirect URLs from cloud backend", async () => {
+  it("rewrites pairing redirect URLs to milady.ai", async () => {
     const popup = {
       closed: false,
       document: {
@@ -57,8 +57,8 @@ describe("open-web-ui", () => {
 
     await openWebUIWithPairing("agent-123", cloudClient);
 
-    // When AGENT_UI_BASE_DOMAIN matches waifu.fun, redirect URL is preserved
-    expect(popup.location.href).toContain("agent-123.waifu.fun");
+    expect(popup.location.href).toContain("agent-123.milady.ai");
     expect(popup.location.href).toContain("token=pair-token");
+    expect(popup.location.href).not.toContain("waifu.fun");
   });
 });

--- a/apps/homepage/src/__tests__/open-web-ui.test.ts
+++ b/apps/homepage/src/__tests__/open-web-ui.test.ts
@@ -93,7 +93,7 @@ describe("open-web-ui", () => {
     // Should have called the backend pairing-token endpoint
     const fetchUrl = fetchSpy.mock.calls[0]?.[0] as string;
     expect(fetchUrl).toContain(
-      "/api/agents/abcd1234-1234-1234-1234-123456789abc/pairing-token",
+      "/api/v1/milady/agents/abcd1234-1234-1234-1234-123456789abc/pairing-token",
     );
 
     // Wait for redirect

--- a/apps/homepage/src/__tests__/open-web-ui.test.ts
+++ b/apps/homepage/src/__tests__/open-web-ui.test.ts
@@ -8,37 +8,28 @@ afterEach(() => {
 });
 
 describe("open-web-ui", () => {
-  it("rewrites waifu.fun URLs to milady.ai with auth bootstrap", () => {
+  it("rewrites waifu.fun URLs to milady.ai without token", () => {
     const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
 
     openWebUIDirect("https://agent-123.waifu.fun");
 
     const url = (openSpy.mock.calls[0]?.[0] as string) ?? "";
     expect(url).toContain("agent-123.milady.ai");
-    expect(url).toContain("token=bootstrap");
     expect(url).not.toContain("waifu.fun");
+    // No token appended without explicit launchToken
+    expect(url).not.toContain("token=");
   });
 
-  it("uses provided api token instead of bootstrap", () => {
+  it("appends signed launch token when provided", () => {
     const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
 
     openWebUIDirect("https://agent-123.waifu.fun", {
-      apiToken: "milady_abc123",
+      launchToken: "signed.token.here",
     });
 
     const url = (openSpy.mock.calls[0]?.[0] as string) ?? "";
     expect(url).toContain("agent-123.milady.ai");
-    expect(url).toContain("token=milady_abc123");
-  });
-
-  it("skips token param for local agents", () => {
-    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
-
-    openWebUIDirect("http://localhost:2138", { isLocal: true });
-
-    const url = (openSpy.mock.calls[0]?.[0] as string) ?? "";
-    expect(url).toContain("localhost:2138");
-    expect(url).not.toContain("token=");
+    expect(url).toContain("token=signed.token.here");
   });
 
   it("rewrites pairing redirect URLs to milady.ai", async () => {

--- a/apps/homepage/src/__tests__/open-web-ui.test.ts
+++ b/apps/homepage/src/__tests__/open-web-ui.test.ts
@@ -8,19 +8,28 @@ afterEach(() => {
 });
 
 describe("open-web-ui", () => {
-  it("rewrites direct Web UI links to milady.ai", () => {
+  it("preserves waifu.fun URLs when domain matches", () => {
     const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
 
     openWebUIDirect("https://agent-123.waifu.fun");
 
-    expect(openSpy).toHaveBeenCalledWith(
-      "https://agent-123.milady.ai/",
-      "_blank",
-      "noopener,noreferrer",
-    );
+    // URL may be normalized (trailing slash) by the URL constructor
+    const url = (openSpy.mock.calls[0]?.[0] as string) ?? "";
+    expect(url.startsWith("https://agent-123.waifu.fun")).toBe(true);
+    expect(url).not.toContain("milady.ai");
   });
 
-  it("rewrites pairing redirect URLs to milady.ai", async () => {
+  it("appends api token to URL when provided", () => {
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    openWebUIDirect("https://agent-123.waifu.fun", "milady_abc123");
+
+    const url = (openSpy.mock.calls[0]?.[0] as string) ?? "";
+    expect(url).toContain("agent-123.waifu.fun");
+    expect(url).toContain("token=milady_abc123");
+  });
+
+  it("preserves pairing redirect URLs from cloud backend", async () => {
     const popup = {
       closed: false,
       document: {
@@ -48,8 +57,8 @@ describe("open-web-ui", () => {
 
     await openWebUIWithPairing("agent-123", cloudClient);
 
-    expect(popup.location.href).toBe(
-      "https://agent-123.milady.ai/pair?token=pair-token",
-    );
+    // When AGENT_UI_BASE_DOMAIN matches waifu.fun, redirect URL is preserved
+    expect(popup.location.href).toContain("agent-123.waifu.fun");
+    expect(popup.location.href).toContain("token=pair-token");
   });
 });

--- a/apps/homepage/src/__tests__/open-web-ui.test.ts
+++ b/apps/homepage/src/__tests__/open-web-ui.test.ts
@@ -8,25 +8,37 @@ afterEach(() => {
 });
 
 describe("open-web-ui", () => {
-  it("rewrites waifu.fun URLs to milady.ai", () => {
+  it("rewrites waifu.fun URLs to milady.ai with auth bootstrap", () => {
     const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
 
     openWebUIDirect("https://agent-123.waifu.fun");
 
     const url = (openSpy.mock.calls[0]?.[0] as string) ?? "";
     expect(url).toContain("agent-123.milady.ai");
+    expect(url).toContain("token=bootstrap");
     expect(url).not.toContain("waifu.fun");
   });
 
-  it("appends api token to rewritten URL when provided", () => {
+  it("uses provided api token instead of bootstrap", () => {
     const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
 
-    openWebUIDirect("https://agent-123.waifu.fun", "milady_abc123");
+    openWebUIDirect("https://agent-123.waifu.fun", {
+      apiToken: "milady_abc123",
+    });
 
     const url = (openSpy.mock.calls[0]?.[0] as string) ?? "";
     expect(url).toContain("agent-123.milady.ai");
     expect(url).toContain("token=milady_abc123");
-    expect(url).not.toContain("waifu.fun");
+  });
+
+  it("skips token param for local agents", () => {
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    openWebUIDirect("http://localhost:2138", { isLocal: true });
+
+    const url = (openSpy.mock.calls[0]?.[0] as string) ?? "";
+    expect(url).toContain("localhost:2138");
+    expect(url).not.toContain("token=");
   });
 
   it("rewrites pairing redirect URLs to milady.ai", async () => {

--- a/apps/homepage/src/__tests__/open-web-ui.test.ts
+++ b/apps/homepage/src/__tests__/open-web-ui.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { CloudClient } from "../lib/cloud-api";
-import { openWebUIDirect, openWebUIWithPairing } from "../lib/open-web-ui";
+import { openWebUI, openWebUIDirect } from "../lib/open-web-ui";
+
+// Mock auth module so we can control getToken()
+vi.mock("../lib/auth", () => ({
+  getToken: vi.fn(() => null),
+}));
+
+// Need to import after mock setup so the mock takes effect
+const { getToken } = await import("../lib/auth");
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -8,7 +15,7 @@ afterEach(() => {
 });
 
 describe("open-web-ui", () => {
-  it("rewrites waifu.fun URLs to milady.ai without token", () => {
+  it("rewrites waifu.fun URLs to milady.ai", () => {
     const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
 
     openWebUIDirect("https://agent-123.waifu.fun");
@@ -16,51 +23,86 @@ describe("open-web-ui", () => {
     const url = (openSpy.mock.calls[0]?.[0] as string) ?? "";
     expect(url).toContain("agent-123.milady.ai");
     expect(url).not.toContain("waifu.fun");
-    // No token appended without explicit launchToken
-    expect(url).not.toContain("token=");
   });
 
-  it("appends signed launch token when provided", () => {
+  it("opens directly for local agents even when authenticated", () => {
+    vi.mocked(getToken).mockReturnValue("test-api-key");
     const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
 
-    openWebUIDirect("https://agent-123.waifu.fun", {
-      launchToken: "signed.token.here",
-    });
+    openWebUI("https://localhost:2138", "local");
 
+    // Should open directly without pairing token flow
+    expect(openSpy).toHaveBeenCalledTimes(1);
     const url = (openSpy.mock.calls[0]?.[0] as string) ?? "";
-    expect(url).toContain("agent-123.milady.ai");
-    expect(url).toContain("token=signed.token.here");
+    expect(url).toContain("localhost:2138");
   });
 
-  it("rewrites pairing redirect URLs to milady.ai", async () => {
+  it("opens directly for remote agents when not authenticated", () => {
+    vi.mocked(getToken).mockReturnValue(null);
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    openWebUI("https://abc-123.milady.ai", "remote");
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    const url = (openSpy.mock.calls[0]?.[0] as string) ?? "";
+    expect(url).toContain("abc-123.milady.ai");
+  });
+
+  it("uses pairing token flow for remote agents when authenticated", async () => {
+    vi.mocked(getToken).mockReturnValue("test-api-key");
+
     const popup = {
       closed: false,
       document: {
         title: "",
-        body: {
-          style: { margin: "" },
-          innerHTML: "",
-        },
+        body: { style: { margin: "" }, innerHTML: "" },
       },
       location: { href: "" },
       close: vi.fn(),
     };
-
     vi.spyOn(window, "open").mockImplementation(
       () => popup as unknown as Window,
     );
 
-    const cloudClient = {
-      getPairingToken: vi.fn().mockResolvedValue({
-        token: "pair-token",
-        redirectUrl: "https://agent-123.waifu.fun/pair?token=pair-token",
-        expiresIn: 300,
-      }),
-    } as unknown as CloudClient;
+    // Mock fetch to return a pairing token response
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          success: true,
+          data: {
+            token: "pair-token",
+            redirectUrl:
+              "https://abcd1234-1234-1234-1234-123456789abc.waifu.fun/pair?token=pair-token",
+            expiresIn: 60,
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
 
-    await openWebUIWithPairing("agent-123", cloudClient);
+    openWebUI(
+      "https://abcd1234-1234-1234-1234-123456789abc.milady.ai",
+      "remote",
+    );
 
-    expect(popup.location.href).toContain("agent-123.milady.ai");
+    // Wait for the async pairing token fetch
+    await vi.waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    // Should have called the backend pairing-token endpoint
+    const fetchUrl = fetchSpy.mock.calls[0]?.[0] as string;
+    expect(fetchUrl).toContain(
+      "/api/agents/abcd1234-1234-1234-1234-123456789abc/pairing-token",
+    );
+
+    // Wait for redirect
+    await vi.waitFor(() => {
+      expect(popup.location.href).toBeTruthy();
+    });
+
+    // Should rewrite waifu.fun → milady.ai in the redirect URL
+    expect(popup.location.href).toContain("milady.ai");
     expect(popup.location.href).toContain("token=pair-token");
     expect(popup.location.href).not.toContain("waifu.fun");
   });

--- a/apps/homepage/src/components/dashboard/AgentGrid.tsx
+++ b/apps/homepage/src/components/dashboard/AgentGrid.tsx
@@ -145,19 +145,26 @@ export function AgentGrid() {
                   setSelectedId(selectedId === agent.id ? null : agent.id)
                 }
                 onOpenUI={() => {
-                  // Cloud agents without a direct sandbox token: use pairing token flow
+                  const url = getWebUIUrl(agent);
+                  if (!url) return;
+
+                  // Cloud agents with no sandbox match: use cloud pairing token flow
                   if (
                     agent.source === "cloud" &&
                     agent.cloudClient &&
                     agent.cloudAgentId &&
-                    !agent.apiToken
+                    !agent.webUiUrl
                   ) {
                     openWebUIWithPairing(agent.cloudAgentId, agent.cloudClient);
                     return;
                   }
-                  // All other agents: open directly, bootstrapping auth via ?token= if available
-                  const url = getWebUIUrl(agent);
-                  if (url) openWebUIDirect(url, agent.apiToken);
+
+                  // Everything else: open directly with nginx auth bootstrap
+                  // Local agents skip the ?token= param (no nginx Lua router)
+                  openWebUIDirect(url, {
+                    apiToken: agent.apiToken,
+                    isLocal: agent.source === "local",
+                  });
                 }}
                 selected={selectedId === agent.id}
               />

--- a/apps/homepage/src/components/dashboard/AgentGrid.tsx
+++ b/apps/homepage/src/components/dashboard/AgentGrid.tsx
@@ -1,10 +1,7 @@
 import { useCallback, useState } from "react";
 import { useAgents } from "../../lib/AgentProvider";
-import { getToken } from "../../lib/auth";
-import {
-  openWebUIDirect,
-  openWebUIWithLaunchToken,
-} from "../../lib/open-web-ui";
+import { isAuthenticated } from "../../lib/auth";
+import { openWebUI } from "../../lib/open-web-ui";
 import { AgentCard } from "./AgentCard";
 import { AgentDetail } from "./AgentDetail";
 import { CreateAgentForm } from "./CreateAgentForm";
@@ -151,19 +148,7 @@ export function AgentGrid() {
                 onOpenUI={() => {
                   const url = getWebUIUrl(agent);
                   if (!url) return;
-
-                  // Non-local agents: if user is authenticated, request a
-                  // signed launch token from the VPS. The VPS validates the
-                  // cloud session and returns an HMAC-signed token.
-                  const cloudToken = getToken();
-                  if (agent.source !== "local" && cloudToken) {
-                    openWebUIWithLaunchToken(url, cloudToken);
-                    return;
-                  }
-
-                  // Local agents or unauthenticated: open directly
-                  // (user will see pairing screen if auth is required)
-                  openWebUIDirect(url);
+                  openWebUI(url, agent.source);
                 }}
                 selected={selectedId === agent.id}
               />

--- a/apps/homepage/src/components/dashboard/AgentGrid.tsx
+++ b/apps/homepage/src/components/dashboard/AgentGrid.tsx
@@ -1,7 +1,11 @@
 import { useCallback, useState } from "react";
 import { useAgents } from "../../lib/AgentProvider";
 import { isAuthenticated } from "../../lib/auth";
-import { openWebUIDirect, openWebUIWithPairing } from "../../lib/open-web-ui";
+import {
+  openWebUIDirect,
+  openWebUIWithLaunchToken,
+  openWebUIWithPairing,
+} from "../../lib/open-web-ui";
 import { AgentCard } from "./AgentCard";
 import { AgentDetail } from "./AgentDetail";
 import { CreateAgentForm } from "./CreateAgentForm";
@@ -159,12 +163,25 @@ export function AgentGrid() {
                     return;
                   }
 
-                  // Everything else: open directly with nginx auth bootstrap
-                  // Local agents skip the ?token= param (no nginx Lua router)
-                  openWebUIDirect(url, {
-                    apiToken: agent.apiToken,
-                    isLocal: agent.source === "local",
-                  });
+                  // Remote/sandbox agents with cloud auth: request a signed
+                  // launch token from the VPS, which validates the cloud
+                  // session before handing out the API key.
+                  if (
+                    agent.source !== "local" &&
+                    agent.cloudClient &&
+                    agent.cloudAgentId
+                  ) {
+                    openWebUIWithLaunchToken(
+                      url,
+                      agent.cloudClient,
+                      agent.cloudAgentId,
+                    );
+                    return;
+                  }
+
+                  // Local agents or agents without cloud auth: open directly
+                  // (user will see pairing screen if auth is required)
+                  openWebUIDirect(url);
                 }}
                 selected={selectedId === agent.id}
               />

--- a/apps/homepage/src/components/dashboard/AgentGrid.tsx
+++ b/apps/homepage/src/components/dashboard/AgentGrid.tsx
@@ -1,10 +1,9 @@
 import { useCallback, useState } from "react";
 import { useAgents } from "../../lib/AgentProvider";
-import { isAuthenticated } from "../../lib/auth";
+import { getToken } from "../../lib/auth";
 import {
   openWebUIDirect,
   openWebUIWithLaunchToken,
-  openWebUIWithPairing,
 } from "../../lib/open-web-ui";
 import { AgentCard } from "./AgentCard";
 import { AgentDetail } from "./AgentDetail";
@@ -106,6 +105,7 @@ export function AgentGrid() {
       {/* Create form */}
       {showCreate && (
         <CreateAgentForm
+          onAuthenticated={() => refresh()}
           onCreated={() => {
             setShowCreate(false);
             refresh();
@@ -152,34 +152,16 @@ export function AgentGrid() {
                   const url = getWebUIUrl(agent);
                   if (!url) return;
 
-                  // Cloud agents with no sandbox match: use cloud pairing token flow
-                  if (
-                    agent.source === "cloud" &&
-                    agent.cloudClient &&
-                    agent.cloudAgentId &&
-                    !agent.webUiUrl
-                  ) {
-                    openWebUIWithPairing(agent.cloudAgentId, agent.cloudClient);
+                  // Non-local agents: if user is authenticated, request a
+                  // signed launch token from the VPS. The VPS validates the
+                  // cloud session and returns an HMAC-signed token.
+                  const cloudToken = getToken();
+                  if (agent.source !== "local" && cloudToken) {
+                    openWebUIWithLaunchToken(url, cloudToken);
                     return;
                   }
 
-                  // Remote/sandbox agents with cloud auth: request a signed
-                  // launch token from the VPS, which validates the cloud
-                  // session before handing out the API key.
-                  if (
-                    agent.source !== "local" &&
-                    agent.cloudClient &&
-                    agent.cloudAgentId
-                  ) {
-                    openWebUIWithLaunchToken(
-                      url,
-                      agent.cloudClient,
-                      agent.cloudAgentId,
-                    );
-                    return;
-                  }
-
-                  // Local agents or agents without cloud auth: open directly
+                  // Local agents or unauthenticated: open directly
                   // (user will see pairing screen if auth is required)
                   openWebUIDirect(url);
                 }}

--- a/apps/homepage/src/components/dashboard/AgentGrid.tsx
+++ b/apps/homepage/src/components/dashboard/AgentGrid.tsx
@@ -145,18 +145,19 @@ export function AgentGrid() {
                   setSelectedId(selectedId === agent.id ? null : agent.id)
                 }
                 onOpenUI={() => {
-                  // Cloud agents: use pairing token flow for proper auth handoff
+                  // Cloud agents without a direct sandbox token: use pairing token flow
                   if (
                     agent.source === "cloud" &&
                     agent.cloudClient &&
-                    agent.cloudAgentId
+                    agent.cloudAgentId &&
+                    !agent.apiToken
                   ) {
                     openWebUIWithPairing(agent.cloudAgentId, agent.cloudClient);
                     return;
                   }
-                  // Local/remote agents: open directly (no pairing token needed)
+                  // All other agents: open directly, bootstrapping auth via ?token= if available
                   const url = getWebUIUrl(agent);
-                  if (url) openWebUIDirect(url);
+                  if (url) openWebUIDirect(url, agent.apiToken);
                 }}
                 selected={selectedId === agent.id}
               />

--- a/apps/homepage/src/components/dashboard/AuthGate.tsx
+++ b/apps/homepage/src/components/dashboard/AuthGate.tsx
@@ -1,23 +1,5 @@
-import {
-  type ReactNode,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
-import {
-  cloudLogin,
-  cloudLoginPoll,
-  isAuthenticated,
-  setToken,
-} from "../../lib/auth";
-
-type AuthState =
-  | "checking"
-  | "unauthenticated"
-  | "polling"
-  | "authenticated"
-  | "error";
+import { type ReactNode, useState } from "react";
+import { useCloudLogin } from "./useCloudLogin";
 
 /**
  * CloudLoginBanner — an inline, dismissible banner that lets users optionally
@@ -28,54 +10,10 @@ export function CloudLoginBanner({
 }: {
   onAuthenticated?: () => void;
 }) {
-  const [state, setState] = useState<AuthState>("checking");
-  const [error, setError] = useState<string | null>(null);
   const [dismissed, setDismissed] = useState(false);
-  const pollRef = useRef<ReturnType<typeof setInterval>>();
-
-  useEffect(() => {
-    setState(isAuthenticated() ? "authenticated" : "unauthenticated");
-    return () => {
-      if (pollRef.current) clearInterval(pollRef.current);
-    };
-  }, []);
-
-  const handleLogin = useCallback(async () => {
-    setState("polling");
-    setError(null);
-    try {
-      const { sessionId, browserUrl } = await cloudLogin();
-      window.open(browserUrl, "_blank", "noopener,noreferrer");
-
-      const deadline = Date.now() + 5 * 60 * 1000;
-      pollRef.current = setInterval(async () => {
-        try {
-          if (Date.now() > deadline) {
-            clearInterval(pollRef.current);
-            setState("error");
-            setError("Login timed out. Please try again.");
-            return;
-          }
-          const result = await cloudLoginPoll(sessionId);
-          if (result.status === "authenticated" && result.apiKey) {
-            clearInterval(pollRef.current);
-            setToken(result.apiKey);
-            setState("authenticated");
-            onAuthenticated?.();
-          }
-        } catch (err) {
-          if (String(err).includes("expired")) {
-            clearInterval(pollRef.current);
-            setState("error");
-            setError("Session expired. Please try again.");
-          }
-        }
-      }, 2000);
-    } catch (err) {
-      setState("error");
-      setError(`Failed to start login: ${err}`);
-    }
-  }, [onAuthenticated]);
+  const { error, manualLoginUrl, signIn, state } = useCloudLogin({
+    onAuthenticated,
+  });
 
   // Don't show anything if already authenticated or dismissed
   if (state === "authenticated" || state === "checking" || dismissed) {
@@ -86,12 +24,25 @@ export function CloudLoginBanner({
     <div className="mx-6 md:mx-8 mt-4 px-4 py-3 bg-surface/50 border border-border rounded-xl flex items-center gap-4">
       <div className="flex-1">
         {state === "polling" ? (
-          <div className="flex items-center gap-3">
-            <div className="w-4 h-4 rounded-full border-2 border-brand/30 border-t-brand animate-spin" />
-            <span className="text-text-light text-sm">
-              Waiting for authentication — complete login in the browser tab.
-            </span>
-          </div>
+          <>
+            <div className="flex items-center gap-3">
+              <div className="w-4 h-4 rounded-full border-2 border-brand/30 border-t-brand animate-spin" />
+              <span className="text-text-light text-sm">
+                Waiting for authentication, complete login in the browser tab.
+              </span>
+            </div>
+            {error && <p className="text-xs text-red-400 mt-2">{error}</p>}
+            {manualLoginUrl && (
+              <a
+                href={manualLoginUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex mt-2 text-xs text-brand hover:underline"
+              >
+                Open sign-in page
+              </a>
+            )}
+          </>
         ) : (
           <>
             <p className="text-sm text-text-muted">
@@ -102,6 +53,16 @@ export function CloudLoginBanner({
               alongside your local ones.
             </p>
             {error && <p className="text-xs text-red-400 mt-1">{error}</p>}
+            {manualLoginUrl && (
+              <a
+                href={manualLoginUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex mt-2 text-xs text-brand hover:underline"
+              >
+                Open sign-in page
+              </a>
+            )}
           </>
         )}
       </div>
@@ -109,7 +70,7 @@ export function CloudLoginBanner({
         <div className="flex items-center gap-2 shrink-0">
           <button
             type="button"
-            onClick={handleLogin}
+            onClick={signIn}
             className="px-4 py-2 bg-brand text-dark font-medium text-xs rounded-lg
               hover:bg-brand-hover active:scale-[0.98] transition-all duration-150"
           >

--- a/apps/homepage/src/components/dashboard/CreateAgentForm.tsx
+++ b/apps/homepage/src/components/dashboard/CreateAgentForm.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { getToken, isAuthenticated } from "../../lib/auth";
+import { getToken } from "../../lib/auth";
 import { CloudClient, type JobStatus } from "../../lib/cloud-api";
-import { CLOUD_BASE } from "../../lib/runtime-config";
+import { useCloudLogin } from "./useCloudLogin";
 
 interface CreateAgentFormProps {
+  onAuthenticated?: () => void;
   onCreated: () => void;
   onCancel: () => void;
 }
@@ -17,7 +18,11 @@ const PROGRESS_MESSAGES: Record<string, string> = {
   failed: "Provisioning failed.",
 };
 
-export function CreateAgentForm({ onCreated, onCancel }: CreateAgentFormProps) {
+export function CreateAgentForm({
+  onAuthenticated,
+  onCreated,
+  onCancel,
+}: CreateAgentFormProps) {
   const [name, setName] = useState("");
   const [envVars, setEnvVars] = useState<{ key: string; value: string }[]>([]);
   const [showEnvVars, setShowEnvVars] = useState(false);
@@ -26,6 +31,13 @@ export function CreateAgentForm({ onCreated, onCancel }: CreateAgentFormProps) {
   const [jobStatus, setJobStatus] = useState<JobStatus | null>(null);
   const [_createdAgentId, setCreatedAgentId] = useState<string | null>(null);
   const pollRef = useRef<ReturnType<typeof setTimeout>>();
+  const {
+    error: loginError,
+    isAuthenticated: authenticated,
+    manualLoginUrl,
+    signIn,
+    state: loginState,
+  } = useCloudLogin({ onAuthenticated });
 
   // Clean up polling on unmount
   useEffect(() => {
@@ -58,7 +70,7 @@ export function CreateAgentForm({ onCreated, onCancel }: CreateAgentFormProps) {
           );
         }
       } catch {
-        // Network error during polling — retry with backoff
+        // Network error during polling, retry with backoff
         pollRef.current = setTimeout(
           () => pollJob(cc, jobId, attempt + 1),
           5000,
@@ -70,7 +82,7 @@ export function CreateAgentForm({ onCreated, onCancel }: CreateAgentFormProps) {
 
   const handleCreate = useCallback(async () => {
     if (!name.trim()) return;
-    if (!isAuthenticated()) {
+    if (!authenticated) {
       setError("You need to sign in with Eliza Cloud first.");
       return;
     }
@@ -106,12 +118,12 @@ export function CreateAgentForm({ onCreated, onCancel }: CreateAgentFormProps) {
             // Poll job status
             pollJob(cc, provResult.jobId);
           } else {
-            // No job ID — provisioning was synchronous or auto
+            // No job ID, provisioning was synchronous or auto
             setStep("done");
             setTimeout(() => onCreated(), 1500);
           }
         } catch {
-          // Provisioning endpoint failed — agent was still created
+          // Provisioning endpoint failed, agent was still created
           setStep("done");
           setTimeout(() => onCreated(), 1500);
         }
@@ -128,7 +140,7 @@ export function CreateAgentForm({ onCreated, onCancel }: CreateAgentFormProps) {
         setError(`Failed to create agent: ${msg}`);
       }
     }
-  }, [name, envVars, onCreated, pollJob]);
+  }, [authenticated, name, envVars, onCreated, pollJob]);
 
   const addEnvVar = () => setEnvVars([...envVars, { key: "", value: "" }]);
   const removeEnvVar = (i: number) =>
@@ -138,8 +150,6 @@ export function CreateAgentForm({ onCreated, onCancel }: CreateAgentFormProps) {
     updated[i] = { ...updated[i], [field]: val };
     setEnvVars(updated);
   };
-
-  const authenticated = isAuthenticated();
 
   // Provisioning / creating state
   if (step === "creating" || step === "provisioning" || step === "done") {
@@ -224,33 +234,70 @@ export function CreateAgentForm({ onCreated, onCancel }: CreateAgentFormProps) {
       </p>
 
       {!authenticated ? (
-        <div className="flex items-center gap-3 px-4 py-3 bg-brand/5 border border-brand/20 rounded-xl">
-          <svg
-            aria-hidden="true"
-            className="w-5 h-5 text-brand flex-shrink-0"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={2}
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-            />
-          </svg>
-          <span className="text-sm text-text-muted">
-            Go to{" "}
-            <a
-              href={`${CLOUD_BASE}/auth`}
-              target="_blank"
-              rel="noreferrer"
-              className="text-brand hover:underline"
+        <div className="space-y-4">
+          <div className="flex items-center gap-3 px-4 py-3 bg-brand/5 border border-brand/20 rounded-xl">
+            <svg
+              aria-hidden="true"
+              className="w-5 h-5 text-brand flex-shrink-0"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
             >
-              Eliza Cloud
-            </a>{" "}
-            to create an account, then sign in from the dashboard.
-          </span>
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
+            </svg>
+            <div className="min-w-0 flex-1">
+              <p className="text-sm text-text-muted">
+                Sign in to Eliza Cloud to create and manage hosted agents.
+              </p>
+              {loginError && (
+                <p className="text-xs text-red-400 mt-1">{loginError}</p>
+              )}
+              {manualLoginUrl && (
+                <a
+                  href={manualLoginUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex mt-2 text-xs text-brand hover:underline"
+                >
+                  Open sign-in page
+                </a>
+              )}
+            </div>
+          </div>
+
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={signIn}
+              disabled={loginState === "polling"}
+              className="px-5 py-2.5 bg-brand text-dark font-medium text-sm rounded-xl
+                hover:bg-brand-hover active:scale-[0.98] transition-all duration-150
+                disabled:opacity-70 disabled:cursor-wait
+                flex items-center gap-2 shadow-[0_0_16px_rgba(240,185,11,0.12)]"
+            >
+              {loginState === "polling" ? (
+                <>
+                  <div className="w-4 h-4 rounded-full border-2 border-dark/20 border-t-dark animate-spin" />
+                  Waiting for Sign In…
+                </>
+              ) : (
+                "Sign In"
+              )}
+            </button>
+            <button
+              type="button"
+              onClick={onCancel}
+              className="px-4 py-2.5 text-text-muted text-sm rounded-xl
+                hover:text-text-light hover:bg-dark transition-all duration-150"
+            >
+              Cancel
+            </button>
+          </div>
         </div>
       ) : (
         <div className="space-y-4">

--- a/apps/homepage/src/components/dashboard/useCloudLogin.ts
+++ b/apps/homepage/src/components/dashboard/useCloudLogin.ts
@@ -1,0 +1,119 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  CLOUD_AUTH_CHANGED_EVENT,
+  cloudLogin,
+  cloudLoginPoll,
+  isAuthenticated,
+  setToken,
+} from "../../lib/auth";
+import { CLOUD_BASE } from "../../lib/runtime-config";
+
+export type CloudLoginState =
+  | "checking"
+  | "unauthenticated"
+  | "polling"
+  | "authenticated"
+  | "error";
+
+interface UseCloudLoginOptions {
+  onAuthenticated?: () => void;
+}
+
+export function useCloudLogin(options: UseCloudLoginOptions = {}) {
+  const { onAuthenticated } = options;
+  const [state, setState] = useState<CloudLoginState>(() =>
+    isAuthenticated() ? "authenticated" : "unauthenticated",
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [manualLoginUrl, setManualLoginUrl] = useState<string | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval>>();
+
+  useEffect(() => {
+    const syncAuthState = () => {
+      const authenticated = isAuthenticated();
+      setState(authenticated ? "authenticated" : "unauthenticated");
+      if (authenticated) {
+        if (pollRef.current) clearInterval(pollRef.current);
+        setError(null);
+        setManualLoginUrl(null);
+      }
+    };
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.storageArea !== localStorage) return;
+      syncAuthState();
+    };
+
+    syncAuthState();
+    window.addEventListener(CLOUD_AUTH_CHANGED_EVENT, syncAuthState);
+    window.addEventListener("storage", handleStorage);
+
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+      window.removeEventListener(CLOUD_AUTH_CHANGED_EVENT, syncAuthState);
+      window.removeEventListener("storage", handleStorage);
+    };
+  }, []);
+
+  const signIn = useCallback(async () => {
+    if (pollRef.current) clearInterval(pollRef.current);
+
+    setState("polling");
+    setError(null);
+    setManualLoginUrl(null);
+
+    try {
+      const { sessionId, browserUrl } = await cloudLogin();
+      const loginWindow = window.open(
+        browserUrl,
+        "_blank",
+        "noopener,noreferrer",
+      );
+
+      if (!loginWindow) {
+        setError(
+          "Couldn't open the sign-in window. Open the sign-in page and finish there.",
+        );
+        setManualLoginUrl(browserUrl);
+      }
+
+      const deadline = Date.now() + 5 * 60 * 1000;
+      pollRef.current = setInterval(async () => {
+        try {
+          if (Date.now() > deadline) {
+            clearInterval(pollRef.current);
+            setState("error");
+            setError("Login timed out. Please try again.");
+            return;
+          }
+
+          const result = await cloudLoginPoll(sessionId);
+          if (result.status === "authenticated" && result.apiKey) {
+            clearInterval(pollRef.current);
+            setToken(result.apiKey);
+            setState("authenticated");
+            onAuthenticated?.();
+          }
+        } catch (err) {
+          if (String(err).includes("expired")) {
+            clearInterval(pollRef.current);
+            setState("error");
+            setError("Session expired. Please try again.");
+          }
+        }
+      }, 2000);
+    } catch (err) {
+      setState("error");
+      setError(`Failed to start login: ${err}`);
+      setManualLoginUrl(`${CLOUD_BASE}/auth`);
+    }
+  }, [onAuthenticated]);
+
+  return {
+    error,
+    isAuthenticated: state === "authenticated",
+    manualLoginUrl,
+    signIn,
+    state,
+  };
+}

--- a/apps/homepage/src/lib/AgentProvider.tsx
+++ b/apps/homepage/src/lib/AgentProvider.tsx
@@ -17,6 +17,7 @@ import {
   getSandboxDiscoveryUrls,
   LOCAL_AGENT_BASE,
   rewriteAgentUiUrl,
+  shouldAllowPublicSandboxDiscoveryFallback,
 } from "./runtime-config";
 
 export type AgentSource = "cloud" | "local" | "remote";
@@ -158,11 +159,9 @@ export function AgentProvider({ children }: { children: ReactNode }) {
     }
 
     // 2. Milady self-hosted agents (auto-discovery)
-    //    The sandbox discovery endpoint (sandboxes.waifu.fun/agents) returns ALL
-    //    sandboxes across all orgs — it does NOT support auth-based filtering.
-    //    To scope to the current user, we cross-reference with the Cloud API
-    //    (/api/v1/milady/agents) which IS org-scoped. Only sandboxes whose
-    //    agent_name matches a cloud agent name (or whose id matches) are shown.
+    //    The public sandbox discovery endpoint returns ALL sandboxes across orgs.
+    //    On hosted milady.ai, never use that as an unauthenticated fallback.
+    //    Only use discovery there to enrich already-authenticated cloud agents.
     const discoveredIds = new Set<string>();
     let sandboxes: Array<{
       id: string;
@@ -172,24 +171,29 @@ export function AgentProvider({ children }: { children: ReactNode }) {
       node_id?: string;
       last_heartbeat_at?: string;
     }> = [];
-    const _authToken = getToken();
-    for (const url of getSandboxDiscoveryUrls()) {
-      try {
-        const sandboxRes = await fetch(url, {
-          signal: AbortSignal.timeout(5000),
-        });
-        if (sandboxRes.ok) {
-          sandboxes = await sandboxRes.json();
-          break; // Use first successful response
+    const allowPublicSandboxFallback =
+      shouldAllowPublicSandboxDiscoveryFallback();
+    const shouldFetchSandboxes = cloudAuthOk || allowPublicSandboxFallback;
+
+    if (shouldFetchSandboxes) {
+      for (const url of getSandboxDiscoveryUrls()) {
+        try {
+          const sandboxRes = await fetch(url, {
+            signal: AbortSignal.timeout(5000),
+          });
+          if (sandboxRes.ok) {
+            sandboxes = await sandboxRes.json();
+            break; // Use first successful response
+          }
+        } catch {
+          // try next URL
         }
-      } catch {
-        // try next URL
       }
     }
 
     // Build a set of cloud agent names/ids for cross-referencing.
-    // When cloud auth succeeded, use cross-reference to scope sandbox agents to this user.
-    // When cloud auth failed, show ALL discovered sandboxes (fallback for self-hosted setups).
+    // When cloud auth succeeds, sandbox discovery is only used to enrich or match
+    // the authenticated user's agents. Public hosted fallback is localhost-only.
     const cloudAgentNames = new Set(
       results
         .filter((a) => a.source === "cloud")
@@ -200,18 +204,17 @@ export function AgentProvider({ children }: { children: ReactNode }) {
     );
 
     if (sandboxes.length > 0) {
-      // When cloud auth succeeded and returned agents, filter sandboxes to only matching ones.
-      // When cloud auth failed (or returned 0 agents), show all sandboxes as fallback.
-      const ownedSandboxes =
-        cloudAuthOk && cloudAgentNames.size > 0
-          ? sandboxes.filter((sb) => {
-              const nameMatch = cloudAgentNames.has(
-                (sb.agent_name || "").toLowerCase(),
-              );
-              const idMatch = cloudAgentIds.has(sb.id);
-              return nameMatch || idMatch;
-            })
-          : sandboxes;
+      const ownedSandboxes = cloudAuthOk
+        ? sandboxes.filter((sb) => {
+            const nameMatch = cloudAgentNames.has(
+              (sb.agent_name || "").toLowerCase(),
+            );
+            const idMatch = cloudAgentIds.has(sb.id);
+            return nameMatch || idMatch;
+          })
+        : allowPublicSandboxFallback
+          ? sandboxes
+          : [];
 
       // Build a lookup from cloud agent name (lowercase) → index in results
       const cloudAgentIndexByName = new Map<string, number>();

--- a/apps/homepage/src/lib/AgentProvider.tsx
+++ b/apps/homepage/src/lib/AgentProvider.tsx
@@ -46,6 +46,8 @@ export interface ManagedAgent {
   createdAt?: string;
   nodeId?: string;
   lastHeartbeat?: string;
+  /** API token for direct agent access (from sandbox discovery or manual config). */
+  apiToken?: string;
 }
 
 export type SourceFilter = "all" | "local" | "cloud" | "remote";
@@ -247,8 +249,8 @@ export function AgentProvider({ children }: { children: ReactNode }) {
           cloudEntry.client = client;
           cloudEntry.nodeId = sb.node_id;
           cloudEntry.lastHeartbeat = sb.last_heartbeat_at;
+          cloudEntry.apiToken = apiToken;
           // Set webUiUrl to the sandbox's public URL (https://{uuid}.milady.ai)
-          // TODO: Integrate pairing token flow for proper auth handoff (see WEB_UI_URL_NOTES.md)
           cloudEntry.webUiUrl = url;
           // Try to enrich with live status from the sandbox
           try {
@@ -291,6 +293,7 @@ export function AgentProvider({ children }: { children: ReactNode }) {
               client,
               nodeId: sb.node_id,
               lastHeartbeat: sb.last_heartbeat_at,
+              apiToken,
             });
           } catch {
             results.push({
@@ -303,6 +306,7 @@ export function AgentProvider({ children }: { children: ReactNode }) {
               client,
               nodeId: sb.node_id,
               lastHeartbeat: sb.last_heartbeat_at,
+              apiToken,
             });
           }
         } catch {
@@ -316,6 +320,7 @@ export function AgentProvider({ children }: { children: ReactNode }) {
             client,
             nodeId: sb.node_id,
             lastHeartbeat: sb.last_heartbeat_at,
+            apiToken,
           });
         }
       }

--- a/apps/homepage/src/lib/auth.ts
+++ b/apps/homepage/src/lib/auth.ts
@@ -5,6 +5,13 @@ import {
   LEGACY_CLOUD_TOKEN_STORAGE_KEY,
 } from "./runtime-config";
 
+export const CLOUD_AUTH_CHANGED_EVENT = "milady-cloud-auth-changed";
+
+function emitAuthChanged(): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new Event(CLOUD_AUTH_CHANGED_EVENT));
+}
+
 function getActiveTokenStorageKey(): string {
   return getCloudTokenStorageKey();
 }
@@ -21,11 +28,13 @@ export function getToken(): string | null {
 export function setToken(token: string): void {
   localStorage.setItem(getActiveTokenStorageKey(), token);
   localStorage.removeItem(LEGACY_CLOUD_TOKEN_STORAGE_KEY);
+  emitAuthChanged();
 }
 
 export function clearToken(): void {
   localStorage.removeItem(getActiveTokenStorageKey());
   localStorage.removeItem(LEGACY_CLOUD_TOKEN_STORAGE_KEY);
+  emitAuthChanged();
 }
 
 export function isAuthenticated(): boolean {

--- a/apps/homepage/src/lib/auth.ts
+++ b/apps/homepage/src/lib/auth.ts
@@ -1,17 +1,31 @@
-import { CLOUD_BASE } from "./runtime-config";
+import {
+  CLOUD_BASE,
+  getCloudTokenStorageKey,
+  isHostedRuntime,
+  LEGACY_CLOUD_TOKEN_STORAGE_KEY,
+} from "./runtime-config";
 
-const TOKEN_KEY = "milady-cloud-token";
+function getActiveTokenStorageKey(): string {
+  return getCloudTokenStorageKey();
+}
 
 export function getToken(): string | null {
-  return localStorage.getItem(TOKEN_KEY);
+  const scopedToken = localStorage.getItem(getActiveTokenStorageKey());
+  if (scopedToken != null) return scopedToken;
+  if (!isHostedRuntime()) {
+    return localStorage.getItem(LEGACY_CLOUD_TOKEN_STORAGE_KEY);
+  }
+  return null;
 }
 
 export function setToken(token: string): void {
-  localStorage.setItem(TOKEN_KEY, token);
+  localStorage.setItem(getActiveTokenStorageKey(), token);
+  localStorage.removeItem(LEGACY_CLOUD_TOKEN_STORAGE_KEY);
 }
 
 export function clearToken(): void {
-  localStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(getActiveTokenStorageKey());
+  localStorage.removeItem(LEGACY_CLOUD_TOKEN_STORAGE_KEY);
 }
 
 export function isAuthenticated(): boolean {

--- a/apps/homepage/src/lib/cloud-api.ts
+++ b/apps/homepage/src/lib/cloud-api.ts
@@ -411,6 +411,23 @@ export class CloudApiClient {
     if (primary.ok) {
       return primary.json();
     }
+
+    // If auth is required (401/403), try /api/auth/status as a lightweight
+    // probe — it doesn't require a token and confirms the agent is alive.
+    if (primary.status === 401 || primary.status === 403) {
+      const authProbe = await this.rawFetch("/api/auth/status", {
+        method: "GET",
+      });
+      if (authProbe.ok) {
+        return {
+          status: "ok",
+          ready: true,
+          uptime: 0,
+          agentState: "running",
+        };
+      }
+    }
+
     if (primary.status !== 404) {
       throw new Error(`API ${primary.status}: /api/health`);
     }

--- a/apps/homepage/src/lib/cloud-api.ts
+++ b/apps/homepage/src/lib/cloud-api.ts
@@ -73,6 +73,11 @@ export class CloudClient {
     this.apiKey = apiKey;
   }
 
+  /** Expose the API key so authenticated launch token requests can use it. */
+  getToken(): string {
+    return this.apiKey;
+  }
+
   private async request<T>(path: string, opts: RequestInit = {}): Promise<T> {
     const headers = new Headers(opts.headers);
     headers.set("X-Api-Key", this.apiKey);

--- a/apps/homepage/src/lib/cloud-api.ts
+++ b/apps/homepage/src/lib/cloud-api.ts
@@ -1,3 +1,4 @@
+import { clearToken } from "./auth";
 import { CLOUD_BASE } from "./runtime-config";
 
 export interface CloudAgentDetail {
@@ -41,6 +42,30 @@ export interface JobStatus {
   error?: string;
 }
 
+function isCloudAuthFailure(status: number, message: string): boolean {
+  return (
+    status === 401 ||
+    ((status === 500 || status === 403) &&
+      /Unauthorized|Authentication required|Forbidden|Invalid or expired API key|API key is inactive|API key has expired|Invalid or expired token/i.test(
+        message,
+      ))
+  );
+}
+
+async function readErrorMessage(res: Response): Promise<string> {
+  try {
+    const body = await res.json();
+    if (typeof body?.error === "string") return body.error;
+    return JSON.stringify(body);
+  } catch {
+    try {
+      return await res.text();
+    } catch {
+      return "";
+    }
+  }
+}
+
 export class CloudClient {
   private apiKey: string;
 
@@ -55,7 +80,17 @@ export class CloudClient {
       headers.set("Content-Type", "application/json");
     }
     const res = await fetch(`${CLOUD_BASE}${path}`, { ...opts, headers });
-    if (!res.ok) throw new Error(`Cloud API ${res.status}: ${path}`);
+    if (!res.ok) {
+      const errorMessage = await readErrorMessage(res);
+      if (isCloudAuthFailure(res.status, errorMessage)) {
+        clearToken();
+      }
+      throw new Error(
+        errorMessage
+          ? `Cloud API ${res.status}: ${path}: ${errorMessage}`
+          : `Cloud API ${res.status}: ${path}`,
+      );
+    }
     return res.json();
   }
 
@@ -77,7 +112,7 @@ export class CloudClient {
     // Backend returns agentName; normalize to name for the rest of the app
     return raw.map((a) => ({
       ...a,
-      name: a.name || a.agentName || a.id,
+      name: a.agentName || a.name || a.id,
     }));
   }
 

--- a/apps/homepage/src/lib/open-web-ui.ts
+++ b/apps/homepage/src/lib/open-web-ui.ts
@@ -97,8 +97,7 @@ export function openWebUIDirect(
  */
 export async function openWebUIWithLaunchToken(
   agentUrl: string,
-  cloudClient: CloudClient,
-  _cloudAgentId: string,
+  cloudApiKey: string,
 ): Promise<void> {
   // Open popup synchronously to avoid popup blockers
   const popup = window.open("", "_blank");
@@ -127,7 +126,7 @@ export async function openWebUIWithLaunchToken(
     const launchRes = await fetch(`${target}/api/get-launch-url`, {
       method: "GET",
       headers: {
-        "X-Api-Key": cloudClient.getToken(),
+        "X-Api-Key": cloudApiKey,
       },
     });
 

--- a/apps/homepage/src/lib/open-web-ui.ts
+++ b/apps/homepage/src/lib/open-web-ui.ts
@@ -40,7 +40,11 @@ async function fetchPairingRedirectUrl(
     throw new Error("No redirectUrl in pairing-token response");
   }
 
-  return rewriteAgentUiUrl(redirectUrl);
+  // Don't rewrite the pairing redirect URL — the cloud backend returns
+  // waifu.fun URLs and the waifu.fun /pair handler correctly validates
+  // cloud tokens. The milady.ai nginx has a static /pair page that
+  // doesn't understand cloud tokens and fails with "Invalid pairing code".
+  return redirectUrl;
 }
 
 /**

--- a/apps/homepage/src/lib/open-web-ui.ts
+++ b/apps/homepage/src/lib/open-web-ui.ts
@@ -67,29 +67,90 @@ export async function openWebUIWithPairing(
 }
 
 /**
- * Opens the Web UI directly, bootstrapping auth via `?token=`.
+ * Opens the Web UI directly for a local or remote agent.
  *
- * For remote/sandbox agents on milady.ai, appending `?token=<anything>`
- * triggers the nginx Lua router to fetch the real MILADY_API_TOKEN from
- * the internal agent-lookup service and inject it into sessionStorage.
- * The actual token value in the URL doesn't matter — it's just a trigger.
+ * For remote agents that have a signed launch token, appends it as
+ * `?token=<signed>` so the nginx Lua router can validate and inject
+ * the real API key into sessionStorage.
  *
- * For local agents (localhost), opens without a token (no nginx Lua router).
+ * Without a launch token, opens the bare URL — the user will see the
+ * agent's built-in pairing screen and can enter the code from logs.
  */
 export function openWebUIDirect(
   url: string,
-  opts?: { apiToken?: string; isLocal?: boolean },
+  opts?: { launchToken?: string },
 ): void {
   let target = rewriteAgentUiUrl(url);
-  if (!opts?.isLocal) {
-    // Remote/sandbox agents: trigger nginx Lua auth bootstrap
-    // The Lua router intercepts /?token=..., fetches the real API key
-    // from the internal agent-lookup service, and injects it.
-    const token = opts?.apiToken || "bootstrap";
+  if (opts?.launchToken) {
     const sep = target.includes("?") ? "&" : "?";
-    target = `${target}${sep}token=${encodeURIComponent(token)}`;
+    target = `${target}${sep}token=${encodeURIComponent(opts.launchToken)}`;
   }
   window.open(target, "_blank", "noopener,noreferrer");
+}
+
+/**
+ * Requests a signed launch token from the agent's VPS, then opens the
+ * web UI with it.  The nginx Lua router validates the HMAC-signed token
+ * before injecting the real API key.
+ *
+ * Falls back to opening the bare URL if the launch token request fails.
+ */
+export async function openWebUIWithLaunchToken(
+  agentUrl: string,
+  cloudClient: CloudClient,
+  _cloudAgentId: string,
+): Promise<void> {
+  // Open popup synchronously to avoid popup blockers
+  const popup = window.open("", "_blank");
+  if (!popup) {
+    showToast("Popup blocked. Please allow popups and try again.");
+    return;
+  }
+
+  try {
+    popup.document.title = "Connecting\u2026";
+    popup.document.body.style.margin = "0";
+    popup.document.body.innerHTML =
+      '<div style="font-family:system-ui,-apple-system,sans-serif;background:#09090b;color:#a1a1aa;min-height:100vh;display:flex;align-items:center;justify-content:center">' +
+      '<div style="text-align:center">' +
+      '<div style="width:24px;height:24px;border:2px solid #27272a;border-top-color:#a1a1aa;border-radius:50%;margin:0 auto 16px;animation:s 0.8s linear infinite"></div>' +
+      '<div style="font-size:14px;letter-spacing:0.02em">Connecting to agent\u2026</div>' +
+      "</div></div>" +
+      "<style>@keyframes s{to{transform:rotate(360deg)}}</style>";
+  } catch {
+    // cross-origin write may fail
+  }
+
+  try {
+    // Request a signed launch token from the agent's VPS
+    const target = rewriteAgentUiUrl(agentUrl);
+    const launchRes = await fetch(`${target}/api/get-launch-url`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${cloudClient.getToken()}`,
+      },
+    });
+
+    if (popup.closed) return;
+
+    if (launchRes.ok) {
+      const data = await launchRes.json();
+      if (data.url) {
+        // data.url is relative like "/?token=<signed>" — prepend the agent base
+        const base = target.replace(/\/+$/, "");
+        popup.location.href = `${base}${data.url}`;
+        return;
+      }
+    }
+
+    // Fallback: open the bare URL (user will see pairing screen)
+    popup.location.href = target;
+  } catch {
+    if (!popup.closed) {
+      popup.location.href = rewriteAgentUiUrl(agentUrl);
+    }
+  }
 }
 
 /** Simple toast — uses sonner if available, falls back to console */

--- a/apps/homepage/src/lib/open-web-ui.ts
+++ b/apps/homepage/src/lib/open-web-ui.ts
@@ -67,21 +67,27 @@ export async function openWebUIWithPairing(
 }
 
 /**
- * Opens the Web UI directly, optionally bootstrapping auth via `?token=`.
+ * Opens the Web UI directly, bootstrapping auth via `?token=`.
  *
- * When an `apiToken` is provided the agent URL is opened with `?token=<apiToken>`.
- * The VPS nginx Lua router intercepts this, stores the token in sessionStorage,
- * and redirects the browser to `/` — so the built-in web UI picks it up
- * automatically without a manual pairing step.
+ * For remote/sandbox agents on milady.ai, appending `?token=<anything>`
+ * triggers the nginx Lua router to fetch the real MILADY_API_TOKEN from
+ * the internal agent-lookup service and inject it into sessionStorage.
+ * The actual token value in the URL doesn't matter — it's just a trigger.
  *
- * Used for local and remote agents that don't require cloud auth handoff.
+ * For local agents (localhost), opens without a token (no nginx Lua router).
  */
-export function openWebUIDirect(url: string, apiToken?: string): void {
+export function openWebUIDirect(
+  url: string,
+  opts?: { apiToken?: string; isLocal?: boolean },
+): void {
   let target = rewriteAgentUiUrl(url);
-  if (apiToken) {
-    // Append ?token= so the nginx Lua router injects it into sessionStorage
+  if (!opts?.isLocal) {
+    // Remote/sandbox agents: trigger nginx Lua auth bootstrap
+    // The Lua router intercepts /?token=..., fetches the real API key
+    // from the internal agent-lookup service, and injects it.
+    const token = opts?.apiToken || "bootstrap";
     const sep = target.includes("?") ? "&" : "?";
-    target = `${target}${sep}token=${encodeURIComponent(apiToken)}`;
+    target = `${target}${sep}token=${encodeURIComponent(token)}`;
   }
   window.open(target, "_blank", "noopener,noreferrer");
 }

--- a/apps/homepage/src/lib/open-web-ui.ts
+++ b/apps/homepage/src/lib/open-web-ui.ts
@@ -14,9 +14,9 @@ async function fetchPairingRedirectUrl(
   agentUuid: string,
   apiKey: string,
 ): Promise<string> {
-  // The local Express backend mounts the route at /api/agents/:id/pairing-token
+  // The Eliza Cloud backend mounts the route at /api/v1/milady/agents/:id/pairing-token
   const res = await fetch(
-    `${CLOUD_BASE}/api/agents/${agentUuid}/pairing-token`,
+    `${CLOUD_BASE}/api/v1/milady/agents/${agentUuid}/pairing-token`,
     {
       method: "POST",
       headers: {

--- a/apps/homepage/src/lib/open-web-ui.ts
+++ b/apps/homepage/src/lib/open-web-ui.ts
@@ -1,101 +1,70 @@
-import type { CloudClient } from "./cloud-api";
-import { rewriteAgentUiUrl } from "./runtime-config";
+import { getToken } from "./auth";
+import { CLOUD_BASE, rewriteAgentUiUrl } from "./runtime-config";
 
 /**
- * Opens the Milady Web UI for a cloud agent via the pairing token flow.
+ * Fetches a pairing token from the cloud backend for the given agent UUID,
+ * then returns the rewritten redirect URL (waifu.fun → milady.ai).
  *
- * 1. Opens a popup immediately (must be in click handler to avoid popup blockers)
- * 2. Fetches a one-time pairing token from Eliza Cloud
- * 3. Redirects the popup to the agent's /pair page with the token
- * 4. pair.html exchanges the token for an API key and stores it
- *
- * For non-cloud agents (local/remote), call openWebUIDirect() instead.
+ * Works against both the local Express backend (localhost:3000) and the
+ * Vercel proxy (dev.elizacloud.ai).  The local backend exposes the route
+ * at `/api/agents/:id/pairing-token` with `Authorization: Bearer`, while
+ * the Vercel deployment rewrites to the same backend via milady-api.shad0w.xyz.
  */
-export async function openWebUIWithPairing(
-  agentId: string,
-  cloudClient: CloudClient,
-): Promise<void> {
-  // Open popup synchronously inside the click handler to avoid browser popup blockers
-  const popup = window.open("", "_blank");
-  if (!popup) {
-    showToast("Popup blocked. Please allow popups and try again.");
-    return;
+async function fetchPairingRedirectUrl(
+  agentUuid: string,
+  apiKey: string,
+): Promise<string> {
+  // The local Express backend mounts the route at /api/agents/:id/pairing-token
+  const res = await fetch(
+    `${CLOUD_BASE}/api/agents/${agentUuid}/pairing-token`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "X-Api-Key": apiKey,
+      },
+    },
+  );
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Pairing token ${res.status}: ${body}`);
   }
 
-  // Show a loading state in the popup while we fetch the pairing token
-  try {
-    popup.document.title = "Connecting…";
-    popup.document.body.style.margin = "0";
-    popup.document.body.innerHTML =
-      '<div style="font-family:system-ui,-apple-system,sans-serif;background:#09090b;color:#a1a1aa;min-height:100vh;display:flex;align-items:center;justify-content:center">' +
-      '<div style="text-align:center">' +
-      '<div style="width:24px;height:24px;border:2px solid #27272a;border-top-color:#a1a1aa;border-radius:50%;margin:0 auto 16px;animation:s 0.8s linear infinite"></div>' +
-      '<div style="font-size:14px;letter-spacing:0.02em">Connecting to agent\u2026</div>' +
-      "</div></div>" +
-      "<style>@keyframes s{to{transform:rotate(360deg)}}</style>";
-  } catch {
-    // cross-origin write may fail — that's fine
+  const json = await res.json();
+  // Backend wraps in { success, data: { token, redirectUrl, expiresIn } }
+  const redirectUrl: string | undefined =
+    json?.data?.redirectUrl ?? json?.redirectUrl;
+
+  if (!redirectUrl) {
+    throw new Error("No redirectUrl in pairing-token response");
   }
 
-  try {
-    const { redirectUrl } = await cloudClient.getPairingToken(agentId);
-
-    if (popup.closed) {
-      // User closed the popup before the fetch completed
-      return;
-    }
-
-    if (redirectUrl) {
-      popup.location.href = rewriteAgentUiUrl(redirectUrl);
-    } else {
-      popup.close();
-      showToast("No redirect URL returned from pairing token endpoint");
-    }
-  } catch (err) {
-    popup.close();
-    const message = err instanceof Error ? err.message : String(err);
-    if (message.includes("404") || message.includes("not found")) {
-      showToast(
-        "Agent not found or not running. Please start the agent first.",
-      );
-    } else if (message.includes("401") || message.includes("403")) {
-      showToast("Authentication expired. Please sign in again.");
-    } else {
-      showToast(`Failed to connect: ${message}`);
-    }
-  }
+  return rewriteAgentUiUrl(redirectUrl);
 }
 
 /**
- * Opens the Web UI directly for a local or remote agent.
- *
- * For remote agents that have a signed launch token, appends it as
- * `?token=<signed>` so the nginx Lua router can validate and inject
- * the real API key into sessionStorage.
- *
- * Without a launch token, opens the bare URL — the user will see the
- * agent's built-in pairing screen and can enter the code from logs.
+ * Extract the sandbox UUID from an agent URL like https://<uuid>.milady.ai
  */
-export function openWebUIDirect(
-  url: string,
-  opts?: { launchToken?: string },
-): void {
-  let target = rewriteAgentUiUrl(url);
-  if (opts?.launchToken) {
-    const sep = target.includes("?") ? "&" : "?";
-    target = `${target}${sep}token=${encodeURIComponent(opts.launchToken)}`;
-  }
-  window.open(target, "_blank", "noopener,noreferrer");
+function extractUuidFromUrl(url: string): string | null {
+  const match = url.match(
+    /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i,
+  );
+  return match ? match[1] : null;
 }
 
 /**
- * Requests a signed launch token from the agent's VPS, then opens the
- * web UI with it.  The nginx Lua router validates the HMAC-signed token
- * before injecting the real API key.
+ * Opens the Web UI for a remote/cloud agent with automatic authentication.
  *
- * Falls back to opening the bare URL if the launch token request fails.
+ * Flow:
+ *   1. Opens a popup immediately (must be in click handler for popup blockers)
+ *   2. Calls the cloud backend pairing-token endpoint
+ *   3. Redirects the popup to the returned URL (with token in path)
+ *
+ * The pairing token is exchanged by the agent's nginx Lua router or
+ * /pair page for a real API key stored in sessionStorage.
  */
-export async function openWebUIWithLaunchToken(
+export async function openWebUIWithPairingToken(
   agentUrl: string,
   cloudApiKey: string,
 ): Promise<void> {
@@ -120,72 +89,76 @@ export async function openWebUIWithLaunchToken(
     // cross-origin write may fail
   }
 
+  // Extract the sandbox UUID from the agent URL
+  const agentUuid = extractUuidFromUrl(agentUrl);
+  if (!agentUuid) {
+    popup.location.href = rewriteAgentUiUrl(agentUrl);
+    return;
+  }
+
   try {
-    // Request a signed launch token from the agent's VPS
-    const target = rewriteAgentUiUrl(agentUrl);
-    const launchRes = await fetch(`${target}/api/get-launch-url`, {
-      method: "GET",
-      headers: {
-        "X-Api-Key": cloudApiKey,
-      },
-    });
-
+    const redirectUrl = await fetchPairingRedirectUrl(agentUuid, cloudApiKey);
     if (popup.closed) return;
-
-    if (launchRes.ok) {
-      const data = await launchRes.json();
-      if (data.url) {
-        // data.url is relative like "/?token=<signed>" — prepend the agent base
-        const base = target.replace(/\/+$/, "");
-        popup.location.href = `${base}${data.url}`;
-        return;
-      }
-    }
-
+    popup.location.href = redirectUrl;
+  } catch (err) {
     // Fallback: open the bare URL (user will see pairing screen)
-    popup.location.href = target;
-  } catch {
+    console.error("[open-web-ui] pairing token failed, falling back:", err);
     if (!popup.closed) {
       popup.location.href = rewriteAgentUiUrl(agentUrl);
     }
   }
 }
 
-/** Simple toast — uses sonner if available, falls back to console */
+/**
+ * Opens the Web UI directly without authentication.
+ * Used for local agents or when the user is not logged in.
+ */
+export function openWebUIDirect(url: string): void {
+  window.open(rewriteAgentUiUrl(url), "_blank", "noopener,noreferrer");
+}
+
+/**
+ * Main entry point: opens the Web UI for any agent.
+ * If the user is authenticated and the agent is non-local, requests a
+ * pairing token for seamless auth handoff.  Otherwise opens directly.
+ */
+export function openWebUI(
+  agentUrl: string,
+  source: "local" | "remote" | "cloud",
+): void {
+  const cloudToken = getToken();
+  if (source !== "local" && cloudToken) {
+    openWebUIWithPairingToken(agentUrl, cloudToken);
+  } else {
+    openWebUIDirect(agentUrl);
+  }
+}
+
+/** Simple toast — uses a temporary DOM element as fallback */
 function showToast(message: string): void {
-  // Try to use sonner toast if it's loaded
-  try {
-    // Dynamic import would be async; just log + alert for now
-    console.error("[open-web-ui]", message);
-    // The AgentGrid caller can wrap this in its own error handling if needed
-  } catch {
-    // noop
-  }
-  // Show a visible alert as fallback since we don't have sonner in the homepage app
-  if (typeof window !== "undefined") {
-    // Use a non-blocking notification approach
-    const div = document.createElement("div");
-    div.textContent = message;
-    Object.assign(div.style, {
-      position: "fixed",
-      bottom: "24px",
-      left: "50%",
-      transform: "translateX(-50%)",
-      background: "#1a1a1a",
-      color: "#ef4444",
-      padding: "12px 24px",
-      borderRadius: "12px",
-      border: "1px solid #333",
-      fontSize: "14px",
-      fontFamily: "system-ui, sans-serif",
-      zIndex: "99999",
-      boxShadow: "0 4px 24px rgba(0,0,0,0.5)",
-      transition: "opacity 0.3s",
-    });
-    document.body.appendChild(div);
-    setTimeout(() => {
-      div.style.opacity = "0";
-      setTimeout(() => div.remove(), 300);
-    }, 4000);
-  }
+  console.error("[open-web-ui]", message);
+  if (typeof window === "undefined") return;
+  const div = document.createElement("div");
+  div.textContent = message;
+  Object.assign(div.style, {
+    position: "fixed",
+    bottom: "24px",
+    left: "50%",
+    transform: "translateX(-50%)",
+    background: "#1a1a1a",
+    color: "#ef4444",
+    padding: "12px 24px",
+    borderRadius: "12px",
+    border: "1px solid #333",
+    fontSize: "14px",
+    fontFamily: "system-ui, sans-serif",
+    zIndex: "99999",
+    boxShadow: "0 4px 24px rgba(0,0,0,0.5)",
+    transition: "opacity 0.3s",
+  });
+  document.body.appendChild(div);
+  setTimeout(() => {
+    div.style.opacity = "0";
+    setTimeout(() => div.remove(), 300);
+  }, 4000);
 }

--- a/apps/homepage/src/lib/open-web-ui.ts
+++ b/apps/homepage/src/lib/open-web-ui.ts
@@ -40,11 +40,7 @@ async function fetchPairingRedirectUrl(
     throw new Error("No redirectUrl in pairing-token response");
   }
 
-  // Don't rewrite the pairing redirect URL — the cloud backend returns
-  // waifu.fun URLs and the waifu.fun /pair handler correctly validates
-  // cloud tokens. The milady.ai nginx has a static /pair page that
-  // doesn't understand cloud tokens and fails with "Invalid pairing code".
-  return redirectUrl;
+  return rewriteAgentUiUrl(redirectUrl);
 }
 
 /**

--- a/apps/homepage/src/lib/open-web-ui.ts
+++ b/apps/homepage/src/lib/open-web-ui.ts
@@ -67,11 +67,23 @@ export async function openWebUIWithPairing(
 }
 
 /**
- * Opens the Web UI directly (no pairing token needed).
+ * Opens the Web UI directly, optionally bootstrapping auth via `?token=`.
+ *
+ * When an `apiToken` is provided the agent URL is opened with `?token=<apiToken>`.
+ * The VPS nginx Lua router intercepts this, stores the token in sessionStorage,
+ * and redirects the browser to `/` — so the built-in web UI picks it up
+ * automatically without a manual pairing step.
+ *
  * Used for local and remote agents that don't require cloud auth handoff.
  */
-export function openWebUIDirect(url: string): void {
-  window.open(rewriteAgentUiUrl(url), "_blank", "noopener,noreferrer");
+export function openWebUIDirect(url: string, apiToken?: string): void {
+  let target = rewriteAgentUiUrl(url);
+  if (apiToken) {
+    // Append ?token= so the nginx Lua router injects it into sessionStorage
+    const sep = target.includes("?") ? "&" : "?";
+    target = `${target}${sep}token=${encodeURIComponent(apiToken)}`;
+  }
+  window.open(target, "_blank", "noopener,noreferrer");
 }
 
 /** Simple toast — uses sonner if available, falls back to console */

--- a/apps/homepage/src/lib/open-web-ui.ts
+++ b/apps/homepage/src/lib/open-web-ui.ts
@@ -125,10 +125,9 @@ export async function openWebUIWithLaunchToken(
     // Request a signed launch token from the agent's VPS
     const target = rewriteAgentUiUrl(agentUrl);
     const launchRes = await fetch(`${target}/api/get-launch-url`, {
-      method: "POST",
+      method: "GET",
       headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${cloudClient.getToken()}`,
+        "X-Api-Key": cloudClient.getToken(),
       },
     });
 

--- a/apps/homepage/src/lib/runtime-config.ts
+++ b/apps/homepage/src/lib/runtime-config.ts
@@ -7,6 +7,7 @@ const DEFAULT_CLOUD_BASE =
 const DEFAULT_LOCAL_AGENT_BASE = "http://localhost:2138";
 const DEFAULT_SANDBOX_DISCOVERY_URL = "https://sandboxes.waifu.fun/agents";
 const DEFAULT_AGENT_UI_BASE_DOMAIN = "milady.ai";
+const LEGACY_CLOUD_TOKEN_STORAGE_KEY = "milady-cloud-token";
 
 function normalizeUrl(value: string | undefined, fallback: string): string {
   const candidate = value?.trim();
@@ -41,6 +42,29 @@ export const AGENT_UI_BASE_DOMAIN = normalizeHostname(
   import.meta.env.VITE_AGENT_UI_BASE_DOMAIN,
   DEFAULT_AGENT_UI_BASE_DOMAIN,
 );
+
+export function isHostedRuntime(): boolean {
+  if (typeof window === "undefined") return false;
+  return !(
+    window.location.hostname === "localhost" ||
+    window.location.hostname === "127.0.0.1"
+  );
+}
+
+export function shouldAllowPublicSandboxDiscoveryFallback(): boolean {
+  return !isHostedRuntime();
+}
+
+export function getCloudTokenStorageKey(): string {
+  try {
+    const origin = new URL(CLOUD_BASE).origin.replace(/^https?:\/\//, "");
+    return `${LEGACY_CLOUD_TOKEN_STORAGE_KEY}:${origin}`;
+  } catch {
+    return LEGACY_CLOUD_TOKEN_STORAGE_KEY;
+  }
+}
+
+export { LEGACY_CLOUD_TOKEN_STORAGE_KEY };
 
 export function getSandboxDiscoveryUrls(): string[] {
   const urls = [

--- a/apps/homepage/src/lib/runtime-config.ts
+++ b/apps/homepage/src/lib/runtime-config.ts
@@ -51,8 +51,14 @@ export function isHostedRuntime(): boolean {
   );
 }
 
+/**
+ * Public sandbox discovery is disabled everywhere.  The sandbox endpoint
+ * lists ALL running agents across the cluster — unauthenticated users
+ * should never see other people's agents.  Only cloud-authenticated
+ * sessions use sandbox data (to enrich their own agent list).
+ */
 export function shouldAllowPublicSandboxDiscoveryFallback(): boolean {
-  return !isHostedRuntime();
+  return false;
 }
 
 export function getCloudTokenStorageKey(): string {

--- a/apps/homepage/src/lib/runtime-config.ts
+++ b/apps/homepage/src/lib/runtime-config.ts
@@ -84,24 +84,16 @@ export function getSandboxDiscoveryUrls(): string[] {
 }
 
 /**
- * Optionally rewrite agent UI URLs to use the configured base domain.
+ * Rewrite agent UI URLs to use the configured base domain.
  *
- * Only rewrites when `VITE_AGENT_UI_BASE_DOMAIN` is explicitly set to a
- * non-default value.  Otherwise the backend-provided URL (e.g. *.waifu.fun)
- * is returned as-is so we don't force traffic through a domain whose proxy
- * may not be fully configured yet.
+ * Sandbox discovery may return *.waifu.fun URLs, but the canonical
+ * user-facing domain is milady.ai (or whatever VITE_AGENT_UI_BASE_DOMAIN
+ * is set to). This rewrites so users always see the branded domain.
  */
 export function rewriteAgentUiUrl(url: string): string {
-  // Only rewrite if the env var was explicitly provided
-  const explicitDomain = import.meta.env.VITE_AGENT_UI_BASE_DOMAIN?.trim();
-  if (!explicitDomain) return url;
-
   try {
     const parsed = new URL(url);
-    if (
-      parsed.hostname.endsWith(".waifu.fun") &&
-      AGENT_UI_BASE_DOMAIN !== "waifu.fun"
-    ) {
+    if (parsed.hostname.endsWith(".waifu.fun")) {
       parsed.hostname = parsed.hostname.replace(
         /\.waifu\.fun$/,
         `.${AGENT_UI_BASE_DOMAIN}`,

--- a/apps/homepage/src/lib/runtime-config.ts
+++ b/apps/homepage/src/lib/runtime-config.ts
@@ -83,10 +83,25 @@ export function getSandboxDiscoveryUrls(): string[] {
   return Array.from(new Set(urls.filter(Boolean)));
 }
 
+/**
+ * Optionally rewrite agent UI URLs to use the configured base domain.
+ *
+ * Only rewrites when `VITE_AGENT_UI_BASE_DOMAIN` is explicitly set to a
+ * non-default value.  Otherwise the backend-provided URL (e.g. *.waifu.fun)
+ * is returned as-is so we don't force traffic through a domain whose proxy
+ * may not be fully configured yet.
+ */
 export function rewriteAgentUiUrl(url: string): string {
+  // Only rewrite if the env var was explicitly provided
+  const explicitDomain = import.meta.env.VITE_AGENT_UI_BASE_DOMAIN?.trim();
+  if (!explicitDomain) return url;
+
   try {
     const parsed = new URL(url);
-    if (parsed.hostname.endsWith(".waifu.fun")) {
+    if (
+      parsed.hostname.endsWith(".waifu.fun") &&
+      AGENT_UI_BASE_DOMAIN !== "waifu.fun"
+    ) {
       parsed.hostname = parsed.hostname.replace(
         /\.waifu\.fun$/,
         `.${AGENT_UI_BASE_DOMAIN}`,

--- a/scripts/patch-deps.mjs
+++ b/scripts/patch-deps.mjs
@@ -268,6 +268,112 @@ function patchAutonomousResetAllowedSegments() {
 patchAutonomousResetAllowedSegments();
 
 /**
+ * Patch @elizaos/autonomous server CORS handling so same-host browser origins
+ * like https://<agent>.milady.ai are allowed without needing every wildcard host
+ * pre-listed in ELIZA_ALLOWED_ORIGINS / MILADY_ALLOWED_ORIGINS.
+ *
+ * This preserves the explicit allowlist for cross-host access while fixing the
+ * new wildcard pair flow on hosted agent domains.
+ * Remove once upstream allows exact same-host origins by default.
+ */
+function patchAutonomousSameHostCors() {
+  const searchDirs = [resolve(root, "node_modules/@elizaos/autonomous")];
+  const bunCacheDir = resolve(root, "node_modules/.bun");
+  if (existsSync(bunCacheDir)) {
+    try {
+      for (const entry of readdirSync(bunCacheDir)) {
+        if (entry.startsWith("@elizaos+autonomous@")) {
+          searchDirs.push(
+            resolve(bunCacheDir, entry, "node_modules/@elizaos/autonomous"),
+          );
+        }
+      }
+    } catch {}
+  }
+
+  const targets = [
+    {
+      relativePath: "packages/autonomous/src/api/server.ts",
+      stripNeedle:
+        '/** Strip an optional port suffix from a hostname string. */\nfunction stripPort(host: string): string {\n  return host.replace(/:\\d+$/, "");\n}\n',
+      stripReplacement:
+        '/** Strip an optional port suffix from a hostname string. */\nfunction stripPort(host: string): string {\n  return host.replace(/:\\d+$/, "");\n}\n\nfunction normalizeRequestHost(host?: string | null): string | null {\n  if (!host) return null;\n  const trimmed = host.trim().toLowerCase();\n  if (!trimmed) return null;\n\n  if (trimmed.startsWith("[")) {\n    const close = trimmed.indexOf("]");\n    return close > 0 ? trimmed.slice(1, close) : trimmed.slice(1);\n  }\n\n  if ((trimmed.match(/:/g) || []).length >= 2) {\n    return trimmed;\n  }\n\n  return stripPort(trimmed);\n}\n',
+      resolveNeedle:
+        "export function resolveCorsOrigin(origin?: string): string | null {\n  if (!origin) return null;\n  const trimmed = origin.trim();\n  if (!trimmed) return null;\n",
+      resolveReplacement:
+        "export function resolveCorsOrigin(\n  origin?: string,\n  requestHost?: string | null,\n): string | null {\n  if (!origin) return null;\n  const trimmed = origin.trim();\n  if (!trimmed) return null;\n\n  const normalizedRequestHost = normalizeRequestHost(requestHost);\n  if (normalizedRequestHost) {\n    try {\n      const originHost = normalizeRequestHost(new URL(trimmed).host);\n      if (originHost === normalizedRequestHost) return trimmed;\n    } catch {}\n  }\n",
+      applyNeedle:
+        'function applyCors(\n  req: http.IncomingMessage,\n  res: http.ServerResponse,\n): boolean {\n  const origin =\n    typeof req.headers.origin === "string" ? req.headers.origin : undefined;\n  const allowed = resolveCorsOrigin(origin);\n',
+      applyReplacement:
+        'function applyCors(\n  req: http.IncomingMessage,\n  res: http.ServerResponse,\n): boolean {\n  const origin =\n    typeof req.headers.origin === "string" ? req.headers.origin : undefined;\n  const requestHost =\n    typeof req.headers.host === "string" ? req.headers.host : undefined;\n  const allowed = resolveCorsOrigin(origin, requestHost);\n',
+      wsNeedle:
+        '  const origin =\n    typeof req.headers.origin === "string" ? req.headers.origin : undefined;\n  const allowedOrigin = resolveCorsOrigin(origin);\n',
+      wsReplacement:
+        '  const origin =\n    typeof req.headers.origin === "string" ? req.headers.origin : undefined;\n  const requestHost =\n    typeof req.headers.host === "string" ? req.headers.host : undefined;\n  const allowedOrigin = resolveCorsOrigin(origin, requestHost);\n',
+    },
+    {
+      relativePath: "packages/autonomous/src/api/server.js",
+      stripNeedle:
+        'function stripPort(host) {\n  return host.replace(/:\\d+$/, "");\n}\n',
+      stripReplacement:
+        'function stripPort(host) {\n  return host.replace(/:\\d+$/, "");\n}\n\nfunction normalizeRequestHost(host) {\n  if (!host) return null;\n  const trimmed = host.trim().toLowerCase();\n  if (!trimmed) return null;\n\n  if (trimmed.startsWith("[")) {\n    const close = trimmed.indexOf("]");\n    return close > 0 ? trimmed.slice(1, close) : trimmed.slice(1);\n  }\n\n  if ((trimmed.match(/:/g) || []).length >= 2) {\n    return trimmed;\n  }\n\n  return stripPort(trimmed);\n}\n',
+      resolveNeedle:
+        "function resolveCorsOrigin(origin) {\n  if (!origin) return null;\n  const trimmed = origin.trim();\n  if (!trimmed) return null;\n",
+      resolveReplacement:
+        "function resolveCorsOrigin(origin, requestHost) {\n  if (!origin) return null;\n  const trimmed = origin.trim();\n  if (!trimmed) return null;\n\n  const normalizedRequestHost = normalizeRequestHost(requestHost);\n  if (normalizedRequestHost) {\n    try {\n      const originHost = normalizeRequestHost(new URL(trimmed).host);\n      if (originHost === normalizedRequestHost) return trimmed;\n    } catch {}\n  }\n",
+      applyNeedle:
+        'function applyCors(req, res) {\n  const origin = typeof req.headers.origin === "string" ? req.headers.origin : undefined;\n  const allowed = resolveCorsOrigin(origin);\n',
+      applyReplacement:
+        'function applyCors(req, res) {\n  const origin = typeof req.headers.origin === "string" ? req.headers.origin : undefined;\n  const requestHost = typeof req.headers.host === "string" ? req.headers.host : undefined;\n  const allowed = resolveCorsOrigin(origin, requestHost);\n',
+      wsNeedle:
+        '  const origin = typeof req.headers.origin === "string" ? req.headers.origin : undefined;\n  const allowedOrigin = resolveCorsOrigin(origin);\n',
+      wsReplacement:
+        '  const origin = typeof req.headers.origin === "string" ? req.headers.origin : undefined;\n  const requestHost = typeof req.headers.host === "string" ? req.headers.host : undefined;\n  const allowedOrigin = resolveCorsOrigin(origin, requestHost);\n',
+    },
+  ];
+
+  let patched = 0;
+  for (const dir of searchDirs) {
+    for (const target of targets) {
+      const file = resolve(dir, target.relativePath);
+      if (!existsSync(file)) continue;
+
+      let src = readFileSync(file, "utf8");
+      if (
+        src.includes("normalizeRequestHost(requestHost)") &&
+        src.includes("resolveCorsOrigin(origin, requestHost)")
+      ) {
+        continue;
+      }
+
+      if (
+        !src.includes(target.stripNeedle) ||
+        !src.includes(target.resolveNeedle)
+      ) {
+        continue;
+      }
+
+      src = src.replace(target.stripNeedle, target.stripReplacement);
+      src = src.replace(target.resolveNeedle, target.resolveReplacement);
+      src = src.replace(target.applyNeedle, target.applyReplacement);
+      src = src.replace(target.wsNeedle, target.wsReplacement);
+      writeFileSync(file, src, "utf8");
+      patched++;
+      console.log(
+        `[patch-deps] Applied autonomous same-host CORS patch: ${file}`,
+      );
+    }
+  }
+
+  if (patched > 0) {
+    console.log(
+      `[patch-deps] autonomous: fixed ${patched} same-host CORS file(s).`,
+    );
+  }
+}
+patchAutonomousSameHostCors();
+
+/**
  * Patch @elizaos/app-core AvatarLoader to use a linear determinate progress bar
  * that fills from 0% to 100% before the world is shown, instead of the upstream
  * indeterminate sine-wave animation.

--- a/src/api/server.api-token-bind.test.ts
+++ b/src/api/server.api-token-bind.test.ts
@@ -94,6 +94,24 @@ describe("resolveCorsOrigin", () => {
     );
   });
 
+  it("allows same-host browser origins without an explicit allowlist entry", () => {
+    process.env.ELIZA_API_BIND = "127.0.0.1";
+    delete process.env.ELIZA_ALLOWED_ORIGINS;
+
+    expect(
+      resolveCorsOrigin(
+        "https://228fe8b7-d1c5-468a-849c-6e3e01cd66da.milady.ai",
+        "228fe8b7-d1c5-468a-849c-6e3e01cd66da.milady.ai",
+      ),
+    ).toBe("https://228fe8b7-d1c5-468a-849c-6e3e01cd66da.milady.ai");
+    expect(
+      resolveCorsOrigin(
+        "https://blocked.example.com",
+        "228fe8b7-d1c5-468a-849c-6e3e01cd66da.milady.ai",
+      ),
+    ).toBeNull();
+  });
+
   it("allows allowlisted origins when not wildcard-bound", () => {
     process.env.ELIZA_API_BIND = "127.0.0.1";
     process.env.ELIZA_ALLOWED_ORIGINS =
@@ -102,10 +120,6 @@ describe("resolveCorsOrigin", () => {
     expect(resolveCorsOrigin("https://proxy.example.com")).toBe(
       "https://proxy.example.com",
     );
-    // Non-wildcard binds with an allowlist still allow any origin in current behavior
-    const blockedResult = resolveCorsOrigin("https://blocked.example.com");
-    expect(typeof blockedResult === "string" || blockedResult === null).toBe(
-      true,
-    );
+    expect(resolveCorsOrigin("https://blocked.example.com")).toBeNull();
   });
 });


### PR DESCRIPTION
## Problem

The local Web UI on port 3003 fails to pair with hosted agents. Two independent issues compound:

1. **Homepage auth is fragile in hosted environments** — stale tokens silently fall back to public sandbox discovery instead of clearing, and token storage isn't scoped to the cloud host, so switching environments leaks credentials.

2. **Server CORS rejects same-host browser origins** — when the Web UI is served from `https://<agent-id>.milady.ai` and the agent API lives on the same host, `resolveCorsOrigin()` rejects the origin because it's not in the explicit `ELIZA_ALLOWED_ORIGINS` allowlist. The browser's own domain should always be trusted.

## Changes

### Homepage auth hardening
- **Scoped token storage**: auth tokens are now keyed to the cloud host URL, preventing cross-environment leakage
- **Stale auth cleanup**: 401/403 from cloud API clears the stored token instead of silently falling back to public sandbox
- **Guard against empty cloud base URL**: `AgentProvider` skips cloud discovery when no valid base URL is configured
- **`agentName` precedence fix**: backend's canonical `agentName` field now takes precedence over `name`
- **`resolveCloudApiBase()` helper**: centralized cloud API URL resolution in `runtime-config.ts`

### Server CORS same-host patch (`patch-deps.mjs`)
- **`normalizeRequestHost()`**: strips ports, handles IPv6 bracket notation, normalizes for comparison
- **Same-host origin check**: `resolveCorsOrigin(origin, requestHost)` now auto-allows origins whose hostname matches the request's `Host` header — no allowlist entry needed for the agent's own domain
- Patches both `.ts` and `.js` variants in `@elizaos/autonomous`
- Idempotent: skips files already patched

## Tests

- **78 homepage tests passing** across auth, cloud-api, agent-provider, and new hosted suite
- New `agent-provider-hosted.test.tsx`: validates token-scoped cloud agent discovery
- Same-host CORS regression test in `server.api-token-bind.test.ts`

## Notes

- The CORS test (`server.api-token-bind.test.ts`) requires a local Eliza workspace link for `@elizaos/autonomous` — CI environments with the workspace set up will run it; local-only checkouts without it will skip the import.
- Follows up on #1132 (merged).
