### PR TITLE
fix(homepage): tighten live mobile hero and install CTA

### DIFF
--- a/apps/homepage/src/App.tsx
+++ b/apps/homepage/src/App.tsx
@@ -11,28 +11,25 @@ export function Homepage() {
       id="top"
       className="relative min-h-screen bg-dark text-text-light font-sans selection:bg-brand selection:text-dark"
     >
-      {/* 1. Base Dark Background */}
       <div className="fixed inset-0 z-0 bg-dark pointer-events-none" />
 
-      {/* Main scrolling container */}
       <div className="relative w-full">
-        {/* LAYER 1: Background Layout (The massive typography, moves with scroll) */}
-        <div className="relative z-10 w-full min-h-screen pointer-events-none">
-          <HeroBackground />
-        </div>
-
-        {/* LAYER 2: Foreground UI — Download dock pinned to hero bottom */}
-        <div
+        <section
           id="install"
-          className="absolute top-0 left-0 right-0 z-30 pointer-events-none"
+          className="relative z-10 min-h-[100svh] overflow-hidden"
         >
-          <div className="w-full min-h-[100svh] flex flex-col items-center justify-end pb-6 sm:pb-10 lg:pb-12 px-4 sm:px-6 gap-4 sm:gap-6 pointer-events-auto">
-            <DownloadIcons />
-            <HeroInstallDock />
-          </div>
-        </div>
+          <HeroBackground />
 
-        {/* Content sections below Hero */}
+          <div className="relative z-30 flex min-h-[100svh] flex-col items-center px-4 pt-[max(5rem,12svh)] pb-8 sm:px-6 sm:pt-0 sm:pb-10 lg:pb-12 pointer-events-auto">
+            <div className="w-full min-h-[clamp(14rem,42svh,22rem)] sm:min-h-[62svh]" />
+
+            <div className="mt-auto flex w-full flex-col items-center gap-4 sm:gap-6">
+              <DownloadIcons />
+              <HeroInstallDock />
+            </div>
+          </div>
+        </section>
+
         <main className="relative z-30 pointer-events-auto bg-dark">
           <Privacy />
           <Features />

--- a/apps/homepage/src/components/DownloadIcons.tsx
+++ b/apps/homepage/src/components/DownloadIcons.tsx
@@ -222,11 +222,11 @@ export function DownloadIcons() {
         })}
       </ul>
 
-      <div className="flex flex-col items-center gap-2 font-mono text-[9px] sm:text-[11px] text-brand w-full max-w-[90vw] sm:max-w-none">
-        <code className="px-2 sm:px-3 py-1.5 border border-brand/30 bg-brand/5 select-all cursor-text break-all sm:break-normal">
+      <div className="flex w-full max-w-sm flex-col items-center gap-2 font-mono text-[9px] sm:max-w-none sm:text-[11px] text-brand">
+        <code className="w-full px-3 sm:px-3 py-2 border border-brand/30 bg-brand/5 select-all cursor-text whitespace-pre-wrap break-all rounded-md text-center leading-relaxed sm:w-auto sm:text-left sm:whitespace-normal sm:break-normal">
           {releaseData.scripts.shell.command}
         </code>
-        <code className="px-2 sm:px-3 py-1.5 border border-brand/30 bg-brand/5 select-all cursor-text break-all sm:break-normal">
+        <code className="w-full px-3 sm:px-3 py-2 border border-brand/30 bg-brand/5 select-all cursor-text whitespace-pre-wrap break-all rounded-md text-center leading-relaxed sm:w-auto sm:text-left sm:whitespace-normal sm:break-normal">
           {releaseData.scripts.powershell.command}
         </code>
       </div>

--- a/apps/homepage/src/components/Hero.tsx
+++ b/apps/homepage/src/components/Hero.tsx
@@ -82,7 +82,7 @@ export function HeroBackground() {
   };
 
   return (
-    <section className="absolute inset-0 flex flex-col items-center justify-center px-4 sm:px-6 md:px-12 pt-16 sm:pt-12 pointer-events-none overflow-hidden">
+    <section className="absolute inset-0 flex flex-col items-center justify-start sm:justify-center px-4 sm:px-6 md:px-12 pt-24 sm:pt-12 pb-44 sm:pb-0 pointer-events-none overflow-hidden">
       <div className="hidden sm:block absolute top-12 left-12 w-6 h-6 border-t-2 border-l-2 border-white/20" />
       <div className="hidden sm:block absolute top-12 right-12 w-6 h-6 border-t-2 border-r-2 border-white/20" />
       <div className="hidden sm:block absolute bottom-12 left-12 w-6 h-6 border-b-2 border-l-2 border-white/20" />
@@ -100,7 +100,7 @@ export function HeroBackground() {
       >
         <motion.h1
           variants={itemVariants}
-          className="text-[18vw] sm:text-[11vw] lg:text-[13vw] font-black leading-[0.78] tracking-tighter uppercase text-white/95 flex flex-col items-center pointer-events-none select-none mt-8 sm:mt-12"
+          className="text-[16vw] sm:text-[11vw] lg:text-[13vw] font-black leading-[0.76] tracking-tighter uppercase text-white/95 flex flex-col items-center pointer-events-none select-none mt-4 sm:mt-12 max-w-[10ch] sm:max-w-none"
         >
           <span>MILADY</span>
           <span className="text-brand drop-shadow-lg text-[13vw] sm:text-inherit">

--- a/apps/homepage/src/generated/release-data.ts
+++ b/apps/homepage/src/generated/release-data.ts
@@ -1,5 +1,5 @@
 export const releaseData = {
-  generatedAt: "2026-03-19T12:05:53.328Z",
+  generatedAt: "2026-03-19T20:59:47.794Z",
   scripts: {
     shell: {
       url: "https://milady.ai/install.sh",

--- a/scripts/write-homepage-release-data.mjs
+++ b/scripts/write-homepage-release-data.mjs
@@ -16,7 +16,7 @@ const OUTPUT_PATH = path.resolve(
 const RELEASES_URL = `https://api.github.com/repos/${REPOSITORY}/releases?per_page=20`;
 const RELEASES_PAGE_URL = `https://github.com/${REPOSITORY}/releases`;
 
-const installBaseUrl = "https://eliza.ai";
+const installBaseUrl = "https://milady.ai";
 const scripts = {
   shell: {
     url: `${installBaseUrl}/install.sh`,


### PR DESCRIPTION
## Summary
- tighten the mobile homepage hero composition so the wordmark doesn't fight the install dock on iPhone widths
- make the install command pills readable on phone-sized screens
- fix homepage release metadata generation to use `milady.ai` install URLs instead of `eliza.ai`

## What changed
- replace the old absolute bottom-pinned hero overlay with a safer mobile hero shell that reserves space above the CTA stack
- move the mobile hero title higher and give it dedicated bottom breathing room
- keep install command pills full-width and wrapped on mobile
- update `scripts/write-homepage-release-data.mjs` and regenerated homepage release data to point at `https://milady.ai/install.{sh,ps1}`

## Validation
- `bun run --cwd apps/homepage test`
- `bun run build:homepage`
- `codex review --uncommitted`
- compared live `https://milady.ai` mobile rendering vs local preview after changes
