### PR TITLE
release: fix Electrobun readiness checks

### DIFF
--- a/.github/workflows/release-electrobun.yml
+++ b/.github/workflows/release-electrobun.yml
@@ -43,7 +43,7 @@ permissions:
 
 env:
   CI: "true"
-  BUN_VERSION: "1.3.10"
+  BUN_VERSION: "1.3.9" # pinned: 1.3.10 clean-lockfile breaks Windows frozen installs
 
 jobs:
   prepare:

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
         "@elizaos/app-hyperscape": "1.0.0",
         "@elizaos/autonomous": "2.0.0-alpha.77",
         "@elizaos/core": "2.0.0-alpha.77",
-        "@elizaos/plugin-agent-orchestrator": "alpha",
+        "@elizaos/plugin-agent-orchestrator": "0.3.14",
         "@elizaos/plugin-agent-skills": "alpha",
         "@elizaos/plugin-anthropic": "alpha",
         "@elizaos/plugin-cron": "alpha",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "@elizaos/app-hyperscape": "1.0.0",
     "@elizaos/autonomous": "2.0.0-alpha.77",
     "@elizaos/core": "2.0.0-alpha.77",
-    "@elizaos/plugin-agent-orchestrator": "alpha",
+    "@elizaos/plugin-agent-orchestrator": "0.3.14",
     "@elizaos/plugin-agent-skills": "alpha",
     "@elizaos/plugin-anthropic": "alpha",
     "@elizaos/plugin-cron": "alpha",

--- a/scripts/electrobun-release-workflow-drift.test.ts
+++ b/scripts/electrobun-release-workflow-drift.test.ts
@@ -103,7 +103,7 @@ describe("Electrobun release workflow drift", () => {
     );
     const releaseCheckIndex = workflow.indexOf("run: bun run release:check");
 
-    expect(workflow).toContain('BUN_VERSION: "1.3.10"');
+    expect(workflow).toContain('BUN_VERSION: "1.3.9"');
     expect(workflow).toContain("bun-version: $" + "{{ env.BUN_VERSION }}");
     expect(workflow).not.toContain("bun-version: latest");
     expect(validateJobIndex).toBeGreaterThan(-1);

--- a/scripts/release-check.test.ts
+++ b/scripts/release-check.test.ts
@@ -6,7 +6,9 @@ import {
   hasLifecycleScriptReferencingMissingFile,
   isExactVersion,
   isExactVersionSpecifier,
+  isNpmOverrideConflictError,
   isPackPathCoveredByFilesList,
+  parseBunPackDryRunOutput,
   shouldSkipExactPackDryRun,
 } from "./release-check";
 
@@ -156,5 +158,49 @@ describe("release-check package guards", () => {
         () => true,
       ),
     ).toBe(false);
+  });
+
+  it("parses Bun dry-run pack output into publish file entries", () => {
+    const results = parseBunPackDryRunOutput(`bun pack v1.3.10
+
+packed 9.97KB package.json
+packed 1.51KB dist/entry.js
+packed 4.70KB scripts/run-repo-setup.mjs
+bundled @elizaos/plugin-agent-orchestrator
+
+miladyai-2.0.0-alpha.92.tgz
+`);
+
+    expect(results).toEqual([
+      {
+        files: [
+          { path: "package.json" },
+          { path: "dist/entry.js" },
+          { path: "scripts/run-repo-setup.mjs" },
+        ],
+      },
+    ]);
+  });
+
+  it("detects npm override conflicts for pack fallback", () => {
+    expect(
+      isNpmOverrideConflictError({
+        name: "Error",
+        message: "pack failed",
+        stdout: '{"error":{"code":"EOVERRIDE"}}',
+        stderr:
+          "npm error code EOVERRIDE\nnpm error Override for @elizaos/core conflicts with direct dependency",
+      }),
+    ).toBe(false);
+
+    const error = new Error("pack failed") as Error & {
+      stdout?: string;
+      stderr?: string;
+    };
+    error.stdout = '{"error":{"code":"EOVERRIDE"}}';
+    error.stderr =
+      "npm error code EOVERRIDE\nnpm error Override for @elizaos/core conflicts with direct dependency";
+
+    expect(isNpmOverrideConflictError(error)).toBe(true);
   });
 });

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -21,6 +21,14 @@ const requiredPaths = [
 const forbiddenPrefixes = ["dist/Milady.app/"];
 const orchestratorPackageName = "@elizaos/plugin-agent-orchestrator";
 const orchestratorBrokenLifecycleTarget = "./scripts/ensure-node-pty.mjs";
+const autonomousServerPathCandidates = [
+  "node_modules/@elizaos/autonomous/packages/autonomous/src/api/server.js",
+  "packages/autonomous/src/api/server.ts",
+] as const;
+const autonomousElizaPathCandidates = [
+  "node_modules/@elizaos/autonomous/packages/autonomous/src/runtime/eliza.js",
+  "packages/autonomous/src/runtime/eliza.ts",
+] as const;
 const requiredWorkflowSnippets = [
   'BUN_VERSION: "1.3.9"',
   "name: Validate Release Inputs",
@@ -130,13 +138,49 @@ type DependencyPackageJson = {
   scripts?: Record<string, string>;
 };
 
+export function parseBunPackDryRunOutput(raw: string): PackResult[] {
+  const files = raw
+    .split("\n")
+    .map((line) => line.match(/^packed\s+\S+\s+(.+)$/)?.[1]?.trim())
+    .filter((path): path is string => Boolean(path))
+    .map((path) => ({ path }));
+
+  return [{ files }];
+}
+
+export function isNpmOverrideConflictError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const execError = error as Error & {
+    stdout?: string;
+    stderr?: string;
+  };
+  const combinedOutput = `${execError.stdout ?? ""}\n${execError.stderr ?? ""}`;
+  return combinedOutput.includes("EOVERRIDE");
+}
+
 function runPackDry(): PackResult[] {
-  const raw = execSync("npm pack --dry-run --json --ignore-scripts", {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
-    maxBuffer: 1024 * 1024 * 100,
-  });
-  return JSON.parse(raw) as PackResult[];
+  try {
+    const raw = execSync("npm pack --dry-run --json --ignore-scripts", {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      maxBuffer: 1024 * 1024 * 100,
+    });
+    return JSON.parse(raw) as PackResult[];
+  } catch (error) {
+    if (!isNpmOverrideConflictError(error)) {
+      throw error;
+    }
+
+    const raw = execSync("bun pm pack --dry-run --ignore-scripts", {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      maxBuffer: 1024 * 1024 * 100,
+    });
+    return parseBunPackDryRunOutput(raw);
+  }
 }
 
 export function findLocalPackHotspots(
@@ -219,6 +263,24 @@ export function hasLifecycleScriptReferencingMissingFile(
 
   return !pathExists(resolve(packageDir, relativeTarget));
 }
+
+function readExistingReleaseCheckFile(
+  label: string,
+  candidates: readonly string[],
+): string {
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return readFileSync(candidate, "utf8");
+    }
+  }
+
+  console.error(`release-check: could not find ${label}. Checked:`);
+  for (const candidate of candidates) {
+    console.error(`  - ${candidate}`);
+  }
+  process.exit(1);
+}
+
 function runFastLocalPackCheck(hotspots: string[]) {
   console.warn(
     "release-check: skipping exact npm pack --dry-run because local desktop build artifacts are present and package.json whitelists broad build directories:",
@@ -559,9 +621,9 @@ function assertMacSmokeScriptLaunchesPackagedLauncherDirectly() {
 }
 
 function assertServerDynamicHyperscapeImport() {
-  const serverSource = readFileSync(
-    "packages/autonomous/src/api/server.ts",
-    "utf8",
+  const serverSource = readExistingReleaseCheckFile(
+    "autonomous API server source",
+    autonomousServerPathCandidates,
   );
 
   // @elizaos/app-hyperscape/routes must be a dynamic import (lazy) so the
@@ -591,9 +653,9 @@ function assertServerDynamicHyperscapeImport() {
 }
 
 function assertStartApiServerCatchBlockSafety() {
-  const elizaSource = readFileSync(
-    "packages/autonomous/src/runtime/eliza.ts",
-    "utf8",
+  const elizaSource = readExistingReleaseCheckFile(
+    "autonomous runtime source",
+    autonomousElizaPathCandidates,
   );
 
   // The catch block around startApiServer must use console.error so errors
@@ -606,7 +668,7 @@ function assertStartApiServerCatchBlockSafety() {
   }
 
   // In server-only mode, a failed API server must be fatal.
-  const catchIndex = elizaSource.indexOf("} catch (apiErr)");
+  const catchIndex = elizaSource.indexOf("catch (apiErr)");
   if (catchIndex === -1) {
     console.error(
       "release-check: eliza.ts must have a catch (apiErr) block around startApiServer.",


### PR DESCRIPTION
## Summary
- pin the Electrobun release workflow to the guarded Bun version expected by release-check
- update release-check to read the current autonomous bundle sources and fall back to Bun pack when npm pack hits EOVERRIDE
- pin the bundled orchestrator dependency exactly and cover the checker changes with unit tests

## Validation
- bunx vitest run scripts/release-check.test.ts scripts/electrobun-release-workflow-drift.test.ts
- bunx tsdown && echo '{"type":"module"}' > dist/package.json && node --import tsx scripts/write-build-info.ts && bun run release:check
- bun run pre-review:local