### PR TITLE
release: fix inno app root detection

### DIFF
--- a/packaging/inno/build-inno.ps1
+++ b/packaging/inno/build-inno.ps1
@@ -133,10 +133,16 @@ if (-not $launcher) {
   throw "launcher.exe not found under $BuildDir"
 }
 
-$sourceDir = Split-Path -Parent $launcher.FullName
-$miladyDistEntry = Join-Path $sourceDir "resources\app\milady-dist\entry.js"
+$launcherParent = Split-Path -Parent $launcher.FullName
+# launcher.exe lives under bin/ in the Electrobun app bundle; the app root is one level up
+$sourceDir = if ((Split-Path -Leaf $launcherParent) -eq "bin") {
+  Split-Path -Parent $launcherParent
+} else {
+  $launcherParent
+}
+$miladyDistEntry = Join-Path $sourceDir "Resources\app\milady-dist\entry.js"
 if (-not (Test-Path $miladyDistEntry)) {
-  throw "Packaged app directory does not contain resources\app\milady-dist\entry.js: $sourceDir"
+  throw "Packaged app directory does not contain Resources\app\milady-dist\entry.js: $sourceDir"
 }
 
 New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
@@ -161,8 +167,8 @@ $generated = $generated.Replace("__DEFAULT_DIR_NAME__", (Escape-InnoValue $defau
 $generated = $generated.Replace("__DEFAULT_GROUP_NAME__", (Escape-InnoValue $appName))
 $generated = $generated.Replace("__OUTPUT_DIR__", (Escape-InnoValue (Resolve-Path $OutputDir).Path))
 $generated = $generated.Replace("__OUTPUT_BASE_FILENAME__", (Escape-InnoValue $outputBaseFilename))
-$generated = $generated.Replace("__SOURCE_DIR__", (Escape-InnoValue $sourceDir))
-$generated = $generated.Replace("__ICON_FILE__", (Escape-InnoValue $iconPath))
+$generated = $generated.Replace("__SOURCE_DIR__", (Escape-InnoValue (Resolve-Path $sourceDir).Path))
+$generated = $generated.Replace("__ICON_FILE__", (Escape-InnoValue (Resolve-Path $iconPath).Path))
 $generated = $generated.Replace("__SIGN_SETUP_LINES__", $signSection)
 
 $generatedIssPath = Join-Path $env:RUNNER_TEMP "milady-$normalizedChannel-installer.iss"

--- a/scripts/electrobun-release-workflow-drift.test.ts
+++ b/scripts/electrobun-release-workflow-drift.test.ts
@@ -39,6 +39,7 @@ const WINDOWS_PACKAGED_TEST_PATH = path.join(
   ROOT,
   "apps/app/test/electrobun-packaged/electrobun-windows-startup.e2e.spec.ts",
 );
+const INNO_BUILD_SCRIPT_PATH = path.join(ROOT, "packaging/inno/build-inno.ps1");
 const ELECTROBUN_CONFIG_PATH = path.join(
   ROOT,
   "apps/app/electrobun/electrobun.config.ts",
@@ -261,6 +262,22 @@ describe("Electrobun release workflow drift", () => {
       'Get-ChildItem -Path "apps/app/electrobun/artifacts" -File -Filter "Milady-Setup-*.exe"',
     );
     expect(workflow).toContain("$minimumBytes = 50MB");
+  });
+
+  it("normalizes the Windows launcher path back to the app root before packaging with Inno", () => {
+    const script = fs.readFileSync(INNO_BUILD_SCRIPT_PATH, "utf8");
+
+    expect(script).toContain(
+      "# launcher.exe lives under bin/ in the Electrobun app bundle; the app root is one level up",
+    );
+    expect(script).toContain(
+      'if ((Split-Path -Leaf $launcherParent) -eq "bin") {',
+    );
+    expect(script).toContain("Split-Path -Parent $launcherParent");
+    expect(script).toContain(
+      'Join-Path $sourceDir "Resources\\app\\milady-dist\\entry.js"',
+    );
+    expect(script).toContain("Resolve-Path $sourceDir");
   });
 
   it("treats the staged macOS app as an intermediate signed bundle, not a notarized final artifact", () => {


### PR DESCRIPTION
## Summary
- treat `bin/launcher.exe` as living under the Electrobun app root instead of using the `bin` directory as the installer source root
- resolve the normalized app root and icon paths before templating the generated `.iss` file
- add a regression check that keeps the Inno packaging script aligned with the expected `bin -> app root` structure

## Testing
- bunx vitest run scripts/electrobun-release-workflow-drift.test.ts
- bun run lint
- bun run pre-review:local