### PR TITLE
release: disable browser surface by default

### DIFF
--- a/apps/app/electrobun/scripts/smoke-test-windows.ps1
+++ b/apps/app/electrobun/scripts/smoke-test-windows.ps1
@@ -173,79 +173,69 @@ if (-not $requireInstaller -and -not $launcher) {
       Write-Warning "Falling back to installer path."
     }
   }
-
-  if ($launcher) {
-    $launcher = Write-ReusableLauncherPath -Launcher $launcher -TemporaryRoot $tempExtractDir
-    Write-Host "Using $launcherSource launcher: $($launcher.FullName)"
-    $launcherDir = Split-Path -Parent $launcher.FullName
-    $launcherProcess = Start-Process -FilePath $launcher.FullName -WorkingDirectory $launcherDir -PassThru
-    $launcherStarted = $true
-  } else {
-    $installer = Get-ChildItem -Path $resolvedArtifactsDir -File -Filter "Milady-Setup-*.exe" -ErrorAction SilentlyContinue |
-      Select-Object -First 1
-
-    if (-not $installer) {
-      $installer = Get-ChildItem -Path $resolvedArtifactsDir -File -Filter "*Setup*.exe" -ErrorAction SilentlyContinue |
-      Select-Object -First 1
-    }
-
-    if (-not $installer) {
-      $installerZip = Get-ChildItem -Path $resolvedArtifactsDir -File -Filter "Milady-Setup-*.exe.zip" -ErrorAction SilentlyContinue |
-        Select-Object -First 1
-      if (-not $installerZip) {
-        $installerZip = Get-ChildItem -Path $resolvedArtifactsDir -File -Filter "*Setup*.zip" -ErrorAction SilentlyContinue |
-        Select-Object -First 1
-      }
-      if (-not $installerZip) {
-        throw "No launcher.exe, packaged .tar.zst, installer .exe, or installer .zip found under $resolvedArtifactsDir"
-      }
-
-      New-Item -ItemType Directory -Force -Path $tempExtractDir | Out-Null
-      Expand-Archive -Path $installerZip.FullName -DestinationPath $tempExtractDir -Force
-      $installer = Get-ChildItem -Path $tempExtractDir -Recurse -File -Filter "*Setup*.exe" -ErrorAction SilentlyContinue |
-        Select-Object -First 1
-    }
-
-    if (-not $installer) {
-      throw "No installer executable found for Windows smoke test."
-    }
-
-    Write-Host "Installing via Inno Setup: $($installer.FullName)"
-    Remove-Item $installerRoot -Recurse -Force -ErrorAction SilentlyContinue
-    New-Item -ItemType Directory -Force -Path $installerRoot | Out-Null
-
-    $installerArgs = @(
-      "/VERYSILENT",
-      "/SUPPRESSMSGBOXES",
-      "/NORESTART",
-      "/SP-",
-      "/DIR=$installerRoot"
-    )
-
-    $installerProcess = Start-Process -FilePath $installer.FullName -ArgumentList $installerArgs -WorkingDirectory (Split-Path -Parent $installer.FullName) -PassThru -Wait
-    if ($installerProcess.ExitCode -ne 0) {
-      throw "Windows installer exited with code $($installerProcess.ExitCode)"
-    }
-
-    $launcher = Find-Launcher $installerRoot
-    if (-not $launcher) {
-      throw "Installed launcher.exe not found under $installerRoot"
-    }
-
-    $launcherSource = "installed Inno package"
-    $launcher = Write-ReusableLauncherPath -Launcher $launcher -TemporaryRoot $tempExtractDir
-    Write-Host "Using $launcherSource launcher: $($launcher.FullName)"
-    $launcherDir = Split-Path -Parent $launcher.FullName
-    $launcherProcess = Start-Process -FilePath $launcher.FullName -WorkingDirectory $launcherDir -PassThru
-    $launcherStarted = $true
-  }
-} else {
-  $launcher = Write-ReusableLauncherPath -Launcher $launcher -TemporaryRoot $tempExtractDir
-  Write-Host "Using $launcherSource launcher: $($launcher.FullName)"
-  $launcherDir = Split-Path -Parent $launcher.FullName
-  $launcherProcess = Start-Process -FilePath $launcher.FullName -WorkingDirectory $launcherDir -PassThru
-  $launcherStarted = $true
 }
+
+# Installer-required runs skip build/tarball reuse and validate the installed package directly.
+if (-not $launcher) {
+  $installer = Get-ChildItem -Path $resolvedArtifactsDir -File -Filter "Milady-Setup-*.exe" -ErrorAction SilentlyContinue |
+    Select-Object -First 1
+
+  if (-not $installer) {
+    $installer = Get-ChildItem -Path $resolvedArtifactsDir -File -Filter "*Setup*.exe" -ErrorAction SilentlyContinue |
+      Select-Object -First 1
+  }
+
+  if (-not $installer) {
+    $installerZip = Get-ChildItem -Path $resolvedArtifactsDir -File -Filter "Milady-Setup-*.exe.zip" -ErrorAction SilentlyContinue |
+      Select-Object -First 1
+    if (-not $installerZip) {
+      $installerZip = Get-ChildItem -Path $resolvedArtifactsDir -File -Filter "*Setup*.zip" -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    }
+    if (-not $installerZip) {
+      throw "No launcher.exe, packaged .tar.zst, installer .exe, or installer .zip found under $resolvedArtifactsDir"
+    }
+
+    New-Item -ItemType Directory -Force -Path $tempExtractDir | Out-Null
+    Expand-Archive -Path $installerZip.FullName -DestinationPath $tempExtractDir -Force
+    $installer = Get-ChildItem -Path $tempExtractDir -Recurse -File -Filter "*Setup*.exe" -ErrorAction SilentlyContinue |
+      Select-Object -First 1
+  }
+
+  if (-not $installer) {
+    throw "No installer executable found for Windows smoke test."
+  }
+
+  Write-Host "Installing via Inno Setup: $($installer.FullName)"
+  Remove-Item $installerRoot -Recurse -Force -ErrorAction SilentlyContinue
+  New-Item -ItemType Directory -Force -Path $installerRoot | Out-Null
+
+  $installerArgs = @(
+    "/VERYSILENT",
+    "/SUPPRESSMSGBOXES",
+    "/NORESTART",
+    "/SP-",
+    "/DIR=$installerRoot"
+  )
+
+  $installerProcess = Start-Process -FilePath $installer.FullName -ArgumentList $installerArgs -WorkingDirectory (Split-Path -Parent $installer.FullName) -PassThru -Wait
+  if ($installerProcess.ExitCode -ne 0) {
+    throw "Windows installer exited with code $($installerProcess.ExitCode)"
+  }
+
+  $launcher = Find-Launcher $installerRoot
+  if (-not $launcher) {
+    throw "Installed launcher.exe not found under $installerRoot"
+  }
+
+  $launcherSource = "installed Inno package"
+}
+
+$launcher = Write-ReusableLauncherPath -Launcher $launcher -TemporaryRoot $tempExtractDir
+Write-Host "Using $launcherSource launcher: $($launcher.FullName)"
+$launcherDir = Split-Path -Parent $launcher.FullName
+$launcherProcess = Start-Process -FilePath $launcher.FullName -WorkingDirectory $launcherDir -PassThru
+$launcherStarted = $true
 
 # Bypass proxy for loopback — WinHTTP (used by Invoke-WebRequest) respects
 # system proxy settings on GitHub Actions runners, causing 127.0.0.1 requests

--- a/apps/app/electrobun/src/__tests__/application-menu.test.ts
+++ b/apps/app/electrobun/src/__tests__/application-menu.test.ts
@@ -6,6 +6,7 @@ import {
 
 function getMenu(
   label: string,
+  browserEnabled = false,
   detachedWindows: Array<{
     id: string;
     surface:
@@ -22,6 +23,7 @@ function getMenu(
 ) {
   const menu = buildApplicationMenu({
     isMac: true,
+    browserEnabled,
     heartbeatSnapshot: EMPTY_HEARTBEAT_MENU_SNAPSHOT,
     detachedWindows,
   });
@@ -32,6 +34,7 @@ describe("buildApplicationMenu", () => {
   it("renders surface-first top-level menus without the redundant agent menu", () => {
     const menu = buildApplicationMenu({
       isMac: true,
+      browserEnabled: false,
       heartbeatSnapshot: EMPTY_HEARTBEAT_MENU_SNAPSHOT,
       detachedWindows: [],
     });
@@ -42,7 +45,6 @@ describe("buildApplicationMenu", () => {
       "Edit",
       "View",
       "Cloud",
-      "Browser",
       "Plugins",
       "Connectors",
       "Heartbeats",
@@ -68,6 +70,7 @@ describe("buildApplicationMenu", () => {
   it("renders heartbeat monitoring summary in the native menu", () => {
     const heartbeatsMenu = buildApplicationMenu({
       isMac: false,
+      browserEnabled: false,
       heartbeatSnapshot: {
         ...EMPTY_HEARTBEAT_MENU_SNAPSHOT,
         loading: false,
@@ -142,47 +145,66 @@ describe("buildApplicationMenu", () => {
     ];
 
     const pluginsLabels = (
-      getMenu("Plugins", detachedWindows)?.submenu ?? []
+      getMenu("Plugins", false, detachedWindows)?.submenu ?? []
     ).map((item) => item.label ?? item.type ?? "");
     const connectorsLabels = (
-      getMenu("Connectors", detachedWindows)?.submenu ?? []
+      getMenu("Connectors", false, detachedWindows)?.submenu ?? []
     ).map((item) => item.label ?? item.type ?? "");
-    const cloudLabels = (getMenu("Cloud", detachedWindows)?.submenu ?? []).map(
-      (item) => item.label ?? item.type ?? "",
-    );
-    const browserLabels = (
-      getMenu("Browser", detachedWindows)?.submenu ?? []
+    const cloudLabels = (
+      getMenu("Cloud", false, detachedWindows)?.submenu ?? []
     ).map((item) => item.label ?? item.type ?? "");
     const heartbeatsLabels = (
-      getMenu("Heartbeats", detachedWindows)?.submenu ?? []
+      getMenu("Heartbeats", false, detachedWindows)?.submenu ?? []
     ).map((item) => item.label ?? item.type ?? "");
     const windowLabels = (
-      getMenu("Window", detachedWindows)?.submenu ?? []
+      getMenu("Window", false, detachedWindows)?.submenu ?? []
     ).map((item) => item.label ?? item.type ?? "");
 
     expect(pluginsLabels).toContain("Open New Plugins Window");
     expect(pluginsLabels).toContain("Milady Plugins");
     expect(cloudLabels).toContain("Open Cloud Window");
     expect(cloudLabels).toContain("Eliza Cloud");
-    expect(browserLabels).toContain("Open Browser Window");
-    expect(browserLabels).toContain("Milady Browser");
     expect(connectorsLabels).toContain("Open New Connectors Window");
     expect(connectorsLabels).toContain("Milady Connectors");
     expect(heartbeatsLabels).toContain("Milady Heartbeats");
-    expect(windowLabels).toContain("New Browser Window");
     expect(windowLabels).toContain("New Chat Window");
     expect(windowLabels).toContain("New Plugins Window");
     expect(windowLabels).toContain("New Cloud Window");
-    expect(windowLabels).toContain("Milady Browser");
     expect(windowLabels).toContain("Milady Chat");
     expect(windowLabels).toContain("Eliza Cloud");
     expect(windowLabels).toContain("Milady Settings");
+    expect(windowLabels).not.toContain("New Browser Window");
+    expect(windowLabels).not.toContain("Milady Browser");
+  });
+
+  it("can re-enable browser menus when explicitly requested", () => {
+    const detachedWindows = [
+      {
+        id: "browser_1",
+        surface: "browser" as const,
+        title: "Milady Browser",
+        singleton: false,
+      },
+    ];
+
+    const browserLabels = (
+      getMenu("Browser", true, detachedWindows)?.submenu ?? []
+    ).map((item) => item.label ?? item.type ?? "");
+    const windowLabels = (
+      getMenu("Window", true, detachedWindows)?.submenu ?? []
+    ).map((item) => item.label ?? item.type ?? "");
+
+    expect(browserLabels).toContain("Open Browser Window");
+    expect(browserLabels).toContain("Milady Browser");
+    expect(windowLabels).toContain("New Browser Window");
+    expect(windowLabels).toContain("Milady Browser");
   });
 
   it("surfaces heartbeat load failures without removing the menu", () => {
     const labels = (
       buildApplicationMenu({
         isMac: true,
+        browserEnabled: false,
         heartbeatSnapshot: {
           ...EMPTY_HEARTBEAT_MENU_SNAPSHOT,
           loading: false,

--- a/apps/app/electrobun/src/application-menu.ts
+++ b/apps/app/electrobun/src/application-menu.ts
@@ -164,26 +164,31 @@ function buildBrowserMenu(
 
 export function buildApplicationMenu({
   isMac,
+  browserEnabled,
   heartbeatSnapshot,
   detachedWindows,
 }: {
   isMac: boolean;
+  browserEnabled: boolean;
   heartbeatSnapshot: HeartbeatMenuSnapshot;
   detachedWindows: ManagedWindowSnapshot[];
 }): ApplicationMenuItem[] {
-  const pluginsWindows = detachedWindows.filter(
+  const visibleDetachedWindows = browserEnabled
+    ? detachedWindows
+    : detachedWindows.filter((window) => window.surface !== "browser");
+  const pluginsWindows = visibleDetachedWindows.filter(
     (window) => window.surface === "plugins",
   );
-  const connectorsWindows = detachedWindows.filter(
+  const connectorsWindows = visibleDetachedWindows.filter(
     (window) => window.surface === "connectors",
   );
-  const heartbeatWindows = detachedWindows.filter(
+  const heartbeatWindows = visibleDetachedWindows.filter(
     (window) => window.surface === "triggers",
   );
-  const browserWindows = detachedWindows.filter(
+  const browserWindows = visibleDetachedWindows.filter(
     (window) => window.surface === "browser",
   );
-  const cloudWindows = detachedWindows.filter(
+  const cloudWindows = visibleDetachedWindows.filter(
     (window) => window.surface === "cloud",
   );
 
@@ -249,7 +254,7 @@ export function buildApplicationMenu({
       ],
     },
     buildCloudMenu(cloudWindows),
-    buildBrowserMenu(browserWindows),
+    ...(browserEnabled ? [buildBrowserMenu(browserWindows)] : []),
     buildSurfaceMenu("Plugins", "plugins", pluginsWindows),
     buildSurfaceMenu("Connectors", "connectors", connectorsWindows),
     buildSurfaceMenu(
@@ -272,7 +277,14 @@ export function buildApplicationMenu({
           : []),
         { type: "separator" },
         { label: "Show Milady", action: "show" },
-        { label: "New Browser Window", action: "new-window:browser" },
+        ...(browserEnabled
+          ? [
+              {
+                label: "New Browser Window",
+                action: "new-window:browser",
+              } satisfies ApplicationMenuItem,
+            ]
+          : []),
         { label: "New Chat Window", action: "new-window:chat" },
         { label: "New Heartbeats Window", action: "new-window:triggers" },
         { label: "New Plugins Window", action: "new-window:plugins" },
@@ -280,7 +292,10 @@ export function buildApplicationMenu({
         { label: "New Cloud Window", action: "new-window:cloud" },
         { label: "Settings Window", action: "open-settings" },
         { type: "separator" },
-        ...buildOpenWindowItems(detachedWindows, "No open detached windows"),
+        ...buildOpenWindowItems(
+          visibleDetachedWindows,
+          "No open detached windows",
+        ),
       ] as ApplicationMenuItem[],
     },
   ];

--- a/apps/app/electrobun/src/index.ts
+++ b/apps/app/electrobun/src/index.ts
@@ -70,6 +70,10 @@ type HeartbeatMenuHealthResponse = {
 
 const HEARTBEAT_MENU_REFRESH_MS = 30_000;
 const CONFIG_EXPORT_FILE_NAME = "milady-config.json";
+// Browser surface stays off by default until the packaged WebGPU/browser path
+// is hardened across the supported desktop release targets.
+const BROWSER_SURFACE_ENABLED =
+  process.env.MILADY_ENABLE_BROWSER_SURFACE === "1";
 let heartbeatMenuSnapshot: HeartbeatMenuSnapshot =
   EMPTY_HEARTBEAT_MENU_SNAPSHOT;
 let heartbeatMenuRefreshTimer: ReturnType<typeof setInterval> | null = null;
@@ -82,6 +86,7 @@ function setupApplicationMenu(): void {
   const isMac = process.platform === "darwin";
   const menu = buildApplicationMenu({
     isMac,
+    browserEnabled: BROWSER_SURFACE_ENABLED,
     heartbeatSnapshot: heartbeatMenuSnapshot,
     detachedWindows: surfaceWindowManager?.listWindows() ?? [],
   });
@@ -1125,6 +1130,20 @@ function initializeBundledWebGPU(): void {
  * On Linux/Windows with CEF, upstream Electrobun support is needed.
  */
 function checkWebGpuBrowserSupport(): void {
+  if (!BROWSER_SURFACE_ENABLED) {
+    console.warn("[WebGPU Browser] Browser surface disabled in this build.");
+    setTimeout(() => {
+      sendToActiveRenderer("webgpu:browserStatus", {
+        available: false,
+        reason: "Browser surface disabled in this build.",
+        renderer: "unknown",
+        chromeBetaPath: null,
+        downloadUrl: null,
+      });
+    }, 2000);
+    return;
+  }
+
   const status = checkWebGpuSupport();
   if (status.available) {
     console.log(`[WebGPU Browser] ${status.reason}`);

--- a/packaging/inno/build-inno.ps1
+++ b/packaging/inno/build-inno.ps1
@@ -133,10 +133,16 @@ if (-not $launcher) {
   throw "launcher.exe not found under $BuildDir"
 }
 
-$sourceDir = Split-Path -Parent $launcher.FullName
-$miladyDistEntry = Join-Path $sourceDir "resources\app\milady-dist\entry.js"
+$launcherParent = Split-Path -Parent $launcher.FullName
+# launcher.exe lives under bin/ in the Electrobun app bundle; the app root is one level up
+$sourceDir = if ((Split-Path -Leaf $launcherParent) -eq "bin") {
+  Split-Path -Parent $launcherParent
+} else {
+  $launcherParent
+}
+$miladyDistEntry = Join-Path $sourceDir "Resources\app\milady-dist\entry.js"
 if (-not (Test-Path $miladyDistEntry)) {
-  throw "Packaged app directory does not contain resources\app\milady-dist\entry.js: $sourceDir"
+  throw "Packaged app directory does not contain Resources\app\milady-dist\entry.js: $sourceDir"
 }
 
 New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
@@ -161,8 +167,8 @@ $generated = $generated.Replace("__DEFAULT_DIR_NAME__", (Escape-InnoValue $defau
 $generated = $generated.Replace("__DEFAULT_GROUP_NAME__", (Escape-InnoValue $appName))
 $generated = $generated.Replace("__OUTPUT_DIR__", (Escape-InnoValue (Resolve-Path $OutputDir).Path))
 $generated = $generated.Replace("__OUTPUT_BASE_FILENAME__", (Escape-InnoValue $outputBaseFilename))
-$generated = $generated.Replace("__SOURCE_DIR__", (Escape-InnoValue $sourceDir))
-$generated = $generated.Replace("__ICON_FILE__", (Escape-InnoValue $iconPath))
+$generated = $generated.Replace("__SOURCE_DIR__", (Escape-InnoValue (Resolve-Path $sourceDir).Path))
+$generated = $generated.Replace("__ICON_FILE__", (Escape-InnoValue (Resolve-Path $iconPath).Path))
 $generated = $generated.Replace("__SIGN_SETUP_LINES__", $signSection)
 
 $generatedIssPath = Join-Path $env:RUNNER_TEMP "milady-$normalizedChannel-installer.iss"

--- a/scripts/electrobun-release-workflow-drift.test.ts
+++ b/scripts/electrobun-release-workflow-drift.test.ts
@@ -39,6 +39,7 @@ const WINDOWS_PACKAGED_TEST_PATH = path.join(
   ROOT,
   "apps/app/test/electrobun-packaged/electrobun-windows-startup.e2e.spec.ts",
 );
+const INNO_BUILD_SCRIPT_PATH = path.join(ROOT, "packaging/inno/build-inno.ps1");
 const ELECTROBUN_CONFIG_PATH = path.join(
   ROOT,
   "apps/app/electrobun/electrobun.config.ts",
@@ -261,6 +262,22 @@ describe("Electrobun release workflow drift", () => {
       'Get-ChildItem -Path "apps/app/electrobun/artifacts" -File -Filter "Milady-Setup-*.exe"',
     );
     expect(workflow).toContain("$minimumBytes = 50MB");
+  });
+
+  it("normalizes the Windows launcher path back to the app root before packaging with Inno", () => {
+    const script = fs.readFileSync(INNO_BUILD_SCRIPT_PATH, "utf8");
+
+    expect(script).toContain(
+      "# launcher.exe lives under bin/ in the Electrobun app bundle; the app root is one level up",
+    );
+    expect(script).toContain(
+      'if ((Split-Path -Leaf $launcherParent) -eq "bin") {',
+    );
+    expect(script).toContain("Split-Path -Parent $launcherParent");
+    expect(script).toContain(
+      'Join-Path $sourceDir "Resources\\app\\milady-dist\\entry.js"',
+    );
+    expect(script).toContain("Resolve-Path $sourceDir");
   });
 
   it("treats the staged macOS app as an intermediate signed bundle, not a notarized final artifact", () => {

--- a/scripts/electrobun-release-workflow-drift.test.ts
+++ b/scripts/electrobun-release-workflow-drift.test.ts
@@ -413,9 +413,25 @@ describe("Electrobun release workflow drift", () => {
       'Write-Host "Using $launcherSource launcher:',
     );
     expect(smokeScript).toContain(
+      "Installer-required runs skip build/tarball reuse and validate the installed package directly.",
+    );
+    expect(smokeScript).toContain(
       "$persistLauncherPathFile = $env:MILADY_TEST_WINDOWS_LAUNCHER_PATH_FILE",
     );
     expect(smokeScript).toContain("Set-Content -Path $persistLauncherPathFile");
+    const tarballBranchIndex = smokeScript.indexOf(
+      'Get-ChildItem -Path $resolvedArtifactsDir -File -Filter "*.tar.zst"',
+    );
+    const installerFallbackIndex = smokeScript.indexOf(
+      "if (-not $launcher) {",
+      tarballBranchIndex,
+    );
+    const installerLaunchIndex = smokeScript.indexOf(
+      'Write-Host "Installing via Inno Setup: $($installer.FullName)"',
+    );
+    expect(tarballBranchIndex).toBeGreaterThan(-1);
+    expect(installerFallbackIndex).toBeGreaterThan(tarballBranchIndex);
+    expect(installerLaunchIndex).toBeGreaterThan(installerFallbackIndex);
     expect(workflow).toContain(
       "MILADY_TEST_WINDOWS_LAUNCHER_PATH_FILE: $" +
         "{{ runner.temp }}\\milady-windows-ui-launcher.txt",

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -541,6 +541,7 @@ function assertWindowsSmokeScriptHasLeadingParamBlock() {
     "/VERYSILENT",
     "installed Inno package",
     "$persistLauncherPathFile = $env:MILADY_TEST_WINDOWS_LAUNCHER_PATH_FILE",
+    "Installer-required runs skip build/tarball reuse and validate the installed package directly.",
     "Using $launcherSource launcher:",
     "Using packaged tarball:",
     "Find-Launcher $selfExtractionRoot",


### PR DESCRIPTION
## Summary
- disable the browser surface by default in the desktop shell
- stop advertising browser windows in the native menu unless explicitly re-enabled
- skip the browser WebGPU startup probe when the surface is disabled

## Testing
- bunx vitest run apps/app/electrobun/src/__tests__/application-menu.test.ts
- bun run check
- bun run pre-review:local