### PR TITLE
release: restore windows smoke install root

### DIFF
--- a/.github/workflows/release-electrobun.yml
+++ b/.github/workflows/release-electrobun.yml
@@ -713,7 +713,10 @@ jobs:
           # server.listen() and the health endpoint never becomes reachable.
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           MILADY_WINDOWS_SMOKE_REQUIRE_INSTALLER: "1"
-          MILADY_TEST_WINDOWS_INSTALL_DIR: ${{ runner.temp }}\milady-windows-installed
+          # Keep the installer smoke target on the same short root that the
+          # last all-green Windows release used; the longer runner temp path
+          # regressed into an Inno exit code 5 before launcher handoff.
+          MILADY_TEST_WINDOWS_INSTALL_DIR: C:\mi
           MILADY_TEST_WINDOWS_LAUNCHER_DIR: ${{ runner.temp }}\milady-windows-ui-launcher
           MILADY_TEST_WINDOWS_LAUNCHER_PATH_FILE: ${{ runner.temp }}\milady-windows-ui-launcher.txt
         run: |

--- a/scripts/electrobun-release-workflow-drift.test.ts
+++ b/scripts/electrobun-release-workflow-drift.test.ts
@@ -255,6 +255,7 @@ describe("Electrobun release workflow drift", () => {
     expect(workflow).toContain('$extractDir = "C:\\m"');
     expect(workflow).toContain("milady-dist/entry.js found");
     expect(workflow).toContain('-BuildDir "C:\\m"');
+    expect(workflow).toContain("MILADY_TEST_WINDOWS_INSTALL_DIR: C:\\mi");
     expect(workflow).toContain(
       "name: Verify Windows public installer looks complete",
     );
@@ -440,10 +441,7 @@ describe("Electrobun release workflow drift", () => {
     // the workflow also sets it so the entire process tree inherits it.
     expect(workflow).toContain('MILADY_DISABLE_LOCAL_EMBEDDINGS: "1"');
     expect(workflow).toContain('MILADY_WINDOWS_SMOKE_REQUIRE_INSTALLER: "1"');
-    expect(workflow).toContain(
-      "MILADY_TEST_WINDOWS_INSTALL_DIR: $" +
-        "{{ runner.temp }}\\milady-windows-installed",
-    );
+    expect(workflow).toContain("MILADY_TEST_WINDOWS_INSTALL_DIR: C:\\mi");
     expect(workflow).toContain(
       'Add-Content -Path $env:GITHUB_ENV -Value "MILADY_TEST_WINDOWS_LAUNCHER_PATH=$launcherPath"',
     );

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -97,6 +97,7 @@ const requiredWorkflowSnippets = [
   "MILADY_ELECTROBUN_NOTARIZE: 0",
   'MILADY_DISABLE_LOCAL_EMBEDDINGS: "1"',
   'MILADY_WINDOWS_SMOKE_REQUIRE_INSTALLER: "1"',
+  "MILADY_TEST_WINDOWS_INSTALL_DIR: C:\\mi",
   "ANTHROPIC_API_KEY: $" + "{{ secrets.ANTHROPIC_API_KEY }}",
   'Join-Path $PWD "apps/app/electrobun/node_modules/electrobun"',
   "if ($null -eq $resolvedRceditPackageJson)",


### PR DESCRIPTION
## Summary
- restore the Windows installer smoke target to `C:\mi`, matching the last all-green Electrobun release run
- update the workflow drift test and `release:check` so the short install root stays pinned
- keep the fix scoped to the Windows release smoke path only

## Why
The current release run `23328314163` builds the Windows installer successfully, then fails in `smoke-test-windows.ps1` with `Windows installer exited with code 5` before writing the reusable launcher path. The last all-green Windows release job `67705928578` used `MILADY_TEST_WINDOWS_INSTALL_DIR: C:\mi` and completed successfully.

## Testing
- `bunx vitest run scripts/electrobun-release-workflow-drift.test.ts`
- `bunx tsdown`
- `node --import tsx scripts/write-build-info.ts`
- `bun run release:check`
- `bun run lint`
- `bun run pre-review:local`
