### PR TITLE
release: force agent boot for packaged smoke

### DIFF
--- a/apps/app/electrobun/scripts/smoke-test-windows.ps1
+++ b/apps/app/electrobun/scripts/smoke-test-windows.ps1
@@ -116,6 +116,7 @@ if ($resolvedBuildDir) {
 
 Stop-MiladyProcesses
 $env:ELECTROBUN_CONSOLE = "1"
+$env:MILADY_FORCE_AUTOSTART_AGENT = "1"
 
 if (Test-Path $selfExtractionRoot) {
   Remove-Item $selfExtractionRoot -Recurse -Force -ErrorAction SilentlyContinue

--- a/apps/app/electrobun/scripts/smoke-test.sh
+++ b/apps/app/electrobun/scripts/smoke-test.sh
@@ -298,8 +298,11 @@ build_launcher_command() {
       LANG="$launch_lang"
       LC_ALL="$launch_lc_all"
       TERM="${TERM:-dumb}"
+      MILADY_FORCE_AUTOSTART_AGENT=1
       "$LAUNCHER_PATH"
     )
+  else
+    LAUNCH_COMMAND=(/usr/bin/env MILADY_FORCE_AUTOSTART_AGENT=1 "$LAUNCHER_PATH")
   fi
 }
 

--- a/apps/app/electrobun/src/deferred-agent-startup.test.ts
+++ b/apps/app/electrobun/src/deferred-agent-startup.test.ts
@@ -39,6 +39,13 @@ describe("deferred agent startup (desktop)", () => {
     expect(source).toContain("pushApiBaseToRenderer");
   });
 
+  it("allows smoke runs to opt into embedded agent startup on boot", () => {
+    expect(source).toContain(
+      'process.env.MILADY_FORCE_AUTOSTART_AGENT === "1"',
+    );
+    expect(source).toContain("void _startAgent(currentWindow);");
+  });
+
   it("preserves the agentStart RPC handler for renderer-triggered startup", () => {
     const handlersPath = path.resolve(__dirname, "rpc-handlers.ts");
     const handlers = fs.readFileSync(handlersPath, "utf8");

--- a/apps/app/electrobun/src/index.ts
+++ b/apps/app/electrobun/src/index.ts
@@ -74,6 +74,7 @@ const CONFIG_EXPORT_FILE_NAME = "milady-config.json";
 // is hardened across the supported desktop release targets.
 const BROWSER_SURFACE_ENABLED =
   process.env.MILADY_ENABLE_BROWSER_SURFACE === "1";
+const FORCE_AUTOSTART_AGENT = process.env.MILADY_FORCE_AUTOSTART_AGENT === "1";
 let heartbeatMenuSnapshot: HeartbeatMenuSnapshot =
   EMPTY_HEARTBEAT_MENU_SNAPSHOT;
 let heartbeatMenuRefreshTimer: ReturnType<typeof setInterval> | null = null;
@@ -1301,6 +1302,9 @@ async function main(): Promise<void> {
         rt.externalApi.base,
         process.env.MILADY_API_TOKEN,
       );
+    } else if (FORCE_AUTOSTART_AGENT) {
+      console.log("[Main] Forcing embedded agent startup on boot.");
+      void _startAgent(currentWindow);
     }
   }
 


### PR DESCRIPTION
## Summary
- add a smoke-only autostart override for the embedded desktop agent
- set that override in the packaged macOS and Windows smoke scripts
- keep deferred agent startup as the default product behavior and cover the override in tests

## Why
The packaged macOS smoke harness waits for the embedded backend to report a started port, but the desktop bootstrap no longer starts the embedded agent on launch by default. That made the release smoke fail even with the browser surface disabled. This keeps normal deferred startup intact while restoring green-release behavior for packaged smoke runs.

## Testing
- `bunx vitest run apps/app/electrobun/src/deferred-agent-startup.test.ts apps/app/electrobun/src/__tests__/startup-bootstrap.test.ts`
- `bun run lint`
- `bun run pre-review:local`
