### PR TITLE
release: fix workflow drift for package publishing

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Sync Capacitor
         working-directory: apps/app
-        run: npx cap sync android
+        run: bun run cap:sync:android
 
       - name: Decode keystore
         run: |

--- a/.github/workflows/apple-store-release.yml
+++ b/.github/workflows/apple-store-release.yml
@@ -145,7 +145,7 @@ jobs:
 
       - name: Sync Capacitor iOS
         working-directory: apps/app
-        run: npx cap sync ios
+        run: bun run cap:sync:ios
 
       - name: Update Xcode project version
         working-directory: apps/app/ios/App/App.xcodeproj

--- a/.github/workflows/build-cloud-image.yml
+++ b/.github/workflows/build-cloud-image.yml
@@ -101,7 +101,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: deploy/Dockerfile.cloud-full-ui
+          file: ./deploy/Dockerfile
           platforms: linux/amd64
           push: ${{ github.event_name == 'push' || inputs.push == true }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -5,7 +5,7 @@
 # when a new GitHub release is published.
 #
 # Required secret: HOMEBREW_TAP_TOKEN
-#   A GitHub PAT with repo scope for milady-ai/homebrew-milady
+#   A GitHub PAT with repo scope for milady-ai/homebrew-tap
 
 name: Update Homebrew Tap
 
@@ -36,10 +36,10 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Triggering Homebrew update for version: $VERSION"
 
-      - name: Dispatch to homebrew-milady tap
+      - name: Dispatch to homebrew-tap
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          repository: milady-ai/homebrew-milady
+          repository: milady-ai/homebrew-tap
           event-type: update-homebrew
           client-payload: '{"version": "${{ steps.meta.outputs.version }}"}'

--- a/scripts/release-support-workflows-drift.test.ts
+++ b/scripts/release-support-workflows-drift.test.ts
@@ -1,0 +1,55 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const BUILD_CLOUD_IMAGE_WORKFLOW = path.join(
+  ROOT,
+  ".github/workflows/build-cloud-image.yml",
+);
+const ANDROID_RELEASE_WORKFLOW = path.join(
+  ROOT,
+  ".github/workflows/android-release.yml",
+);
+const APPLE_STORE_RELEASE_WORKFLOW = path.join(
+  ROOT,
+  ".github/workflows/apple-store-release.yml",
+);
+const UPDATE_HOMEBREW_WORKFLOW = path.join(
+  ROOT,
+  ".github/workflows/update-homebrew.yml",
+);
+
+describe("release support workflow drift", () => {
+  it("builds the cloud full-ui image from the checked-in full app Dockerfile", () => {
+    const workflow = fs.readFileSync(BUILD_CLOUD_IMAGE_WORKFLOW, "utf8");
+
+    expect(workflow).toContain("type=raw,value=cloud-full-ui");
+    expect(workflow).toContain("file: ./deploy/Dockerfile");
+    expect(workflow).not.toContain("Dockerfile.cloud-full-ui");
+  });
+
+  it("syncs Android Capacitor via the repo-supported app script", () => {
+    const workflow = fs.readFileSync(ANDROID_RELEASE_WORKFLOW, "utf8");
+
+    expect(workflow).toContain("working-directory: apps/app");
+    expect(workflow).toContain("run: bun run cap:sync:android");
+    expect(workflow).not.toContain("run: npx cap sync android");
+  });
+
+  it("syncs iOS Capacitor via the repo-supported app script", () => {
+    const workflow = fs.readFileSync(APPLE_STORE_RELEASE_WORKFLOW, "utf8");
+
+    expect(workflow).toContain("working-directory: apps/app");
+    expect(workflow).toContain("run: bun run cap:sync:ios");
+    expect(workflow).not.toContain("run: npx cap sync ios");
+  });
+
+  it("dispatches Homebrew updates to the actual tap repository", () => {
+    const workflow = fs.readFileSync(UPDATE_HOMEBREW_WORKFLOW, "utf8");
+
+    expect(workflow).toContain("repository: milady-ai/homebrew-tap");
+    expect(workflow).not.toContain("repository: milady-ai/homebrew-milady");
+  });
+});


### PR DESCRIPTION
## Summary
- fix cloud image workflow to use the checked-in full UI Dockerfile
- switch Android and iOS release sync steps to the repo-supported Bun Capacitor scripts
- point Homebrew dispatch at the real tap repo and add a regression test for all four workflow drifts

## Validation
- bunx vitest run scripts/release-support-workflows-drift.test.ts
- bun run pre-review:local

## Release failures addressed
- build-cloud-image: referenced missing deploy/Dockerfile.cloud-full-ui
- android-release: used npx cap sync android instead of the repo script
- apple-store-release: used npx cap sync ios instead of the repo script
- update-homebrew: dispatched to nonexistent milady-ai/homebrew-milady repo