### PR TITLE
release: timeout hung windows inno builds

### DIFF
--- a/packaging/inno/build-inno.ps1
+++ b/packaging/inno/build-inno.ps1
@@ -175,9 +175,39 @@ $generatedIssPath = Join-Path $env:RUNNER_TEMP "milady-$normalizedChannel-instal
 Set-Content -Path $generatedIssPath -Value $generated -Encoding utf8
 
 try {
-  & $isccPath "/Qp" $generatedIssPath
-  if ($LASTEXITCODE -ne 0) {
-    throw "ISCC.exe failed with exit code $LASTEXITCODE"
+  $isccTimeout = [TimeSpan]::FromMinutes(25)
+  $isccHeartbeatInterval = [TimeSpan]::FromSeconds(30)
+  $isccArguments = @("/Qp", $generatedIssPath)
+  $isccArgumentDisplay = $isccArguments | ForEach-Object { if ($_ -match '\s') { "`"$_`"" } else { $_ } }
+  $isccStartedAt = Get-Date
+
+  Write-Host "Starting ISCC.exe: $isccPath $($isccArgumentDisplay -join ' ')"
+
+  $isccProcess = Start-Process -FilePath $isccPath -ArgumentList $isccArguments -PassThru -NoNewWindow
+
+  while (-not $isccProcess.HasExited) {
+    Start-Sleep -Milliseconds ([int]$isccHeartbeatInterval.TotalMilliseconds)
+    $isccProcess.Refresh()
+    if ($isccProcess.HasExited) {
+      break
+    }
+
+    $elapsed = (Get-Date) - $isccStartedAt
+    Write-Host "ISCC.exe still running after $([math]::Round($elapsed.TotalMinutes, 1)) minutes..."
+
+    if ($elapsed -ge $isccTimeout) {
+      try {
+        Stop-Process -Id $isccProcess.Id -Force -ErrorAction Stop
+      } catch {
+        Write-Warning "Failed to terminate hung ISCC.exe process $($isccProcess.Id): $($_.Exception.Message)"
+      }
+
+      throw "ISCC.exe timed out after $([int]$isccTimeout.TotalMinutes) minutes while building the Windows installer."
+    }
+  }
+
+  if ($isccProcess.ExitCode -ne 0) {
+    throw "ISCC.exe failed with exit code $($isccProcess.ExitCode)"
   }
 
   $installerPath = Join-Path (Resolve-Path $OutputDir).Path "$outputBaseFilename.exe"

--- a/scripts/electrobun-release-workflow-drift.test.ts
+++ b/scripts/electrobun-release-workflow-drift.test.ts
@@ -305,6 +305,26 @@ describe("Electrobun release workflow drift", () => {
     expect(script).toContain("Resolve-Path $sourceDir");
   });
 
+  it("bounds hung Inno compiler runs with heartbeat logging and a hard timeout", () => {
+    const script = fs.readFileSync(INNO_BUILD_SCRIPT_PATH, "utf8");
+
+    expect(script).toContain("$isccTimeout = [TimeSpan]::FromMinutes(25)");
+    expect(script).toContain(
+      "$isccHeartbeatInterval = [TimeSpan]::FromSeconds(30)",
+    );
+    expect(script).toContain(
+      "Write-Host \"Starting ISCC.exe: $isccPath $($isccArgumentDisplay -join ' ')\"",
+    );
+    expect(script).toContain("Start-Process -FilePath $isccPath");
+    expect(script).toContain(
+      'Write-Host "ISCC.exe still running after $([math]::Round($elapsed.TotalMinutes, 1)) minutes..."',
+    );
+    expect(script).toContain("Stop-Process -Id $isccProcess.Id -Force");
+    expect(script).toContain(
+      'throw "ISCC.exe timed out after $([int]$isccTimeout.TotalMinutes) minutes while building the Windows installer."',
+    );
+  });
+
   it("treats the staged macOS app as an intermediate signed bundle, not a notarized final artifact", () => {
     const stageScript = fs.readFileSync(MACOS_STAGE_SCRIPT_PATH, "utf8");
 

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -580,6 +580,32 @@ function assertWindowsSmokeScriptHasLeadingParamBlock() {
   }
 }
 
+function assertInnoBuildScriptHasTimeoutAndHeartbeat() {
+  const script = readFileSync("packaging/inno/build-inno.ps1", "utf8");
+  const requiredSnippets = [
+    "$isccTimeout = [TimeSpan]::FromMinutes(25)",
+    "$isccHeartbeatInterval = [TimeSpan]::FromSeconds(30)",
+    "Write-Host \"Starting ISCC.exe: $isccPath $($isccArgumentDisplay -join ' ')\"",
+    "Start-Process -FilePath $isccPath",
+    'Write-Host "ISCC.exe still running after $([math]::Round($elapsed.TotalMinutes, 1)) minutes..."',
+    "Stop-Process -Id $isccProcess.Id -Force",
+    'throw "ISCC.exe timed out after $([int]$isccTimeout.TotalMinutes) minutes while building the Windows installer."',
+  ];
+  const missingSnippets = requiredSnippets.filter(
+    (snippet) => !script.includes(snippet),
+  );
+
+  if (missingSnippets.length > 0) {
+    console.error(
+      "release-check: build-inno.ps1 must supervise ISCC.exe with heartbeat logging and a hard timeout.",
+    );
+    for (const snippet of missingSnippets) {
+      console.error(`  - ${snippet}`);
+    }
+    process.exit(1);
+  }
+}
+
 function assertMacSmokeScriptLaunchesPackagedLauncherDirectly() {
   const script = readFileSync(
     "apps/app/electrobun/scripts/smoke-test.sh",
@@ -714,6 +740,7 @@ function main() {
   assertElectrobunConfigHasPostWrapSigner();
   assertMacArtifactStagerLooksCorrect();
   assertWindowsSmokeScriptHasLeadingParamBlock();
+  assertInnoBuildScriptHasTimeoutAndHeartbeat();
   assertMacSmokeScriptLaunchesPackagedLauncherDirectly();
   assertServerDynamicHyperscapeImport();
   assertStartApiServerCatchBlockSafety();


### PR DESCRIPTION
## Summary
- supervise Windows Inno Setup builds with heartbeat logging and a 25 minute timeout
- lock the new ISCC timeout behavior into release drift coverage and release-check

## Testing
- bunx vitest run scripts/electrobun-release-workflow-drift.test.ts
- bunx @biomejs/biome check scripts/electrobun-release-workflow-drift.test.ts scripts/release-check.ts
- bun run release:check