### PR TITLE
fix: refresh bun lock for release validation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3764,7 +3764,7 @@
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
-    "milady-cloud-agent/@elizaos/core": ["@elizaos/core@2.0.0-alpha.78", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "adze": "^2.2.5", "crypto-browserify": "^3.12.0", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-A6Y1Umd9DhRKJiuhueuoT7dWmDtWCnTUo/kWEZF1m4efF7kiKsLVfppJ+oS0pwSHvuurR4/T6IC1woO5nFMmzw=="],
+    "milady-cloud-agent/@elizaos/core": ["@elizaos/core@2.0.0-alpha.80", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "adze": "^2.2.5", "crypto-browserify": "^3.12.0", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-Ga0LI92fxS3XcnazagwUiWfo6iXRvuIKu+Ilkh9Crzx8H5xG+9U3bDngaUSzaFn9KrZyIVk4EuOIAqNsxZPRlg=="],
 
     "miller-rabin/bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
 


### PR DESCRIPTION
## Summary
- refresh bun.lock so validate-release no longer mutates the lockfile under --frozen-lockfile
- keep the release flow aligned with the current milady-cloud-agent core resolution

## Testing
- bun install --frozen-lockfile --ignore-scripts
- bun run release:check