### PR TITLE
release: disable stale bun cache fallback

### DIFF
--- a/.github/workflows/release-electrobun.yml
+++ b/.github/workflows/release-electrobun.yml
@@ -107,7 +107,6 @@ jobs:
         with:
           path: ~/.bun/install/cache
           key: bun-electrobun-validate-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-electrobun-validate-
 
       - name: Install root dependencies
         run: bun install --frozen-lockfile --ignore-scripts
@@ -182,7 +181,6 @@ jobs:
         with:
           path: ~/.bun/install/cache
           key: bun-electrobun-${{ matrix.platform.artifact-name }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-electrobun-${{ matrix.platform.artifact-name }}-
 
       - name: Install root dependencies
         # --ignore-scripts skips native dependency install scripts (e.g. @tensorflow/tfjs-node

--- a/scripts/electrobun-release-workflow-drift.test.ts
+++ b/scripts/electrobun-release-workflow-drift.test.ts
@@ -123,6 +123,22 @@ describe("Electrobun release workflow drift", () => {
     expect(workflow).toContain(`bun install failed after \${attempt} attempts`);
   });
 
+  it("avoids stale per-platform Bun cache fallback during desktop builds", () => {
+    const workflow = fs.readFileSync(WORKFLOW_PATH, "utf8");
+
+    expect(workflow).toContain(
+      "key: bun-electrobun-$" +
+        "{{ matrix.platform.artifact-name }}" +
+        "-$" +
+        "{{ hashFiles('bun.lock') }}",
+    );
+    expect(workflow).not.toContain(
+      "restore-keys: bun-electrobun-$" +
+        "{{ matrix.platform.artifact-name }}" +
+        "-",
+    );
+  });
+
   it("installs Inno Setup on Windows without relying on winget", () => {
     const workflow = fs.readFileSync(WORKFLOW_PATH, "utf8");
 
@@ -137,7 +153,7 @@ describe("Electrobun release workflow drift", () => {
     );
   });
 
-  it("uses a non-matrix cache key in validate-release", () => {
+  it("uses an exact non-matrix cache key in validate-release", () => {
     const workflow = fs.readFileSync(WORKFLOW_PATH, "utf8");
     const validateSection = workflow.slice(
       workflow.indexOf("name: Validate Release Inputs"),
@@ -147,7 +163,9 @@ describe("Electrobun release workflow drift", () => {
     expect(validateSection).toContain(
       "key: bun-electrobun-validate-$" + "{{ hashFiles('bun.lock') }}",
     );
-    expect(validateSection).toContain("restore-keys: bun-electrobun-validate-");
+    expect(validateSection).not.toContain(
+      "restore-keys: bun-electrobun-validate-",
+    );
     expect(validateSection).not.toContain("matrix.platform.artifact-name");
   });
 

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -38,7 +38,6 @@ const requiredWorkflowSnippets = [
   "for attempt in 1 2 3; do",
   `bun install failed on attempt \${attempt}; retrying in 15 seconds`,
   "key: bun-electrobun-validate-$" + "{{ hashFiles('bun.lock') }}",
-  "restore-keys: bun-electrobun-validate-",
   "name: Ensure avatar assets",
   "node scripts/ensure-avatars.mjs",
   "Install quiet macOS packaging wrappers",
@@ -109,6 +108,10 @@ const requiredWorkflowSnippets = [
 const forbiddenWorkflowSnippets = [
   ' -name "*.exe" -o \\',
   'bun install -g "rcedit@4.0.1"',
+  "restore-keys: bun-electrobun-validate-",
+  "restore-keys: bun-electrobun-$" +
+    "{{ matrix.platform.artifact-name }}" +
+    "-",
 ];
 const requiredElectrobunConfigSnippets = [
   'postBuild: "scripts/postwrap-sign-runtime-macos.ts"',


### PR DESCRIPTION
## Summary
- remove Bun cache restore fallbacks from release validation and desktop build jobs
- prevent stale per-platform cache archives from mutating bun.lock under --frozen-lockfile

## Testing
- bunx vitest run scripts/electrobun-release-workflow-drift.test.ts
- bunx @biomejs/biome check .github/workflows/release-electrobun.yml scripts/electrobun-release-workflow-drift.test.ts scripts/release-check.ts
- bun run release:check