### PR TITLE
release: drop bun install cache from workflow

### DIFF
--- a/.github/workflows/release-electrobun.yml
+++ b/.github/workflows/release-electrobun.yml
@@ -102,12 +102,6 @@ jobs:
         with:
           bun-version: ${{ env.BUN_VERSION }}
 
-      - name: Cache Bun install
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: bun-electrobun-validate-${{ hashFiles('bun.lock') }}
-
       - name: Install root dependencies
         run: bun install --frozen-lockfile --ignore-scripts
 
@@ -175,12 +169,6 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
-
-      - name: Cache Bun install
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: bun-electrobun-${{ matrix.platform.artifact-name }}-${{ hashFiles('bun.lock') }}
 
       - name: Install root dependencies
         # --ignore-scripts skips native dependency install scripts (e.g. @tensorflow/tfjs-node

--- a/scripts/electrobun-release-workflow-drift.test.ts
+++ b/scripts/electrobun-release-workflow-drift.test.ts
@@ -123,20 +123,17 @@ describe("Electrobun release workflow drift", () => {
     expect(workflow).toContain(`bun install failed after \${attempt} attempts`);
   });
 
-  it("avoids stale per-platform Bun cache fallback during desktop builds", () => {
+  it("does not restore Bun install cache during desktop builds", () => {
     const workflow = fs.readFileSync(WORKFLOW_PATH, "utf8");
+    const buildJobLabel = "name: Build $" + "{{ matrix.platform.name }}";
+    const buildSection = workflow.slice(
+      workflow.indexOf(buildJobLabel),
+      workflow.indexOf("  create-release:"),
+    );
 
-    expect(workflow).toContain(
-      "key: bun-electrobun-$" +
-        "{{ matrix.platform.artifact-name }}" +
-        "-$" +
-        "{{ hashFiles('bun.lock') }}",
-    );
-    expect(workflow).not.toContain(
-      "restore-keys: bun-electrobun-$" +
-        "{{ matrix.platform.artifact-name }}" +
-        "-",
-    );
+    expect(buildSection).not.toContain("name: Cache Bun install");
+    expect(buildSection).not.toContain("path: ~/.bun/install/cache");
+    expect(buildSection).not.toContain("bun-electrobun-");
   });
 
   it("installs Inno Setup on Windows without relying on winget", () => {
@@ -153,19 +150,16 @@ describe("Electrobun release workflow drift", () => {
     );
   });
 
-  it("uses an exact non-matrix cache key in validate-release", () => {
+  it("does not restore Bun install cache in validate-release", () => {
     const workflow = fs.readFileSync(WORKFLOW_PATH, "utf8");
     const validateSection = workflow.slice(
       workflow.indexOf("name: Validate Release Inputs"),
       workflow.indexOf("  build:"),
     );
 
-    expect(validateSection).toContain(
-      "key: bun-electrobun-validate-$" + "{{ hashFiles('bun.lock') }}",
-    );
-    expect(validateSection).not.toContain(
-      "restore-keys: bun-electrobun-validate-",
-    );
+    expect(validateSection).not.toContain("name: Cache Bun install");
+    expect(validateSection).not.toContain("path: ~/.bun/install/cache");
+    expect(validateSection).not.toContain("bun-electrobun-validate-");
     expect(validateSection).not.toContain("matrix.platform.artifact-name");
   });
 

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -37,7 +37,6 @@ const requiredWorkflowSnippets = [
   "run: bun run release:check",
   "for attempt in 1 2 3; do",
   `bun install failed on attempt \${attempt}; retrying in 15 seconds`,
-  "key: bun-electrobun-validate-$" + "{{ hashFiles('bun.lock') }}",
   "name: Ensure avatar assets",
   "node scripts/ensure-avatars.mjs",
   "Install quiet macOS packaging wrappers",
@@ -108,10 +107,17 @@ const requiredWorkflowSnippets = [
 const forbiddenWorkflowSnippets = [
   ' -name "*.exe" -o \\',
   'bun install -g "rcedit@4.0.1"',
+  "name: Cache Bun install",
+  "path: ~/.bun/install/cache",
   "restore-keys: bun-electrobun-validate-",
   "restore-keys: bun-electrobun-$" +
     "{{ matrix.platform.artifact-name }}" +
     "-",
+  "key: bun-electrobun-validate-$" + "{{ hashFiles('bun.lock') }}",
+  "key: bun-electrobun-$" +
+    "{{ matrix.platform.artifact-name }}" +
+    "-$" +
+    "{{ hashFiles('bun.lock') }}",
 ];
 const requiredElectrobunConfigSnippets = [
   'postBuild: "scripts/postwrap-sign-runtime-macos.ts"',


### PR DESCRIPTION
## Summary\n- remove Bun install cache restores from release validation and platform build jobs\n- keep the existing retry loop, but force each job to resolve dependencies from the checked-in lockfile\n- update workflow drift coverage so the release workflow cannot reintroduce Bun install caching\n\n## Testing\n- bunx vitest run scripts/electrobun-release-workflow-drift.test.ts\n- bunx @biomejs/biome check .github/workflows/release-electrobun.yml scripts/electrobun-release-workflow-drift.test.ts scripts/release-check.ts\n- bun run release:check