### PR TITLE
release: pin cloud agent template deps

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -332,9 +332,9 @@
     "deploy/cloud-agent-template": {
       "name": "milady-cloud-agent",
       "dependencies": {
-        "@elizaos/core": "alpha",
+        "@elizaos/core": "2.0.0-alpha.77",
         "@elizaos/plugin-elizacloud": "2.0.0-alpha.7",
-        "@elizaos/plugin-sql": "alpha",
+        "@elizaos/plugin-sql": "2.0.0-alpha.17",
         "tsx": "4.21.0",
       },
     },
@@ -3763,8 +3763,6 @@
     "md5.js/hash-base": ["hash-base@3.1.2", "", { "dependencies": { "inherits": "^2.0.4", "readable-stream": "^2.3.8", "safe-buffer": "^5.2.1", "to-buffer": "^1.2.1" } }, "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
-
-    "milady-cloud-agent/@elizaos/core": ["@elizaos/core@2.0.0-alpha.80", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "adze": "^2.2.5", "crypto-browserify": "^3.12.0", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-Ga0LI92fxS3XcnazagwUiWfo6iXRvuIKu+Ilkh9Crzx8H5xG+9U3bDngaUSzaFn9KrZyIVk4EuOIAqNsxZPRlg=="],
 
     "miller-rabin/bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
 

--- a/deploy/cloud-agent-template/package.json
+++ b/deploy/cloud-agent-template/package.json
@@ -6,8 +6,8 @@
     "start": "tsx entrypoint.ts"
   },
   "dependencies": {
-    "@elizaos/core": "alpha",
-    "@elizaos/plugin-sql": "alpha",
+    "@elizaos/core": "2.0.0-alpha.77",
+    "@elizaos/plugin-sql": "2.0.0-alpha.17",
     "@elizaos/plugin-elizacloud": "2.0.0-alpha.7",
     "tsx": "4.21.0"
   }

--- a/scripts/release-check.test.ts
+++ b/scripts/release-check.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   bundlesDependency,
+  findFloatingDependencySpecs,
   findLocalPackHotspots,
   hasLifecycleScriptReferencingMissingFile,
   isExactVersion,
@@ -95,6 +96,24 @@ describe("release-check package guards", () => {
     expect(isExactVersion("2.0.0-alpha.87")).toBe(true);
     expect(isExactVersion("0.0.1-beta.1")).toBe(true);
     expect(isExactVersion("3.2.1-rc.0")).toBe(true);
+  });
+
+  it("flags floating release dependencies in the cloud-agent template", () => {
+    expect(
+      findFloatingDependencySpecs(
+        {
+          dependencies: {
+            "@elizaos/core": "alpha",
+            "@elizaos/plugin-elizacloud": "2.0.0-alpha.7",
+            "@elizaos/plugin-sql": "^2.0.0-alpha.17",
+          },
+        },
+        ["@elizaos/core", "@elizaos/plugin-elizacloud", "@elizaos/plugin-sql"],
+      ),
+    ).toEqual([
+      { name: "@elizaos/core", specifier: "alpha" },
+      { name: "@elizaos/plugin-sql", specifier: "^2.0.0-alpha.17" },
+    ]);
   });
 
   it("accepts only strict semver specifiers for orchestrator release pins", () => {

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -139,6 +139,11 @@ type RootPackageJson = {
   files?: string[];
   scripts?: Record<string, string>;
 };
+const cloudAgentTemplateReleaseDependencies = [
+  "@elizaos/core",
+  "@elizaos/plugin-elizacloud",
+  "@elizaos/plugin-sql",
+] as const;
 
 /**
  * Returns true if the version specifier is an exact pinned version
@@ -287,6 +292,22 @@ export function hasLifecycleScriptReferencingMissingFile(
   return !pathExists(resolve(packageDir, relativeTarget));
 }
 
+export function findFloatingDependencySpecs(
+  pkg: RootPackageJson,
+  dependencyNames: readonly string[],
+): Array<{ name: string; specifier: string }> {
+  const dependencies = pkg.dependencies ?? {};
+
+  return dependencyNames.flatMap((name) => {
+    const specifier = dependencies[name];
+    if (!isExactVersionSpecifier(specifier)) {
+      return [{ name, specifier: specifier ?? "<missing>" }];
+    }
+
+    return [];
+  });
+}
+
 function readExistingReleaseCheckFile(
   label: string,
   candidates: readonly string[],
@@ -419,6 +440,26 @@ function assertOrchestratorVersionPinned() {
     console.error(
       `release-check: ${orchestratorPackageName} must be pinned to an exact version (e.g. "0.3.14"), but found "${version}". Floating tags like "next" or ranges like "^0.3.14" are not allowed for release builds.`,
     );
+    process.exit(1);
+  }
+}
+
+function assertCloudAgentTemplateDependenciesPinned() {
+  const cloudAgentPackage = JSON.parse(
+    readFileSync("deploy/cloud-agent-template/package.json", "utf8"),
+  ) as RootPackageJson;
+  const floating = findFloatingDependencySpecs(
+    cloudAgentPackage,
+    cloudAgentTemplateReleaseDependencies,
+  );
+
+  if (floating.length > 0) {
+    console.error(
+      "release-check: deploy/cloud-agent-template/package.json must pin release dependencies to exact versions.",
+    );
+    for (const dependency of floating) {
+      console.error(`  - ${dependency.name}: ${dependency.specifier}`);
+    }
     process.exit(1);
   }
 }
@@ -755,6 +796,7 @@ function main() {
   assertStartApiServerCatchBlockSafety();
   assertBundledAgentOrchestratorInstallFix();
   assertOrchestratorVersionPinned();
+  assertCloudAgentTemplateDependenciesPinned();
   const localHotspots = findLocalPackHotspots();
   if (shouldSkipExactPackDryRun(localHotspots)) {
     runFastLocalPackCheck(localHotspots);


### PR DESCRIPTION
## Summary\n- pin the cloud agent template's floating Eliza release dependencies to exact versions\n- regenerate bun.lock with Bun 1.3.9 so frozen installs stop mutating during release validation\n- add a release-check guard and unit coverage so floating template dependencies cannot regress\n\n## Testing\n- bunx -p bun@1.3.9 bun install --frozen-lockfile --ignore-scripts\n- bunx vitest run scripts/release-check.test.ts scripts/electrobun-release-workflow-drift.test.ts\n- bunx @biomejs/biome check deploy/cloud-agent-template/package.json scripts/release-check.ts scripts/release-check.test.ts .github/workflows/release-electrobun.yml scripts/electrobun-release-workflow-drift.test.ts\n- bun run release:check