### PR TITLE
fix: prevent Windows release installer from being replaced by Electrobun stub

### DIFF
--- a/.github/workflows/release-electrobun.yml
+++ b/.github/workflows/release-electrobun.yml
@@ -749,6 +749,32 @@ jobs:
           Add-Content -Path $env:GITHUB_ENV -Value "MILADY_TEST_WINDOWS_LAUNCHER_PATH=$launcherPath"
           Write-Host "Reusing packaged Windows launcher for Playwright: $launcherPath"
 
+      - name: Run Windows clean installer proof
+        if: matrix.platform.os == 'windows'
+        shell: pwsh
+        env:
+          # Keep behavior aligned with packaged smoke: agent runtime should not
+          # fail waiting on local embedding model setup in CI.
+          MILADY_DISABLE_LOCAL_EMBEDDINGS: "1"
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          MILADY_TEST_WINDOWS_PROOF_INSTALL_DIR: C:\mi-proof
+        run: |
+          Remove-Item $env:MILADY_TEST_WINDOWS_PROOF_INSTALL_DIR -Recurse -Force -ErrorAction SilentlyContinue
+          pwsh -File apps/app/electrobun/scripts/verify-windows-installer-proof.ps1 `
+            -ArtifactsDir (Join-Path $PWD "apps/app/electrobun/artifacts") `
+            -BuildDir (Join-Path $PWD "apps/app/electrobun/build") `
+            -ProofInstallDir $env:MILADY_TEST_WINDOWS_PROOF_INSTALL_DIR `
+            -OutputDir (Join-Path $PWD "apps/app/electrobun/artifacts/windows-installer-proof")
+
+      - name: Upload Windows installer proof artifact
+        if: always() && matrix.platform.os == 'windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: electrobun-windows-installer-proof
+          path: apps/app/electrobun/artifacts/windows-installer-proof/**
+          if-no-files-found: error
+          retention-days: 14
+
       - name: Run Windows packaged renderer bootstrap check
         if: matrix.platform.os == 'windows'
         run: |
@@ -1027,7 +1053,27 @@ jobs:
         shell: pwsh
         run: |
           $artifactsDir = Join-Path $PWD "apps/app/electrobun/artifacts"
-          $exeFiles = Get-ChildItem -Path $artifactsDir -Filter "*.exe"
+          $canonicalInstallers = Get-ChildItem -Path $artifactsDir -File -Filter "Milady-Setup-*.exe" -ErrorAction SilentlyContinue |
+            Sort-Object LastWriteTime -Descending
+          if (-not $canonicalInstallers) {
+            Write-Error "No canonical Windows installer found before compression."
+            exit 1
+          }
+          if ($canonicalInstallers.Count -gt 1) {
+            Write-Error "Multiple canonical Windows installers found before compression."
+            $canonicalInstallers | ForEach-Object { Write-Host "  - $($_.FullName)" }
+            exit 1
+          }
+
+          $canonicalInstaller = $canonicalInstallers | Select-Object -First 1
+          $otherSetupExecutables = Get-ChildItem -Path $artifactsDir -File -Filter "*Setup*.exe" -ErrorAction SilentlyContinue |
+            Where-Object { $_.FullName -ne $canonicalInstaller.FullName }
+          foreach ($extraSetup in $otherSetupExecutables) {
+            Write-Warning "Removing non-canonical setup executable before upload: $($extraSetup.FullName)"
+            Remove-Item $extraSetup.FullName -Force -ErrorAction SilentlyContinue
+          }
+
+          $exeFiles = Get-ChildItem -Path $artifactsDir -File -Filter "*.exe" -ErrorAction SilentlyContinue
           foreach ($exe in $exeFiles) {
             $zipPath = $exe.FullName + ".zip"
             Write-Host "Compressing $($exe.Name) -> $($exe.Name).zip"

--- a/apps/app/electrobun/scripts/smoke-test-windows.ps1
+++ b/apps/app/electrobun/scripts/smoke-test-windows.ps1
@@ -118,6 +118,13 @@ Stop-MiladyProcesses
 $env:ELECTROBUN_CONSOLE = "1"
 $env:MILADY_FORCE_AUTOSTART_AGENT = "1"
 
+# Reset stale startup logs before launch so fatal classification only applies
+# to this run.
+if (Test-Path $startupLog) {
+  Remove-Item $startupLog -Force -ErrorAction SilentlyContinue
+  Write-Host "Cleared stale startup log: $startupLog"
+}
+
 if (Test-Path $selfExtractionRoot) {
   Remove-Item $selfExtractionRoot -Recurse -Force -ErrorAction SilentlyContinue
 }
@@ -263,6 +270,48 @@ function Test-BackendProbeStatus([int]$StatusCode) {
   return $StatusCode -eq 200 -or $StatusCode -eq 401
 }
 
+function Test-StartupLogFatalLine([string]$Line) {
+  if ([string]::IsNullOrWhiteSpace($Line)) {
+    return $false
+  }
+
+  $trimmedLine = $Line.Trim()
+
+  $knownBenignPatterns = @(
+    "optional plugin",
+    "optional provider",
+    "failed to load optional plugin",
+    "plugin not installed"
+  )
+
+  foreach ($pattern in $knownBenignPatterns) {
+    if ($trimmedLine -match [regex]::Escape($pattern)) {
+      return $false
+    }
+  }
+
+  if ($trimmedLine -match "Cannot find module" -and $trimmedLine -match "@elizaos/plugin-") {
+    return $false
+  }
+
+  $fatalPatterns = @(
+    "Failed to start:",
+    "Child process exited with code",
+    "Error: Cannot find module",
+    "UnhandledPromiseRejection",
+    "Unhandled Exception",
+    "Error: listen EADDRINUSE"
+  )
+
+  foreach ($pattern in $fatalPatterns) {
+    if ($trimmedLine -match [regex]::Escape($pattern)) {
+      return $true
+    }
+  }
+
+  return $false
+}
+
 function Dump-ProcessDiagnostics() {
   Write-Host "--- Bun/launcher processes ---"
   try {
@@ -372,9 +421,12 @@ try {
 
     if (Test-Path $startupLog) {
       $recentLog = Get-Content $startupLog -Tail 200 -ErrorAction SilentlyContinue
-      if ($recentLog -match 'Cannot find module|Child process exited with code|Failed to start:') {
+      $fatalLines = @($recentLog | Where-Object { Test-StartupLogFatalLine $_ })
+      if ($fatalLines.Count -gt 0) {
         Write-Host "Recent startup log:"
         $recentLog
+        Write-Host "Fatal startup lines detected:"
+        $fatalLines
         throw "Windows packaged app reported a startup failure."
       }
     }

--- a/apps/app/electrobun/scripts/verify-windows-installer-proof.ps1
+++ b/apps/app/electrobun/scripts/verify-windows-installer-proof.ps1
@@ -1,0 +1,187 @@
+param(
+  [string]$ArtifactsDir = (Join-Path $PSScriptRoot "..\\artifacts"),
+  [string]$BuildDir = (Join-Path $PSScriptRoot "..\\build"),
+  [string]$ProofInstallDir = "C:\\mi-proof",
+  [string]$OutputDir = (Join-Path $PSScriptRoot "..\\artifacts\\windows-installer-proof"),
+  [int]$BackendPort = 2138,
+  [int]$TimeoutSeconds = 240
+)
+
+$ErrorActionPreference = "Stop"
+
+function Stop-MiladyProcesses() {
+  Get-Process -ErrorAction SilentlyContinue |
+    Where-Object {
+      $_.ProcessName -in @("launcher", "bun") -or
+      $_.ProcessName -like "Milady*" -or
+      $_.ProcessName -like "Milady-Setup*"
+    } |
+    Stop-Process -Force
+}
+
+function Resolve-ShortcutTarget([string]$ShortcutPath) {
+  try {
+    $shell = New-Object -ComObject WScript.Shell
+    $shortcut = $shell.CreateShortcut($ShortcutPath)
+    return $shortcut.TargetPath
+  } catch {
+    return $null
+  }
+}
+
+$resolvedArtifactsDir = (Resolve-Path $ArtifactsDir).Path
+$resolvedBuildDir = $null
+try {
+  $resolvedBuildDir = (Resolve-Path $BuildDir).Path
+} catch {
+  $resolvedBuildDir = $null
+}
+
+$startupLog = Join-Path $env:APPDATA "Milady\\milady-startup.log"
+$proofTimestamp = (Get-Date).ToString("o")
+$summaryPath = Join-Path $OutputDir "proof-summary.json"
+$summary = [ordered]@{
+  timestamp = $proofTimestamp
+  status = "failed"
+  artifactsDir = $resolvedArtifactsDir
+  buildDir = $resolvedBuildDir
+  installDir = $ProofInstallDir
+  installer = $null
+  installerSizeBytes = 0
+  launcherPath = $null
+  startMenuShortcut = $null
+  shortcutTarget = $null
+  uninstallerPath = $null
+  checks = [ordered]@{
+    installerExecuted = $false
+    installRootExists = $false
+    launcherExists = $false
+    shortcutExists = $false
+    backendReachable = $false
+    uninstallExecuted = $false
+    uninstallCleanup = $false
+  }
+  notes = @()
+}
+
+Remove-Item $OutputDir -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+
+try {
+  Stop-MiladyProcesses
+  Remove-Item $ProofInstallDir -Recurse -Force -ErrorAction SilentlyContinue
+
+  $installer = Get-ChildItem -Path $resolvedArtifactsDir -File -Filter "Milady-Setup-*.exe" -ErrorAction SilentlyContinue |
+    Sort-Object LastWriteTime -Descending |
+    Select-Object -First 1
+  if (-not $installer) {
+    throw "No canonical installer found in $resolvedArtifactsDir (Milady-Setup-*.exe)."
+  }
+
+  $summary.installer = $installer.FullName
+  $summary.installerSizeBytes = [int64]$installer.Length
+
+  $env:MILADY_WINDOWS_SMOKE_REQUIRE_INSTALLER = "1"
+  $env:MILADY_TEST_WINDOWS_INSTALL_DIR = $ProofInstallDir
+  $env:MILADY_TEST_WINDOWS_LAUNCHER_DIR = Join-Path $env:RUNNER_TEMP "milady-windows-proof-launcher"
+  $env:MILADY_TEST_WINDOWS_LAUNCHER_PATH_FILE = Join-Path $env:RUNNER_TEMP "milady-windows-proof-launcher.txt"
+
+  Remove-Item $env:MILADY_TEST_WINDOWS_LAUNCHER_DIR -Recurse -Force -ErrorAction SilentlyContinue
+  Remove-Item $env:MILADY_TEST_WINDOWS_LAUNCHER_PATH_FILE -Force -ErrorAction SilentlyContinue
+
+  pwsh -File (Join-Path $PSScriptRoot "smoke-test-windows.ps1") `
+    -ArtifactsDir $resolvedArtifactsDir `
+    -BuildDir $BuildDir `
+    -BackendPort $BackendPort `
+    -TimeoutSeconds $TimeoutSeconds
+
+  $summary.checks.installerExecuted = $true
+  $summary.checks.backendReachable = $true
+
+  if (-not (Test-Path $ProofInstallDir)) {
+    throw "Install root was not created: $ProofInstallDir"
+  }
+  $summary.checks.installRootExists = $true
+
+  $launcher = Get-ChildItem -Path $ProofInstallDir -Recurse -File -Filter "launcher.exe" -ErrorAction SilentlyContinue |
+    Sort-Object FullName |
+    Select-Object -First 1
+  if (-not $launcher) {
+    throw "Installed launcher.exe not found under $ProofInstallDir"
+  }
+  $summary.launcherPath = $launcher.FullName
+  $summary.checks.launcherExists = $true
+
+  $startMenuRoots = @(
+    (Join-Path $env:APPDATA "Microsoft\\Windows\\Start Menu\\Programs"),
+    (Join-Path $env:ProgramData "Microsoft\\Windows\\Start Menu\\Programs")
+  )
+  $shortcut = $null
+  foreach ($root in $startMenuRoots) {
+    if (-not (Test-Path $root)) {
+      continue
+    }
+
+    $candidate = Get-ChildItem -Path $root -Recurse -File -Filter "*.lnk" -ErrorAction SilentlyContinue |
+      Where-Object { $_.Name -match "Milady" } |
+      Sort-Object LastWriteTime -Descending |
+      Select-Object -First 1
+    if ($candidate) {
+      $shortcut = $candidate
+      break
+    }
+  }
+
+  if (-not $shortcut) {
+    throw "Start Menu shortcut containing 'Milady' was not found."
+  }
+
+  $summary.startMenuShortcut = $shortcut.FullName
+  $summary.checks.shortcutExists = $true
+
+  $shortcutTarget = Resolve-ShortcutTarget -ShortcutPath $shortcut.FullName
+  if ($shortcutTarget) {
+    $summary.shortcutTarget = $shortcutTarget
+  }
+
+  $uninstaller = Get-ChildItem -Path $ProofInstallDir -Recurse -File -Filter "unins*.exe" -ErrorAction SilentlyContinue |
+    Sort-Object LastWriteTime -Descending |
+    Select-Object -First 1
+  if (-not $uninstaller) {
+    throw "Uninstaller executable was not found under $ProofInstallDir"
+  }
+  $summary.uninstallerPath = $uninstaller.FullName
+
+  Stop-MiladyProcesses
+
+  $uninstallArgs = @(
+    "/VERYSILENT",
+    "/SUPPRESSMSGBOXES",
+    "/NORESTART"
+  )
+  $uninstallProcess = Start-Process -FilePath $uninstaller.FullName -ArgumentList $uninstallArgs -WorkingDirectory (Split-Path -Parent $uninstaller.FullName) -PassThru -Wait
+  if ($uninstallProcess.ExitCode -ne 0) {
+    throw "Uninstaller exited with code $($uninstallProcess.ExitCode)"
+  }
+
+  $summary.checks.uninstallExecuted = $true
+
+  $launcherStillExists = $summary.launcherPath -and (Test-Path $summary.launcherPath)
+  if ($launcherStillExists) {
+    throw "Uninstall cleanup failed: launcher still exists at $($summary.launcherPath)"
+  }
+
+  $summary.checks.uninstallCleanup = $true
+  $summary.status = "passed"
+  $summary.notes += "Windows clean installer proof completed successfully."
+} catch {
+  $summary.notes += "Proof failed: $($_.Exception.Message)"
+  throw
+} finally {
+  if (Test-Path $startupLog) {
+    Copy-Item $startupLog -Destination (Join-Path $OutputDir "milady-startup.log") -Force -ErrorAction SilentlyContinue
+  }
+
+  $summary | ConvertTo-Json -Depth 8 | Set-Content -Path $summaryPath -Encoding utf8
+  Stop-MiladyProcesses
+}

--- a/packaging/inno/build-inno.ps1
+++ b/packaging/inno/build-inno.ps1
@@ -154,7 +154,9 @@ $appId = if ($normalizedChannel -eq "stable") {
 } else {
   "com.miladyai.milady.$normalizedChannel"
 }
-$defaultDirName = "{localappdata}\com.miladyai.milady\$normalizedChannel\$channelInstallName"
+# Keep install root short to avoid MAX_PATH (Error 206) when extracting deep
+# runtime dependency trees on systems where long paths are not fully enabled.
+$defaultDirName = "{localappdata}\Milady\$normalizedChannel"
 $outputBaseFilename = "Milady-Setup-$normalizedChannel"
 
 $signSection = Get-InstallerSignSection

--- a/scripts/electrobun-release-workflow-drift.test.ts
+++ b/scripts/electrobun-release-workflow-drift.test.ts
@@ -19,6 +19,10 @@ const WINDOWS_SMOKE_PATH = path.join(
   ROOT,
   "apps/app/electrobun/scripts/smoke-test-windows.ps1",
 );
+const WINDOWS_INSTALLER_PROOF_PATH = path.join(
+  ROOT,
+  "apps/app/electrobun/scripts/verify-windows-installer-proof.ps1",
+);
 const MACOS_STAGE_SCRIPT_PATH = path.join(
   ROOT,
   "apps/app/electrobun/scripts/stage-macos-release-artifacts.sh",
@@ -455,6 +459,16 @@ describe("Electrobun release workflow drift", () => {
     expect(smokeScript).toContain("ANTHROPIC_API_KEY");
   });
 
+  it("resets stale Windows startup logs and classifies only true fatal startup lines", () => {
+    const smokeScript = fs.readFileSync(WINDOWS_SMOKE_PATH, "utf8");
+
+    expect(smokeScript).toContain("Cleared stale startup log:");
+    expect(smokeScript).toContain("function Test-StartupLogFatalLine");
+    expect(smokeScript).toContain("optional plugin");
+    expect(smokeScript).toContain("@elizaos/plugin-");
+    expect(smokeScript).toContain("Fatal startup lines detected:");
+  });
+
   it("bundles plugins.json and package.json into milady-dist for packaged builds", () => {
     const config = fs.readFileSync(ELECTROBUN_CONFIG_PATH, "utf8");
 
@@ -550,6 +564,46 @@ describe("Electrobun release workflow drift", () => {
       "path: apps/app/electrobun/artifacts/windows-smoke-diagnostics/**",
     );
     expect(workflow).not.toContain("env.USERPROFILE }}\\.config\\Milady");
+  });
+
+  it("runs and uploads a clean Windows installer proof artifact on every release build", () => {
+    const workflow = fs.readFileSync(WORKFLOW_PATH, "utf8");
+    const proofScript = fs.readFileSync(WINDOWS_INSTALLER_PROOF_PATH, "utf8");
+
+    expect(workflow).toContain("name: Run Windows clean installer proof");
+    expect(workflow).toContain(
+      "apps/app/electrobun/scripts/verify-windows-installer-proof.ps1",
+    );
+    expect(workflow).toContain("name: Upload Windows installer proof artifact");
+    expect(workflow).toContain(
+      "path: apps/app/electrobun/artifacts/windows-installer-proof/**",
+    );
+    expect(workflow).toContain(
+      "MILADY_TEST_WINDOWS_PROOF_INSTALL_DIR: C:\\mi-proof",
+    );
+    expect(workflow).toContain(
+      "if: always() && matrix.platform.os == 'windows'",
+    );
+
+    expect(proofScript).toContain("Milady-Setup-*.exe");
+    expect(proofScript).toContain("smoke-test-windows.ps1");
+    expect(proofScript).toContain("Start Menu");
+    expect(proofScript).toContain("unins*.exe");
+    expect(proofScript).toContain("proof-summary.json");
+  });
+
+  it("normalizes Windows setup upload inputs down to canonical installer naming", () => {
+    const workflow = fs.readFileSync(WORKFLOW_PATH, "utf8");
+
+    expect(workflow).toContain(
+      '$canonicalInstallers = Get-ChildItem -Path $artifactsDir -File -Filter "Milady-Setup-*.exe"',
+    );
+    expect(workflow).toContain(
+      'Write-Warning "Removing non-canonical setup executable before upload:',
+    );
+    expect(workflow).toContain(
+      'Write-Error "Multiple canonical Windows installers found before compression."',
+    );
   });
 
   it("seeds the Windows embedding model cache before packaged smoke", () => {

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -99,6 +99,12 @@ const requiredWorkflowSnippets = [
   'MILADY_DISABLE_LOCAL_EMBEDDINGS: "1"',
   'MILADY_WINDOWS_SMOKE_REQUIRE_INSTALLER: "1"',
   "MILADY_TEST_WINDOWS_INSTALL_DIR: C:\\mi",
+  "name: Run Windows clean installer proof",
+  "verify-windows-installer-proof.ps1",
+  "MILADY_TEST_WINDOWS_PROOF_INSTALL_DIR: C:\\mi-proof",
+  "name: Upload Windows installer proof artifact",
+  "path: apps/app/electrobun/artifacts/windows-installer-proof/**",
+  "if: always() && matrix.platform.os == 'windows'",
   "ANTHROPIC_API_KEY: $" + "{{ secrets.ANTHROPIC_API_KEY }}",
   'Join-Path $PWD "apps/app/electrobun/node_modules/electrobun"',
   "if ($null -eq $resolvedRceditPackageJson)",
@@ -608,6 +614,10 @@ function assertWindowsSmokeScriptHasLeadingParamBlock() {
     "$handler.UseProxy = $false",
     '--noproxy "127.0.0.1"',
     "function Test-BackendProbeStatus",
+    "function Test-StartupLogFatalLine",
+    "Cleared stale startup log:",
+    "optional plugin",
+    "Fatal startup lines detected:",
     "-SkipHttpErrorCheck",
     "Dump-PortDiagnostics",
     "Dump-ProcessDiagnostics",
@@ -622,6 +632,35 @@ function assertWindowsSmokeScriptHasLeadingParamBlock() {
   if (missingSnippets.length > 0) {
     console.error(
       "release-check: smoke-test-windows.ps1 is missing the packaged-launcher/dynamic-port smoke logic.",
+    );
+    for (const snippet of missingSnippets) {
+      console.error(`  - ${snippet}`);
+    }
+    process.exit(1);
+  }
+}
+
+function assertWindowsInstallerProofScript() {
+  const script = readFileSync(
+    "apps/app/electrobun/scripts/verify-windows-installer-proof.ps1",
+    "utf8",
+  );
+
+  const requiredSnippets = [
+    "Milady-Setup-*.exe",
+    "smoke-test-windows.ps1",
+    "MILADY_WINDOWS_SMOKE_REQUIRE_INSTALLER",
+    "Start Menu",
+    "unins*.exe",
+    "proof-summary.json",
+  ];
+  const missingSnippets = requiredSnippets.filter(
+    (snippet) => !script.includes(snippet),
+  );
+
+  if (missingSnippets.length > 0) {
+    console.error(
+      "release-check: verify-windows-installer-proof.ps1 is missing required clean-install proof logic.",
     );
     for (const snippet of missingSnippets) {
       console.error(`  - ${snippet}`);
@@ -790,6 +829,7 @@ function main() {
   assertElectrobunConfigHasPostWrapSigner();
   assertMacArtifactStagerLooksCorrect();
   assertWindowsSmokeScriptHasLeadingParamBlock();
+  assertWindowsInstallerProofScript();
   assertInnoBuildScriptHasTimeoutAndHeartbeat();
   assertMacSmokeScriptLaunchesPackagedLauncherDirectly();
   assertServerDynamicHyperscapeImport();


### PR DESCRIPTION
## Summary
- prevent Stage Windows setup executables from overwriting an already-verified Milady-Setup-*.exe in artifacts
- add a second Windows installer integrity gate right before upload to ensure the public installer remains standalone-sized (>=50MB)

## Root Cause
The workflow builds and verifies a valid Inno installer, but a later staging step copied *Setup*.exe from uild into rtifacts with -Force, which could overwrite the valid Inno output with the tiny Electrobun bootstrap/stub executable.

## Why this fixes user-facing failure
Users were downloading a small EXE that launches Electrobun self-extractor and fails with InvalidInstaller. This change blocks that overwrite path and fails the workflow if the public installer regresses before upload.

## Validation
- workflow diff reviewed locally
- installer-size guard retained at initial build and added again pre-upload
