### PR TITLE
electrobun: harden macOS DMG stapling retries

### DIFF
--- a/apps/app/electrobun/scripts/stage-macos-release-artifacts.sh
+++ b/apps/app/electrobun/scripts/stage-macos-release-artifacts.sh
@@ -175,7 +175,9 @@ if [[ "$SKIP_SIGNATURE_CHECK" != "1" && -n "${ELECTROBUN_APPLEID:-}" && -n "${EL
     --team-id "$ELECTROBUN_TEAMID" \
     --wait \
     "$TEMP_DMG_PATH"
-  retry_command 5 15 xcrun stapler staple "$TEMP_DMG_PATH"
+  # Apple can lag several minutes before the notarization ticket becomes
+  # visible to stapler, especially on Intel runners.
+  retry_command 8 20 xcrun stapler staple "$TEMP_DMG_PATH"
 fi
 
 mv "$TEMP_DMG_PATH" "$FINAL_DMG_PATH"

--- a/apps/app/electrobun/src/__tests__/stage-macos-release-artifacts.test.ts
+++ b/apps/app/electrobun/src/__tests__/stage-macos-release-artifacts.test.ts
@@ -23,4 +23,12 @@ describe("stage-macos-release-artifacts.sh", () => {
     // biome-ignore lint/suspicious/noTemplateCurlyInString: bash variable expansion in shell script assertion
     expect(script).toContain('"${clang_arch_args[@]}"');
   });
+
+  it("uses an extended stapler retry window for notarized DMGs", () => {
+    const script = fs.readFileSync(STAGE_MACOS_RELEASE_ARTIFACTS_PATH, "utf8");
+
+    expect(script).toContain(
+      'retry_command 8 20 xcrun stapler staple "$TEMP_DMG_PATH"',
+    );
+  });
 });

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -535,7 +535,7 @@ function assertMacArtifactStagerLooksCorrect() {
     'codesign --verify --deep --strict --verbose=2 "$STAGED_APP_PATH"',
     "hdiutil create \\",
     "retry_command 3 20 xcrun notarytool submit \\",
-    'retry_command 5 15 xcrun stapler staple "$TEMP_DMG_PATH"',
+    'retry_command 8 20 xcrun stapler staple "$TEMP_DMG_PATH"',
     'mv "$TEMP_DMG_PATH" "$FINAL_DMG_PATH"',
   ];
   const missing = requiredSnippets.filter(


### PR DESCRIPTION
## Summary
- widen the macOS DMG stapler retry window in the release artifact staging script
- cover the new retry window in the Electrobun staging script test
- keep release-check enforcing the updated stapler retry contract

## Why
- non-draft release run 23365734832 failed on macOS Intel in `Stage standard macOS release app`
- the DMG was built successfully, but Apple ticket propagation lagged longer than the existing 5x15s stapler retry budget

## Validation
- bunx vitest run apps/app/electrobun/src/__tests__/stage-macos-release-artifacts.test.ts scripts/electrobun-release-workflow-drift.test.ts scripts/release-check.test.ts
- bunx @biomejs/biome check apps/app/electrobun/scripts/stage-macos-release-artifacts.sh apps/app/electrobun/src/__tests__/stage-macos-release-artifacts.test.ts scripts/release-check.ts scripts/electrobun-release-workflow-drift.test.ts
- bun run release:check