### PR TITLE
electrobun: fix windows packaged bootstrap check

### DIFF
--- a/apps/app/test/electrobun-packaged/electrobun-windows-startup.e2e.spec.ts
+++ b/apps/app/test/electrobun-packaged/electrobun-windows-startup.e2e.spec.ts
@@ -7,6 +7,7 @@ import { promisify } from "node:util";
 import { expect, test } from "@playwright/test";
 
 import { type MockApiServer, startMockApiServer } from "./mock-api";
+import { hasPackagedRendererBootstrapRequests } from "./windows-bootstrap";
 
 const execFileAsync = promisify(execFile);
 const here = path.dirname(fileURLToPath(import.meta.url));
@@ -151,7 +152,7 @@ async function waitForRendererBootstrap(
       );
     }
 
-    if (api.requests.some((request) => request.includes("/api/status"))) {
+    if (hasPackagedRendererBootstrapRequests(api.requests)) {
       return;
     }
 
@@ -226,14 +227,14 @@ test("packaged Windows app bootstraps the renderer against the external API over
     await expect
       .poll(
         () =>
-          api?.requests.filter((request) => request.includes("/api/status"))
-            .length ?? 0,
+          api ? hasPackagedRendererBootstrapRequests(api.requests) : false,
         {
           timeout: 30_000,
-          message: "Expected the packaged renderer to poll /api/status",
+          message:
+            "Expected the packaged renderer to reach the external API bootstrap requests",
         },
       )
-      .toBeGreaterThan(0);
+      .toBe(true);
 
     await expect
       .poll(
@@ -247,9 +248,7 @@ test("packaged Windows app bootstraps the renderer against the external API over
       )
       .toBe("running");
 
-    expect(
-      api.requests.some((request) => request.includes("/api/status")),
-    ).toBe(true);
+    expect(hasPackagedRendererBootstrapRequests(api.requests)).toBe(true);
     expect(api.requests.length).toBeGreaterThan(0);
 
     const stdoutText = processLogs?.stdout.join("") ?? "";

--- a/apps/app/test/electrobun-packaged/windows-bootstrap.test.ts
+++ b/apps/app/test/electrobun-packaged/windows-bootstrap.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { hasPackagedRendererBootstrapRequests } from "./windows-bootstrap";
+
+describe("hasPackagedRendererBootstrapRequests", () => {
+  it("accepts the legacy /api/status startup marker", () => {
+    expect(
+      hasPackagedRendererBootstrapRequests([
+        "GET /api/triggers",
+        "GET /api/status",
+      ]),
+    ).toBe(true);
+  });
+
+  it("accepts the current renderer bootstrap sequence via drop status", () => {
+    expect(
+      hasPackagedRendererBootstrapRequests([
+        "GET /api/triggers",
+        "GET /api/triggers/health",
+        "GET /api/drop/status",
+        "GET /api/config",
+      ]),
+    ).toBe(true);
+  });
+
+  it("accepts the current renderer bootstrap sequence via stream settings", () => {
+    expect(
+      hasPackagedRendererBootstrapRequests([
+        "GET /api/config",
+        "POST /api/stream/settings",
+      ]),
+    ).toBe(true);
+  });
+
+  it("rejects main-process heartbeat traffic on its own", () => {
+    expect(
+      hasPackagedRendererBootstrapRequests([
+        "GET /api/triggers",
+        "GET /api/triggers/health",
+      ]),
+    ).toBe(false);
+  });
+
+  it("rejects config-only traffic without a renderer-owned follow-up", () => {
+    expect(hasPackagedRendererBootstrapRequests(["GET /api/config"])).toBe(
+      false,
+    );
+  });
+});

--- a/apps/app/test/electrobun-packaged/windows-bootstrap.ts
+++ b/apps/app/test/electrobun-packaged/windows-bootstrap.ts
@@ -1,0 +1,21 @@
+function hasRequestForPath(
+  requests: readonly string[],
+  pathname: string,
+): boolean {
+  return requests.some((request) => request.endsWith(` ${pathname}`));
+}
+
+export function hasPackagedRendererBootstrapRequests(
+  requests: readonly string[],
+): boolean {
+  if (hasRequestForPath(requests, "/api/status")) {
+    return true;
+  }
+
+  const sawConfig = hasRequestForPath(requests, "/api/config");
+  const sawRendererOwnedBootstrapRequest =
+    hasRequestForPath(requests, "/api/drop/status") ||
+    hasRequestForPath(requests, "/api/stream/settings");
+
+  return sawConfig && sawRendererOwnedBootstrapRequest;
+}

--- a/scripts/electrobun-release-workflow-drift.test.ts
+++ b/scripts/electrobun-release-workflow-drift.test.ts
@@ -39,6 +39,10 @@ const WINDOWS_PACKAGED_TEST_PATH = path.join(
   ROOT,
   "apps/app/test/electrobun-packaged/electrobun-windows-startup.e2e.spec.ts",
 );
+const WINDOWS_PACKAGED_BOOTSTRAP_HELPER_PATH = path.join(
+  ROOT,
+  "apps/app/test/electrobun-packaged/windows-bootstrap.ts",
+);
 const INNO_BUILD_SCRIPT_PATH = path.join(ROOT, "packaging/inno/build-inno.ps1");
 const ELECTROBUN_CONFIG_PATH = path.join(
   ROOT,
@@ -566,11 +570,22 @@ describe("Electrobun release workflow drift", () => {
       WINDOWS_PACKAGED_TEST_PATH,
       "utf8",
     );
+    const windowsBootstrapHelper = fs.readFileSync(
+      WINDOWS_PACKAGED_BOOTSTRAP_HELPER_PATH,
+      "utf8",
+    );
 
     expect(windowsPackagedTest).toContain(
       "MILADY_DESKTOP_TEST_API_BASE: api.baseUrl",
     );
-    expect(windowsPackagedTest).toContain('request.includes("/api/status")');
+    expect(windowsPackagedTest).toContain('from "./windows-bootstrap"');
+    expect(windowsPackagedTest).toContain(
+      "hasPackagedRendererBootstrapRequests(api.requests)",
+    );
+    expect(windowsBootstrapHelper).toContain('"/api/status"');
+    expect(windowsBootstrapHelper).toContain('"/api/config"');
+    expect(windowsBootstrapHelper).toContain('"/api/drop/status"');
+    expect(windowsBootstrapHelper).toContain('"/api/stream/settings"');
     expect(windowsPackagedTest).toContain("waitForRendererBootstrap");
     expect(windowsPackagedTest).not.toContain("chromium.connectOverCDP");
     expect(windowsPackagedTest).not.toContain("--remote-debugging-port");


### PR DESCRIPTION
## Summary\n- accept the current packaged Windows renderer bootstrap request sequence instead of only /api/status\n- add a deterministic unit test for the bootstrap request predicate\n- keep the release workflow drift test aligned with the packaged bootstrap helper\n\n## Testing\n- bunx vitest run apps/app/test/electrobun-packaged/windows-bootstrap.test.ts scripts/electrobun-release-workflow-drift.test.ts\n- bun run release:check