### PR TITLE
milady: fix vite config character catalog import

### DIFF
--- a/apps/app/test/app/vite-config.test.ts
+++ b/apps/app/test/app/vite-config.test.ts
@@ -1,0 +1,46 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadConfigFromFile } from "vite";
+import { describe, expect, it } from "vitest";
+
+const TEST_DIR = fileURLToPath(new URL(".", import.meta.url));
+const APP_DIR = path.resolve(TEST_DIR, "../..");
+const CONFIG_PATH = path.join(APP_DIR, "vite.config.ts");
+
+function getPluginNames(plugins: unknown[]): string[] {
+  const names: string[] = [];
+
+  for (const plugin of plugins) {
+    if (Array.isArray(plugin)) {
+      names.push(...getPluginNames(plugin));
+      continue;
+    }
+
+    if (
+      plugin &&
+      typeof plugin === "object" &&
+      "name" in plugin &&
+      typeof plugin.name === "string"
+    ) {
+      names.push(plugin.name);
+    }
+  }
+
+  return names;
+}
+
+describe("app vite config", () => {
+  it("loads through Vite's bundled config loader", async () => {
+    const loaded = await loadConfigFromFile(
+      { command: "build", mode: "test" },
+      CONFIG_PATH,
+      APP_DIR,
+    );
+
+    expect(loaded).not.toBeNull();
+
+    const pluginNames = getPluginNames(loaded?.config.plugins ?? []);
+    expect(pluginNames).toContain("public-src");
+    expect(pluginNames).toContain("desktop-cors");
+  });
+});

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -1,11 +1,14 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { MILADY_CHARACTER_ASSETS } from "@miladyai/app-core/character-catalog";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react-swc";
 import type { Plugin } from "vite";
 import { defineConfig } from "vite";
+// Keep this as a workspace-relative import so Vite transpiles the TS module
+// while bundling the config instead of asking Node to load a package-exported
+// .ts file directly in CI.
+import { MILADY_CHARACTER_ASSETS } from "../../packages/app-core/src/character-catalog.ts";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const miladyRoot = path.resolve(here, "../..");


### PR DESCRIPTION
## Summary
- fix the app Vite config to load the character catalog through a workspace-relative source import
- add a regression test that loads the config through Vite's bundled config loader
- unblock the CI build path used by the end-to-end validation workflow

## Validation
- bun run build
- bunx vitest run --config vitest.unit.config.ts apps/app/test/app/vite-config.test.ts
- bun run pre-review:local