### PR TITLE
fix(electrobun): enable browser surface by default

### DIFF
--- a/apps/app/electrobun/src/browser-surface-flag.test.ts
+++ b/apps/app/electrobun/src/browser-surface-flag.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { isBrowserSurfaceEnabled } from "./browser-surface-flag";
+
+describe("isBrowserSurfaceEnabled", () => {
+  it("defaults to enabled when unset", () => {
+    expect(isBrowserSurfaceEnabled({})).toBe(true);
+  });
+
+  it.each([
+    "0",
+    "false",
+    "no",
+    "off",
+  ])("disables the browser surface for %s", (value) => {
+    expect(
+      isBrowserSurfaceEnabled({ MILADY_ENABLE_BROWSER_SURFACE: value }),
+    ).toBe(false);
+  });
+
+  it.each([
+    "1",
+    "true",
+    "yes",
+    "on",
+  ])("keeps the browser surface enabled for %s", (value) => {
+    expect(
+      isBrowserSurfaceEnabled({ MILADY_ENABLE_BROWSER_SURFACE: value }),
+    ).toBe(true);
+  });
+});

--- a/apps/app/electrobun/src/browser-surface-flag.ts
+++ b/apps/app/electrobun/src/browser-surface-flag.ts
@@ -1,0 +1,12 @@
+export function isBrowserSurfaceEnabled(
+  env: Record<string, string | undefined>,
+): boolean {
+  const normalized = env.MILADY_ENABLE_BROWSER_SURFACE?.trim().toLowerCase();
+
+  return !(
+    normalized === "0" ||
+    normalized === "false" ||
+    normalized === "no" ||
+    normalized === "off"
+  );
+}

--- a/apps/app/electrobun/src/index.ts
+++ b/apps/app/electrobun/src/index.ts
@@ -29,6 +29,7 @@ import {
   parseSettingsWindowAction,
 } from "./application-menu";
 import { showBackgroundNoticeOnce } from "./background-notice";
+import { isBrowserSurfaceEnabled } from "./browser-surface-flag";
 import {
   type CloudAuthWindowLike,
   CloudAuthWindowManager,
@@ -71,10 +72,12 @@ type HeartbeatMenuHealthResponse = {
 
 const HEARTBEAT_MENU_REFRESH_MS = 30_000;
 const CONFIG_EXPORT_FILE_NAME = "milady-config.json";
-// Browser surface stays off by default until the packaged WebGPU/browser path
-// is hardened across the supported desktop release targets.
-const BROWSER_SURFACE_ENABLED =
-  process.env.MILADY_ENABLE_BROWSER_SURFACE === "1";
+// Browser surface ships enabled by default. Set
+// MILADY_ENABLE_BROWSER_SURFACE=0 to force-disable it for local debugging or
+// release triage.
+const BROWSER_SURFACE_ENABLED = isBrowserSurfaceEnabled(
+  process.env as Record<string, string | undefined>,
+);
 let heartbeatMenuSnapshot: HeartbeatMenuSnapshot =
   EMPTY_HEARTBEAT_MENU_SNAPSHOT;
 let heartbeatMenuRefreshTimer: ReturnType<typeof setInterval> | null = null;


### PR DESCRIPTION
## Summary
- enable the Electrobun browser surface by default in the desktop main process
- keep an explicit env opt-out via `MILADY_ENABLE_BROWSER_SURFACE=0`
- add a narrow regression test for the browser-surface flag parser

## Why
- browser commands and detached-surface routing were already wired in the renderer and RPC layer
- the main process still defaulted the browser surface off and reported it as disabled, which kept the native menu/status out of sync with the rest of the app

## Validation
- `bunx vitest run apps/app/electrobun/src/browser-surface-flag.test.ts apps/app/electrobun/src/__tests__/application-menu.test.ts packages/app-core/src/chat/index.test.ts packages/app-core/src/utils/desktop-workspace.test.ts packages/app-core/src/components/DesktopWorkspaceSection.test.tsx`
- `bun run check`