### PR TITLE
fix(app-core): stabilize browser surface webview

### DIFF
--- a/packages/app-core/src/components/BrowserSurfaceWindow.test.ts
+++ b/packages/app-core/src/components/BrowserSurfaceWindow.test.ts
@@ -60,12 +60,17 @@ describe("BrowserSurfaceWindow", () => {
     const getSpy = vi
       .spyOn(window.customElements, "get")
       .mockImplementation((name: string) =>
-        name === "electrobun-webview" ? FakeElectrobunWebview : originalGet(name),
+        name === "electrobun-webview"
+          ? FakeElectrobunWebview
+          : originalGet(name),
       );
     const originalCreateElement = document.createElement.bind(document);
     const createSpy = vi
       .spyOn(document, "createElement")
-      .mockImplementation(((tagName: string, options?: ElementCreationOptions) =>
+      .mockImplementation(((
+        tagName: string,
+        options?: ElementCreationOptions,
+      ) =>
         originalCreateElement(
           tagName === "electrobun-webview" ? elementName : tagName,
           options,

--- a/packages/app-core/src/components/BrowserSurfaceWindow.tsx
+++ b/packages/app-core/src/components/BrowserSurfaceWindow.tsx
@@ -107,7 +107,12 @@ export function BrowserSurfaceWindow() {
       webview.off("dom-ready", handleDomReady);
       webview.off("new-window-open", handleNewWindowOpen);
     };
-  }, [applyNavigationUrl, navigateTo, syncNavigationState, webviewTagAvailable]);
+  }, [
+    applyNavigationUrl,
+    navigateTo,
+    syncNavigationState,
+    webviewTagAvailable,
+  ]);
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -201,8 +206,7 @@ export function BrowserSurfaceWindow() {
           })
         ) : (
           <div className="flex flex-1 items-center justify-center bg-black/5 px-6 text-center text-sm text-muted">
-            Browser surface is only available in the Electrobun desktop
-            runtime.
+            Browser surface is only available in the Electrobun desktop runtime.
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- stop the detached browser surface from crashing on mount in the native Electrobun runtime
- guard the browser surface when the custom webview tag is unavailable
- add a regression that proves typed URL entry drives the webview

## Root cause
- `BrowserSurfaceWindow` passed `sandbox=""` into Electrobun's `electrobun-webview` custom element
- Electrobun exposes `sandbox` as a getter-only property on that element, so React's prop assignment raised `Attempted to assign to readonly property`

## Live verification
- launched `Milady-dev` locally from this branch
- opened `Browser > Open Browser Window`
- typed `https://example.com` into the browser address field with real keystrokes
- confirmed the runtime logged `loadURLInWebView: webview 3 loading URL: https://example.com/`
- confirmed the browser window status bar and address field updated to `https://example.com/`

## Validation
- `bunx vitest run packages/app-core/src/components/BrowserSurfaceWindow.test.ts apps/app/electrobun/src/browser-surface-flag.test.ts apps/app/electrobun/src/__tests__/application-menu.test.ts packages/app-core/src/chat/index.test.ts packages/app-core/src/utils/desktop-workspace.test.ts`
- `bun run check`