### PR TITLE
fix(api): require auth for wallet key export

### DIFF
--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -617,11 +617,6 @@ function ensureCompatSensitiveRouteAuthorized(
   req: Pick<http.IncomingMessage, "headers">,
   res: http.ServerResponse,
 ): boolean {
-  const env = process.env.NODE_ENV;
-  if (env === "development" || env === "dev") {
-    return true;
-  }
-
   if (!getCompatApiToken()) {
     sendJsonErrorResponse(
       res,

--- a/packages/app-core/src/api/server.wallet-keys.test.ts
+++ b/packages/app-core/src/api/server.wallet-keys.test.ts
@@ -141,25 +141,29 @@ describe("GET /api/wallet/keys", () => {
     }
   });
 
-  it("rejects loopback requests without a token during active onboarding", async () => {
-    await fs.writeFile(
-      path.join(tempDir, "eliza.json"),
-      JSON.stringify({
-        meta: { onboardingComplete: false },
-        logging: { level: "error" },
-      }),
-    );
+  it.each(["production", "development"])(
+    "rejects loopback requests without a token during active onboarding in %s",
+    async (nodeEnv) => {
+      process.env.NODE_ENV = nodeEnv;
+      await fs.writeFile(
+        path.join(tempDir, "eliza.json"),
+        JSON.stringify({
+          meta: { onboardingComplete: false },
+          logging: { level: "error" },
+        }),
+      );
 
-    const server = await startApiServer({ port: 0, runtime: RUNTIME_STUB });
-    try {
-      // Sensitive routes require an API token even for loopback requests.
-      // Without ELIZA_API_TOKEN / MILADY_API_TOKEN the server returns 403.
-      const { status } = await req(server.port, "GET", "/api/wallet/keys");
-      expect(status).toBe(403);
-    } finally {
-      await server.close();
-    }
-  });
+      const server = await startApiServer({ port: 0, runtime: RUNTIME_STUB });
+      try {
+        // Sensitive routes require an API token even for loopback requests.
+        // Without ELIZA_API_TOKEN / MILADY_API_TOKEN the server returns 403.
+        const { status } = await req(server.port, "GET", "/api/wallet/keys");
+        expect(status).toBe(403);
+      } finally {
+        await server.close();
+      }
+    },
+  );
 
   it("returns 200 with a valid auth token during onboarding", async () => {
     await fs.writeFile(


### PR DESCRIPTION
## Summary
- remove the dev-only auth bypass for `GET /api/wallet/keys`
- keep wallet key export token-protected during onboarding in every environment
- add a regression covering both `production` and `development`

## Testing
- `bunx vitest run packages/app-core/src/api/server.wallet-keys.test.ts packages/app-core/src/api/auth-routes.test.ts packages/app-core/src/api/server.websocket-auth.test.ts`
- `bun run check`
- `bun run pre-review:local`