### PR TITLE
fix: restore windows avatar startup and electrobun release checks

### DIFF
--- a/.github/workflows/release-electrobun.yml
+++ b/.github/workflows/release-electrobun.yml
@@ -22,6 +22,27 @@ on:
   push:
     tags:
       - "v*"
+  workflow_call:
+    inputs:
+      tag:
+        description: "Release tag override (e.g. v2.0.0-alpha.3)"
+        required: false
+        type: string
+      draft:
+        description: "Create the GitHub release as a draft"
+        required: false
+        type: boolean
+        default: false
+      publish_release:
+        description: "Create the GitHub release and upload updater files"
+        required: false
+        type: boolean
+        default: false
+      publish_docker:
+        description: "Publish the Docker image after the release step"
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       tag:
@@ -107,6 +128,19 @@ jobs:
 
       - name: Run repository postinstall patches
         run: bun run postinstall
+
+      - name: Prepare Whisper model artifact
+        run: |
+          bash apps/app/electrobun/scripts/ensure-whisper-model.sh base.en
+          mkdir -p .artifacts/whisper-model
+          cp "$HOME/.cache/milady/whisper/ggml-base.en.bin" .artifacts/whisper-model/ggml-base.en.bin
+
+      - name: Upload Whisper model artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: whisper-model-base-en
+          path: .artifacts/whisper-model/ggml-base.en.bin
+          if-no-files-found: error
 
       - name: Align version with release tag
         run: node scripts/align-electrobun-version.mjs
@@ -208,8 +242,21 @@ jobs:
             ~/.cache/milady/whisper
             node_modules/whisper-node/lib/whisper.cpp/main
             node_modules/whisper-node/lib/whisper.cpp/build
-          key: whisper-${{ matrix.platform.artifact-name }}-${{ hashFiles('apps/app/electrobun/scripts/build-whisper.sh', 'apps/app/electrobun/scripts/build-whisper-universal.sh') }}
+          key: whisper-${{ matrix.platform.artifact-name }}-${{ hashFiles('apps/app/electrobun/scripts/build-whisper.sh', 'apps/app/electrobun/scripts/build-whisper-universal.sh', 'apps/app/electrobun/scripts/ensure-whisper-model.sh') }}
           restore-keys: whisper-${{ matrix.platform.artifact-name }}-
+
+      - name: Download Whisper model artifact
+        if: matrix.platform.os == 'macos' || matrix.platform.os == 'linux'
+        uses: actions/download-artifact@v4
+        with:
+          name: whisper-model-base-en
+          path: .artifacts/whisper-model
+
+      - name: Seed Whisper model cache
+        if: matrix.platform.os == 'macos' || matrix.platform.os == 'linux'
+        run: |
+          mkdir -p "$HOME/.cache/milady/whisper"
+          cp .artifacts/whisper-model/ggml-base.en.bin "$HOME/.cache/milady/whisper/ggml-base.en.bin"
 
       - name: Align version with release tag
         run: node scripts/align-electrobun-version.mjs
@@ -1112,6 +1159,7 @@ jobs:
 
   release:
     name: Create Release
+    if: ${{ github.event_name != 'workflow_call' || inputs.publish_release }}
     needs: [prepare, build]
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
@@ -1220,6 +1268,7 @@ jobs:
 
   publish-docker:
     name: Publish Docker Image
+    if: ${{ github.event_name != 'workflow_call' || inputs.publish_docker }}
     needs: [prepare, release]
     permissions:
       contents: read

--- a/.github/workflows/test-electrobun-release.yml
+++ b/.github/workflows/test-electrobun-release.yml
@@ -10,7 +10,8 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  contents: write
+  packages: write
 
 jobs:
   electrobun-release:

--- a/.github/workflows/test-electrobun-release.yml
+++ b/.github/workflows/test-electrobun-release.yml
@@ -1,0 +1,22 @@
+name: Test Electrobun Release
+
+on:
+  pull_request:
+    branches: [main, develop]
+  workflow_dispatch:
+
+concurrency:
+  group: test-electrobun-release-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  electrobun-release:
+    uses: ./.github/workflows/release-electrobun.yml
+    with:
+      draft: false
+      publish_release: false
+      publish_docker: false
+    secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -229,10 +229,10 @@ jobs:
           packages/app-core/test/app/startup-backend-missing.e2e.test.ts
           packages/app-core/test/app/startup-token-401.e2e.test.ts
 
-  # Desktop build/packaging validation lives in release-electrobun.yml.
-  # The old electron-ui-e2e and electron-packaged-dmg-e2e jobs were removed
-  # after the Electrobun migration — they were always-skipped on PRs
-  # (gated on refs/tags/v) and duplicated work the release workflow does.
+  # Desktop build/packaging validation now runs in test-electrobun-release.yml
+  # on pull requests, and in release-electrobun.yml for tagged releases.
+  # The old electron-ui-e2e and electron-packaged-dmg-e2e jobs remain removed
+  # after the Electrobun migration.
 
   cloud-live-e2e:
     name: Cloud Live E2E (Eliza Cloud)

--- a/apps/app/electrobun/scripts/build-whisper-universal.sh
+++ b/apps/app/electrobun/scripts/build-whisper-universal.sh
@@ -60,23 +60,8 @@ echo "[whisper-universal] Result: $(file main)"
 lipo -detailed_info main
 echo ""
 
-# --- Download model if not already present ---
-mkdir -p "$WHISPER_MODEL_DIR"
-mkdir -p "$WHISPER_MODEL_CACHE_DIR"
-
-if [ -f "$WHISPER_MODEL_PATH" ]; then
-  echo "[whisper-universal] === Whisper model already present: $WHISPER_MODEL_PATH ==="
-elif [ -f "$WHISPER_MODEL_CACHE_PATH" ]; then
-  echo "[whisper-universal] === Restoring whisper model from cache: $WHISPER_MODEL_CACHE_PATH ==="
-  cp "$WHISPER_MODEL_CACHE_PATH" "$WHISPER_MODEL_PATH"
-else
-  echo "[whisper-universal] === Downloading model: $WHISPER_MODEL_FILENAME ==="
-  bash models/download-ggml-model.sh "$MODEL"
-fi
-
-if [ -f "$WHISPER_MODEL_PATH" ]; then
-  cp "$WHISPER_MODEL_PATH" "$WHISPER_MODEL_CACHE_PATH"
-fi
+# --- Ensure model is available ---
+bash "$SCRIPT_DIR/ensure-whisper-model.sh" "$MODEL"
 
 # --- Verify both slices execute ---
 echo "[whisper-universal] === Verifying arm64 execution ==="

--- a/apps/app/electrobun/scripts/build-whisper.sh
+++ b/apps/app/electrobun/scripts/build-whisper.sh
@@ -10,7 +10,8 @@
 set -euo pipefail
 
 MODEL="${1:-base.en}"
-WHISPER_DIR="$(cd "$(dirname "$0")/../../../.." && pwd)/node_modules/whisper-node/lib/whisper.cpp"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WHISPER_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)/node_modules/whisper-node/lib/whisper.cpp"
 WHISPER_MODEL_DIR="$WHISPER_DIR/models"
 WHISPER_MODEL_FILENAME="ggml-${MODEL}.bin"
 WHISPER_MODEL_PATH="$WHISPER_MODEL_DIR/$WHISPER_MODEL_FILENAME"
@@ -27,22 +28,7 @@ echo "==> Building whisper.cpp in $WHISPER_DIR"
 cd "$WHISPER_DIR"
 make -j"$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 4)"
 
-mkdir -p "$WHISPER_MODEL_DIR"
-mkdir -p "$WHISPER_MODEL_CACHE_DIR"
-
-if [ -f "$WHISPER_MODEL_PATH" ]; then
-  echo "==> Whisper model already present: $WHISPER_MODEL_PATH"
-elif [ -f "$WHISPER_MODEL_CACHE_PATH" ]; then
-  echo "==> Restoring whisper model from cache: $WHISPER_MODEL_CACHE_PATH"
-  cp "$WHISPER_MODEL_CACHE_PATH" "$WHISPER_MODEL_PATH"
-else
-  echo "==> Downloading model: $WHISPER_MODEL_FILENAME"
-  bash models/download-ggml-model.sh "$MODEL"
-fi
-
-if [ -f "$WHISPER_MODEL_PATH" ]; then
-  cp "$WHISPER_MODEL_PATH" "$WHISPER_MODEL_CACHE_PATH"
-fi
+bash "$SCRIPT_DIR/ensure-whisper-model.sh" "$MODEL"
 
 echo "==> Done. Binary: $WHISPER_DIR/main"
 echo "    Model:  $WHISPER_MODEL_PATH"

--- a/apps/app/electrobun/scripts/ensure-whisper-model.sh
+++ b/apps/app/electrobun/scripts/ensure-whisper-model.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Ensure the requested whisper.cpp model exists in both the working tree and the
+# shared Milady cache. This is intentionally separate from the native binary
+# build so CI can prepare the model once and fan it out to all desktop jobs.
+#
+# Usage:
+#   bash apps/app/electrobun/scripts/ensure-whisper-model.sh [model]
+#
+set -euo pipefail
+
+MODEL="${1:-base.en}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WHISPER_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)/node_modules/whisper-node/lib/whisper.cpp"
+WHISPER_MODEL_DIR="$WHISPER_DIR/models"
+WHISPER_MODEL_FILENAME="ggml-${MODEL}.bin"
+WHISPER_MODEL_PATH="$WHISPER_MODEL_DIR/$WHISPER_MODEL_FILENAME"
+WHISPER_MODEL_CACHE_DIR="${MILADY_WHISPER_MODEL_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/milady/whisper}"
+WHISPER_MODEL_CACHE_PATH="$WHISPER_MODEL_CACHE_DIR/$WHISPER_MODEL_FILENAME"
+DOWNLOAD_ATTEMPTS="${MILADY_WHISPER_DOWNLOAD_ATTEMPTS:-4}"
+RETRY_DELAY_SECONDS="${MILADY_WHISPER_DOWNLOAD_RETRY_DELAY_SECONDS:-15}"
+
+if [ ! -d "$WHISPER_DIR" ]; then
+  echo "Error: whisper.cpp not found at $WHISPER_DIR" >&2
+  echo "Run 'bun install' first." >&2
+  exit 1
+fi
+
+mkdir -p "$WHISPER_MODEL_DIR"
+mkdir -p "$WHISPER_MODEL_CACHE_DIR"
+
+if [ -f "$WHISPER_MODEL_PATH" ]; then
+  echo "==> Whisper model already present: $WHISPER_MODEL_PATH"
+elif [ -f "$WHISPER_MODEL_CACHE_PATH" ]; then
+  echo "==> Restoring whisper model from cache: $WHISPER_MODEL_CACHE_PATH"
+  cp "$WHISPER_MODEL_CACHE_PATH" "$WHISPER_MODEL_PATH"
+else
+  cd "$WHISPER_DIR"
+
+  for attempt in $(seq 1 "$DOWNLOAD_ATTEMPTS"); do
+    echo "==> Downloading model attempt ${attempt}/${DOWNLOAD_ATTEMPTS}: $WHISPER_MODEL_FILENAME"
+    rm -f "$WHISPER_MODEL_PATH"
+
+    if bash models/download-ggml-model.sh "$MODEL"; then
+      break
+    fi
+
+    if [ "$attempt" -eq "$DOWNLOAD_ATTEMPTS" ]; then
+      echo "Error: failed to download $WHISPER_MODEL_FILENAME after ${DOWNLOAD_ATTEMPTS} attempts" >&2
+      exit 1
+    fi
+
+    echo "==> Download failed; retrying in ${RETRY_DELAY_SECONDS}s" >&2
+    sleep "$RETRY_DELAY_SECONDS"
+  done
+fi
+
+if [ ! -f "$WHISPER_MODEL_PATH" ]; then
+  echo "Error: whisper model missing after restore/download: $WHISPER_MODEL_PATH" >&2
+  exit 1
+fi
+
+cp "$WHISPER_MODEL_PATH" "$WHISPER_MODEL_CACHE_PATH"
+
+echo "==> Whisper model ready: $WHISPER_MODEL_PATH"
+echo "    Cache: $WHISPER_MODEL_CACHE_PATH"

--- a/docs/build-and-release.md
+++ b/docs/build-and-release.md
@@ -1,6 +1,6 @@
 # Build and release (CI, desktop binaries)
 
-`.github/workflows/release-electrobun.yml` is the canonical desktop release workflow. `.github/workflows/release.yml` remains a manual legacy desktop fallback only.
+`.github/workflows/release-electrobun.yml` is the canonical desktop release workflow and reusable desktop release-build graph. `.github/workflows/test-electrobun-release.yml` calls that same graph on pull requests in build-only mode, and `.github/workflows/release.yml` remains a manual legacy desktop fallback only.
 
 Why the release pipeline and desktop bundle work the way they do.
 
@@ -57,7 +57,8 @@ CI workflows that need Node (for node-gyp / native modules or npm registry) were
 
 ## Where this runs
 
-- **Electrobun release:** `.github/workflows/release-electrobun.yml` — on version tag push; builds macOS arm64, macOS x64, Windows x64, and Linux x64 Electrobun artifacts plus update channel files.
+- **Electrobun PR release validation:** `.github/workflows/test-electrobun-release.yml` — on pull requests; runs the same Electrobun release build matrix in build-only mode without creating a GitHub release.
+- **Electrobun release:** `.github/workflows/release-electrobun.yml` — on version tag push or manual dispatch; builds macOS arm64, macOS x64, Windows x64, and Linux x64 Electrobun artifacts plus update channel files.
 - **Legacy desktop compatibility stub:** `.github/workflows/release.yml` — manual workflow that only points maintainers at the Electrobun release path.
 - **Local desktop build:** From repo root, use the Electrobun path: `bun run build:desktop` for a local bundle build, then `bash apps/app/electrobun/scripts/smoke-test.sh` for packaged desktop verification.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miladyai",
-  "version": "2.0.0-alpha.93",
+  "version": "2.0.0-alpha.116",
   "description": "Cute agents for the acceleration",
   "homepage": "https://github.com/milady-ai/milady",
   "author": {

--- a/packages/app-core/src/components/avatar/VrmEngine.ts
+++ b/packages/app-core/src/components/avatar/VrmEngine.ts
@@ -138,7 +138,9 @@ type RendererLike = Pick<
   toneMapping?: THREE.ToneMapping;
   toneMappingExposure?: number;
   xr?: THREE.WebGLRenderer["xr"];
-  setAnimationLoop?: (callback: ((time: number, frame?: any) => void) | null) => void;
+  setAnimationLoop?: (
+    callback: ((time: number, frame?: any) => void) | null,
+  ) => void;
 };
 
 type TeleportFallbackShader = {
@@ -216,6 +218,7 @@ const SPARK_MAX_PIXEL_RADIUS = 96;
 const SPARK_MAX_PIXEL_RADIUS_NEAR = 28;
 const MAX_RENDERER_PIXEL_RATIO = 2;
 const AVATAR_RENDERER_OVERRIDE_KEY = "eliza.avatarRenderer";
+const LOOKING_GLASS_ENABLED_KEY = "eliza.avatarLookingGlass";
 const KNOWN_VRM_WEBGPU_WARNING =
   'TSL: "transformedNormalView" is deprecated. Use "normalView" instead.';
 
@@ -260,6 +263,20 @@ function getPreferredAvatarRendererBackend(): RendererBackend {
     return normalizedOverride;
   }
   return isElectrobunAvatarRuntime() ? "webgpu" : "webgl";
+}
+
+function isLookingGlassEnabled(): boolean {
+  if (typeof window === "undefined" || !isElectrobunAvatarRuntime()) {
+    return false;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(LOOKING_GLASS_ENABLED_KEY);
+    const normalized = raw?.trim().toLowerCase();
+    return normalized === "1" || normalized === "true" || normalized === "on";
+  } catch {
+    return false;
+  }
 }
 
 function installKnownVrmWebGpuWarningFilter(): () => void {
@@ -1703,7 +1720,7 @@ export class VrmEngine {
         }
         this.renderer = renderer;
         this.rendererBackend = backend;
-        if (backend === "webgl") {
+        if (backend === "webgl" && isLookingGlassEnabled()) {
           // Looking Glass: create a SEPARATE hidden renderer so the main
           // canvas and camera are never affected by the XR polyfill.
           this.setupLookingGlass();
@@ -1865,7 +1882,8 @@ export class VrmEngine {
     const lkgCanvas = document.createElement("canvas");
     lkgCanvas.width = 1;
     lkgCanvas.height = 1;
-    lkgCanvas.style.cssText = "position:fixed;top:0;left:0;width:1px;height:1px;opacity:0;pointer-events:none;z-index:-1;";
+    lkgCanvas.style.cssText =
+      "position:fixed;top:0;left:0;width:1px;height:1px;opacity:0;pointer-events:none;z-index:-1;";
     document.body.appendChild(lkgCanvas);
 
     const lkgR = new THREE.WebGLRenderer({
@@ -1889,11 +1907,11 @@ export class VrmEngine {
     vrBtn.id = "VRButton";
     // Override VRButton's default styles, then force hidden
     vrBtn.style.cssText =
-      "position:fixed;top:50%;left:20px;transform:translateY(-50%);"
-      + "padding:12px 24px;border:1px solid rgba(255,255,255,0.4);"
-      + "border-radius:8px;background:rgba(0,0,0,0.6);"
-      + "color:#fff;font:13px sans-serif;cursor:pointer;z-index:2147483647;"
-      + "pointer-events:auto;";
+      "position:fixed;top:50%;left:20px;transform:translateY(-50%);" +
+      "padding:12px 24px;border:1px solid rgba(255,255,255,0.4);" +
+      "border-radius:8px;background:rgba(0,0,0,0.6);" +
+      "color:#fff;font:13px sans-serif;cursor:pointer;z-index:2147483647;" +
+      "pointer-events:auto;";
     // Force hidden — must be set after cssText and re-applied if VRButton
     // resets its style (it uses a timeout to update button text/style).
     vrBtn.style.display = "none";

--- a/packages/app-core/src/components/avatar/VrmViewer.tsx
+++ b/packages/app-core/src/components/avatar/VrmViewer.tsx
@@ -154,6 +154,7 @@ export function VrmViewer(props: VrmViewerProps) {
   const currentVrmPathRef = useRef<string>("");
   const currentWorldPathRef = useRef<string>("");
   const worldLoadPromiseRef = useRef<Promise<void> | null>(null);
+  const rendererInitFailedRef = useRef(false);
   const pointerStateRef = useRef<{
     active: boolean;
     id: number | null;
@@ -185,6 +186,39 @@ export function VrmViewer(props: VrmViewerProps) {
   onEngineReadyRef.current = props.onEngineReady;
   onEngineStateRef.current = props.onEngineState;
   onRevealStartRef.current = props.onRevealStart;
+
+  const reportRendererInitFailure = useEffectEvent((error: unknown) => {
+    rendererInitFailedRef.current = true;
+    currentVrmPathRef.current = "";
+    currentWorldPathRef.current = "";
+    worldLoadPromiseRef.current = null;
+    revealStartedRef.current = false;
+
+    const fallbackMessage =
+      error instanceof Error && error.message.trim()
+        ? error.message
+        : "Failed to initialize VRM renderer.";
+    const currentState = engineRef.current?.getState();
+
+    onEngineStateRef.current?.(
+      currentState
+        ? {
+            ...currentState,
+            vrmLoaded: false,
+            revealStarted: false,
+            loadError: currentState.loadError ?? fallbackMessage,
+          }
+        : {
+            vrmLoaded: false,
+            vrmName: null,
+            loadError: fallbackMessage,
+            idlePlaying: false,
+            idleTime: 0,
+            idleTracks: 0,
+            revealStarted: false,
+          },
+    );
+  });
 
   const syncDebugRegistry = useEffectEvent(() => {
     if (!import.meta.env.DEV) return;
@@ -272,6 +306,8 @@ export function VrmViewer(props: VrmViewerProps) {
         onEngineReadyRef.current?.(engine);
       },
       (error) => {
+        if (!mountedRef.current) return;
+        reportRendererInitFailure(error);
         console.warn("Failed to initialize VRM renderer:", error);
       },
     );
@@ -295,7 +331,7 @@ export function VrmViewer(props: VrmViewerProps) {
 
   useEffect(() => {
     const engine = engineRef.current;
-    if (!engine) return;
+    if (!engine || rendererInitFailedRef.current) return;
     engine.setPaused(!(props.active ?? true));
   }, [props.active]);
 
@@ -375,6 +411,7 @@ export function VrmViewer(props: VrmViewerProps) {
         onEngineStateRef.current?.(state);
       } catch (err) {
         if (err instanceof Error && err.name === "AbortError") return;
+        if (rendererInitFailedRef.current) return;
         if (currentVrmPathRef.current === vrmUrl) {
           currentVrmPathRef.current = "";
         }
@@ -392,7 +429,7 @@ export function VrmViewer(props: VrmViewerProps) {
 
   useEffect(() => {
     const engine = engineRef.current;
-    if (!engine) return;
+    if (!engine || rendererInitFailedRef.current) return;
 
     const worldUrl = props.worldUrl ?? "";
     if (worldUrl === currentWorldPathRef.current) return;
@@ -406,6 +443,7 @@ export function VrmViewer(props: VrmViewerProps) {
         if (!mountedRef.current || abortController.signal.aborted) return;
         await engine.setWorldUrl(worldUrl || null);
       } catch (err) {
+        if (rendererInitFailedRef.current) return;
         console.warn("Failed to load splat world:", err);
       } finally {
         if (worldLoadPromiseRef.current === worldLoadPromise) {

--- a/packages/app-core/src/components/avatar/__tests__/VrmEngine.test.ts
+++ b/packages/app-core/src/components/avatar/__tests__/VrmEngine.test.ts
@@ -778,6 +778,19 @@ describe("VrmEngine", () => {
       expect(hoisted.mockWebGpuRendererInstance.init).toHaveBeenCalledTimes(1);
     });
 
+    it("keeps Looking Glass disabled by default on Electrobun WebGL startup", async () => {
+      (
+        window as Window & { __electrobunWindowId?: number }
+      ).__electrobunWindowId = 1;
+      const canvas = createMockCanvas();
+
+      engine.setup(canvas, vi.fn(), { rendererPreference: "webgl" });
+      await waitForEngineReady(engine);
+
+      expect(engine.isInitialized()).toBe(true);
+      expect(globalThis.requestAnimationFrame).toHaveBeenCalled();
+    });
+
     it("cleans up WebGL resources during dispose()", async () => {
       const canvas = createMockCanvas();
       engine.setup(canvas, vi.fn());

--- a/packages/app-core/test/app/vrm-viewer.test.tsx
+++ b/packages/app-core/test/app/vrm-viewer.test.tsx
@@ -34,10 +34,12 @@ vi.mock("@miladyai/app-core/components/avatar/VrmEngine", () => {
 
     private readyPromise: Promise<void>;
     private resolveReadyPromise: () => void = () => {};
+    private rejectReadyPromise: (error?: unknown) => void = () => {};
 
     constructor() {
-      this.readyPromise = new Promise<void>((resolve) => {
+      this.readyPromise = new Promise<void>((resolve, reject) => {
         this.resolveReadyPromise = resolve;
+        this.rejectReadyPromise = reject;
       });
       MockVrmEngine.instances.push(this);
     }
@@ -48,6 +50,10 @@ vi.mock("@miladyai/app-core/components/avatar/VrmEngine", () => {
 
     resolveReady(): void {
       this.resolveReadyPromise();
+    }
+
+    rejectReady(error: unknown): void {
+      this.rejectReadyPromise(error);
     }
   }
 
@@ -68,6 +74,7 @@ type MockVrmEngineInstance = {
   setWorldUrl: ReturnType<typeof vi.fn>;
   loadVrmFromUrl: ReturnType<typeof vi.fn>;
   resolveReady: () => void;
+  rejectReady: (error: unknown) => void;
 };
 
 function getMockInstances(): MockVrmEngineInstance[] {
@@ -290,6 +297,71 @@ describe("VrmViewer", () => {
     expect(instance?.setWorldUrl).toHaveBeenLastCalledWith(
       "/worlds/companion-night.spz",
     );
+
+    await act(async () => {
+      renderer?.unmount();
+    });
+  });
+
+  it("surfaces renderer init failures as load errors without retrying VRM or world loads", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const onEngineState = vi.fn();
+    let renderer: TestRenderer.ReactTestRenderer | null = null;
+
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <VrmViewer
+          vrmPath="/vrms/eliza-1.vrm.gz"
+          worldUrl="/worlds/companion-day.spz"
+          mouthOpen={0}
+          onEngineState={onEngineState}
+        />,
+        {
+          createNodeMock: (element) => {
+            if (element.type === "canvas") {
+              return {
+                getBoundingClientRect: () => ({
+                  width: 640,
+                  height: 480,
+                  top: 0,
+                  left: 0,
+                  bottom: 480,
+                  right: 640,
+                  x: 0,
+                  y: 0,
+                  toJSON: () => ({}),
+                }),
+              };
+            }
+            return null;
+          },
+        },
+      );
+    });
+
+    const [instance] = getMockInstances();
+
+    await act(async () => {
+      instance?.rejectReady(new Error("Error creating WebGL context."));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(onEngineState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        vrmLoaded: false,
+        loadError: "Error creating WebGL context.",
+      }),
+    );
+    expect(instance?.setWorldUrl).not.toHaveBeenCalled();
+    expect(instance?.loadVrmFromUrl).not.toHaveBeenCalled();
+
+    const warningLabels = warnSpy.mock.calls.map((call) => call[0]);
+    expect(warningLabels).toContain("Failed to initialize VRM renderer:");
+    expect(warningLabels).not.toContain("Failed to load VRM:");
+    expect(warningLabels).not.toContain("Failed to load splat world:");
+
+    warnSpy.mockRestore();
 
     await act(async () => {
       renderer?.unmount();

--- a/scripts/electrobun-release-workflow-drift.test.ts
+++ b/scripts/electrobun-release-workflow-drift.test.ts
@@ -131,6 +131,26 @@ describe("Electrobun release workflow drift", () => {
     expect(workflow).toContain(`bun install failed after \${attempt} attempts`);
   });
 
+  it("prepares one shared whisper model artifact before desktop staging", () => {
+    const workflow = fs.readFileSync(WORKFLOW_PATH, "utf8");
+    const prepareModelIndex = workflow.indexOf("name: Prepare Whisper model artifact");
+    const uploadModelIndex = workflow.indexOf("name: Upload Whisper model artifact");
+    const downloadModelIndex = workflow.indexOf("name: Download Whisper model artifact");
+    const seedModelIndex = workflow.indexOf("name: Seed Whisper model cache");
+    const stageIndex = workflow.indexOf("name: Stage desktop bundle inputs");
+
+    expect(prepareModelIndex).toBeGreaterThan(-1);
+    expect(uploadModelIndex).toBeGreaterThan(prepareModelIndex);
+    expect(downloadModelIndex).toBeGreaterThan(-1);
+    expect(seedModelIndex).toBeGreaterThan(downloadModelIndex);
+    expect(stageIndex).toBeGreaterThan(seedModelIndex);
+    expect(workflow).toContain(
+      "bash apps/app/electrobun/scripts/ensure-whisper-model.sh base.en",
+    );
+    expect(workflow).toContain("name: whisper-model-base-en");
+    expect(workflow).toContain('cp "$HOME/.cache/milady/whisper/ggml-base.en.bin"');
+  });
+
   it("does not restore Bun install cache during desktop builds", () => {
     const workflow = fs.readFileSync(WORKFLOW_PATH, "utf8");
     const buildJobLabel = "name: Build $" + "{{ matrix.platform.name }}";

--- a/scripts/electrobun-test-workflow-drift.test.ts
+++ b/scripts/electrobun-test-workflow-drift.test.ts
@@ -42,6 +42,9 @@ describe("Electrobun test workflow drift", () => {
 
     expect(workflow).toContain("pull_request:");
     expect(workflow).toContain("branches: [main, develop]");
+    expect(workflow).toContain("permissions:");
+    expect(workflow).toContain("contents: write");
+    expect(workflow).toContain("packages: write");
     expect(workflow).toContain(
       "uses: ./.github/workflows/release-electrobun.yml",
     );

--- a/scripts/electrobun-test-workflow-drift.test.ts
+++ b/scripts/electrobun-test-workflow-drift.test.ts
@@ -4,6 +4,10 @@ import { describe, expect, it } from "vitest";
 
 const ROOT = path.resolve(import.meta.dirname, "..");
 const WORKFLOW_PATH = path.join(ROOT, ".github/workflows/test.yml");
+const PR_RELEASE_WORKFLOW_PATH = path.join(
+  ROOT,
+  ".github/workflows/test-electrobun-release.yml",
+);
 
 describe("Electrobun test workflow drift", () => {
   // Desktop build/packaging validation (preload bridge, diagnostics, DMG
@@ -31,5 +35,19 @@ describe("Electrobun test workflow drift", () => {
     expect(workflow).toContain(
       'name: Run repository postinstall patches\n        run: bun run postinstall\n        env:\n          SKIP_AVATAR_CLONE: "1"\n          MILADY_NO_VISION_DEPS: "1"',
     );
+  });
+
+  it("runs the canonical Electrobun release build graph on pull requests without publishing", () => {
+    const workflow = fs.readFileSync(PR_RELEASE_WORKFLOW_PATH, "utf8");
+
+    expect(workflow).toContain("pull_request:");
+    expect(workflow).toContain("branches: [main, develop]");
+    expect(workflow).toContain(
+      "uses: ./.github/workflows/release-electrobun.yml",
+    );
+    expect(workflow).toContain("draft: false");
+    expect(workflow).toContain("publish_release: false");
+    expect(workflow).toContain("publish_docker: false");
+    expect(workflow).toContain("secrets: inherit");
   });
 });

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -135,6 +135,9 @@ const forbiddenWorkflowSnippets = [
 const requiredElectrobunPrWorkflowSnippets = [
   "pull_request:",
   "branches: [main, develop]",
+  "permissions:",
+  "contents: write",
+  "packages: write",
   "uses: ./.github/workflows/release-electrobun.yml",
   "publish_release: false",
   "publish_docker: false",

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -31,6 +31,7 @@ const autonomousElizaPathCandidates = [
 ] as const;
 const requiredWorkflowSnippets = [
   'BUN_VERSION: "1.3.9"',
+  "workflow_call:",
   "name: Validate Release Inputs",
   "bun-version: $" + "{{ env.BUN_VERSION }}",
   "name: Release readiness checks",
@@ -39,6 +40,10 @@ const requiredWorkflowSnippets = [
   `bun install failed on attempt \${attempt}; retrying in 15 seconds`,
   "name: Ensure avatar assets",
   "node scripts/ensure-avatars.mjs",
+  "name: Prepare Whisper model artifact",
+  "bash apps/app/electrobun/scripts/ensure-whisper-model.sh base.en",
+  "name: Upload Whisper model artifact",
+  "name: whisper-model-base-en",
   "Install quiet macOS packaging wrappers",
   "apps/app/electrobun/scripts/hdiutil-wrapper.sh",
   "apps/app/electrobun/scripts/xcrun-wrapper.sh",
@@ -46,6 +51,8 @@ const requiredWorkflowSnippets = [
   "ELECTROBUN_REAL_HDIUTIL: /usr/bin/hdiutil",
   "ELECTROBUN_REAL_XCRUN: /usr/bin/xcrun",
   "ELECTROBUN_REAL_ZIP: /usr/bin/zip",
+  "name: Download Whisper model artifact",
+  "name: Seed Whisper model cache",
   "Stage desktop bundle inputs",
   "node scripts/desktop-build.mjs stage --variant=base --build-whisper",
   "Inject version.json into bundle (Windows)",
@@ -124,6 +131,15 @@ const forbiddenWorkflowSnippets = [
     "{{ matrix.platform.artifact-name }}" +
     "-$" +
     "{{ hashFiles('bun.lock') }}",
+];
+const requiredElectrobunPrWorkflowSnippets = [
+  "pull_request:",
+  "branches: [main, develop]",
+  "uses: ./.github/workflows/release-electrobun.yml",
+  "publish_release: false",
+  "publish_docker: false",
+  "draft: false",
+  "secrets: inherit",
 ];
 const requiredElectrobunConfigSnippets = [
   'postBuild: "scripts/postwrap-sign-runtime-macos.ts"',
@@ -504,6 +520,26 @@ function assertReleaseWorkflowHasNotaryWrapper() {
   }
 }
 
+function assertElectrobunPrWorkflowExists() {
+  const workflow = readFileSync(
+    ".github/workflows/test-electrobun-release.yml",
+    "utf8",
+  );
+  const missing = requiredElectrobunPrWorkflowSnippets.filter(
+    (snippet) => !workflow.includes(snippet),
+  );
+
+  if (missing.length > 0) {
+    console.error(
+      "release-check: Electrobun PR release workflow is missing reusable build-only wiring:",
+    );
+    for (const snippet of missing) {
+      console.error(`  - ${snippet}`);
+    }
+    process.exit(1);
+  }
+}
+
 function assertElectrobunConfigHasPostWrapSigner() {
   const config = readFileSync(
     "apps/app/electrobun/electrobun.config.ts",
@@ -825,8 +861,9 @@ function assertStartApiServerCatchBlockSafety() {
 }
 
 function main() {
-  assertReleaseWorkflowHasNotaryWrapper();
-  assertElectrobunConfigHasPostWrapSigner();
+assertReleaseWorkflowHasNotaryWrapper();
+assertElectrobunPrWorkflowExists();
+assertElectrobunConfigHasPostWrapSigner();
   assertMacArtifactStagerLooksCorrect();
   assertWindowsSmokeScriptHasLeadingParamBlock();
   assertWindowsInstallerProofScript();

--- a/scripts/whisper-build-script-drift.test.ts
+++ b/scripts/whisper-build-script-drift.test.ts
@@ -1,0 +1,51 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ROOT = path.resolve(import.meta.dirname, "..");
+const BUILD_WHISPER_PATH = path.join(
+  ROOT,
+  "apps/app/electrobun/scripts/build-whisper.sh",
+);
+const BUILD_WHISPER_UNIVERSAL_PATH = path.join(
+  ROOT,
+  "apps/app/electrobun/scripts/build-whisper-universal.sh",
+);
+const ENSURE_WHISPER_MODEL_PATH = path.join(
+  ROOT,
+  "apps/app/electrobun/scripts/ensure-whisper-model.sh",
+);
+
+describe("Whisper build script drift", () => {
+  it("delegates model restore/download to the shared helper", () => {
+    const buildWhisper = fs.readFileSync(BUILD_WHISPER_PATH, "utf8");
+    const buildWhisperUniversal = fs.readFileSync(
+      BUILD_WHISPER_UNIVERSAL_PATH,
+      "utf8",
+    );
+
+    expect(buildWhisper).toContain('ensure-whisper-model.sh" "$MODEL"');
+    expect(buildWhisper).not.toContain(
+      'bash models/download-ggml-model.sh "$MODEL"',
+    );
+
+    expect(buildWhisperUniversal).toContain(
+      'ensure-whisper-model.sh" "$MODEL"',
+    );
+    expect(buildWhisperUniversal).not.toContain(
+      'bash models/download-ggml-model.sh "$MODEL"',
+    );
+  });
+
+  it("retries whisper model downloads before failing CI", () => {
+    const helper = fs.readFileSync(ENSURE_WHISPER_MODEL_PATH, "utf8");
+
+    expect(helper).toContain("MILADY_WHISPER_DOWNLOAD_ATTEMPTS");
+    expect(helper).toContain("MILADY_WHISPER_DOWNLOAD_RETRY_DELAY_SECONDS");
+    expect(helper).toContain("Restoring whisper model from cache");
+    expect(helper).toContain("Downloading model attempt");
+    expect(helper).toContain('bash models/download-ggml-model.sh "$MODEL"');
+    expect(helper).toContain("retrying in ${RETRY_DELAY_SECONDS}s");
+  });
+});


### PR DESCRIPTION
## Summary
- restore last-green Windows avatar startup behavior by disabling the new Looking Glass WebGL path unless explicitly opted in
- surface renderer init failures through the existing VRM fallback path so Windows does not hang on the avatar loader
- keep the full Electrobun release build graph running in PR checks and bump the next canary release version to `v2.0.0-alpha.116`

## Testing
- `bunx vitest run packages/app-core/src/components/avatar/__tests__/VrmEngine.test.ts packages/app-core/test/app/vrm-viewer.test.tsx`
