### PR TITLE
release: resolve electrobun package dir in CI

### DIFF
--- a/.github/workflows/release-electrobun.yml
+++ b/.github/workflows/release-electrobun.yml
@@ -349,10 +349,55 @@ jobs:
           chmod +x "$wrapper_dir/zip"
           echo "$wrapper_dir" >> "$GITHUB_PATH"
 
+      - name: Resolve electrobun package dir
+        id: resolve-electrobun
+        shell: bash
+        run: |
+          package_dir="$(node <<'NODE'
+          const { createRequire } = require("node:module");
+          const fs = require("node:fs");
+          const path = require("node:path");
+
+          const workspacePackageJson = path.resolve("apps/app/electrobun/package.json");
+          const req = createRequire(workspacePackageJson);
+          const entryPath = req.resolve("electrobun");
+          let packageDir = path.dirname(entryPath);
+
+          while (!fs.existsSync(path.join(packageDir, "package.json"))) {
+            const parentDir = path.dirname(packageDir);
+            if (parentDir === packageDir) {
+              throw new Error(
+                `Could not find electrobun package.json starting from ${entryPath}`,
+              );
+            }
+            packageDir = parentDir;
+          }
+
+          const manifestPath = path.join(packageDir, "package.json");
+          const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+          if (manifest.name !== "electrobun") {
+            throw new Error(
+              `Resolved unexpected package at ${manifestPath}: ${manifest.name}`,
+            );
+          }
+
+          process.stdout.write(packageDir);
+          NODE
+          )"
+
+          if [ -z "$package_dir" ]; then
+            echo "::error::Failed to resolve electrobun package directory"
+            exit 1
+          fi
+
+          echo "Resolved electrobun package dir: $package_dir"
+          echo "package-dir=$package_dir" >> "$GITHUB_OUTPUT"
+          echo "cache-dir=$package_dir/.cache" >> "$GITHUB_OUTPUT"
+
       - name: Cache local electrobun core downloads
         uses: actions/cache@v4
         with:
-          path: apps/app/electrobun/node_modules/electrobun/.cache
+          path: ${{ steps.resolve-electrobun.outputs.cache-dir }}
           key: electrobun-core-${{ matrix.platform.artifact-name }}-${{ hashFiles('apps/app/electrobun/package.json') }}
           restore-keys: electrobun-core-${{ matrix.platform.artifact-name }}-
 
@@ -360,26 +405,7 @@ jobs:
         if: matrix.platform.os == 'windows'
         shell: pwsh
         run: |
-          $electrobunDir = Join-Path $PWD "apps/app/electrobun/node_modules/electrobun"
-          $resolvedElectrobunDir = node -e @'
-            const fs = require("node:fs");
-            const packageDir = process.argv[1];
-            try {
-              process.stdout.write(fs.realpathSync(packageDir));
-            } catch (error) {
-              process.stdout.write(packageDir);
-            }
-          '@ $electrobunDir
-          if ($null -eq $resolvedElectrobunDir) {
-            $resolvedElectrobunDir = $electrobunDir
-          } elseif ($resolvedElectrobunDir -is [array]) {
-            $resolvedElectrobunDir = ($resolvedElectrobunDir -join "")
-          }
-          $resolvedElectrobunDir = "$resolvedElectrobunDir".Trim()
-          if ([string]::IsNullOrWhiteSpace($resolvedElectrobunDir)) {
-            $resolvedElectrobunDir = $electrobunDir
-          }
-          Write-Host "Resolved electrobun package dir: $resolvedElectrobunDir"
+          $resolvedElectrobunDir = '${{ steps.resolve-electrobun.outputs.package-dir }}'
 
           $resolvedRceditPackageJson = node -e @'
             const { createRequire } = require("node:module");
@@ -467,26 +493,7 @@ jobs:
         if: matrix.platform.os == 'windows'
         shell: pwsh
         run: |
-          $electrobunDir = Join-Path $PWD "apps/app/electrobun/node_modules/electrobun"
-          $resolvedElectrobunDir = node -e @'
-            const fs = require("node:fs");
-            const packageDir = process.argv[1];
-            try {
-              process.stdout.write(fs.realpathSync(packageDir));
-            } catch (error) {
-              process.stdout.write(packageDir);
-            }
-          '@ $electrobunDir
-          if ($null -eq $resolvedElectrobunDir) {
-            $resolvedElectrobunDir = $electrobunDir
-          } elseif ($resolvedElectrobunDir -is [array]) {
-            $resolvedElectrobunDir = ($resolvedElectrobunDir -join "")
-          }
-          $resolvedElectrobunDir = "$resolvedElectrobunDir".Trim()
-          if ([string]::IsNullOrWhiteSpace($resolvedElectrobunDir)) {
-            $resolvedElectrobunDir = $electrobunDir
-          }
-          Write-Host "Resolved electrobun package dir: $resolvedElectrobunDir"
+          $resolvedElectrobunDir = '${{ steps.resolve-electrobun.outputs.package-dir }}'
           $cacheDir     = Join-Path $resolvedElectrobunDir ".cache"
           $binDir       = Join-Path $resolvedElectrobunDir "bin"
           $cliBinary    = Join-Path $cacheDir "electrobun.exe"

--- a/scripts/electrobun-release-workflow-drift.test.ts
+++ b/scripts/electrobun-release-workflow-drift.test.ts
@@ -235,11 +235,27 @@ describe("Electrobun release workflow drift", () => {
     );
     expect(workflow).toContain("electrobun CLI checksum mismatch");
     expect(workflow).toContain("Verified electrobun CLI SHA256:");
+    expect(workflow).toContain("name: Resolve electrobun package dir");
+    expect(workflow).toContain("id: resolve-electrobun");
     expect(workflow).toContain(
-      "process.stdout.write(fs.realpathSync(packageDir));",
+      'const workspacePackageJson = path.resolve("apps/app/electrobun/package.json");',
+    );
+    expect(workflow).toContain('const entryPath = req.resolve("electrobun");');
+    expect(workflow).toContain(
+      "Could not find electrobun package.json starting from",
+    );
+    expect(workflow).toContain("Resolved unexpected package at");
+    expect(workflow).toContain(
+      'echo "package-dir=$package_dir" >> "$GITHUB_OUTPUT"',
     );
     expect(workflow).toContain(
-      'Write-Host "Resolved electrobun package dir: $resolvedElectrobunDir"',
+      'echo "cache-dir=$package_dir/.cache" >> "$GITHUB_OUTPUT"',
+    );
+    expect(workflow).toContain(
+      "$resolvedElectrobunDir = '" +
+        "$" +
+        "{{ steps.resolve-electrobun.outputs.package-dir }}" +
+        "'",
     );
     expect(workflow).toContain(
       '$cacheDir     = Join-Path $resolvedElectrobunDir ".cache"',
@@ -254,6 +270,9 @@ describe("Electrobun release workflow drift", () => {
       'Get-ChildItem -Path (Join-Path $PWD "node_modules\\.bun") -Directory -Filter "rcedit@*"',
     );
     expect(workflow).toContain("Seeding rcedit from $seedRceditDir");
+    expect(workflow).not.toContain(
+      'Join-Path $PWD "apps/app/electrobun/node_modules/electrobun"',
+    );
     expect(workflow).not.toContain('bun install -g "rcedit@4.0.1"');
   });
 
@@ -282,8 +301,14 @@ describe("Electrobun release workflow drift", () => {
 
     expect(stageIndex).toBeGreaterThan(-1);
     expect(cacheIndex).toBeGreaterThan(stageIndex);
+    expect(cacheIndex).toBeGreaterThan(
+      workflow.indexOf("name: Resolve electrobun package dir"),
+    );
     expect(workflow).toContain("name: Cache local electrobun core downloads");
     expect(workflow).toContain(
+      "path: $" + "{{ steps.resolve-electrobun.outputs.cache-dir }}",
+    );
+    expect(workflow).not.toContain(
       "path: apps/app/electrobun/node_modules/electrobun/.cache",
     );
     expect(workflow).not.toContain(

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -93,8 +93,19 @@ const requiredWorkflowSnippets = [
   "$expectedHash = $asset.digest.Substring(7).ToLowerInvariant()",
   "$actualHash = (Get-FileHash -Path $tarPath -Algorithm SHA256).Hash.ToLowerInvariant()",
   "electrobun CLI checksum mismatch",
-  "process.stdout.write(fs.realpathSync(packageDir));",
-  'Write-Host "Resolved electrobun package dir: $resolvedElectrobunDir"',
+  "name: Resolve electrobun package dir",
+  "id: resolve-electrobun",
+  'const workspacePackageJson = path.resolve("apps/app/electrobun/package.json");',
+  'const entryPath = req.resolve("electrobun");',
+  "Could not find electrobun package.json starting from",
+  "Resolved unexpected package at",
+  'echo "package-dir=$package_dir" >> "$GITHUB_OUTPUT"',
+  'echo "cache-dir=$package_dir/.cache" >> "$GITHUB_OUTPUT"',
+  "path: $" + "{{ steps.resolve-electrobun.outputs.cache-dir }}",
+  "$resolvedElectrobunDir = '" +
+    "$" +
+    "{{ steps.resolve-electrobun.outputs.package-dir }}" +
+    "'",
   '$cacheDir     = Join-Path $resolvedElectrobunDir ".cache"',
   '$resolvedRceditDir = Join-Path $resolvedElectrobunDir "node_modules\\rcedit"',
   '(Join-Path (Split-Path -Parent $resolvedElectrobunDir) "rcedit")',
@@ -113,7 +124,6 @@ const requiredWorkflowSnippets = [
   "path: apps/app/electrobun/artifacts/windows-installer-proof/**",
   "if: always() && matrix.platform.os == 'windows'",
   "ANTHROPIC_API_KEY: $" + "{{ secrets.ANTHROPIC_API_KEY }}",
-  'Join-Path $PWD "apps/app/electrobun/node_modules/electrobun"',
   "if ($null -eq $resolvedRceditPackageJson)",
   '$resolvedRceditPackageJson = "$resolvedRceditPackageJson".Trim()',
 ];


### PR DESCRIPTION
## Summary
- resolve the real electrobun package directory from apps/app/electrobun/package.json in the release workflow
- use that resolved package dir for Windows helper steps and the electrobun cache path
- update workflow drift guards so the hardcoded workspace-local path cannot regress

## Testing
- bunx vitest run scripts/electrobun-release-workflow-drift.test.ts scripts/release-check.test.ts
- bun run release:check
- bunx @biomejs/biome check .github/workflows/release-electrobun.yml scripts/electrobun-release-workflow-drift.test.ts scripts/release-check.ts