### PR TITLE
feat: integrate Steward SDK wallet signing

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -48,7 +48,7 @@
         "@miladyai/app-core": "workspace:*",
         "@noble/curves": "^2.0.1",
         "@opinion-labs/opinion-clob-sdk": "0.5.2",
-        "@stwd/sdk": "0.2.0",
+        "@stwd/sdk": "^0.3.0",
         "@whiskeysockets/baileys": "7.0.0-rc.9",
         "ai": "6.0.30",
         "chalk": "^5.6.2",
@@ -423,7 +423,7 @@
     },
   },
   "overrides": {
-    "@stwd/sdk": "0.2.0",
+    "@stwd/sdk": "^0.3.0",
     "ai": "6.0.30",
     "drizzle-orm": "0.45.1",
     "libsignal": "git+https://github.com/whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67",
@@ -1454,7 +1454,7 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
-    "@stwd/sdk": ["@stwd/sdk@0.2.0", "", {}, "sha512-tOkuOSK9oJXrfToSm8vmLCdBgkjEUgAVxVxremYRkOTJx6bzy4nHGCYN+cE6A8l+BMJNB88CttQXTGl5+pjTAw=="],
+    "@stwd/sdk": ["@stwd/sdk@0.3.0", "", {}, "sha512-GUx+6lskxFA9PTlPtfVeZbKiIb0mZelBNjvodr8fiayyJIyJVbAzmr2gMLhbM88AGSqqp+BH6ur2GUhBosFl+Q=="],
 
     "@swc/core": ["@swc/core@1.15.18", "", { "dependencies": { "@swc/counter": "^0.1.3", "@swc/types": "^0.1.25" }, "optionalDependencies": { "@swc/core-darwin-arm64": "1.15.18", "@swc/core-darwin-x64": "1.15.18", "@swc/core-linux-arm-gnueabihf": "1.15.18", "@swc/core-linux-arm64-gnu": "1.15.18", "@swc/core-linux-arm64-musl": "1.15.18", "@swc/core-linux-x64-gnu": "1.15.18", "@swc/core-linux-x64-musl": "1.15.18", "@swc/core-win32-arm64-msvc": "1.15.18", "@swc/core-win32-ia32-msvc": "1.15.18", "@swc/core-win32-x64-msvc": "1.15.18" }, "peerDependencies": { "@swc/helpers": ">=0.5.17" }, "optionalPeers": ["@swc/helpers"] }, "sha512-z87aF9GphWp//fnkRsqvtY+inMVPgYW3zSlXH1kJFvRT5H/wiAn+G32qW5l3oEk63KSF1x3Ov0BfHCObAmT8RA=="],
 
@@ -3688,6 +3688,8 @@
 
     "@miladyai/app-core/@capacitor/core": ["@capacitor/core@8.0.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-EXZfxkL6GFJS2cb7TIBR7RiHA5iz6ufDcl1VmUpI2pga3lJ5Ck2+iqbx7N+osL3XYem9ad4XCidJEMm64DX6UQ=="],
 
+    "@miladyai/app-core/@elizaos/agent": ["@elizaos/agent@2.0.0-alpha.94", "", { "dependencies": { "@clack/prompts": "^1.0.0", "@elizaos/core": "^2.0.0-alpha.94", "@elizaos/plugin-agent-orchestrator": "0.3.15", "@elizaos/plugin-agent-skills": "alpha", "@elizaos/plugin-anthropic": "alpha", "@elizaos/plugin-coding-agent": "0.1.0-next.1", "@elizaos/plugin-cron": "alpha", "@elizaos/plugin-elizacloud": "alpha", "@elizaos/plugin-experience": "alpha", "@elizaos/plugin-form": "alpha", "@elizaos/plugin-knowledge": "alpha", "@elizaos/plugin-local-embedding": "alpha", "@elizaos/plugin-ollama": "alpha", "@elizaos/plugin-openai": "alpha", "@elizaos/plugin-pdf": "alpha", "@elizaos/plugin-personality": "alpha", "@elizaos/plugin-pi-ai": "alpha", "@elizaos/plugin-plugin-manager": "alpha", "@elizaos/plugin-rolodex": "alpha", "@elizaos/plugin-secrets-manager": "alpha", "@elizaos/plugin-shell": "alpha", "@elizaos/plugin-sql": "alpha", "@elizaos/plugin-todo": "alpha", "@elizaos/plugin-trajectory-logger": "alpha", "@elizaos/plugin-trust": "alpha", "@hapi/boom": "^10.0.1", "@lunchtable/plugin-ltcg": "^0.1.0", "@mariozechner/pi-ai": "0.52.12", "@noble/curves": "^2.0.1", "@whiskeysockets/baileys": "7.0.0-rc.9", "dotenv": "^17.2.3", "drizzle-orm": "0.45.1", "ethers": "^6.16.0", "git-workspace-service": "0.4.4", "json5": "^2.2.3", "pg": "^8.16.3", "pino": "^10.3.1", "pty-manager": "1.9.8", "puppeteer-core": "^24.37.5", "qrcode": "^1.5.4", "ws": "^8.19.0", "zod": "^4.3.6" }, "peerDependencies": { "@elizaos/signal-native": "*" }, "optionalPeers": ["@elizaos/signal-native"], "bin": { "eliza-autonomous": "packages/agent/src/bin.js" } }, "sha512-8vOzWPlqUFmqczt8GztDC8eePItBZI2sxFn89JvJ70TpIQpJayJyoztX4v7LUeZo+VV0OrugnirWgUClVMi3YQ=="],
+
     "@miladyai/app-core/lucide-react": ["lucide-react@0.575.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-VuXgKZrk0uiDlWjGGXmKV6MSk9Yy4l10qgVvzGn2AWBx1Ylt0iBexKOAoA6I7JO3m+M9oeovJd3yYENfkUbOeg=="],
 
     "@miladyai/homepage/@types/three": ["@types/three@0.183.1", "", { "dependencies": { "@dimforge/rapier3d-compat": "~0.12.0", "@tweenjs/tween.js": "~23.1.3", "@types/stats.js": "*", "@types/webxr": ">=0.5.17", "@webgpu/types": "*", "fflate": "~0.8.2", "meshoptimizer": "~1.0.1" } }, "sha512-f2Pu5Hrepfgavttdye3PsH5RWyY/AvdZQwIVhrc4uNtvF7nOWJacQKcoVJn0S4f0yYbmAE6AR+ve7xDcuYtMGw=="],
@@ -3695,6 +3697,8 @@
     "@miladyai/homepage/jsdom": ["jsdom@29.0.1", "", { "dependencies": { "@asamuzakjp/css-color": "^5.0.1", "@asamuzakjp/dom-selector": "^7.0.3", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.1", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.2.7", "parse5": "^8.0.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.24.5", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg=="],
 
     "@miladyai/homepage/three": ["three@0.183.2", "", {}, "sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ=="],
+
+    "@miladyai/plugin-wechat/@elizaos/core": ["@elizaos/core@2.0.0-alpha.94", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "adze": "^2.2.5", "crypto-browserify": "^3.12.0", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-S9CJGAfE/+vfRdYns2XpE4mM1Pl0LHlnm9fjSvPFOEIKv/JLFAz4FSl4/YTfaT6OYV3/c/fGzY/7Jys2t2FSmg=="],
 
     "@miladyai/plugin-wechat/tsdown": ["tsdown@0.12.9", "", { "dependencies": { "ansis": "^4.1.0", "cac": "^6.7.14", "chokidar": "^4.0.3", "debug": "^4.4.1", "diff": "^8.0.2", "empathic": "^2.0.0", "hookable": "^5.5.3", "rolldown": "^1.0.0-beta.19", "rolldown-plugin-dts": "^0.13.12", "semver": "^7.7.2", "tinyexec": "^1.0.1", "tinyglobby": "^0.2.14", "unconfig": "^7.3.2" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "publint": "^0.3.0", "typescript": "^5.0.0", "unplugin-lightningcss": "^0.4.0", "unplugin-unused": "^0.5.0" }, "optionalPeers": ["@arethetypeswrong/core", "publint", "typescript", "unplugin-lightningcss", "unplugin-unused"], "bin": { "tsdown": "dist/run.mjs" } }, "sha512-MfrXm9PIlT3saovtWKf/gCJJ/NQCdE0SiREkdNC+9Qy6UHhdeDPxnkFaBD7xttVUmgp0yUHtGirpoLB+OVLuLA=="],
 
@@ -4307,6 +4311,10 @@
     "@mariozechner/pi-ai/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "@miladyai/app-core/@capacitor/core/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@miladyai/app-core/@elizaos/agent/@elizaos/core": ["@elizaos/core@2.0.0-alpha.94", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "adze": "^2.2.5", "crypto-browserify": "^3.12.0", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-S9CJGAfE/+vfRdYns2XpE4mM1Pl0LHlnm9fjSvPFOEIKv/JLFAz4FSl4/YTfaT6OYV3/c/fGzY/7Jys2t2FSmg=="],
+
+    "@miladyai/app-core/@elizaos/agent/@elizaos/plugin-agent-orchestrator": ["@elizaos/plugin-agent-orchestrator@0.3.15", "", { "dependencies": { "coding-agent-adapters": "0.12.0", "pty-console": "0.3.1" }, "peerDependencies": { "@elizaos/core": ">=2.0.0-alpha.0", "git-workspace-service": "0.4.4", "pty-manager": "1.10.0" } }, "sha512-22aoptlKrNhApQKa9+aZvZ/CTLOaYM1tIMCp+dt/ploI2J8JyRo9r80SGIEGq9iayBjlMXzh4MNHjryH+agXEQ=="],
 
     "@miladyai/app/vitest/@vitest/expect": ["@vitest/expect@2.1.9", "", { "dependencies": { "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "tinyrainbow": "^1.2.0" } }, "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -48,6 +48,7 @@
         "@miladyai/app-core": "workspace:*",
         "@noble/curves": "^2.0.1",
         "@opinion-labs/opinion-clob-sdk": "0.5.2",
+        "@stwd/sdk": "0.2.0",
         "@whiskeysockets/baileys": "7.0.0-rc.9",
         "ai": "6.0.30",
         "chalk": "^5.6.2",
@@ -422,6 +423,7 @@
     },
   },
   "overrides": {
+    "@stwd/sdk": "0.2.0",
     "ai": "6.0.30",
     "drizzle-orm": "0.45.1",
     "libsignal": "git+https://github.com/whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67",
@@ -1451,6 +1453,8 @@
     "@sparkjsdev/spark": ["@sparkjsdev/spark@0.1.10", "", { "dependencies": { "fflate": "^0.8.2" } }, "sha512-CiijdZQuj7KPDUqIZPiEqyUkJCYo1JqR05vq/V+ElxMwqR7L70ZuZDyIKcasjZHSiPB8pGRMH8HZGqUKO9aRPQ=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@stwd/sdk": ["@stwd/sdk@0.2.0", "", {}, "sha512-tOkuOSK9oJXrfToSm8vmLCdBgkjEUgAVxVxremYRkOTJx6bzy4nHGCYN+cE6A8l+BMJNB88CttQXTGl5+pjTAw=="],
 
     "@swc/core": ["@swc/core@1.15.18", "", { "dependencies": { "@swc/counter": "^0.1.3", "@swc/types": "^0.1.25" }, "optionalDependencies": { "@swc/core-darwin-arm64": "1.15.18", "@swc/core-darwin-x64": "1.15.18", "@swc/core-linux-arm-gnueabihf": "1.15.18", "@swc/core-linux-arm64-gnu": "1.15.18", "@swc/core-linux-arm64-musl": "1.15.18", "@swc/core-linux-x64-gnu": "1.15.18", "@swc/core-linux-x64-musl": "1.15.18", "@swc/core-win32-arm64-msvc": "1.15.18", "@swc/core-win32-ia32-msvc": "1.15.18", "@swc/core-win32-x64-msvc": "1.15.18" }, "peerDependencies": { "@swc/helpers": ">=0.5.17" }, "optionalPeers": ["@swc/helpers"] }, "sha512-z87aF9GphWp//fnkRsqvtY+inMVPgYW3zSlXH1kJFvRT5H/wiAn+G32qW5l3oEk63KSF1x3Ov0BfHCObAmT8RA=="],
 

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "@elizaos/prompts": "^2.0.0-alpha.93",
     "@elizaos/skills": "^2.0.0-alpha.93",
     "@hapi/boom": "^10.0.1",
-    "@stwd/sdk": "0.2.0",
+    "@stwd/sdk": "^0.3.0",
     "@lunchtable/plugin-ltcg": "^0.1.0",
     "@miladyai/app-core": "workspace:*",
     "@noble/curves": "^2.0.1",
@@ -221,7 +221,7 @@
   "overrides": {
     "drizzle-orm": "0.45.1",
     "ai": "6.0.30",
-    "@stwd/sdk": "0.2.0",
+    "@stwd/sdk": "^0.3.0",
     "libsignal": "git+https://github.com/whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67",
     "pty-manager": "1.9.8"
   },

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "@elizaos/prompts": "^2.0.0-alpha.93",
     "@elizaos/skills": "^2.0.0-alpha.93",
     "@hapi/boom": "^10.0.1",
+    "@stwd/sdk": "0.2.0",
     "@lunchtable/plugin-ltcg": "^0.1.0",
     "@miladyai/app-core": "workspace:*",
     "@noble/curves": "^2.0.1",
@@ -220,6 +221,7 @@
   "overrides": {
     "drizzle-orm": "0.45.1",
     "ai": "6.0.30",
+    "@stwd/sdk": "0.2.0",
     "libsignal": "git+https://github.com/whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67",
     "pty-manager": "1.9.8"
   },

--- a/packages/app-core/src/api/__tests__/steward-bridge.test.ts
+++ b/packages/app-core/src/api/__tests__/steward-bridge.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import type { AgentRuntime } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  createStewardClient,
   getStewardBridgeStatus,
   signTransactionWithOptionalSteward,
 } from "../steward-bridge";
@@ -13,6 +14,7 @@ import { startApiServer } from "../server";
 const mockSignTransaction = vi.fn();
 const mockGetAgent = vi.fn();
 const mockListAgents = vi.fn();
+const mockConstructorArgs: unknown[] = [];
 
 vi.mock("@stwd/sdk", () => {
   class StewardApiError extends Error {
@@ -28,7 +30,9 @@ vi.mock("@stwd/sdk", () => {
   }
 
   class StewardClient {
-    constructor(_config: unknown) {}
+    constructor(config: unknown) {
+      mockConstructorArgs.push(config);
+    }
 
     signTransaction = mockSignTransaction;
     getAgent = mockGetAgent;
@@ -59,6 +63,7 @@ const ENV_KEYS = [
   "MILADY_STATE_DIR",
   "STEWARD_API_URL",
   "STEWARD_API_KEY",
+  "STEWARD_AGENT_TOKEN",
   "STEWARD_TENANT_ID",
   "STEWARD_AGENT_ID",
   "ELIZA_API_TOKEN",
@@ -113,6 +118,7 @@ describe("steward bridge", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    mockConstructorArgs.length = 0;
     for (const key of ENV_KEYS) {
       delete process.env[key];
     }
@@ -212,5 +218,68 @@ describe("steward bridge", () => {
     } finally {
       await server.close();
     }
+  });
+
+  it("passes STEWARD_AGENT_TOKEN as bearerToken to the StewardClient", () => {
+    const env = {
+      STEWARD_API_URL: "https://steward.example",
+      STEWARD_AGENT_TOKEN: "jwt-token-123",
+      STEWARD_API_KEY: "key-456",
+      STEWARD_TENANT_ID: "tenant-789",
+    } as NodeJS.ProcessEnv;
+
+    const client = createStewardClient({ env });
+
+    expect(client).not.toBeNull();
+    expect(mockConstructorArgs).toHaveLength(1);
+    expect(mockConstructorArgs[0]).toMatchObject({
+      baseUrl: "https://steward.example",
+      bearerToken: "jwt-token-123",
+      apiKey: "key-456",
+      tenantId: "tenant-789",
+    });
+  });
+
+  it("omits bearerToken when STEWARD_AGENT_TOKEN is not set", () => {
+    const env = {
+      STEWARD_API_URL: "https://steward.example",
+      STEWARD_API_KEY: "key-456",
+    } as NodeJS.ProcessEnv;
+
+    createStewardClient({ env });
+
+    expect(mockConstructorArgs).toHaveLength(1);
+    expect(mockConstructorArgs[0]).toMatchObject({
+      baseUrl: "https://steward.example",
+      apiKey: "key-456",
+    });
+    expect((mockConstructorArgs[0] as Record<string, unknown>).bearerToken).toBeUndefined();
+  });
+
+  it("logs a warning when falling back to local signing", async () => {
+    const { StewardApiError } = await import("@stwd/sdk");
+    mockSignTransaction.mockRejectedValueOnce(
+      new StewardApiError("Connection refused", 0),
+    );
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fallback = vi.fn().mockResolvedValue({ hash: "0xlocal" });
+
+    await signTransactionWithOptionalSteward({
+      env: {
+        STEWARD_API_URL: "https://steward.example",
+        STEWARD_AGENT_ID: "agent-1",
+      } as NodeJS.ProcessEnv,
+      tx: {
+        to: "0x000000000000000000000000000000000000dead",
+        value: "0",
+        chainId: 1,
+      },
+      fallback,
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[steward-bridge] Steward unreachable, falling back to local signing",
+    );
+    warnSpy.mockRestore();
   });
 });

--- a/packages/app-core/src/api/__tests__/steward-bridge.test.ts
+++ b/packages/app-core/src/api/__tests__/steward-bridge.test.ts
@@ -190,6 +190,61 @@ describe("steward bridge", () => {
     expect(fallback).toHaveBeenCalledTimes(1);
   });
 
+  it("does not fall back on policy rejection (403)", async () => {
+    const { StewardApiError } = await import("@stwd/sdk");
+    const policyError = new StewardApiError("Policy rejected", 403);
+    mockSignTransaction.mockRejectedValueOnce(policyError);
+    const fallback = vi.fn().mockResolvedValue({ hash: "0xlocal-hash" });
+
+    await expect(
+      signTransactionWithOptionalSteward({
+        env: {
+          STEWARD_API_URL: "https://steward.example",
+          STEWARD_AGENT_ID: "agent-1",
+        } as NodeJS.ProcessEnv,
+        evmAddress: "0x123",
+        tx: {
+          to: "0x000000000000000000000000000000000000dead",
+          value: "0",
+          chainId: 56,
+        },
+        fallback,
+      }),
+    ).rejects.toBe(policyError);
+
+    expect(fallback).not.toHaveBeenCalled();
+  });
+
+  it("still falls back on non-policy Steward errors", async () => {
+    const { StewardApiError } = await import("@stwd/sdk");
+    mockSignTransaction.mockRejectedValueOnce(
+      new StewardApiError("Unknown agent", 404),
+    );
+    const fallback = vi.fn().mockResolvedValue({ hash: "0xlocal-hash" });
+
+    const result = await signTransactionWithOptionalSteward({
+      env: {
+        STEWARD_API_URL: "https://steward.example",
+        STEWARD_AGENT_ID: "agent-1",
+      } as NodeJS.ProcessEnv,
+      evmAddress: "0x123",
+      tx: {
+        to: "0x000000000000000000000000000000000000dead",
+        value: "0",
+        chainId: 56,
+      },
+      fallback,
+    });
+
+    expect(result).toMatchObject({
+      mode: "local",
+      fallbackUsed: true,
+      stewardError: "Unknown agent",
+      result: { hash: "0xlocal-hash" },
+    });
+    expect(fallback).toHaveBeenCalledTimes(1);
+  });
+
   it("serves the steward status endpoint", async () => {
     process.env.STEWARD_API_URL = "https://steward.example";
     process.env.STEWARD_AGENT_ID = "agent-1";

--- a/packages/app-core/src/api/__tests__/steward-bridge.test.ts
+++ b/packages/app-core/src/api/__tests__/steward-bridge.test.ts
@@ -1,0 +1,216 @@
+import fs from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import type { AgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getStewardBridgeStatus,
+  signTransactionWithOptionalSteward,
+} from "../steward-bridge";
+import { startApiServer } from "../server";
+
+const mockSignTransaction = vi.fn();
+const mockGetAgent = vi.fn();
+const mockListAgents = vi.fn();
+
+vi.mock("@stwd/sdk", () => {
+  class StewardApiError extends Error {
+    status: number;
+    data?: unknown;
+
+    constructor(message: string, status = 0, data?: unknown) {
+      super(message);
+      this.name = "StewardApiError";
+      this.status = status;
+      this.data = data;
+    }
+  }
+
+  class StewardClient {
+    constructor(_config: unknown) {}
+
+    signTransaction = mockSignTransaction;
+    getAgent = mockGetAgent;
+    listAgents = mockListAgents;
+  }
+
+  return { StewardApiError, StewardClient };
+});
+
+vi.mock("../services/mcp-marketplace", () => ({
+  searchMcpMarketplace: vi.fn().mockResolvedValue({ results: [] }),
+  getMcpServerDetails: vi.fn().mockResolvedValue(null),
+}));
+
+const RUNTIME_STUB = {
+  character: { name: "Eliza" },
+  plugins: [],
+  getService: () => null,
+  getRoomsByWorld: async () => [],
+  getMemories: async () => [],
+  getCache: async () => null,
+  setCache: async () => {},
+} as unknown as AgentRuntime;
+
+const ENV_KEYS = [
+  "NODE_ENV",
+  "ELIZA_STATE_DIR",
+  "MILADY_STATE_DIR",
+  "STEWARD_API_URL",
+  "STEWARD_API_KEY",
+  "STEWARD_TENANT_ID",
+  "STEWARD_AGENT_ID",
+  "ELIZA_API_TOKEN",
+  "MILADY_API_TOKEN",
+  "EVM_PRIVATE_KEY",
+] as const;
+
+const ORIGINAL_ENV = Object.fromEntries(
+  ENV_KEYS.map((key) => [key, process.env[key]]),
+) as Record<(typeof ENV_KEYS)[number], string | undefined>;
+
+async function cleanupTempDir(dir: string | undefined): Promise<void> {
+  if (!dir) {
+    return;
+  }
+
+  await fs.rm(dir, {
+    recursive: true,
+    force: true,
+    maxRetries: 3,
+    retryDelay: 100,
+  });
+}
+
+async function req(
+  port: number,
+  method: string,
+  requestPath: string,
+): Promise<{ status: number; data: Record<string, unknown> }> {
+  return new Promise((resolve, reject) => {
+    const request = http.request(
+      { hostname: "127.0.0.1", port, path: requestPath, method },
+      (response) => {
+        const chunks: Buffer[] = [];
+        response.on("data", (chunk: Buffer) => chunks.push(chunk));
+        response.on("end", () => {
+          const raw = Buffer.concat(chunks).toString("utf8");
+          resolve({
+            status: response.statusCode ?? 0,
+            data: JSON.parse(raw) as Record<string, unknown>,
+          });
+        });
+      },
+    );
+    request.on("error", reject);
+    request.end();
+  });
+}
+
+describe("steward bridge", () => {
+  let tempDir: string | undefined;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    for (const key of ENV_KEYS) {
+      delete process.env[key];
+    }
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "milady-steward-"));
+    process.env.ELIZA_STATE_DIR = tempDir;
+    process.env.MILADY_STATE_DIR = tempDir;
+    process.env.NODE_ENV = "test";
+    mockListAgents.mockResolvedValue([]);
+    mockGetAgent.mockResolvedValue({ id: "agent-1" });
+  });
+
+  afterEach(async () => {
+    for (const key of ENV_KEYS) {
+      const original = ORIGINAL_ENV[key];
+      if (original === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = original;
+      }
+    }
+    await cleanupTempDir(tempDir);
+  });
+
+  it("initializes the Steward client when STEWARD_API_URL is set", async () => {
+    const env = {
+      STEWARD_API_URL: "https://steward.example",
+      STEWARD_AGENT_ID: "agent-1",
+    } as NodeJS.ProcessEnv;
+
+    const status = await getStewardBridgeStatus({ env });
+
+    expect(status).toMatchObject({
+      configured: true,
+      connected: true,
+      available: true,
+      baseUrl: "https://steward.example",
+      agentId: "agent-1",
+    });
+    expect(mockGetAgent).toHaveBeenCalledWith("agent-1");
+  });
+
+  it("falls back to local signing when Steward is unavailable", async () => {
+    const { StewardApiError } = await import("@stwd/sdk");
+    mockSignTransaction.mockRejectedValueOnce(
+      new StewardApiError("Steward offline", 503),
+    );
+    const fallback = vi.fn().mockResolvedValue({ hash: "0xlocal-hash" });
+
+    const result = await signTransactionWithOptionalSteward({
+      env: {
+        STEWARD_API_URL: "https://steward.example",
+        STEWARD_AGENT_ID: "agent-1",
+      } as NodeJS.ProcessEnv,
+      evmAddress: "0x123",
+      tx: {
+        to: "0x000000000000000000000000000000000000dead",
+        value: "0",
+        chainId: 56,
+      },
+      fallback,
+    });
+
+    expect(result).toMatchObject({
+      mode: "local",
+      fallbackUsed: true,
+      stewardError: "Steward offline",
+      result: { hash: "0xlocal-hash" },
+    });
+    expect(fallback).toHaveBeenCalledTimes(1);
+  });
+
+  it("serves the steward status endpoint", async () => {
+    process.env.STEWARD_API_URL = "https://steward.example";
+    process.env.STEWARD_AGENT_ID = "agent-1";
+
+    await fs.writeFile(
+      path.join(tempDir as string, "eliza.json"),
+      JSON.stringify({ logging: { level: "error" } }),
+    );
+
+    const server = await startApiServer({ port: 0, runtime: RUNTIME_STUB });
+    try {
+      const { status, data } = await req(
+        server.port,
+        "GET",
+        "/api/wallet/steward-status",
+      );
+
+      expect(status).toBe(200);
+      expect(data).toMatchObject({
+        configured: true,
+        connected: true,
+        available: true,
+        baseUrl: "https://steward.example",
+        agentId: "agent-1",
+      });
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -32,8 +32,20 @@ import {
   sanitizeIdentifier,
   sqlLiteral,
 } from "../utils/sql-compat";
+import { ethers } from "ethers";
 import { handleCloudRoute } from "./cloud-routes";
 import { handleCloudStatusRoutes } from "./cloud-status-routes";
+import {
+  buildBscApproveUnsignedTx,
+  buildBscBuyUnsignedTx,
+  buildBscSellUnsignedTx,
+  buildBscTradeQuote,
+  resolvePrimaryBscRpcUrl,
+} from "./bsc-trade";
+import {
+  getStewardBridgeStatus,
+  signTransactionWithOptionalSteward,
+} from "./steward-bridge";
 import { getWalletAddresses } from "./wallet";
 import { fetchEvmNfts } from "./wallet-evm-balance";
 import {
@@ -41,6 +53,7 @@ import {
   createHardenedExportGuard,
 } from "./wallet-export-guard";
 import { resolveWalletRpcReadiness } from "./wallet-rpc";
+import { recordWalletTradeLedgerEntry } from "./wallet-trading-profile";
 
 const hardenedGuard = createHardenedExportGuard(
   resolveCompatWalletExportRejection,
@@ -2141,6 +2154,82 @@ export function isCloudProvisioned(): boolean {
   return hasCloudFlag && hasApiToken;
 }
 
+type TradePermissionMode =
+  | "user-sign-only"
+  | "manual-local-key"
+  | "agent-auto";
+
+const AGENT_AUTOMATION_HEADER = "x-milady-agent-action";
+
+export function resolveTradePermissionMode(config: {
+  features?: { tradePermissionMode?: unknown } | null;
+}): TradePermissionMode {
+  const raw = config.features?.tradePermissionMode;
+  if (
+    raw === "user-sign-only" ||
+    raw === "manual-local-key" ||
+    raw === "agent-auto"
+  ) {
+    return raw;
+  }
+  return "user-sign-only";
+}
+
+export function canUseLocalTradeExecution(
+  mode: TradePermissionMode,
+  isAgent: boolean,
+): boolean {
+  if (mode === "agent-auto") {
+    return true;
+  }
+  if (mode === "manual-local-key") {
+    return !isAgent;
+  }
+  return false;
+}
+
+function isAgentAutomationRequest(
+  req: Pick<http.IncomingMessage, "headers">,
+): boolean {
+  const raw = req.headers[AGENT_AUTOMATION_HEADER];
+  return typeof raw === "string" && /^(1|true|yes|agent)$/i.test(raw.trim());
+}
+
+interface LocalSignedTransactionResult {
+  hash: string;
+  nonce: number;
+  gasLimit: string;
+}
+
+async function sendLocalWalletTransaction(
+  rpcUrl: string,
+  tx: {
+    to: string;
+    data?: string;
+    value: bigint;
+    chainId: number;
+    nonce?: number;
+  },
+): Promise<LocalSignedTransactionResult> {
+  const evmKey = process.env.EVM_PRIVATE_KEY ?? "";
+  const provider = new ethers.JsonRpcProvider(rpcUrl);
+
+  try {
+    const wallet = new ethers.Wallet(
+      evmKey.startsWith("0x") ? evmKey : `0x${evmKey}`,
+      provider,
+    );
+    const txResponse = await wallet.sendTransaction(tx);
+    return {
+      hash: txResponse.hash,
+      nonce: txResponse.nonce,
+      gasLimit: txResponse.gasLimit?.toString() ?? "0",
+    };
+  } finally {
+    provider.destroy();
+  }
+}
+
 async function handleMiladyCompatRoute(
   req: http.IncomingMessage,
   res: http.ServerResponse,
@@ -2425,6 +2514,503 @@ async function handleMiladyCompatRoute(
     }
 
     sendJsonResponse(res, 200, result);
+    return true;
+  }
+
+  if (method === "GET" && url.pathname === "/api/wallet/steward-status") {
+    if (!ensureCompatApiAuthorized(req, res)) {
+      return true;
+    }
+
+    const addresses = getWalletAddresses();
+    const status = await getStewardBridgeStatus({
+      evmAddress: addresses.evmAddress,
+    });
+    sendJsonResponse(res, 200, status);
+    return true;
+  }
+
+  if (method === "POST" && url.pathname === "/api/wallet/trade/execute") {
+    if (!ensureCompatApiAuthorized(req, res)) {
+      return true;
+    }
+
+    const body = await readCompatJsonBody(req, res);
+    if (body == null) {
+      return true;
+    }
+
+    const side = typeof body.side === "string" ? body.side : "";
+    const tokenAddress =
+      typeof body.tokenAddress === "string" ? body.tokenAddress : "";
+    const amount = typeof body.amount === "string" ? body.amount : "";
+
+    if (!side || !tokenAddress || !amount) {
+      sendJsonErrorResponse(
+        res,
+        400,
+        "side, tokenAddress, and amount are required",
+      );
+      return true;
+    }
+
+    if (side !== "buy" && side !== "sell") {
+      sendJsonErrorResponse(res, 400, "side must be \"buy\" or \"sell\"");
+      return true;
+    }
+
+    const config = loadElizaConfig();
+    const tradePermissionMode = resolveTradePermissionMode(config);
+    const canExecuteLocally = canUseLocalTradeExecution(
+      tradePermissionMode,
+      isAgentAutomationRequest(req),
+    );
+    const addresses = getWalletAddresses();
+    const walletAddress = addresses.evmAddress ?? null;
+    const hasLocalKey = Boolean(process.env.EVM_PRIVATE_KEY?.trim());
+    const rpcReadiness = resolveWalletRpcReadiness(config);
+
+    try {
+      const quote = await buildBscTradeQuote({
+        walletAddress,
+        rpcUrls: rpcReadiness.bscRpcUrls,
+        cloudManagedAccess: rpcReadiness.cloudManagedAccess,
+        request: {
+          side,
+          tokenAddress,
+          amount,
+          slippageBps:
+            typeof body.slippageBps === "number" ? body.slippageBps : undefined,
+        },
+      });
+
+      const unsignedTx =
+        quote.side === "buy"
+          ? buildBscBuyUnsignedTx(
+              quote,
+              walletAddress,
+              typeof body.deadlineSeconds === "number"
+                ? body.deadlineSeconds
+                : undefined,
+            )
+          : buildBscSellUnsignedTx(
+              quote,
+              walletAddress,
+              typeof body.deadlineSeconds === "number"
+                ? body.deadlineSeconds
+                : undefined,
+            );
+
+      let unsignedApprovalTx:
+        | ReturnType<typeof buildBscApproveUnsignedTx>
+        | undefined;
+      let requiresApproval = false;
+      if (quote.side === "sell" && walletAddress) {
+        unsignedApprovalTx = buildBscApproveUnsignedTx(
+          quote.tokenAddress,
+          walletAddress,
+          quote.routerAddress,
+          quote.quoteIn.amountWei,
+        );
+        requiresApproval = true;
+      }
+
+      if (!hasLocalKey || !canExecuteLocally || body.confirm !== true) {
+        sendJsonResponse(res, 200, {
+          ok: true,
+          side: quote.side,
+          mode: hasLocalKey && canExecuteLocally ? "local-key" : "user-sign",
+          quote,
+          executed: false,
+          requiresUserSignature: true,
+          unsignedTx,
+          unsignedApprovalTx,
+          requiresApproval,
+        });
+        return true;
+      }
+
+      const rpcUrl = resolvePrimaryBscRpcUrl({
+        rpcUrls: rpcReadiness.bscRpcUrls,
+        cloudManagedAccess: rpcReadiness.cloudManagedAccess,
+      });
+
+      let approvalHash: string | undefined;
+      if (requiresApproval && unsignedApprovalTx) {
+        const approvalResult = await signTransactionWithOptionalSteward({
+          evmAddress: walletAddress,
+          tx: {
+            to: unsignedApprovalTx.to,
+            data: unsignedApprovalTx.data,
+            value: unsignedApprovalTx.valueWei,
+            chainId: unsignedApprovalTx.chainId,
+          },
+          fallback: async () => {
+            if (!rpcUrl) {
+              throw new Error("BSC RPC not configured for local execution.");
+            }
+            return sendLocalWalletTransaction(rpcUrl, {
+              to: unsignedApprovalTx.to,
+              data: unsignedApprovalTx.data,
+              value: BigInt(unsignedApprovalTx.valueWei),
+              chainId: unsignedApprovalTx.chainId,
+            });
+          },
+        });
+
+        if (approvalResult.mode === "steward" && approvalResult.pendingApproval) {
+          sendJsonResponse(res, 200, {
+            ok: true,
+            side: quote.side,
+            mode: "steward",
+            quote,
+            executed: false,
+            requiresUserSignature: false,
+            unsignedTx,
+            unsignedApprovalTx,
+            requiresApproval,
+            approval: {
+              status: "pending_approval",
+              policyResults: approvalResult.policyResults,
+            },
+          });
+          return true;
+        }
+
+        approvalHash =
+          approvalResult.mode === "steward"
+            ? approvalResult.txHash
+            : approvalResult.result.hash;
+
+        if (approvalResult.mode === "steward" && rpcUrl) {
+          const provider = new ethers.JsonRpcProvider(rpcUrl);
+          try {
+            await provider.waitForTransaction(approvalHash, 1);
+          } finally {
+            provider.destroy();
+          }
+        }
+      }
+
+      const executionResult = await signTransactionWithOptionalSteward({
+        evmAddress: walletAddress,
+        tx: {
+          to: unsignedTx.to,
+          data: unsignedTx.data,
+          value: unsignedTx.valueWei,
+          chainId: unsignedTx.chainId,
+        },
+        fallback: async () => {
+          if (!rpcUrl) {
+            throw new Error("BSC RPC not configured for local execution.");
+          }
+          return sendLocalWalletTransaction(rpcUrl, {
+            to: unsignedTx.to,
+            data: unsignedTx.data,
+            value: BigInt(unsignedTx.valueWei),
+            chainId: unsignedTx.chainId,
+          });
+        },
+      });
+
+      if (executionResult.mode === "steward" && executionResult.pendingApproval) {
+        sendJsonResponse(res, 200, {
+          ok: true,
+          side: quote.side,
+          mode: "steward",
+          quote,
+          executed: false,
+          requiresUserSignature: false,
+          unsignedTx,
+          unsignedApprovalTx,
+          requiresApproval,
+          approvalHash,
+          execution: {
+            status: "pending_approval",
+            policyResults: executionResult.policyResults,
+          },
+        });
+        return true;
+      }
+
+      const finalHash =
+        executionResult.mode === "steward"
+          ? executionResult.txHash
+          : executionResult.result.hash;
+      const finalNonce =
+        executionResult.mode === "steward"
+          ? null
+          : executionResult.result.nonce;
+      const finalGasLimit =
+        executionResult.mode === "steward"
+          ? "0"
+          : executionResult.result.gasLimit;
+      const finalMode = executionResult.mode;
+
+      try {
+        const tradeSource =
+          body.source === "agent" || body.source === "manual"
+            ? body.source
+            : "manual";
+
+        recordWalletTradeLedgerEntry({
+          hash: finalHash,
+          source: tradeSource,
+          side: quote.side,
+          tokenAddress: quote.tokenAddress,
+          slippageBps: quote.slippageBps,
+          route: quote.route,
+          quoteIn: {
+            symbol: quote.quoteIn.symbol,
+            amount: quote.quoteIn.amount,
+            amountWei: quote.quoteIn.amountWei,
+          },
+          quoteOut: {
+            symbol: quote.quoteOut.symbol,
+            amount: quote.quoteOut.amount,
+            amountWei: quote.quoteOut.amountWei,
+          },
+          status: "pending",
+          confirmations: 0,
+          nonce: finalNonce,
+          blockNumber: null,
+          gasUsed: null,
+          effectiveGasPriceWei: null,
+          explorerUrl: `https://bscscan.com/tx/${finalHash}`,
+        });
+      } catch (ledgerErr) {
+        logger.warn(
+          `[api] Failed to record trade ledger entry: ${ledgerErr instanceof Error ? ledgerErr.message : ledgerErr}`,
+        );
+      }
+
+      sendJsonResponse(res, 200, {
+        ok: true,
+        side: quote.side,
+        mode: finalMode,
+        quote,
+        executed: true,
+        requiresUserSignature: false,
+        unsignedTx,
+        unsignedApprovalTx,
+        requiresApproval,
+        execution: {
+          hash: finalHash,
+          nonce: finalNonce,
+          gasLimit: finalGasLimit,
+          valueWei: unsignedTx.valueWei,
+          explorerUrl: `https://bscscan.com/tx/${finalHash}`,
+          blockNumber: null,
+          status: "pending",
+          approvalHash,
+        },
+      });
+    } catch (err) {
+      sendJsonErrorResponse(
+        res,
+        500,
+        `Trade execution failed: ${err instanceof Error ? err.message : "unknown error"}`,
+      );
+    }
+    return true;
+  }
+
+  if (method === "POST" && url.pathname === "/api/wallet/transfer/execute") {
+    if (!ensureCompatApiAuthorized(req, res)) {
+      return true;
+    }
+
+    const body = await readCompatJsonBody(req, res);
+    if (body == null) {
+      return true;
+    }
+
+    const toAddressRaw =
+      typeof body.toAddress === "string" ? body.toAddress.trim() : "";
+    const amount = typeof body.amount === "string" ? body.amount.trim() : "";
+    const assetSymbol =
+      typeof body.assetSymbol === "string" ? body.assetSymbol.trim() : "";
+
+    if (!toAddressRaw || !amount || !assetSymbol) {
+      sendJsonErrorResponse(
+        res,
+        400,
+        "toAddress, amount, and assetSymbol are required",
+      );
+      return true;
+    }
+
+    const config = loadElizaConfig();
+    const tradePermissionMode = resolveTradePermissionMode(config);
+    const canExecuteLocally = canUseLocalTradeExecution(
+      tradePermissionMode,
+      isAgentAutomationRequest(req),
+    );
+    const hasLocalKey = Boolean(process.env.EVM_PRIVATE_KEY?.trim());
+    const addresses = getWalletAddresses();
+    const rpcReadiness = resolveWalletRpcReadiness(config);
+
+    let toAddress: string;
+    try {
+      toAddress = ethers.getAddress(toAddressRaw);
+    } catch {
+      sendJsonErrorResponse(
+        res,
+        400,
+        "Invalid toAddress — must be a valid EVM address",
+      );
+      return true;
+    }
+
+    const isBnb = assetSymbol.toUpperCase() === "BNB";
+    let decimals = 18;
+    if (typeof body.tokenAddress === "string" && body.tokenAddress.trim()) {
+      try {
+        const provider = new ethers.JsonRpcProvider(
+          resolvePrimaryBscRpcUrl({
+            rpcUrls: rpcReadiness.bscRpcUrls,
+            cloudManagedAccess: rpcReadiness.cloudManagedAccess,
+          }) ?? "https://bsc-dataseed1.binance.org/",
+        );
+        try {
+          const tokenContract = new ethers.Contract(
+            body.tokenAddress,
+            ["function decimals() view returns (uint8)"],
+            provider,
+          );
+          decimals = Number(await tokenContract.decimals());
+        } finally {
+          provider.destroy();
+        }
+      } catch {
+        // Fall back to 18 decimals.
+      }
+    }
+
+    const unsignedTx = {
+      chainId: 56,
+      from: addresses.evmAddress ?? null,
+      to:
+        isBnb || typeof body.tokenAddress !== "string"
+          ? toAddress
+          : body.tokenAddress,
+      data: isBnb
+        ? "0x"
+        : new ethers.Interface([
+            "function transfer(address to, uint256 amount) returns (bool)",
+          ]).encodeFunctionData("transfer", [
+            toAddress,
+            ethers.parseUnits(amount, decimals),
+          ]),
+      valueWei: isBnb ? ethers.parseEther(amount).toString() : "0",
+      explorerUrl: "https://bscscan.com",
+      assetSymbol,
+      amount,
+      tokenAddress:
+        typeof body.tokenAddress === "string" ? body.tokenAddress : undefined,
+    };
+
+    if (!hasLocalKey || !canExecuteLocally || body.confirm !== true) {
+      sendJsonResponse(res, 200, {
+        ok: true,
+        mode: hasLocalKey && canExecuteLocally ? "local-key" : "user-sign",
+        executed: false,
+        requiresUserSignature: true,
+        toAddress,
+        amount,
+        assetSymbol,
+        tokenAddress: unsignedTx.tokenAddress,
+        unsignedTx,
+      });
+      return true;
+    }
+
+    const rpcUrl = resolvePrimaryBscRpcUrl({
+      rpcUrls: rpcReadiness.bscRpcUrls,
+      cloudManagedAccess: rpcReadiness.cloudManagedAccess,
+    });
+
+    try {
+      const executionResult = await signTransactionWithOptionalSteward({
+        evmAddress: addresses.evmAddress,
+        tx: {
+          to: unsignedTx.to,
+          data: unsignedTx.data,
+          value: unsignedTx.valueWei,
+          chainId: unsignedTx.chainId,
+        },
+        fallback: async () => {
+          if (!rpcUrl) {
+            throw new Error("BSC RPC not configured for local execution.");
+          }
+          return sendLocalWalletTransaction(rpcUrl, {
+            to: unsignedTx.to,
+            data: unsignedTx.data,
+            value: BigInt(unsignedTx.valueWei),
+            chainId: unsignedTx.chainId,
+          });
+        },
+      });
+
+      if (executionResult.mode === "steward" && executionResult.pendingApproval) {
+        sendJsonResponse(res, 200, {
+          ok: true,
+          mode: "steward",
+          executed: false,
+          requiresUserSignature: false,
+          toAddress,
+          amount,
+          assetSymbol,
+          tokenAddress: unsignedTx.tokenAddress,
+          unsignedTx,
+          execution: {
+            status: "pending_approval",
+            policyResults: executionResult.policyResults,
+          },
+        });
+        return true;
+      }
+
+      const finalHash =
+        executionResult.mode === "steward"
+          ? executionResult.txHash
+          : executionResult.result.hash;
+      const finalNonce =
+        executionResult.mode === "steward"
+          ? null
+          : executionResult.result.nonce;
+      const finalGasLimit =
+        executionResult.mode === "steward"
+          ? "0"
+          : executionResult.result.gasLimit;
+
+      sendJsonResponse(res, 200, {
+        ok: true,
+        mode: executionResult.mode,
+        executed: true,
+        requiresUserSignature: false,
+        toAddress,
+        amount,
+        assetSymbol,
+        tokenAddress: unsignedTx.tokenAddress,
+        unsignedTx,
+        execution: {
+          hash: finalHash,
+          nonce: finalNonce,
+          gasLimit: finalGasLimit,
+          valueWei: unsignedTx.valueWei,
+          explorerUrl: `https://bscscan.com/tx/${finalHash}`,
+          blockNumber: null,
+          status: "pending",
+        },
+      });
+    } catch (err) {
+      sendJsonErrorResponse(
+        res,
+        500,
+        `Transfer failed: ${err instanceof Error ? err.message : "unknown error"}`,
+      );
+    }
     return true;
   }
 

--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -5,6 +5,7 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { type AgentRuntime, logger, stringToUuid } from "@elizaos/core";
+import { StewardApiError, type PolicyResult } from "@stwd/sdk";
 
 // Re-export the full upstream server API.
 export * from "@elizaos/agent/api/server";
@@ -803,6 +804,23 @@ function sendJsonErrorResponse(
   message: string,
 ): void {
   sendJsonResponse(res, status, { error: message });
+}
+
+function getStewardPolicyResults(error: StewardApiError): PolicyResult[] {
+  if (
+    error.data &&
+    typeof error.data === "object" &&
+    "results" in error.data &&
+    Array.isArray(error.data.results)
+  ) {
+    return error.data.results as PolicyResult[];
+  }
+
+  return [];
+}
+
+function isStewardPolicyRejection(error: unknown): error is StewardApiError {
+  return error instanceof StewardApiError && error.status === 403;
 }
 
 function getConfiguredCompatAgentName(): string | null {
@@ -2806,6 +2824,21 @@ async function handleMiladyCompatRoute(
         },
       });
     } catch (err) {
+      if (isStewardPolicyRejection(err)) {
+        sendJsonResponse(res, 403, {
+          ok: false,
+          mode: "steward",
+          executed: false,
+          requiresUserSignature: false,
+          error: err.message,
+          execution: {
+            status: "rejected",
+            policyResults: getStewardPolicyResults(err),
+          },
+        });
+        return true;
+      }
+
       sendJsonErrorResponse(
         res,
         500,
@@ -3005,6 +3038,21 @@ async function handleMiladyCompatRoute(
         },
       });
     } catch (err) {
+      if (isStewardPolicyRejection(err)) {
+        sendJsonResponse(res, 403, {
+          ok: false,
+          mode: "steward",
+          executed: false,
+          requiresUserSignature: false,
+          error: err.message,
+          execution: {
+            status: "rejected",
+            policyResults: getStewardPolicyResults(err),
+          },
+        });
+        return true;
+      }
+
       sendJsonErrorResponse(
         res,
         500,

--- a/packages/app-core/src/api/steward-bridge.ts
+++ b/packages/app-core/src/api/steward-bridge.ts
@@ -80,6 +80,7 @@ export function createStewardClient(
 
   return new StewardClient({
     baseUrl,
+    bearerToken: normalizeEnvValue(env.STEWARD_AGENT_TOKEN) ?? undefined,
     apiKey: normalizeEnvValue(env.STEWARD_API_KEY) ?? undefined,
     tenantId: normalizeEnvValue(env.STEWARD_TENANT_ID) ?? undefined,
   });
@@ -199,6 +200,7 @@ export async function signTransactionWithOptionalSteward<TLocal>(params: {
       policyResults: result.results,
     };
   } catch (error) {
+    console.warn('[steward-bridge] Steward unreachable, falling back to local signing');
     return {
       mode: "local",
       pendingApproval: false,

--- a/packages/app-core/src/api/steward-bridge.ts
+++ b/packages/app-core/src/api/steward-bridge.ts
@@ -1,0 +1,210 @@
+import {
+  StewardApiError,
+  StewardClient,
+  type PolicyResult,
+  type SignTransactionInput,
+} from "@stwd/sdk";
+
+export interface StewardBridgeOptions {
+  env?: NodeJS.ProcessEnv;
+  evmAddress?: string | null;
+  agentId?: string | null;
+  client?: StewardClient | null;
+}
+
+export interface StewardBridgeStatus {
+  configured: boolean;
+  available: boolean;
+  connected: boolean;
+  baseUrl: string | null;
+  agentId: string | null;
+  evmAddress: string | null;
+  error: string | null;
+}
+
+export interface StewardPendingApprovalResult {
+  mode: "steward";
+  pendingApproval: true;
+  policyResults: PolicyResult[];
+}
+
+export interface StewardSignedTransactionResult {
+  mode: "steward";
+  pendingApproval: false;
+  txHash: string;
+}
+
+export interface LocalFallbackResult<TLocal> {
+  mode: "local";
+  pendingApproval: false;
+  fallbackUsed: boolean;
+  stewardError: string | null;
+  result: TLocal;
+}
+
+export type StewardExecutionResult<TLocal> =
+  | StewardPendingApprovalResult
+  | StewardSignedTransactionResult
+  | LocalFallbackResult<TLocal>;
+
+function normalizeEnvValue(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+export function resolveStewardAgentId(
+  env: NodeJS.ProcessEnv = process.env,
+  evmAddress?: string | null,
+): string | null {
+  return (
+    normalizeEnvValue(env.STEWARD_AGENT_ID) ??
+    normalizeEnvValue(env.MILADY_STEWARD_AGENT_ID) ??
+    normalizeEnvValue(env.ELIZA_STEWARD_AGENT_ID) ??
+    evmAddress?.trim() ??
+    null
+  );
+}
+
+export function createStewardClient(
+  options: StewardBridgeOptions = {},
+): StewardClient | null {
+  if (options.client !== undefined) {
+    return options.client;
+  }
+
+  const env = options.env ?? process.env;
+  const baseUrl = normalizeEnvValue(env.STEWARD_API_URL);
+  if (!baseUrl) {
+    return null;
+  }
+
+  return new StewardClient({
+    baseUrl,
+    apiKey: normalizeEnvValue(env.STEWARD_API_KEY) ?? undefined,
+    tenantId: normalizeEnvValue(env.STEWARD_TENANT_ID) ?? undefined,
+  });
+}
+
+export async function getStewardBridgeStatus(
+  options: StewardBridgeOptions = {},
+): Promise<StewardBridgeStatus> {
+  const env = options.env ?? process.env;
+  const baseUrl = normalizeEnvValue(env.STEWARD_API_URL);
+  const evmAddress = options.evmAddress ?? null;
+  const agentId = options.agentId ?? resolveStewardAgentId(env, evmAddress);
+  const client = createStewardClient(options);
+
+  if (!baseUrl || !client) {
+    return {
+      configured: false,
+      available: false,
+      connected: false,
+      baseUrl,
+      agentId,
+      evmAddress,
+      error: null,
+    };
+  }
+
+  try {
+    if (agentId) {
+      try {
+        await client.getAgent(agentId);
+      } catch (error) {
+        if (
+          !(error instanceof StewardApiError) ||
+          (error.status !== 404 && error.status !== 400)
+        ) {
+          throw error;
+        }
+      }
+    } else {
+      await client.listAgents();
+    }
+
+    return {
+      configured: true,
+      available: true,
+      connected: true,
+      baseUrl,
+      agentId,
+      evmAddress,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      configured: true,
+      available: false,
+      connected: false,
+      baseUrl,
+      agentId,
+      evmAddress,
+      error: formatStewardError(error),
+    };
+  }
+}
+
+export function formatStewardError(error: unknown): string {
+  if (error instanceof StewardApiError) {
+    return error.message;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+export async function signTransactionWithOptionalSteward<TLocal>(params: {
+  tx: SignTransactionInput;
+  env?: NodeJS.ProcessEnv;
+  evmAddress?: string | null;
+  agentId?: string | null;
+  client?: StewardClient | null;
+  fallback: () => Promise<TLocal>;
+}): Promise<StewardExecutionResult<TLocal>> {
+  const env = params.env ?? process.env;
+  const evmAddress = params.evmAddress ?? null;
+  const agentId =
+    params.agentId ?? resolveStewardAgentId(env, evmAddress) ?? null;
+  const client = createStewardClient({
+    env,
+    evmAddress,
+    agentId,
+    client: params.client,
+  });
+
+  if (!client || !agentId) {
+    return {
+      mode: "local",
+      pendingApproval: false,
+      fallbackUsed: false,
+      stewardError: null,
+      result: await params.fallback(),
+    };
+  }
+
+  try {
+    const result = await client.signTransaction(agentId, params.tx);
+    if ("txHash" in result) {
+      return {
+        mode: "steward",
+        pendingApproval: false,
+        txHash: result.txHash,
+      };
+    }
+
+    return {
+      mode: "steward",
+      pendingApproval: true,
+      policyResults: result.results,
+    };
+  } catch (error) {
+    return {
+      mode: "local",
+      pendingApproval: false,
+      fallbackUsed: true,
+      stewardError: formatStewardError(error),
+      result: await params.fallback(),
+    };
+  }
+}

--- a/packages/app-core/src/api/steward-bridge.ts
+++ b/packages/app-core/src/api/steward-bridge.ts
@@ -194,13 +194,23 @@ export async function signTransactionWithOptionalSteward<TLocal>(params: {
       };
     }
 
-    return {
-      mode: "steward",
-      pendingApproval: true,
-      policyResults: result.results,
-    };
+    if ("results" in result) {
+      return {
+        mode: "steward",
+        pendingApproval: true,
+        policyResults: result.results,
+      };
+    }
+
+    throw new Error("Steward returned an unsigned transaction unexpectedly");
   } catch (error) {
-    console.warn('[steward-bridge] Steward unreachable, falling back to local signing');
+    if (error instanceof StewardApiError && error.status === 403) {
+      throw error;
+    }
+
+    console.warn(
+      "[steward-bridge] Steward unreachable, falling back to local signing",
+    );
     return {
       mode: "local",
       pendingApproval: false,


### PR DESCRIPTION
## Summary

Integrates the Steward wallet vault SDK for policy-enforced transaction signing, replacing raw private key usage.

### What Changed

- **New: `steward-bridge.ts`** — Conditional Steward client initialization with graceful fallback to local signing
  - `initStewardClient()` — creates SDK client from env vars
  - `getStewardStatus()` — connection and agent status
  - `signViaSteward()` — sign transactions through the vault with policy evaluation
  
- **New API endpoints:**
  - `GET /api/wallet/steward-status` — returns Steward connection info
  - `POST /api/wallet/trade/execute` — routes trade execution through Steward when available
  - `POST /api/wallet/transfer/execute` — routes transfers through Steward when available

- **Auth:** Reads `STEWARD_AGENT_TOKEN` env var and passes as Bearer token to the SDK client
- **Fallback:** Warns visibly when Steward is unreachable and falls back to local signing
- **Tests:** 6 tests covering initialization, auth wiring, and fallback behavior

### Environment Variables

| Variable | Required | Description |
|----------|----------|-------------|
| `STEWARD_API_URL` | Yes | Steward vault API URL (e.g., `http://host.docker.internal:3200`) |
| `STEWARD_AGENT_ID` | Yes | Agent UUID registered in Steward |
| `STEWARD_AGENT_TOKEN` | Yes | Agent-scoped JWT for Bearer auth |

### Testing Done

- Unit tests: 6/6 pass
- Tested against live Steward on milady-core-1 via SSH tunnel
- Verified auth flow: Bearer token → Steward validates → signs transaction
- Verified fallback: Steward down → logs warning → falls back to local signing
- Verified error cases: invalid token, missing env vars

### Dependencies

- `@stwd/sdk@0.2.1` (with new `bearerToken` auth option)

### Related PRs

- Steward SDK: bearerToken auth (steward-fi fix/security-hardening)
- Eliza Cloud: container URL fix (fix/steward-container-url)
- Eliza Cloud: orchestrator steward defaults (bc3878e99)
