### PR TITLE
fix: handle EADDRINUSE in screenshot dev server

### DIFF
--- a/apps/app/electrobun/src/screenshot-dev-server.ts
+++ b/apps/app/electrobun/src/screenshot-dev-server.ts
@@ -96,6 +96,16 @@ export function startScreenshotDevServer(): (() => void) | undefined {
     }
   });
 
+  server.on("error", (err: NodeJS.ErrnoException) => {
+    if (err.code === "EADDRINUSE") {
+      console.warn(
+        `[ScreenshotDev] Failed to start loopback server on 127.0.0.1:${port}: port in use — set MILADY_SCREENSHOT_SERVER_PORT to a free port or stop the other process`,
+      );
+    } else {
+      console.warn("[ScreenshotDev] Server error:", err.message);
+    }
+  });
+
   server.listen(port, "127.0.0.1", () => {
     console.log(
       `[ScreenshotDev] http://127.0.0.1:${port}/cursor-screenshot.png (loopback only` +


### PR DESCRIPTION
## Summary

- Screenshot dev server's `server.listen()` had no error handler
- `EADDRINUSE` on port 31339 (stale process from previous run) threw an uncaught exception that killed the entire Electrobun process
- Desktop app would open and immediately close with no visible error
- Added `server.on("error")` handler to log the port conflict gracefully instead of crashing

## Root cause

Commit `5d833efa` ("milady: desktop stack, companion cloud UX") added the screenshot dev server but without an error handler on `server.listen()`. Any port conflict kills the process.

## Test plan

- [ ] Run `bun run dev:desktop` twice rapidly (second run should gracefully warn about port 31339 instead of crashing)
- [ ] Kill stale processes, run again — should start normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)