### PR TITLE
fix: context provider review feedback

### DIFF
--- a/packages/app-core/src/state/ChatContext.tsx
+++ b/packages/app-core/src/state/ChatContext.tsx
@@ -260,24 +260,51 @@ export function useChatState(): ChatStateValue {
   const ctx = useContext(ChatCtx);
   if (ctx) return ctx;
   if (typeof process !== "undefined" && process.env.NODE_ENV === "test") {
-    return new Proxy({} as ChatStateValue, {
-      get(_, prop) {
-        if (prop === "conversations") return [];
-        if (prop === "conversationMessages") return [];
-        if (prop === "autonomousEvents") return [];
-        if (prop === "ptySessions") return [];
-        if (prop === "unreadConversations") return new Set();
-        if (prop === "chatPendingImages") return [];
-        if (prop === "droppedFiles") return [];
-        if (prop === "chatInput") return "";
-        if (prop === "activeConversationId") return null;
-        if (prop === "activeConversationIdRef") return { current: null };
-        if (prop === "conversationMessagesRef") return { current: [] };
-        return typeof prop === "string" && prop.startsWith("set")
-          ? () => {}
-          : null;
-      },
-    });
+    const noop = () => {};
+    return {
+      chatInput: "",
+      chatSending: false,
+      chatFirstTokenReceived: false,
+      chatLastUsage: null,
+      chatAvatarVisible: false,
+      chatAgentVoiceMuted: false,
+      chatMode: "simple" as ConversationMode,
+      chatAvatarSpeaking: false,
+      conversations: [],
+      activeConversationId: null,
+      companionMessageCutoffTs: 0,
+      conversationMessages: [],
+      autonomousEvents: [],
+      autonomousLatestEventId: null,
+      autonomousRunHealthByRunId: {},
+      ptySessions: [],
+      unreadConversations: new Set<string>(),
+      chatPendingImages: [],
+      droppedFiles: [],
+      shareIngestNotice: null,
+      setChatInput: noop,
+      setChatSending: noop,
+      setChatFirstTokenReceived: noop,
+      setChatLastUsage: noop,
+      setChatAvatarVisible: noop,
+      setChatAgentVoiceMuted: noop,
+      setChatMode: noop,
+      setChatAvatarSpeaking: noop,
+      setConversations: noop as ChatStateValue["setConversations"],
+      setActiveConversationId: noop,
+      setCompanionMessageCutoffTs: noop,
+      setConversationMessages: noop as ChatStateValue["setConversationMessages"],
+      setAutonomousEvents: noop as ChatStateValue["setAutonomousEvents"],
+      setAutonomousLatestEventId: noop,
+      setAutonomousRunHealthByRunId: noop as ChatStateValue["setAutonomousRunHealthByRunId"],
+      setPtySessions: noop as ChatStateValue["setPtySessions"],
+      setUnreadConversations: noop as ChatStateValue["setUnreadConversations"],
+      setChatPendingImages: noop as ChatStateValue["setChatPendingImages"],
+      setDroppedFiles: noop as ChatStateValue["setDroppedFiles"],
+      setShareIngestNotice: noop,
+      activeConversationIdRef: { current: null },
+      conversationMessagesRef: { current: [] },
+    };
   }
   throw new Error(
     "useChatState must be used within ChatProvider or AppProvider",

--- a/packages/app-core/src/state/LifecycleContext.tsx
+++ b/packages/app-core/src/state/LifecycleContext.tsx
@@ -266,18 +266,52 @@ export function useLifecycle(): LifecycleContextValue {
   const ctx = useContext(LifecycleCtx);
   if (ctx) return ctx;
   if (typeof process !== "undefined" && process.env.NODE_ENV === "test") {
-    return new Proxy({} as LifecycleContextValue, {
-      get(_, prop) {
-        if (prop === "startupStatus") return "ready";
-        if (prop === "startupPhase") return "ready";
-        if (prop === "systemWarnings") return [];
-        if (prop === "pendingRestartReasons") return [];
-        if (prop === "agentStatusRef") return { current: null };
-        return typeof prop === "string" && prop.startsWith("set")
-          ? () => {}
-          : null;
+    const noop = () => {};
+    return {
+      connected: false,
+      agentStatus: null,
+      onboardingComplete: false,
+      onboardingUiRevealNonce: 0,
+      onboardingLoading: false,
+      startupPhase: "ready" as StartupPhase,
+      startupStatus: "ready" as AppState["startupStatus"],
+      startupError: null,
+      startupRetryNonce: 0,
+      authRequired: false,
+      actionNotice: null,
+      lifecycleBusy: false,
+      lifecycleAction: null,
+      pendingRestart: false,
+      pendingRestartReasons: [],
+      restartBannerDismissed: false,
+      backendConnection: {
+        state: "disconnected" as const,
+        reconnectAttempt: 0,
+        maxReconnectAttempts: 15,
+        showDisconnectedUI: false,
       },
-    });
+      backendDisconnectedBannerDismissed: false,
+      systemWarnings: [],
+      setConnected: noop,
+      setAgentStatus: noop,
+      setOnboardingComplete: noop,
+      setOnboardingUiRevealNonce: noop as LifecycleContextValue["setOnboardingUiRevealNonce"],
+      setOnboardingLoading: noop,
+      setStartupPhase: noop,
+      setStartupError: noop,
+      setStartupRetryNonce: noop as LifecycleContextValue["setStartupRetryNonce"],
+      setAuthRequired: noop,
+      setActionNotice: noop as LifecycleContextValue["setActionNotice"],
+      setLifecycleBusy: noop,
+      setLifecycleAction: noop,
+      setPendingRestart: noop,
+      setPendingRestartReasons: noop as LifecycleContextValue["setPendingRestartReasons"],
+      setRestartBannerDismissed: noop,
+      setBackendConnection: noop as LifecycleContextValue["setBackendConnection"],
+      setBackendDisconnectedBannerDismissed: noop,
+      setSystemWarnings: noop as LifecycleContextValue["setSystemWarnings"],
+      agentStatusRef: { current: null },
+    };
   }
   throw new Error(
     "useLifecycle must be used within LifecycleProvider or AppProvider",

--- a/packages/app-core/src/state/NavigationContext.tsx
+++ b/packages/app-core/src/state/NavigationContext.tsx
@@ -17,7 +17,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { type Tab, pathForTab } from "../navigation";
+import { COMPANION_ENABLED, type Tab, pathForTab } from "../navigation";
 import {
   deriveUiShellModeForTab,
   getTabForShellView,
@@ -54,8 +54,6 @@ export interface NavigationContextValue {
 const NavigationCtx = createContext<NavigationContextValue | null>(null);
 
 // ── Provider ────────────────────────────────────────────────────────
-
-const COMPANION_ENABLED = true;
 
 export function NavigationProvider({
   children,

--- a/packages/app-core/src/state/index.ts
+++ b/packages/app-core/src/state/index.ts
@@ -8,7 +8,7 @@ export { LifecycleProvider } from "./LifecycleContext";
 export { NavigationProvider } from "./NavigationContext";
 export * from "./parsers";
 export * from "./persistence";
-export { TranslationProvider, useTranslation } from "./TranslationContext";
+export { TranslationProvider } from "./TranslationContext";
 export type { TranslateFn } from "./TranslationContext";
 export * from "./types";
 export * from "./useApp";


### PR DESCRIPTION
## Summary

Addresses review feedback on the context provider refactor (#1242):

- **Typed test fallbacks** — Replace Proxy-based fallbacks in `useChatState` and `useLifecycle` with typed plain objects. Booleans now return `false` (not `null`), matching NavigationContext's pattern. Prevents masking type errors in tests.
- **Remove COMPANION_ENABLED duplicate** — NavigationContext now imports from `../navigation` instead of redeclaring `const COMPANION_ENABLED = true`
- **Remove useTranslation from public exports** — Prevents two separate `t()` instances (one from `useTranslation`, one from `useApp().t`) diverging until wiring is complete

## Test plan
- [x] 16/16 provider tests pass
- [x] Vite build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)