### PR TITLE
refactor: wire NavigationContext as pass-through bridge

### DIFF
--- a/packages/app-core/src/state/AppContext.tsx
+++ b/packages/app-core/src/state/AppContext.tsx
@@ -7022,6 +7022,32 @@ export function AppProvider({
     systemWarnings,
   ]);
 
+  const navigationValue = useMemo(
+    () => ({
+      tab,
+      uiShellMode,
+      lastNativeTab,
+      appsSubTab,
+      agentSubTab,
+      pluginsSubTab,
+      databaseSubTab,
+      setTab,
+      setTabRaw,
+      setUiShellMode,
+      switchUiShellMode,
+      switchShellView,
+      setAppsSubTab,
+      setAgentSubTab,
+      setPluginsSubTab,
+      setDatabaseSubTab,
+    }),
+    [
+      tab, uiShellMode, lastNativeTab,
+      appsSubTab, agentSubTab, pluginsSubTab, databaseSubTab,
+      setTab, setTabRaw, setUiShellMode, switchUiShellMode, switchShellView,
+    ],
+  );
+
   const mergedBranding = useMemo(
     () => ({ ...DEFAULT_BRANDING, ...brandingOverride }),
     [brandingOverride],
@@ -7030,7 +7056,7 @@ export function AppProvider({
   return (
     <BrandingContext.Provider value={mergedBranding}>
       <TranslationProvider uiLanguage={uiLanguage}>
-        <NavigationProvider activeGameViewerUrl={activeGameViewerUrl}>
+        <NavigationProvider value={navigationValue}>
           <LifecycleProvider>
             <ChatProvider>
               <AppContext.Provider value={value}>

--- a/packages/app-core/src/state/NavigationContext.test.tsx
+++ b/packages/app-core/src/state/NavigationContext.test.tsx
@@ -1,47 +1,63 @@
 // @vitest-environment jsdom
-import { act, renderHook } from "@testing-library/react";
+import { renderHook } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { describe, expect, it } from "vitest";
-import { NavigationProvider } from "./NavigationContext";
+import { NavigationProvider, useNavigation } from "./NavigationContext";
+import type { NavigationContextValue } from "./NavigationContext";
 
-// Import the hook directly since it's not publicly exported
-import { useNavigation } from "./NavigationContext";
+const defaultValue: NavigationContextValue = {
+  tab: "companion",
+  uiShellMode: "companion",
+  lastNativeTab: "chat",
+  appsSubTab: "browse",
+  agentSubTab: "character",
+  pluginsSubTab: "features",
+  databaseSubTab: "tables",
+  setTab: () => {},
+  setTabRaw: () => {},
+  setUiShellMode: () => {},
+  switchUiShellMode: () => {},
+  switchShellView: () => {},
+  setAppsSubTab: () => {},
+  setAgentSubTab: () => {},
+  setPluginsSubTab: () => {},
+  setDatabaseSubTab: () => {},
+};
 
 function wrapper({ children }: { children: ReactNode }) {
-  return <NavigationProvider>{children}</NavigationProvider>;
+  return (
+    <NavigationProvider value={defaultValue}>{children}</NavigationProvider>
+  );
 }
 
 describe("NavigationProvider", () => {
-  it("defaults to companion tab", () => {
+  it("provides navigation values from AppProvider", () => {
     const { result } = renderHook(() => useNavigation(), { wrapper });
     expect(result.current.tab).toBe("companion");
     expect(result.current.uiShellMode).toBe("companion");
   });
 
-  it("setTab updates tab", () => {
-    const { result } = renderHook(() => useNavigation(), { wrapper });
-    act(() => {
-      result.current.setTab("settings");
-    });
-    expect(result.current.tab).toBe("settings");
-  });
-
-  it("switchUiShellMode to native uses lastNativeTab", () => {
-    const { result } = renderHook(() => useNavigation(), { wrapper });
-    // Switch to native — should use whatever lastNativeTab is
-    act(() => {
-      result.current.switchUiShellMode("native");
-    });
-    expect(result.current.uiShellMode).toBe("native");
-    // Tab should be a non-companion tab
-    expect(result.current.tab).not.toBe("companion");
-  });
-
-  it("sub-tabs have correct defaults", () => {
+  it("exposes sub-tab defaults", () => {
     const { result } = renderHook(() => useNavigation(), { wrapper });
     expect(result.current.appsSubTab).toBe("browse");
     expect(result.current.agentSubTab).toBe("character");
     expect(result.current.pluginsSubTab).toBe("features");
     expect(result.current.databaseSubTab).toBe("tables");
+  });
+
+  it("passes through custom values", () => {
+    const custom: NavigationContextValue = {
+      ...defaultValue,
+      tab: "settings",
+      uiShellMode: "native",
+    };
+    const customWrapper = ({ children }: { children: ReactNode }) => (
+      <NavigationProvider value={custom}>{children}</NavigationProvider>
+    );
+    const { result } = renderHook(() => useNavigation(), {
+      wrapper: customWrapper,
+    });
+    expect(result.current.tab).toBe("settings");
+    expect(result.current.uiShellMode).toBe("native");
   });
 });

--- a/packages/app-core/src/state/NavigationContext.tsx
+++ b/packages/app-core/src/state/NavigationContext.tsx
@@ -1,34 +1,27 @@
 /**
- * Navigation context — extracted from AppContext.
+ * Navigation context — a bridge layer for AppContext's navigation state.
  *
- * Owns tab, shell mode, sub-tabs, and navigation actions.
- * Almost every component reads `tab` or `uiShellMode` — isolating
- * these prevents the entire tree from re-rendering on unrelated
- * state changes (e.g. chat keystrokes, plugin saves).
+ * AppProvider owns the navigation state (tab, shell mode, sub-tabs) and
+ * passes it through NavigationProvider. Components use useNavigation()
+ * to read only navigation state without subscribing to all of AppContext.
+ *
+ * This is NOT a duplicate of AppContext state — AppProvider passes its
+ * own state objects here. Single source of truth, two access patterns:
+ * - useApp().tab (legacy — re-renders on all state changes)
+ * - useNavigation().tab (preferred — re-renders only on navigation changes)
  */
 
 import {
   createContext,
   type ReactNode,
-  useCallback,
   useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
 } from "react";
-import { COMPANION_ENABLED, type Tab, pathForTab } from "../navigation";
-import {
-  deriveUiShellModeForTab,
-  getTabForShellView,
-} from "./shell-routing";
+import type { Tab } from "../navigation";
 import type { ShellView } from "./types";
 import type { UiShellMode } from "./ui-preferences";
-import {
-  loadLastNativeTab,
-  normalizeUiShellMode,
-  saveLastNativeTab,
-} from "./internal";
+
+// Re-export for consumers
+export type { Tab } from "../navigation";
 
 // ── Types ───────────────────────────────────────────────────────────
 
@@ -55,136 +48,17 @@ const NavigationCtx = createContext<NavigationContextValue | null>(null);
 
 // ── Provider ────────────────────────────────────────────────────────
 
+/**
+ * Accepts a pre-built value from AppProvider. No internal state — single
+ * source of truth remains in AppProvider.
+ */
 export function NavigationProvider({
   children,
-  activeGameViewerUrl = "",
+  value,
 }: {
   children: ReactNode;
-  activeGameViewerUrl?: string;
+  value: NavigationContextValue;
 }) {
-  const [lastNativeTab, setLastNativeTabState] =
-    useState<Tab>(loadLastNativeTab);
-  const [tab, _setTabRawInner] = useState<Tab>(
-    COMPANION_ENABLED ? "companion" : "chat",
-  );
-  const setTabRaw = useCallback((t: Tab) => {
-    _setTabRawInner(t);
-  }, []);
-
-  const uiShellMode = deriveUiShellModeForTab(tab);
-
-  // Sub-tabs
-  const [appsSubTab, setAppsSubTab] = useState<"browse" | "games">("browse");
-  const [agentSubTab, setAgentSubTab] = useState<
-    "character" | "inventory" | "knowledge"
-  >("character");
-  const [pluginsSubTab, setPluginsSubTab] = useState<
-    "features" | "connectors" | "plugins"
-  >("features");
-  const [databaseSubTab, setDatabaseSubTab] = useState<
-    "tables" | "media" | "vectors"
-  >("tables");
-
-  // Remember last native tab for shell switching
-  useEffect(() => {
-    const shouldRemember =
-      tab !== "companion" && tab !== "character" && tab !== "character-select";
-    if (!shouldRemember) return;
-    setLastNativeTabState((prev) => {
-      if (prev === tab) return prev;
-      saveLastNativeTab(tab);
-      return tab;
-    });
-  }, [tab]);
-
-  const setTab = useCallback(
-    (newTab: Tab) => {
-      setTabRaw(newTab);
-      if (newTab === "apps") {
-        setAppsSubTab(activeGameViewerUrl.trim() ? "games" : "browse");
-      }
-      const path = pathForTab(newTab);
-      try {
-        if (window.location.protocol === "file:") {
-          window.location.hash = path;
-        } else {
-          window.history.pushState(null, "", path);
-        }
-      } catch (err) {
-        console.warn("[milady][nav] failed to update browser location", err);
-      }
-    },
-    [activeGameViewerUrl, setTabRaw],
-  );
-
-  const setUiShellMode = useCallback(
-    (mode: UiShellMode) => {
-      const nextMode = normalizeUiShellMode(mode);
-      if (nextMode === "companion") {
-        setTab("companion");
-        return;
-      }
-      setTab(lastNativeTab);
-    },
-    [lastNativeTab, setTab],
-  );
-
-  const switchUiShellMode = useCallback(
-    (mode: UiShellMode) => {
-      const nextMode = normalizeUiShellMode(mode);
-      if (nextMode === uiShellMode) return;
-      if (nextMode === "native") {
-        setTab(lastNativeTab);
-        return;
-      }
-      setTab("companion");
-    },
-    [lastNativeTab, setTab, uiShellMode],
-  );
-
-  const switchShellView = useCallback(
-    (view: ShellView) => {
-      const nextTab = getTabForShellView(view, lastNativeTab);
-      setTab(nextTab);
-    },
-    [lastNativeTab, setTab],
-  );
-
-  const value = useMemo<NavigationContextValue>(
-    () => ({
-      tab,
-      uiShellMode,
-      lastNativeTab,
-      appsSubTab,
-      agentSubTab,
-      pluginsSubTab,
-      databaseSubTab,
-      setTab,
-      setTabRaw,
-      setUiShellMode,
-      switchUiShellMode,
-      switchShellView,
-      setAppsSubTab,
-      setAgentSubTab,
-      setPluginsSubTab,
-      setDatabaseSubTab,
-    }),
-    [
-      tab,
-      uiShellMode,
-      lastNativeTab,
-      appsSubTab,
-      agentSubTab,
-      pluginsSubTab,
-      databaseSubTab,
-      setTab,
-      setTabRaw,
-      setUiShellMode,
-      switchUiShellMode,
-      switchShellView,
-    ],
-  );
-
   return (
     <NavigationCtx.Provider value={value}>
       {children}

--- a/packages/app-core/src/state/index.ts
+++ b/packages/app-core/src/state/index.ts
@@ -1,11 +1,11 @@
 export * from "./AppContext";
 // Sub-context providers are exported for composition inside AppProvider.
-// Consumer hooks (useChatState, useNavigation, useLifecycle) are NOT
-// re-exported here to prevent split-brain — all reads should go through
-// useApp() until AppContext's duplicate state is fully removed.
+// Navigation is safe to consume directly — AppContext reads from
+// NavigationProvider (no duplicate state).
 export { ChatProvider } from "./ChatContext";
 export { LifecycleProvider } from "./LifecycleContext";
-export { NavigationProvider } from "./NavigationContext";
+export { NavigationProvider, useNavigation } from "./NavigationContext";
+export type { NavigationContextValue } from "./NavigationContext";
 export * from "./parsers";
 export * from "./persistence";
 export { TranslationProvider } from "./TranslationContext";


### PR DESCRIPTION
## Summary

Converts NavigationContext from an independent state owner to a pass-through bridge. AppProvider creates navigation state (tab, shell mode, sub-tabs) and passes it to NavigationProvider. `useNavigation()` is now safe to export — it reads the same state as `useApp().tab`.

### Architecture
```
AppProvider (owns state: tab, uiShellMode, sub-tabs, setTab, etc.)
  └─ NavigationProvider (value={navigationValue})  ← pass-through
       └─ useNavigation()  ← reads same state as useApp().tab
```

No duplicate state. No split-brain. Components can use either `useApp().tab` (legacy) or `useNavigation().tab` (preferred — only re-renders on navigation changes).

### What changed
- NavigationProvider accepts `value` prop instead of creating internal state
- AppProvider builds `navigationValue` via `useMemo` and passes it
- `useNavigation` + `NavigationContextValue` exported publicly
- Tests updated for pass-through pattern

## Test plan
- [x] Typecheck passes
- [x] 51/51 tests pass (navigation + translation regression)
- [x] Vite build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)