### PR TITLE
refactor: wire LifecycleContext as pass-through bridge

### DIFF
--- a/packages/app-core/src/state/AppContext.tsx
+++ b/packages/app-core/src/state/AppContext.tsx
@@ -7048,6 +7048,35 @@ export function AppProvider({
     ],
   );
 
+  const lifecycleValue = useMemo(
+    () => ({
+      connected,
+      agentStatus,
+      onboardingComplete,
+      onboardingLoading,
+      startupPhase,
+      startupStatus,
+      startupError,
+      authRequired,
+      actionNotice,
+      lifecycleBusy,
+      lifecycleAction,
+      pendingRestart,
+      pendingRestartReasons,
+      restartBannerDismissed,
+      backendConnection,
+      backendDisconnectedBannerDismissed,
+      systemWarnings,
+    }),
+    [
+      connected, agentStatus, onboardingComplete, onboardingLoading,
+      startupPhase, startupStatus, startupError, authRequired,
+      actionNotice, lifecycleBusy, lifecycleAction,
+      pendingRestart, pendingRestartReasons, restartBannerDismissed,
+      backendConnection, backendDisconnectedBannerDismissed, systemWarnings,
+    ],
+  );
+
   const mergedBranding = useMemo(
     () => ({ ...DEFAULT_BRANDING, ...brandingOverride }),
     [brandingOverride],
@@ -7057,7 +7086,7 @@ export function AppProvider({
     <BrandingContext.Provider value={mergedBranding}>
       <TranslationProvider uiLanguage={uiLanguage}>
         <NavigationProvider value={navigationValue}>
-          <LifecycleProvider>
+          <LifecycleProvider value={lifecycleValue}>
             <ChatProvider>
               <AppContext.Provider value={value}>
                 {children}

--- a/packages/app-core/src/state/LifecycleContext.test.tsx
+++ b/packages/app-core/src/state/LifecycleContext.test.tsx
@@ -1,59 +1,82 @@
 // @vitest-environment jsdom
-import { act, renderHook } from "@testing-library/react";
+import { renderHook } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { describe, expect, it } from "vitest";
-import { LifecycleProvider } from "./LifecycleContext";
+import {
+  LifecycleProvider,
+  useLifecycle,
+  type LifecycleContextValue,
+} from "./LifecycleContext";
 
-// Import hook directly since not publicly exported
-import { useLifecycle } from "./LifecycleContext";
+const defaultValue: LifecycleContextValue = {
+  connected: false,
+  agentStatus: null,
+  onboardingComplete: false,
+  onboardingLoading: false,
+  startupPhase: "starting-backend",
+  startupStatus: "loading",
+  startupError: null,
+  authRequired: false,
+  actionNotice: null,
+  lifecycleBusy: false,
+  lifecycleAction: null,
+  pendingRestart: false,
+  pendingRestartReasons: [],
+  restartBannerDismissed: false,
+  backendConnection: {
+    state: "disconnected",
+    reconnectAttempt: 0,
+    maxReconnectAttempts: 15,
+    showDisconnectedUI: false,
+  },
+  backendDisconnectedBannerDismissed: false,
+  systemWarnings: [],
+};
 
 function wrapper({ children }: { children: ReactNode }) {
-  return <LifecycleProvider>{children}</LifecycleProvider>;
+  return (
+    <LifecycleProvider value={defaultValue}>{children}</LifecycleProvider>
+  );
 }
 
 describe("LifecycleProvider", () => {
-  it("starts in loading state", () => {
+  it("provides lifecycle values from AppProvider", () => {
     const { result } = renderHook(() => useLifecycle(), { wrapper });
     expect(result.current.startupPhase).toBe("starting-backend");
     expect(result.current.startupStatus).toBe("loading");
     expect(result.current.connected).toBe(false);
-    expect(result.current.agentStatus).toBeNull();
   });
 
-  it("setStartupPhase to ready updates startupStatus", () => {
-    const { result } = renderHook(() => useLifecycle(), { wrapper });
-    act(() => {
-      result.current.setOnboardingLoading(false);
-      result.current.setOnboardingComplete(true);
-      result.current.setStartupPhase("ready");
+  it("passes through ready state", () => {
+    const ready: LifecycleContextValue = {
+      ...defaultValue,
+      startupPhase: "ready",
+      startupStatus: "ready",
+      connected: true,
+      onboardingComplete: true,
+    };
+    const readyWrapper = ({ children }: { children: ReactNode }) => (
+      <LifecycleProvider value={ready}>{children}</LifecycleProvider>
+    );
+    const { result } = renderHook(() => useLifecycle(), {
+      wrapper: readyWrapper,
     });
     expect(result.current.startupStatus).toBe("ready");
-  });
-
-  it("setConnected updates connection state", () => {
-    const { result } = renderHook(() => useLifecycle(), { wrapper });
-    act(() => {
-      result.current.setConnected(true);
-    });
     expect(result.current.connected).toBe(true);
+    expect(result.current.onboardingComplete).toBe(true);
   });
 
-  it("setActionNotice shows and auto-clears", async () => {
-    const { result } = renderHook(() => useLifecycle(), { wrapper });
-    act(() => {
-      result.current.setActionNotice("Test notice", "success", 100);
+  it("exposes system warnings", () => {
+    const withWarnings: LifecycleContextValue = {
+      ...defaultValue,
+      systemWarnings: ["test warning"],
+    };
+    const warnWrapper = ({ children }: { children: ReactNode }) => (
+      <LifecycleProvider value={withWarnings}>{children}</LifecycleProvider>
+    );
+    const { result } = renderHook(() => useLifecycle(), {
+      wrapper: warnWrapper,
     });
-    expect(result.current.actionNotice?.text).toBe("Test notice");
-    expect(result.current.actionNotice?.tone).toBe("success");
-  });
-
-  it("setAgentStatus syncs ref", () => {
-    const { result } = renderHook(() => useLifecycle(), { wrapper });
-    const status = { state: "running" as const, agentName: "Jin", model: "anthropic", startedAt: Date.now() };
-    act(() => {
-      result.current.setAgentStatus(status);
-    });
-    expect(result.current.agentStatus).toEqual(status);
-    expect(result.current.agentStatusRef.current).toEqual(status);
+    expect(result.current.systemWarnings).toEqual(["test warning"]);
   });
 });

--- a/packages/app-core/src/state/LifecycleContext.tsx
+++ b/packages/app-core/src/state/LifecycleContext.tsx
@@ -1,31 +1,17 @@
 /**
- * Lifecycle context — extracted from AppContext.
+ * Lifecycle context — a bridge layer for AppContext's lifecycle state.
  *
- * Owns agent connection status, startup phase, onboarding completion,
- * restart state, backend connection, action notices, and system warnings.
+ * AppProvider owns the lifecycle state (agent status, startup phase,
+ * connection, restart, action notices, system warnings) and passes it
+ * through LifecycleProvider. Components use useLifecycle() to read
+ * only lifecycle state without subscribing to all of AppContext.
  *
- * The derived `startupStatus` is computed here so consumers can check
- * a single field instead of combining multiple state variables.
- *
- * Phase 1: State + setters. Complex lifecycle callbacks (handleStart,
- * handleStop, handleRestart) remain in AppContext for now.
+ * Single source of truth — AppProvider passes its own state objects
+ * here. No duplicate state.
  */
 
-import {
-  createContext,
-  type ReactNode,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { createContext, type ReactNode, useContext } from "react";
 import type { AgentStatus } from "../api";
-import {
-  loadPersistedOnboardingComplete,
-  savePersistedOnboardingComplete,
-} from "./persistence";
 import type {
   ActionNotice,
   AppState,
@@ -37,16 +23,13 @@ import type {
 // ── Types ───────────────────────────────────────────────────────────
 
 export interface LifecycleContextValue {
-  // State
   connected: boolean;
   agentStatus: AgentStatus | null;
   onboardingComplete: boolean;
-  onboardingUiRevealNonce: number;
   onboardingLoading: boolean;
   startupPhase: StartupPhase;
   startupStatus: AppState["startupStatus"];
   startupError: StartupErrorState | null;
-  startupRetryNonce: number;
   authRequired: boolean;
   actionNotice: ActionNotice | null;
   lifecycleBusy: boolean;
@@ -57,202 +40,23 @@ export interface LifecycleContextValue {
   backendConnection: AppState["backendConnection"];
   backendDisconnectedBannerDismissed: boolean;
   systemWarnings: string[];
-
-  // Setters
-  setConnected: (v: boolean) => void;
-  setAgentStatus: (v: AgentStatus | null) => void;
-  setOnboardingComplete: (v: boolean) => void;
-  setOnboardingUiRevealNonce: React.Dispatch<React.SetStateAction<number>>;
-  setOnboardingLoading: (v: boolean) => void;
-  setStartupPhase: (v: StartupPhase) => void;
-  setStartupError: (v: StartupErrorState | null) => void;
-  setStartupRetryNonce: React.Dispatch<React.SetStateAction<number>>;
-  setAuthRequired: (v: boolean) => void;
-  setActionNotice: (
-    text: string,
-    tone?: "info" | "success" | "error",
-    ttlMs?: number,
-  ) => void;
-  setLifecycleBusy: (v: boolean) => void;
-  setLifecycleAction: (v: LifecycleAction | null) => void;
-  setPendingRestart: (v: boolean) => void;
-  setPendingRestartReasons: React.Dispatch<React.SetStateAction<string[]>>;
-  setRestartBannerDismissed: (v: boolean) => void;
-  setBackendConnection: React.Dispatch<
-    React.SetStateAction<AppState["backendConnection"]>
-  >;
-  setBackendDisconnectedBannerDismissed: (v: boolean) => void;
-  setSystemWarnings: React.Dispatch<React.SetStateAction<string[]>>;
-
-  // Refs
-  agentStatusRef: React.RefObject<AgentStatus | null>;
 }
 
 const LifecycleCtx = createContext<LifecycleContextValue | null>(null);
 
 // ── Provider ────────────────────────────────────────────────────────
 
-export function LifecycleProvider({ children }: { children: ReactNode }) {
-  const [connected, setConnected] = useState(false);
-  const [agentStatus, setAgentStatusRaw] = useState<AgentStatus | null>(null);
-  const agentStatusRef = useRef<AgentStatus | null>(null);
-  const [onboardingComplete, _setOnboardingCompleteRaw] = useState(
-    loadPersistedOnboardingComplete,
-  );
-  const [onboardingUiRevealNonce, setOnboardingUiRevealNonce] = useState(0);
-  const [onboardingLoading, setOnboardingLoading] = useState(true);
-  const [startupPhase, setStartupPhase] =
-    useState<StartupPhase>("starting-backend");
-  const [startupError, setStartupError] = useState<StartupErrorState | null>(
-    null,
-  );
-  const [startupRetryNonce, setStartupRetryNonce] = useState(0);
-  const [authRequired, setAuthRequired] = useState(false);
-  const [actionNoticeState, setActionNoticeState] =
-    useState<ActionNotice | null>(null);
-  const actionNoticeTimer = useRef<number | null>(null);
-  const [lifecycleBusy, setLifecycleBusy] = useState(false);
-  const [lifecycleAction, setLifecycleAction] =
-    useState<LifecycleAction | null>(null);
-  const [pendingRestart, setPendingRestart] = useState(false);
-  const [pendingRestartReasons, setPendingRestartReasons] = useState<string[]>(
-    [],
-  );
-  const [restartBannerDismissed, setRestartBannerDismissed] = useState(false);
-  const [backendConnection, setBackendConnection] = useState<
-    AppState["backendConnection"]
-  >({
-    state: "disconnected",
-    reconnectAttempt: 0,
-    maxReconnectAttempts: 15,
-    showDisconnectedUI: false,
-  });
-  const [
-    backendDisconnectedBannerDismissed,
-    setBackendDisconnectedBannerDismissed,
-  ] = useState(false);
-  const [systemWarnings, setSystemWarnings] = useState<string[]>([]);
-
-  const setAgentStatus = useCallback((v: AgentStatus | null) => {
-    agentStatusRef.current = v;
-    setAgentStatusRaw(v);
-  }, []);
-
-  const setOnboardingComplete = useCallback((value: boolean) => {
-    _setOnboardingCompleteRaw(value);
-    savePersistedOnboardingComplete(value);
-  }, []);
-
-  const setActionNotice = useCallback(
-    (
-      text: string,
-      tone: "info" | "success" | "error" = "info",
-      ttlMs = 2800,
-    ) => {
-      setActionNoticeState({ tone, text });
-      if (actionNoticeTimer.current != null) {
-        window.clearTimeout(actionNoticeTimer.current);
-      }
-      actionNoticeTimer.current = window.setTimeout(() => {
-        setActionNoticeState(null);
-        actionNoticeTimer.current = null;
-      }, ttlMs);
-    },
-    [],
-  );
-
-  // Clean up timer on unmount
-  // biome-ignore lint/correctness/useExhaustiveDependencies: cleanup only
-  useEffect(() => {
-    return () => {
-      if (actionNoticeTimer.current != null) {
-        window.clearTimeout(actionNoticeTimer.current);
-      }
-    };
-  }, []);
-
-  // Derived
-  const startupStatus = useMemo<AppState["startupStatus"]>(() => {
-    if (startupError) return "recoverable-error";
-    if (authRequired) return "auth-blocked";
-    if (onboardingLoading || startupPhase !== "ready") return "loading";
-    if (!onboardingComplete) return "onboarding";
-    return "ready";
-  }, [
-    authRequired,
-    onboardingComplete,
-    onboardingLoading,
-    startupError,
-    startupPhase,
-  ]);
-
-  const value = useMemo<LifecycleContextValue>(
-    () => ({
-      connected,
-      agentStatus,
-      onboardingComplete,
-      onboardingUiRevealNonce,
-      onboardingLoading,
-      startupPhase,
-      startupStatus,
-      startupError,
-      startupRetryNonce,
-      authRequired,
-      actionNotice: actionNoticeState,
-      lifecycleBusy,
-      lifecycleAction,
-      pendingRestart,
-      pendingRestartReasons,
-      restartBannerDismissed,
-      backendConnection,
-      backendDisconnectedBannerDismissed,
-      systemWarnings,
-      setConnected,
-      setAgentStatus,
-      setOnboardingComplete,
-      setOnboardingUiRevealNonce,
-      setOnboardingLoading,
-      setStartupPhase,
-      setStartupError,
-      setStartupRetryNonce,
-      setAuthRequired,
-      setActionNotice,
-      setLifecycleBusy,
-      setLifecycleAction,
-      setPendingRestart,
-      setPendingRestartReasons,
-      setRestartBannerDismissed,
-      setBackendConnection,
-      setBackendDisconnectedBannerDismissed,
-      setSystemWarnings,
-      agentStatusRef,
-    }),
-    [
-      connected,
-      agentStatus,
-      onboardingComplete,
-      onboardingUiRevealNonce,
-      onboardingLoading,
-      startupPhase,
-      startupStatus,
-      startupError,
-      startupRetryNonce,
-      authRequired,
-      actionNoticeState,
-      lifecycleBusy,
-      lifecycleAction,
-      pendingRestart,
-      pendingRestartReasons,
-      restartBannerDismissed,
-      backendConnection,
-      backendDisconnectedBannerDismissed,
-      systemWarnings,
-      setAgentStatus,
-      setOnboardingComplete,
-      setActionNotice,
-    ],
-  );
-
+/**
+ * Accepts a pre-built value from AppProvider. No internal state — single
+ * source of truth remains in AppProvider.
+ */
+export function LifecycleProvider({
+  children,
+  value,
+}: {
+  children: ReactNode;
+  value: LifecycleContextValue;
+}) {
   return (
     <LifecycleCtx.Provider value={value}>
       {children}
@@ -266,17 +70,14 @@ export function useLifecycle(): LifecycleContextValue {
   const ctx = useContext(LifecycleCtx);
   if (ctx) return ctx;
   if (typeof process !== "undefined" && process.env.NODE_ENV === "test") {
-    const noop = () => {};
     return {
       connected: false,
       agentStatus: null,
       onboardingComplete: false,
-      onboardingUiRevealNonce: 0,
       onboardingLoading: false,
       startupPhase: "ready" as StartupPhase,
       startupStatus: "ready" as AppState["startupStatus"],
       startupError: null,
-      startupRetryNonce: 0,
       authRequired: false,
       actionNotice: null,
       lifecycleBusy: false,
@@ -292,25 +93,6 @@ export function useLifecycle(): LifecycleContextValue {
       },
       backendDisconnectedBannerDismissed: false,
       systemWarnings: [],
-      setConnected: noop,
-      setAgentStatus: noop,
-      setOnboardingComplete: noop,
-      setOnboardingUiRevealNonce: noop as LifecycleContextValue["setOnboardingUiRevealNonce"],
-      setOnboardingLoading: noop,
-      setStartupPhase: noop,
-      setStartupError: noop,
-      setStartupRetryNonce: noop as LifecycleContextValue["setStartupRetryNonce"],
-      setAuthRequired: noop,
-      setActionNotice: noop as LifecycleContextValue["setActionNotice"],
-      setLifecycleBusy: noop,
-      setLifecycleAction: noop,
-      setPendingRestart: noop,
-      setPendingRestartReasons: noop as LifecycleContextValue["setPendingRestartReasons"],
-      setRestartBannerDismissed: noop,
-      setBackendConnection: noop as LifecycleContextValue["setBackendConnection"],
-      setBackendDisconnectedBannerDismissed: noop,
-      setSystemWarnings: noop as LifecycleContextValue["setSystemWarnings"],
-      agentStatusRef: { current: null },
     };
   }
   throw new Error(

--- a/packages/app-core/src/state/index.ts
+++ b/packages/app-core/src/state/index.ts
@@ -3,7 +3,8 @@ export * from "./AppContext";
 // Navigation is safe to consume directly — AppContext reads from
 // NavigationProvider (no duplicate state).
 export { ChatProvider } from "./ChatContext";
-export { LifecycleProvider } from "./LifecycleContext";
+export { LifecycleProvider, useLifecycle } from "./LifecycleContext";
+export type { LifecycleContextValue } from "./LifecycleContext";
 export { NavigationProvider, useNavigation } from "./NavigationContext";
 export type { NavigationContextValue } from "./NavigationContext";
 export * from "./parsers";


### PR DESCRIPTION
## Summary

Same pattern as NavigationContext (#1246) — converts LifecycleProvider to a pass-through bridge. AppProvider owns lifecycle state, passes it to LifecycleProvider. `useLifecycle()` is now safe to export.

### What it provides
`connected`, `agentStatus`, `onboardingComplete`, `startupPhase`, `startupStatus`, `startupError`, `actionNotice`, `lifecycleBusy`, `pendingRestart`, `backendConnection`, `systemWarnings` — read-only, no setters.

### Architecture
```
AppProvider (owns state)
  └─ LifecycleProvider (value={lifecycleValue})  ← pass-through
       └─ useLifecycle()  ← reads same state as useApp()
```

Components using `useLifecycle()` only re-render when lifecycle state changes — not on chat keystrokes, plugin saves, or wallet updates.

## Test plan
- [x] Typecheck passes
- [x] 54/54 tests pass
- [x] Vite build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)