### PR TITLE
refactor: wire ChatContext + LifecycleContext as pass-through bridges

### DIFF
--- a/packages/app-core/src/state/AppContext.tsx
+++ b/packages/app-core/src/state/AppContext.tsx
@@ -7077,6 +7077,39 @@ export function AppProvider({
     ],
   );
 
+  const chatValue = useMemo(
+    () => ({
+      chatInput,
+      chatSending,
+      chatFirstTokenReceived,
+      chatLastUsage,
+      chatAvatarVisible,
+      chatAgentVoiceMuted,
+      chatMode,
+      chatAvatarSpeaking,
+      conversations,
+      activeConversationId,
+      companionMessageCutoffTs,
+      conversationMessages,
+      autonomousEvents,
+      autonomousLatestEventId,
+      autonomousRunHealthByRunId,
+      ptySessions,
+      unreadConversations,
+      chatPendingImages,
+      droppedFiles,
+      shareIngestNotice,
+    }),
+    [
+      chatInput, chatSending, chatFirstTokenReceived, chatLastUsage,
+      chatAvatarVisible, chatAgentVoiceMuted, chatMode, chatAvatarSpeaking,
+      conversations, activeConversationId, companionMessageCutoffTs,
+      conversationMessages, autonomousEvents, autonomousLatestEventId,
+      autonomousRunHealthByRunId, ptySessions, unreadConversations,
+      chatPendingImages, droppedFiles, shareIngestNotice,
+    ],
+  );
+
   const mergedBranding = useMemo(
     () => ({ ...DEFAULT_BRANDING, ...brandingOverride }),
     [brandingOverride],
@@ -7087,7 +7120,7 @@ export function AppProvider({
       <TranslationProvider uiLanguage={uiLanguage}>
         <NavigationProvider value={navigationValue}>
           <LifecycleProvider value={lifecycleValue}>
-            <ChatProvider>
+            <ChatProvider value={chatValue}>
               <AppContext.Provider value={value}>
                 {children}
                 <ConfirmModal {...modalProps} />

--- a/packages/app-core/src/state/ChatContext.test.tsx
+++ b/packages/app-core/src/state/ChatContext.test.tsx
@@ -1,14 +1,34 @@
 // @vitest-environment jsdom
-import { act, renderHook } from "@testing-library/react";
+import { renderHook } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { describe, expect, it } from "vitest";
-import { ChatProvider } from "./ChatContext";
+import { ChatProvider, useChatState, type ChatStateValue } from "./ChatContext";
 
-// Import hook directly since not publicly exported
-import { useChatState } from "./ChatContext";
+const defaultValue: ChatStateValue = {
+  chatInput: "",
+  chatSending: false,
+  chatFirstTokenReceived: false,
+  chatLastUsage: null,
+  chatAvatarVisible: false,
+  chatAgentVoiceMuted: false,
+  chatMode: "simple",
+  chatAvatarSpeaking: false,
+  conversations: [],
+  activeConversationId: null,
+  companionMessageCutoffTs: 0,
+  conversationMessages: [],
+  autonomousEvents: [],
+  autonomousLatestEventId: null,
+  autonomousRunHealthByRunId: {},
+  ptySessions: [],
+  unreadConversations: new Set(),
+  chatPendingImages: [],
+  droppedFiles: [] as string[],
+  shareIngestNotice: "",
+};
 
 function wrapper({ children }: { children: ReactNode }) {
-  return <ChatProvider>{children}</ChatProvider>;
+  return <ChatProvider value={defaultValue}>{children}</ChatProvider>;
 }
 
 describe("ChatProvider", () => {
@@ -21,32 +41,38 @@ describe("ChatProvider", () => {
     expect(result.current.activeConversationId).toBeNull();
   });
 
-  it("setChatInput updates chatInput", () => {
-    const { result } = renderHook(() => useChatState(), { wrapper });
-    act(() => {
-      result.current.setChatInput("hello");
+  it("passes through custom values", () => {
+    const custom: ChatStateValue = {
+      ...defaultValue,
+      chatInput: "hello",
+      chatSending: true,
+      activeConversationId: "conv-123",
+    };
+    const customWrapper = ({ children }: { children: ReactNode }) => (
+      <ChatProvider value={custom}>{children}</ChatProvider>
+    );
+    const { result } = renderHook(() => useChatState(), {
+      wrapper: customWrapper,
     });
     expect(result.current.chatInput).toBe("hello");
-  });
-
-  it("setActiveConversationId syncs ref", () => {
-    const { result } = renderHook(() => useChatState(), { wrapper });
-    act(() => {
-      result.current.setActiveConversationId("conv-123");
-    });
+    expect(result.current.chatSending).toBe(true);
     expect(result.current.activeConversationId).toBe("conv-123");
-    expect(result.current.activeConversationIdRef.current).toBe("conv-123");
   });
 
-  it("setConversationMessages syncs ref", () => {
-    const { result } = renderHook(() => useChatState(), { wrapper });
+  it("exposes conversation messages", () => {
     const msgs = [
       { id: "1", role: "user" as const, text: "hi", timestamp: Date.now() },
     ];
-    act(() => {
-      result.current.setConversationMessages(msgs);
+    const custom: ChatStateValue = {
+      ...defaultValue,
+      conversationMessages: msgs,
+    };
+    const customWrapper = ({ children }: { children: ReactNode }) => (
+      <ChatProvider value={custom}>{children}</ChatProvider>
+    );
+    const { result } = renderHook(() => useChatState(), {
+      wrapper: customWrapper,
     });
     expect(result.current.conversationMessages).toEqual(msgs);
-    expect(result.current.conversationMessagesRef.current).toEqual(msgs);
   });
 });

--- a/packages/app-core/src/state/ChatContext.tsx
+++ b/packages/app-core/src/state/ChatContext.tsx
@@ -1,27 +1,19 @@
 /**
- * Chat context — extracted from AppContext.
+ * Chat context — a bridge layer for AppContext's chat state.
  *
- * Owns the chat state that changes at high frequency: messages,
- * input text, sending status, conversations, and voice state.
+ * AppProvider owns the chat state (messages, conversations, input,
+ * sending status, voice) and passes it through ChatProvider.
+ * Components use useChatState() to read only chat state without
+ * subscribing to all of AppContext.
+ *
  * This is the hottest render path — every keystroke and streaming
- * token triggers updates here. Isolating it prevents settings,
- * plugins, onboarding, and other views from re-rendering.
+ * token triggers updates. Isolating it prevents settings, plugins,
+ * onboarding, and wallet views from re-rendering.
  *
- * Phase 1: State + setters only. The complex callbacks (handleChatSend,
- * etc.) remain in AppContext and read from this context via refs.
- * Components can use useChatState() for read-only chat state without
- * subscribing to the full AppContext.
+ * Single source of truth — AppProvider passes its own state here.
  */
 
-import {
-  createContext,
-  type ReactNode,
-  useCallback,
-  useContext,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { createContext, type ReactNode, useContext } from "react";
 import type {
   CodingAgentSession,
   Conversation,
@@ -32,12 +24,6 @@ import type {
 } from "../api";
 import type { AutonomyRunHealthMap } from "../autonomy";
 import type { ChatTurnUsage } from "./types";
-import {
-  loadChatAvatarVisible,
-  loadChatMode,
-  loadChatVoiceMuted,
-  loadCompanionMessageCutoffTs,
-} from "./internal";
 
 // ── Types ───────────────────────────────────────────────────────────
 
@@ -50,7 +36,6 @@ export interface ChatStateValue {
   chatAgentVoiceMuted: boolean;
   chatMode: ConversationMode;
   chatAvatarSpeaking: boolean;
-
   conversations: Conversation[];
   activeConversationId: string | null;
   companionMessageCutoffTs: number;
@@ -61,206 +46,38 @@ export interface ChatStateValue {
   ptySessions: CodingAgentSession[];
   unreadConversations: Set<string>;
   chatPendingImages: ImageAttachment[];
-  droppedFiles: File[];
-  shareIngestNotice: string | null;
-
-  // Setters — exposed so AppContext callbacks can update chat state
-  setChatInput: (v: string) => void;
-  setChatSending: (v: boolean) => void;
-  setChatFirstTokenReceived: (v: boolean) => void;
-  setChatLastUsage: (v: ChatTurnUsage | null) => void;
-  setChatAvatarVisible: (v: boolean) => void;
-  setChatAgentVoiceMuted: (v: boolean) => void;
-  setChatMode: (v: ConversationMode) => void;
-  setChatAvatarSpeaking: (v: boolean) => void;
-
-  setConversations: React.Dispatch<React.SetStateAction<Conversation[]>>;
-  setActiveConversationId: (v: string | null) => void;
-  setCompanionMessageCutoffTs: (v: number) => void;
-  setConversationMessages: React.Dispatch<
-    React.SetStateAction<ConversationMessage[]>
-  >;
-  setAutonomousEvents: React.Dispatch<
-    React.SetStateAction<StreamEventEnvelope[]>
-  >;
-  setAutonomousLatestEventId: (v: string | null) => void;
-  setAutonomousRunHealthByRunId: React.Dispatch<
-    React.SetStateAction<AutonomyRunHealthMap>
-  >;
-  setPtySessions: React.Dispatch<React.SetStateAction<CodingAgentSession[]>>;
-  setUnreadConversations: React.Dispatch<React.SetStateAction<Set<string>>>;
-  setChatPendingImages: React.Dispatch<
-    React.SetStateAction<ImageAttachment[]>
-  >;
-  setDroppedFiles: React.Dispatch<React.SetStateAction<File[]>>;
-  setShareIngestNotice: (v: string | null) => void;
-
-  // Refs for synchronous access from callbacks
-  activeConversationIdRef: React.RefObject<string | null>;
-  conversationMessagesRef: React.RefObject<ConversationMessage[]>;
+  droppedFiles: string[];
+  shareIngestNotice: string;
 }
 
 const ChatCtx = createContext<ChatStateValue | null>(null);
 
 // ── Provider ────────────────────────────────────────────────────────
 
-export function ChatProvider({ children }: { children: ReactNode }) {
-  const [chatInput, setChatInput] = useState("");
-  const [chatSending, setChatSending] = useState(false);
-  const [chatFirstTokenReceived, setChatFirstTokenReceived] = useState(false);
-  const [chatLastUsage, setChatLastUsage] = useState<ChatTurnUsage | null>(
-    null,
-  );
-  const [chatAvatarVisible, setChatAvatarVisible] = useState(
-    loadChatAvatarVisible,
-  );
-  const [chatAgentVoiceMuted, setChatAgentVoiceMuted] =
-    useState(loadChatVoiceMuted);
-  const [chatMode, setChatMode] = useState<ConversationMode>(loadChatMode);
-  const [chatAvatarSpeaking, setChatAvatarSpeaking] = useState(false);
-  const [conversations, setConversations] = useState<Conversation[]>([]);
-  const [activeConversationId, setActiveConversationId] = useState<
-    string | null
-  >(null);
-  const [companionMessageCutoffTs, setCompanionMessageCutoffTs] = useState(
-    loadCompanionMessageCutoffTs,
-  );
-  const [conversationMessages, setConversationMessages] = useState<
-    ConversationMessage[]
-  >([]);
-  const [autonomousEvents, setAutonomousEvents] = useState<
-    StreamEventEnvelope[]
-  >([]);
-  const [autonomousLatestEventId, setAutonomousLatestEventId] = useState<
-    string | null
-  >(null);
-  const [autonomousRunHealthByRunId, setAutonomousRunHealthByRunId] =
-    useState<AutonomyRunHealthMap>({});
-  const [ptySessions, setPtySessions] = useState<CodingAgentSession[]>([]);
-  const [unreadConversations, setUnreadConversations] = useState<Set<string>>(
-    new Set(),
-  );
-  const [chatPendingImages, setChatPendingImages] = useState<
-    ImageAttachment[]
-  >([]);
-  const [droppedFiles, setDroppedFiles] = useState<File[]>([]);
-  const [shareIngestNotice, setShareIngestNotice] = useState<string | null>(
-    null,
-  );
-
-  const activeConversationIdRef = useRef<string | null>(null);
-  const conversationMessagesRef = useRef<ConversationMessage[]>([]);
-
-  // Keep refs in sync
-  const setActiveConversationIdWrapped = useCallback(
-    (v: string | null) => {
-      activeConversationIdRef.current = v;
-      setActiveConversationId(v);
-    },
-    [],
-  );
-
-  const setConversationMessagesWrapped: React.Dispatch<
-    React.SetStateAction<ConversationMessage[]>
-  > = useCallback(
-    (v: React.SetStateAction<ConversationMessage[]>) => {
-      setConversationMessages((prev) => {
-        const next = typeof v === "function" ? v(prev) : v;
-        conversationMessagesRef.current = next;
-        return next;
-      });
-    },
-    [],
-  );
-
-  const value = useMemo<ChatStateValue>(
-    () => ({
-      chatInput,
-      chatSending,
-      chatFirstTokenReceived,
-      chatLastUsage,
-      chatAvatarVisible,
-      chatAgentVoiceMuted,
-      chatMode,
-      chatAvatarSpeaking,
-
-      conversations,
-      activeConversationId,
-      companionMessageCutoffTs,
-      conversationMessages,
-      autonomousEvents,
-      autonomousLatestEventId,
-      autonomousRunHealthByRunId,
-      ptySessions,
-      unreadConversations,
-      chatPendingImages,
-      droppedFiles,
-      shareIngestNotice,
-      setChatInput,
-      setChatSending,
-      setChatFirstTokenReceived,
-      setChatLastUsage,
-      setChatAvatarVisible,
-      setChatAgentVoiceMuted,
-      setChatMode,
-      setChatAvatarSpeaking,
-
-      setConversations,
-      setActiveConversationId: setActiveConversationIdWrapped,
-      setCompanionMessageCutoffTs,
-      setConversationMessages: setConversationMessagesWrapped,
-      setAutonomousEvents,
-      setAutonomousLatestEventId,
-      setAutonomousRunHealthByRunId,
-      setPtySessions,
-      setUnreadConversations,
-      setChatPendingImages,
-      setDroppedFiles,
-      setShareIngestNotice,
-      activeConversationIdRef,
-      conversationMessagesRef,
-    }),
-    [
-      chatInput,
-      chatSending,
-      chatFirstTokenReceived,
-      chatLastUsage,
-      chatAvatarVisible,
-      chatAgentVoiceMuted,
-      chatMode,
-      chatAvatarSpeaking,
-
-      conversations,
-      activeConversationId,
-      companionMessageCutoffTs,
-      conversationMessages,
-      autonomousEvents,
-      autonomousLatestEventId,
-      autonomousRunHealthByRunId,
-      ptySessions,
-      unreadConversations,
-      chatPendingImages,
-      droppedFiles,
-      shareIngestNotice,
-      setActiveConversationIdWrapped,
-      setConversationMessagesWrapped,
-    ],
-  );
-
+/**
+ * Accepts a pre-built value from AppProvider. No internal state — single
+ * source of truth remains in AppProvider.
+ */
+export function ChatProvider({
+  children,
+  value,
+}: {
+  children: ReactNode;
+  value: ChatStateValue;
+}) {
   return <ChatCtx.Provider value={value}>{children}</ChatCtx.Provider>;
 }
 
 // ── Hook ────────────────────────────────────────────────────────────
 
 /**
- * Use this hook for read-only chat state or chat setters.
- * Components that only need chat data should prefer this over useApp().
+ * Read-only chat state. Components that only need chat data should
+ * prefer this over useApp() to avoid re-rendering on unrelated changes.
  */
 export function useChatState(): ChatStateValue {
   const ctx = useContext(ChatCtx);
   if (ctx) return ctx;
   if (typeof process !== "undefined" && process.env.NODE_ENV === "test") {
-    const noop = () => {};
     return {
       chatInput: "",
       chatSending: false,
@@ -281,29 +98,7 @@ export function useChatState(): ChatStateValue {
       unreadConversations: new Set<string>(),
       chatPendingImages: [],
       droppedFiles: [],
-      shareIngestNotice: null,
-      setChatInput: noop,
-      setChatSending: noop,
-      setChatFirstTokenReceived: noop,
-      setChatLastUsage: noop,
-      setChatAvatarVisible: noop,
-      setChatAgentVoiceMuted: noop,
-      setChatMode: noop,
-      setChatAvatarSpeaking: noop,
-      setConversations: noop as ChatStateValue["setConversations"],
-      setActiveConversationId: noop,
-      setCompanionMessageCutoffTs: noop,
-      setConversationMessages: noop as ChatStateValue["setConversationMessages"],
-      setAutonomousEvents: noop as ChatStateValue["setAutonomousEvents"],
-      setAutonomousLatestEventId: noop,
-      setAutonomousRunHealthByRunId: noop as ChatStateValue["setAutonomousRunHealthByRunId"],
-      setPtySessions: noop as ChatStateValue["setPtySessions"],
-      setUnreadConversations: noop as ChatStateValue["setUnreadConversations"],
-      setChatPendingImages: noop as ChatStateValue["setChatPendingImages"],
-      setDroppedFiles: noop as ChatStateValue["setDroppedFiles"],
-      setShareIngestNotice: noop,
-      activeConversationIdRef: { current: null },
-      conversationMessagesRef: { current: [] },
+      shareIngestNotice: "",
     };
   }
   throw new Error(

--- a/packages/app-core/src/state/index.ts
+++ b/packages/app-core/src/state/index.ts
@@ -1,8 +1,9 @@
 export * from "./AppContext";
-// Sub-context providers are exported for composition inside AppProvider.
-// Navigation is safe to consume directly — AppContext reads from
-// NavigationProvider (no duplicate state).
-export { ChatProvider } from "./ChatContext";
+// Sub-context providers + consumer hooks. All are pass-through bridges —
+// AppProvider owns the state, providers expose it for targeted subscriptions.
+// No duplicate state, no split-brain.
+export { ChatProvider, useChatState } from "./ChatContext";
+export type { ChatStateValue } from "./ChatContext";
 export { LifecycleProvider, useLifecycle } from "./LifecycleContext";
 export type { LifecycleContextValue } from "./LifecycleContext";
 export { NavigationProvider, useNavigation } from "./NavigationContext";


### PR DESCRIPTION
## Summary

Completes the pass-through bridge pattern for all 4 sub-contexts. All contexts now share AppProvider state via useMemo'd value objects — no duplicate state, no split-brain.

### All 4 contexts wired
| Context | Hook | Pattern |
|---------|------|---------|
| TranslationContext | `useTranslation()` | 48 components migrated |
| NavigationContext | `useNavigation()` | Pass-through bridge |
| LifecycleContext | `useLifecycle()` | Pass-through bridge |
| ChatContext | `useChatState()` | Pass-through bridge |

### Type fixes
- `droppedFiles`: `File[]` → `string[]` (matches AppContext)
- `shareIngestNotice`: `string | null` → `string` (matches AppContext)

## Test plan
- [x] Typecheck passes
- [x] 57/57 tests pass
- [x] Vite build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)