### PR TITLE
refactor: migrate AdvancedPageView + ChatModalView to sub-context hooks

### DIFF
--- a/packages/app-core/src/components/AdvancedPageView.tsx
+++ b/packages/app-core/src/components/AdvancedPageView.tsx
@@ -20,7 +20,7 @@ import {
   SkillsView,
 } from "@miladyai/app-core/components";
 import type { Tab } from "@miladyai/app-core/navigation";
-import { useApp } from "@miladyai/app-core/state";
+import { useNavigation } from "../state/NavigationContext";
 import React, { type ReactNode, useState } from "react";
 import { CustomActionsView } from "./CustomActionsView";
 import { DesktopWorkspaceSection } from "./DesktopWorkspaceSection";
@@ -202,7 +202,7 @@ function mapTabToSubTab(tab: Tab): SubTab {
 }
 
 export function AdvancedPageView({ inModal }: { inModal?: boolean } = {}) {
-  const { tab, setTab } = useApp();
+  const { tab, setTab } = useNavigation();
   const [selectedTrajectoryId, setSelectedTrajectoryId] = useState<
     string | null
   >(null);

--- a/packages/app-core/src/components/ChatModalView.tsx
+++ b/packages/app-core/src/components/ChatModalView.tsx
@@ -1,5 +1,5 @@
 import { useRenderGuard } from "@miladyai/app-core/hooks";
-import { useApp } from "@miladyai/app-core/state";
+import { useChatState } from "../state/ChatContext";
 import { memo, useEffect, useState } from "react";
 import { ChatView } from "./ChatView.js";
 import { ConversationsSidebar } from "./ConversationsSidebar.js";
@@ -55,7 +55,7 @@ export const ChatModalView = memo(function ChatModalView({
   onSidebarClose,
 }: ChatModalViewProps) {
   useRenderGuard("ChatModalView");
-  const { activeConversationId } = useApp();
+  const { activeConversationId } = useChatState();
 
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
   const isNarrow = useIsNarrowViewport();


### PR DESCRIPTION
## Summary

First batch of component migrations from `useApp()` to domain-specific hooks:

- **AdvancedPageView** → `useNavigation()` (tab, setTab)
- **ChatModalView** → `useChatState()` (activeConversationId)

These components no longer re-render when unrelated state changes (chat keystrokes, plugin saves, etc.).

Note: VoiceConfigView and MediaSettingsSection use `elizaCloudConnected` which is cloud state — no sub-context yet. Left on `useApp()`.

## Test plan
- [x] Typecheck passes
- [x] 48/48 regression tests pass  
- [x] Vite build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)