### PR TITLE
fix: onboarding UI polish — buttons, provider grid, tabs

### DIFF
--- a/packages/app-core/src/components/onboarding/ActivateStep.tsx
+++ b/packages/app-core/src/components/onboarding/ActivateStep.tsx
@@ -48,7 +48,7 @@ export function ActivateStep() {
           {t("onboarding.back")}
         </Button>
         <Button
-          className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-[rgba(240,238,250,0.94)] text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
+          className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-white text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
           style={{ textShadow: "0 1px 6px rgba(3,5,10,0.55)" }}
           onClick={(e) => {
             const rect = e.currentTarget.getBoundingClientRect();

--- a/packages/app-core/src/components/onboarding/CloudLoginStep.tsx
+++ b/packages/app-core/src/components/onboarding/CloudLoginStep.tsx
@@ -72,7 +72,7 @@ export function CloudLoginStep() {
             </p>
           )}
           <Button
-            className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-[rgba(240,238,250,0.94)] text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
+            className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-white text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
             style={{ textShadow: "0 1px 6px rgba(3,5,10,0.55)" }}
             onClick={(e) => {
               const rect = e.currentTarget.getBoundingClientRect();

--- a/packages/app-core/src/components/onboarding/IdentityStep.tsx
+++ b/packages/app-core/src/components/onboarding/IdentityStep.tsx
@@ -163,7 +163,7 @@ export function IdentityStep() {
             {t("common.cancel")}
           </Button>
           <Button
-            className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-[rgba(240,238,250,0.94)] text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
+            className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-white text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
             style={{ textShadow: "0 1px 6px rgba(3,5,10,0.55)" }}
             disabled={importBusy || !importFile}
             onClick={(e) => {
@@ -234,7 +234,7 @@ export function IdentityStep() {
         style={{ animation: "onboarding-content-fade-in 0.5s ease 0.3s both" }}
       >
         <Button
-          className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-[rgba(240,238,250,0.94)] text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
+          className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-white text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
           style={{ textShadow: "0 1px 6px rgba(3,5,10,0.55)" }}
           onClick={(e) => {
             const rect = e.currentTarget.getBoundingClientRect();

--- a/packages/app-core/src/components/onboarding/OnboardingTabs.tsx
+++ b/packages/app-core/src/components/onboarding/OnboardingTabs.tsx
@@ -1,0 +1,33 @@
+/** Glassmorphic pill-style tab switcher for onboarding panels. */
+export function OnboardingTabs<T extends string>({
+  tabs,
+  active,
+  onChange,
+}: {
+  tabs: { id: T; label: string }[];
+  active: T;
+  onChange: (id: T) => void;
+}) {
+  return (
+    <div className="flex items-center gap-[4px] p-[3px] rounded-[8px] bg-[rgba(255,255,255,0.06)] backdrop-blur-[12px] border border-[rgba(255,255,255,0.08)] w-fit mx-auto mb-4">
+      {tabs.map((tab) => {
+        const isActive = tab.id === active;
+        return (
+          <button
+            key={tab.id}
+            type="button"
+            onClick={() => onChange(tab.id)}
+            className={`relative px-[20px] py-[7px] rounded-[6px] text-[11px] font-semibold tracking-[0.14em] uppercase cursor-pointer transition-all duration-300 border-none outline-none ${
+              isActive
+                ? "bg-[rgba(240,185,11,0.18)] text-[rgba(240,238,250,0.94)] shadow-[0_0_8px_rgba(240,185,11,0.12)]"
+                : "bg-transparent text-[rgba(240,238,250,0.45)] hover:text-[rgba(240,238,250,0.7)] hover:bg-[rgba(255,255,255,0.04)]"
+            }`}
+            style={{ textShadow: "0 1px 6px rgba(3,5,10,0.5)" }}
+          >
+            {tab.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/app-core/src/components/onboarding/RpcStep.tsx
+++ b/packages/app-core/src/components/onboarding/RpcStep.tsx
@@ -204,7 +204,7 @@ export function RpcStep() {
             <>
               <Button
                 type="button"
-                className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-[rgba(240,238,250,0.94)] text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
+                className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-white text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
                 style={{ textShadow: "0 1px 6px rgba(3,5,10,0.55)" }}
                 onClick={(e) => {
                   const rect = e.currentTarget.getBoundingClientRect();
@@ -286,7 +286,7 @@ export function RpcStep() {
             {t("settings.change")}
           </Button>
           <Button
-            className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-[rgba(240,238,250,0.94)] text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
+            className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-white text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
             style={{ textShadow: "0 1px 6px rgba(3,5,10,0.55)" }}
             onClick={() => {
               setState("onboardingRpcSelections", {
@@ -437,7 +437,7 @@ export function RpcStep() {
           {t("onboarding.back")}
         </Button>
         <Button
-          className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-[rgba(240,238,250,0.94)] text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
+          className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-white text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
           style={{ textShadow: "0 1px 6px rgba(3,5,10,0.55)" }}
           onClick={(e) => {
             const rect = e.currentTarget.getBoundingClientRect();

--- a/packages/app-core/src/components/onboarding/WelcomeStep.tsx
+++ b/packages/app-core/src/components/onboarding/WelcomeStep.tsx
@@ -73,7 +73,7 @@ export function WelcomeStep() {
           </Button>
         )}
         <Button
-          className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-[rgba(240,238,250,0.94)] text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
+          className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-white text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
           style={{ textShadow: "0 1px 6px rgba(3,5,10,0.55)" }}
           onClick={(e) => {
             const rect = e.currentTarget.getBoundingClientRect();

--- a/packages/app-core/src/components/onboarding/connection/ConnectionElizaCloudPreProviderScreen.tsx
+++ b/packages/app-core/src/components/onboarding/connection/ConnectionElizaCloudPreProviderScreen.tsx
@@ -2,6 +2,8 @@ import { Button, Input } from "@miladyai/ui";
 import type { ChangeEvent } from "react";
 import type { ConnectionEvent } from "../../../onboarding/connection-flow";
 import { useApp } from "../../../state";
+import { openExternalUrl } from "../../../utils";
+import { OnboardingTabs } from "../OnboardingTabs";
 import { useAdvanceOnboardingWhenElizaCloudOAuthConnected } from "./useAdvanceOnboardingWhenElizaCloudOAuthConnected";
 
 export function ConnectionElizaCloudPreProviderScreen({
@@ -53,64 +55,17 @@ export function ConnectionElizaCloudPreProviderScreen({
       </div>
 
       <div style={{ width: "100%", textAlign: "left" }}>
-        <div
-          style={{
-            display: "flex",
-            gap: "1rem",
-            borderBottom: "1px solid var(--border)",
-            marginBottom: "1rem",
-          }}
-        >
-          <Button
-            variant="ghost"
-            type="button"
-            style={{
-              fontSize: "0.875rem",
-              paddingBottom: "0.5rem",
-              color:
-                onboardingElizaCloudTab === "login"
-                  ? "#f0b90b"
-                  : "var(--muted)",
-              background: "none",
-              border: "none",
-              borderBottom:
-                onboardingElizaCloudTab === "login"
-                  ? "2px solid #f0b90b"
-                  : "2px solid transparent",
-              cursor: "pointer",
-            }}
-            onClick={() => dispatch({ type: "setElizaCloudTab", tab: "login" })}
-          >
-            {t("onboarding.login")}
-          </Button>
-          <Button
-            variant="ghost"
-            type="button"
-            style={{
-              fontSize: "0.875rem",
-              paddingBottom: "0.5rem",
-              borderBottom:
-                onboardingElizaCloudTab === "apikey"
-                  ? "2px solid #f0b90b"
-                  : "2px solid transparent",
-              color:
-                onboardingElizaCloudTab === "apikey"
-                  ? "#f0b90b"
-                  : "var(--muted)",
-              background: "none",
-              border: "none",
-              cursor: "pointer",
-            }}
-            onClick={() =>
-              dispatch({ type: "setElizaCloudTab", tab: "apikey" })
-            }
-          >
-            {t("onboarding.apiKey")}
-          </Button>
-        </div>
+        <OnboardingTabs
+          tabs={[
+            { id: "login" as const, label: t("onboarding.login") },
+            { id: "apikey" as const, label: t("onboarding.apiKey") },
+          ]}
+          active={onboardingElizaCloudTab}
+          onChange={(tab) => dispatch({ type: "setElizaCloudTab", tab })}
+        />
 
         {onboardingElizaCloudTab === "login" ? (
-          <div style={{ textAlign: "center" }}>
+          <div className="flex flex-col items-center gap-3 text-center">
             {elizaCloudConnected ? (
               <div
                 style={{
@@ -144,7 +99,7 @@ export function ConnectionElizaCloudPreProviderScreen({
             ) : (
               <Button
                 type="button"
-                className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-[rgba(240,238,250,0.94)] text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
+                className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-white text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
                 style={{ textShadow: "0 1px 6px rgba(3,5,10,0.55)" }}
                 onClick={(e) => {
                   const rect = e.currentTarget.getBoundingClientRect();
@@ -173,26 +128,13 @@ export function ConnectionElizaCloudPreProviderScreen({
                 );
                 if (urlMatch) {
                   return (
-                    <p
-                      style={{
-                        fontSize: "0.8125rem",
-                        marginTop: "0.5rem",
-                        color: "var(--text)",
-                      }}
+                    <button
+                      type="button"
+                      className="text-sm text-[rgba(240,238,250,0.7)] underline mt-2 cursor-pointer bg-transparent border-none font-inherit hover:text-[rgba(240,238,250,0.95)] transition-colors duration-200"
+                      onClick={() => openExternalUrl(urlMatch[1])}
                     >
-                      Open this link to log in:{" "}
-                      <a
-                        href={urlMatch[1]}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        style={{
-                          color: "var(--text)",
-                          textDecoration: "underline",
-                        }}
-                      >
-                        Click here
-                      </a>
-                    </p>
+                      Open login page in browser
+                    </button>
                   );
                 }
                 return (
@@ -258,7 +200,7 @@ export function ConnectionElizaCloudPreProviderScreen({
           {t("onboarding.back")}
         </Button>
         <Button
-          className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-[rgba(240,238,250,0.94)] text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
+          className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-white text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
           style={{ textShadow: "0 1px 6px rgba(3,5,10,0.55)" }}
           onClick={(e) => {
             const rect = e.currentTarget.getBoundingClientRect();

--- a/packages/app-core/src/components/onboarding/connection/ConnectionHostingScreen.tsx
+++ b/packages/app-core/src/components/onboarding/connection/ConnectionHostingScreen.tsx
@@ -52,7 +52,7 @@ export function ConnectionHostingScreen({
               </div>
             </div>
             <span
-              className="text-[9px] tracking-[0.08em] uppercase text-[rgba(240,238,250,0.94)] bg-[rgba(240,185,11,0.18)] px-2 py-0.5 rounded-full font-semibold ml-auto shrink-0 whitespace-nowrap"
+              className="text-[9px] tracking-[0.08em] uppercase text-white bg-[rgba(240,185,11,0.18)] px-2 py-0.5 rounded-full font-semibold ml-auto shrink-0 whitespace-nowrap"
               style={{ textShadow: "0 1px 6px rgba(3,5,10,0.45)" }}
             >
               {t("onboarding.recommended") ?? "Recommended"}

--- a/packages/app-core/src/components/onboarding/connection/ConnectionProviderDetailScreen.tsx
+++ b/packages/app-core/src/components/onboarding/connection/ConnectionProviderDetailScreen.tsx
@@ -21,6 +21,7 @@ import type { ConnectionEvent } from "../../../onboarding/connection-flow";
 import { getProviderLogo } from "../../../providers";
 import { useApp } from "../../../state";
 import { openExternalUrl } from "../../../utils";
+import { OnboardingTabs } from "../OnboardingTabs";
 import { useAdvanceOnboardingWhenElizaCloudOAuthConnected } from "./useAdvanceOnboardingWhenElizaCloudOAuthConnected";
 
 function formatRequestError(err: unknown): string {
@@ -277,66 +278,17 @@ export function ConnectionProviderDetailScreen({
 
       {onboardingProvider === "elizacloud" && (
         <div style={{ width: "100%", textAlign: "left" }}>
-          <div
-            style={{
-              display: "flex",
-              gap: "1rem",
-              borderBottom: "1px solid var(--border)",
-              marginBottom: "1rem",
-            }}
-          >
-            <Button
-              variant="ghost"
-              type="button"
-              style={{
-                fontSize: "0.875rem",
-                paddingBottom: "0.5rem",
-                color:
-                  onboardingElizaCloudTab === "login"
-                    ? "#f0b90b"
-                    : "var(--muted)",
-                background: "none",
-                border: "none",
-                borderBottom:
-                  onboardingElizaCloudTab === "login"
-                    ? "2px solid #f0b90b"
-                    : "2px solid transparent",
-                cursor: "pointer",
-              }}
-              onClick={() =>
-                dispatch({ type: "setElizaCloudTab", tab: "login" })
-              }
-            >
-              {t("onboarding.login")}
-            </Button>
-            <Button
-              variant="ghost"
-              type="button"
-              style={{
-                fontSize: "0.875rem",
-                paddingBottom: "0.5rem",
-                borderBottom:
-                  onboardingElizaCloudTab === "apikey"
-                    ? "2px solid #f0b90b"
-                    : "2px solid transparent",
-                color:
-                  onboardingElizaCloudTab === "apikey"
-                    ? "#f0b90b"
-                    : "var(--muted)",
-                background: "none",
-                border: "none",
-                cursor: "pointer",
-              }}
-              onClick={() =>
-                dispatch({ type: "setElizaCloudTab", tab: "apikey" })
-              }
-            >
-              {t("onboarding.apiKey")}
-            </Button>
-          </div>
+          <OnboardingTabs
+            tabs={[
+              { id: "login" as const, label: t("onboarding.login") },
+              { id: "apikey" as const, label: t("onboarding.apiKey") },
+            ]}
+            active={onboardingElizaCloudTab}
+            onChange={(tab) => dispatch({ type: "setElizaCloudTab", tab })}
+          />
 
           {onboardingElizaCloudTab === "login" ? (
-            <div style={{ textAlign: "center" }}>
+            <div className="flex flex-col items-center gap-3 text-center">
               {elizaCloudConnected ? (
                 <div
                   style={{
@@ -370,7 +322,7 @@ export function ConnectionProviderDetailScreen({
               ) : (
                 <Button
                   type="button"
-                  className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-[rgba(240,238,250,0.94)] text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
+                  className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-white text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
                   style={{ textShadow: "0 1px 6px rgba(3,5,10,0.55)" }}
                   onClick={handleCloudLogin}
                   disabled={elizaCloudLoginBusy}
@@ -387,26 +339,13 @@ export function ConnectionProviderDetailScreen({
                   );
                   if (urlMatch) {
                     return (
-                      <p
-                        style={{
-                          fontSize: "0.8125rem",
-                          marginTop: "0.5rem",
-                          color: "var(--text)",
-                        }}
+                      <button
+                        type="button"
+                        className="text-sm text-[rgba(240,238,250,0.7)] underline mt-2 cursor-pointer bg-transparent border-none font-inherit hover:text-[rgba(240,238,250,0.95)] transition-colors duration-200"
+                        onClick={() => openExternalUrl(urlMatch[1])}
                       >
-                        Open this link to log in:{" "}
-                        <a
-                          href={urlMatch[1]}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          style={{
-                            color: "var(--text)",
-                            textDecoration: "underline",
-                          }}
-                        >
-                          Click here
-                        </a>
-                      </p>
+                        Open login page in browser
+                      </button>
                     );
                   }
                   return (
@@ -464,63 +403,14 @@ export function ConnectionProviderDetailScreen({
 
       {onboardingProvider === "anthropic-subscription" && (
         <div style={{ textAlign: "left", width: "100%" }}>
-          <div
-            style={{
-              display: "flex",
-              gap: "1rem",
-              borderBottom: "1px solid var(--border)",
-              marginBottom: "0.75rem",
-            }}
-          >
-            <Button
-              variant="ghost"
-              type="button"
-              style={{
-                fontSize: "0.875rem",
-                paddingBottom: "0.5rem",
-                background: "none",
-                border: "none",
-                borderBottom:
-                  onboardingSubscriptionTab === "token"
-                    ? "2px solid #f0b90b"
-                    : "2px solid transparent",
-                color:
-                  onboardingSubscriptionTab === "token"
-                    ? "#f0b90b"
-                    : "var(--muted)",
-                cursor: "pointer",
-              }}
-              onClick={() =>
-                dispatch({ type: "setSubscriptionTab", tab: "token" })
-              }
-            >
-              {t("onboarding.setupToken")}
-            </Button>
-            <Button
-              variant="ghost"
-              type="button"
-              style={{
-                fontSize: "0.875rem",
-                paddingBottom: "0.5rem",
-                background: "none",
-                border: "none",
-                borderBottom:
-                  onboardingSubscriptionTab === "oauth"
-                    ? "2px solid #f0b90b"
-                    : "2px solid transparent",
-                color:
-                  onboardingSubscriptionTab === "oauth"
-                    ? "#f0b90b"
-                    : "var(--muted)",
-                cursor: "pointer",
-              }}
-              onClick={() =>
-                dispatch({ type: "setSubscriptionTab", tab: "oauth" })
-              }
-            >
-              {t("onboarding.oauthLogin")}
-            </Button>
-          </div>
+          <OnboardingTabs
+            tabs={[
+              { id: "token" as const, label: t("onboarding.setupToken") },
+              { id: "oauth" as const, label: t("onboarding.oauthLogin") },
+            ]}
+            active={onboardingSubscriptionTab}
+            onChange={(tab) => dispatch({ type: "setSubscriptionTab", tab })}
+          />
 
           {onboardingSubscriptionTab === "token" ? (
             <>
@@ -607,7 +497,7 @@ export function ConnectionProviderDetailScreen({
             >
               <Button
                 type="button"
-                className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-[rgba(240,238,250,0.94)] text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
+                className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-white text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
                 style={{ textShadow: "0 1px 6px rgba(3,5,10,0.55)" }}
                 onClick={(e) => {
                   const rect = e.currentTarget.getBoundingClientRect();
@@ -677,7 +567,7 @@ export function ConnectionProviderDetailScreen({
               )}
               <Button
                 type="button"
-                className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-[rgba(240,238,250,0.94)] text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
+                className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-white text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
                 style={{ textShadow: "0 1px 6px rgba(3,5,10,0.55)" }}
                 disabled={!anthropicCode}
                 onClick={(e) => {
@@ -761,7 +651,7 @@ export function ConnectionProviderDetailScreen({
             >
               <Button
                 type="button"
-                className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-[rgba(240,238,250,0.94)] text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
+                className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-white text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
                 style={{ textShadow: "0 1px 6px rgba(3,5,10,0.55)" }}
                 onClick={(e) => {
                   const rect = e.currentTarget.getBoundingClientRect();
@@ -853,7 +743,7 @@ export function ConnectionProviderDetailScreen({
               >
                 <Button
                   type="button"
-                  className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-[rgba(240,238,250,0.94)] text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
+                  className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-white text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
                   style={{ textShadow: "0 1px 6px rgba(3,5,10,0.55)" }}
                   disabled={!openaiCallbackUrl}
                   onClick={(e) => {
@@ -1084,7 +974,7 @@ export function ConnectionProviderDetailScreen({
           {t("onboarding.back")}
         </Button>
         <Button
-          className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-[rgba(240,238,250,0.94)] text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
+          className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-white text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
           style={{ textShadow: "0 1px 6px rgba(3,5,10,0.55)" }}
           disabled={isConfirmDisabled}
           onClick={(e) => {

--- a/packages/app-core/src/components/onboarding/connection/ConnectionProviderGridScreen.tsx
+++ b/packages/app-core/src/components/onboarding/connection/ConnectionProviderGridScreen.tsx
@@ -87,20 +87,20 @@ export function ConnectionProviderGridScreen({
               }
             >
               <img
-                src={getProviderLogo(p.id, false, getCustomLogo(p.id))}
+                src={getProviderLogo(p.id, true, getCustomLogo(p.id))}
                 alt={display.name}
                 className="w-6 h-6 rounded-md object-contain shrink-0"
               />
-              <div>
+              <div className="flex-1 min-w-0">
                 <div
-                  className="text-xs text-[rgba(240,238,250,0.88)] leading-[1.3]"
+                  className="text-xs text-[rgba(240,238,250,0.88)] leading-[1.3] truncate"
                   style={{ textShadow: "0 1px 8px rgba(3,5,10,0.6)" }}
                 >
                   {display.name}
                 </div>
                 {display.description && (
                   <div
-                    className="text-[10px] text-[rgba(240,238,250,0.58)] leading-[1.3] line-clamp-2"
+                    className="text-[10px] text-[rgba(240,238,250,0.58)] leading-[1.3] truncate"
                     style={{ textShadow: "0 1px 8px rgba(3,5,10,0.5)" }}
                   >
                     {display.description}
@@ -116,10 +116,7 @@ export function ConnectionProviderGridScreen({
                 </span>
               )}
               {isRecommended && !detectedLabel && (
-                <span
-                  className="text-[9px] tracking-[0.08em] uppercase text-[rgba(240,238,250,0.94)] bg-[rgba(240,185,11,0.18)] px-2 py-0.5 rounded-full font-semibold ml-auto shrink-0 whitespace-nowrap"
-                  style={{ textShadow: "0 1px 6px rgba(3,5,10,0.45)" }}
-                >
+                <span className="text-[8px] tracking-[0.12em] uppercase text-[rgba(240,185,11,0.9)] ml-auto shrink-0 whitespace-nowrap font-medium">
                   {t("onboarding.recommended") ?? "Recommended"}
                 </span>
               )}
@@ -127,10 +124,10 @@ export function ConnectionProviderGridScreen({
           );
         })}
       </div>
-      <div className="flex justify-between items-center gap-6 mt-[18px] pt-3.5 border-t border-white/[0.08]">
+      <div className="flex justify-between items-center gap-6 mt-[18px] pt-3.5 pb-1 border-t border-white/[0.08]">
         <Button
           variant="ghost"
-          className="text-[10px] text-[rgba(240,238,250,0.62)] tracking-[0.15em] uppercase cursor-pointer no-underline bg-none border-none font-inherit transition-colors duration-300 p-0 hover:text-[rgba(240,238,250,0.9)]"
+          className="text-[10px] text-[rgba(240,238,250,0.62)] tracking-[0.15em] uppercase cursor-pointer bg-transparent border-none font-inherit transition-colors duration-300 p-0 hover:text-[rgba(240,238,250,0.9)]"
           style={{ textShadow: "0 1px 8px rgba(3,5,10,0.45)" }}
           onClick={() => {
             if (onboardingRemoteConnected) {

--- a/packages/app-core/src/components/onboarding/connection/ConnectionRemoteBackendScreen.tsx
+++ b/packages/app-core/src/components/onboarding/connection/ConnectionRemoteBackendScreen.tsx
@@ -119,7 +119,7 @@ export function ConnectionRemoteBackendScreen({
           {t("onboarding.back")}
         </Button>
         <Button
-          className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-[rgba(240,238,250,0.94)] text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
+          className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-white text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
           style={{ textShadow: "0 1px 6px rgba(3,5,10,0.55)" }}
           onClick={(e) => {
             const rect = e.currentTarget.getBoundingClientRect();

--- a/packages/app-core/src/components/permissions/StreamingPermissions.tsx
+++ b/packages/app-core/src/components/permissions/StreamingPermissions.tsx
@@ -397,7 +397,7 @@ export function StreamingPermissionsOnboardingView({
         <Button
           variant="default"
           data-testid="permissions-onboarding-continue"
-          className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-[rgba(240,238,250,0.94)] text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
+          className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-white text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
           style={{ textShadow: "0 1px 6px rgba(3,5,10,0.55)" }}
           onClick={(e) => {
             const rect = e.currentTarget.getBoundingClientRect();

--- a/packages/ui/src/components/ui/button.js
+++ b/packages/ui/src/components/ui/button.js
@@ -27,11 +27,7 @@ const buttonVariants = cva("inline-flex items-center justify-center gap-2 whites
 });
 const Button = React.forwardRef(({ className, variant, size, asChild = false, style, ...props }, ref) => {
     const Comp = asChild ? Slot : "button";
-    const isDefault = variant === "default" || variant === undefined;
-    const resolvedStyle = isDefault && !style?.color
-        ? { ...style, color: "var(--primary-foreground)" }
-        : style;
-    return (_jsx(Comp, { className: cn(buttonVariants({ variant, size, className })), ref: ref, style: resolvedStyle, ...props }));
+    return (_jsx(Comp, { className: cn(buttonVariants({ variant, size, className })), ref: ref, style: style, ...props }));
 });
 Button.displayName = "Button";
 export { Button, buttonVariants };

--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -43,16 +43,11 @@ export interface ButtonProps
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, style, ...props }, ref) => {
     const Comp = asChild ? Slot : "button";
-    const isDefault = variant === "default" || variant === undefined;
-    const resolvedStyle =
-      isDefault && !style?.color
-        ? { ...style, color: "var(--primary-foreground)" }
-        : style;
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
-        style={resolvedStyle}
+        style={style}
         {...props}
       />
     );


### PR DESCRIPTION
## Summary
- Remove Button component inline `color: var(--primary-foreground)` override that forced dark text on default variant buttons
- Change all onboarding primary button text to white
- Fix provider grid layout (flex-1, truncate, dark mode icons)
- Replace underline tab UI with glassmorphic pill-style OnboardingTabs component
- Simplify recommended label styling

## Test plan
- [ ] Verify onboarding button text is white on all steps (Welcome, Hosting, AI Providers, Permissions, Launch)
- [ ] Verify provider grid icons are visible (white variants on dark background)
- [ ] Verify Login/API Key tabs use new pill style on Eliza Cloud screens
- [ ] Verify Setup Token/OAuth Login tabs use new pill style on subscription providers
- [ ] Verify non-onboarding buttons are not affected by Button component change

🤖 Generated with [Claude Code](https://claude.com/claude-code)