### PR TITLE
feat: onboarding avatar selection, companion UI fix, chat greeting

### DIFF
--- a/packages/app-core/src/components/ConversationsSidebar.tsx
+++ b/packages/app-core/src/components/ConversationsSidebar.tsx
@@ -271,6 +271,8 @@ export function ConversationsSidebar({
               onConfirmDelete={(id) => void handleConfirmDelete(id)}
               onCancelDelete={() => setConfirmDeleteId(null)}
               onOpenActions={openActionsMenu}
+              onStartEdit={() => handleStartEdit(conv)}
+              onStartDelete={() => setConfirmDeleteId(conv.id)}
             />
           ))
         )}

--- a/packages/app-core/src/components/OnboardingWizard.tsx
+++ b/packages/app-core/src/components/OnboardingWizard.tsx
@@ -14,6 +14,7 @@ import { COMPANION_ENABLED } from "../navigation";
 import { VrmStage } from "./companion/VrmStage";
 import { ActivateStep } from "./onboarding/ActivateStep";
 import { ConnectionStep } from "./onboarding/ConnectionStep";
+import { IdentityStep } from "./onboarding/IdentityStep";
 import { OnboardingPanel } from "./onboarding/OnboardingPanel";
 import { OnboardingStepNav } from "./onboarding/OnboardingStepNav";
 import { PermissionsStep } from "./onboarding/PermissionsStep";
@@ -92,6 +93,8 @@ export function OnboardingWizard() {
         return <ConnectionStep />;
       case "permissions":
         return <PermissionsStep />;
+      case "identity":
+        return <IdentityStep />;
       case "launch":
         return <ActivateStep />;
       default:
@@ -225,12 +228,18 @@ export function OnboardingWizard() {
         </div>
 
         {/* ── Standard overlaid UI — step nav + content panel ── */}
-        <div className="onboarding-ui-overlay">
-          <OnboardingStepNav />
-          <OnboardingPanel step={onboardingStep}>
-            {renderStep()}
-          </OnboardingPanel>
-        </div>
+        {onboardingStep === "identity" ? (
+          <div className="absolute inset-0 z-20 flex flex-col justify-end pointer-events-none [&>*]:pointer-events-auto">
+            <IdentityStep />
+          </div>
+        ) : (
+          <div className="onboarding-ui-overlay">
+            <OnboardingStepNav />
+            <OnboardingPanel step={onboardingStep}>
+              {renderStep()}
+            </OnboardingPanel>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/packages/app-core/src/components/avatar/VrmEngine.ts
+++ b/packages/app-core/src/components/avatar/VrmEngine.ts
@@ -2519,6 +2519,13 @@ export class VrmEngine {
         this.vrmReady = true;
         vrm.scene.visible = true;
         this.startPendingWorldReveal(false);
+        // Teleport animation failed (e.g. WebGPU unavailable) — still notify
+        // the app so companion UI (header, chat) becomes visible.
+        if (typeof window !== "undefined") {
+          window.dispatchEvent(
+            new CustomEvent("eliza:vrm-teleport-complete"),
+          );
+        }
       }
     }
   }

--- a/packages/app-core/src/components/conversations/ConversationListItem.tsx
+++ b/packages/app-core/src/components/conversations/ConversationListItem.tsx
@@ -1,4 +1,5 @@
 import { Button, Input } from "@miladyai/ui";
+import { Pencil, Trash2 } from "lucide-react";
 import type React from "react";
 import { useRef } from "react";
 import { getLocalizedConversationTitle } from "./conversation-utils";
@@ -30,6 +31,8 @@ interface ConversationListItemProps {
       | React.TouchEvent<HTMLButtonElement | HTMLDivElement>,
     conv: { id: string; title: string },
   ) => void;
+  onStartEdit: () => void;
+  onStartDelete: () => void;
 }
 
 export function ConversationListItem({
@@ -51,6 +54,8 @@ export function ConversationListItem({
   onConfirmDelete,
   onCancelDelete,
   onOpenActions,
+  onStartEdit,
+  onStartDelete,
 }: ConversationListItemProps) {
   const longPressTimerRef = useRef<number | null>(null);
   const suppressClickRef = useRef(false);
@@ -81,7 +86,7 @@ export function ConversationListItem({
       key={conv.id}
       data-testid="conv-item"
       data-active={isActive || undefined}
-      className={`w-full ${
+      className={`group w-full ${
         isGameModal
           ? "group relative flex items-start gap-3 w-full p-2.5 rounded-xl cursor-pointer transition-all border border-transparent"
           : "flex items-center pl-3 pr-2 py-2 gap-1 cursor-pointer transition-colors border-l-[3px]"
@@ -153,6 +158,26 @@ export function ConversationListItem({
             </span>
           </Button>
 
+          {!confirmDeleteId && !isEditing && (
+            <div className="flex items-center gap-0.5 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
+              <button
+                type="button"
+                className="p-1 rounded hover:bg-white/10 text-muted hover:text-txt transition-colors"
+                onClick={(e) => { e.stopPropagation(); onStartEdit(); }}
+                title={t("conversations.rename")}
+              >
+                <Pencil className="w-3 h-3" />
+              </button>
+              <button
+                type="button"
+                className="p-1 rounded hover:bg-white/10 text-muted hover:text-danger transition-colors"
+                onClick={(e) => { e.stopPropagation(); onStartDelete(); }}
+                title={t("conversations.delete")}
+              >
+                <Trash2 className="w-3 h-3" />
+              </button>
+            </div>
+          )}
           {confirmDeleteId === conv.id ? (
             <div className="flex items-center gap-1.5 flex-shrink-0">
               <span className="text-[10px] text-danger">

--- a/packages/app-core/src/onboarding/flow.ts
+++ b/packages/app-core/src/onboarding/flow.ts
@@ -8,7 +8,7 @@
  *   and forces side effects (cloud login, finish, provider fill) to stay in
  *   AppContext where they already close over the right state.
  *
- * Consolidated 5-step flow: welcome → hosting → providers → permissions → launch
+ * Consolidated 6-step flow: welcome → hosting → providers → permissions → identity → launch
  *
  * See: docs/guides/onboarding-ui-flow.md
  * Tests: tests/flow.test.ts

--- a/packages/app-core/src/onboarding/tests/flow.test.ts
+++ b/packages/app-core/src/onboarding/tests/flow.test.ts
@@ -1,4 +1,4 @@
-/** Unit tests for onboarding `flow.ts` — unified 5-step flow. */
+/** Unit tests for onboarding `flow.ts` — unified 6-step flow. */
 import { describe, expect, it } from "vitest";
 import {
   canRevertOnboardingTo,
@@ -11,12 +11,13 @@ import {
 
 describe("onboarding flow", () => {
   describe("getStepOrder", () => {
-    it("returns unified 5-step order", () => {
+    it("returns unified 6-step order", () => {
       expect(getStepOrder()).toEqual([
         "welcome",
         "hosting",
         "providers",
         "permissions",
+        "identity",
         "launch",
       ]);
     });
@@ -27,7 +28,8 @@ describe("onboarding flow", () => {
       expect(resolveOnboardingNextStep("welcome")).toBe("hosting");
       expect(resolveOnboardingNextStep("hosting")).toBe("providers");
       expect(resolveOnboardingNextStep("providers")).toBe("permissions");
-      expect(resolveOnboardingNextStep("permissions")).toBe("launch");
+      expect(resolveOnboardingNextStep("permissions")).toBe("identity");
+      expect(resolveOnboardingNextStep("identity")).toBe("launch");
       expect(resolveOnboardingNextStep("launch")).toBe(null);
     });
   });
@@ -38,7 +40,8 @@ describe("onboarding flow", () => {
       expect(resolveOnboardingPreviousStep("hosting")).toBe("welcome");
       expect(resolveOnboardingPreviousStep("providers")).toBe("hosting");
       expect(resolveOnboardingPreviousStep("permissions")).toBe("providers");
-      expect(resolveOnboardingPreviousStep("launch")).toBe("permissions");
+      expect(resolveOnboardingPreviousStep("identity")).toBe("permissions");
+      expect(resolveOnboardingPreviousStep("launch")).toBe("identity");
     });
   });
 
@@ -64,13 +67,14 @@ describe("onboarding flow", () => {
   });
 
   describe("getOnboardingNavMetas", () => {
-    it("returns all 5 steps regardless of current step", () => {
+    it("returns all 6 steps regardless of current step", () => {
       const metas = getOnboardingNavMetas("providers", false);
       expect(metas.map((m) => m.id)).toEqual([
         "welcome",
         "hosting",
         "providers",
         "permissions",
+        "identity",
         "launch",
       ]);
     });
@@ -81,6 +85,7 @@ describe("onboarding flow", () => {
         "hosting",
         "providers",
         "permissions",
+        "identity",
         "launch",
       ]);
     });
@@ -94,6 +99,7 @@ describe("onboarding flow", () => {
       );
       expect(getFlaminaTopicForOnboardingStep("welcome")).toBe(null);
       expect(getFlaminaTopicForOnboardingStep("hosting")).toBe(null);
+      expect(getFlaminaTopicForOnboardingStep("identity")).toBe(null);
       expect(getFlaminaTopicForOnboardingStep("launch")).toBe(null);
     });
   });

--- a/packages/app-core/src/state/AppContext.tsx
+++ b/packages/app-core/src/state/AppContext.tsx
@@ -2689,19 +2689,29 @@ export function AppProvider({
       resetConversationDraftState();
 
       try {
-        const { conversation, greeting } = await client.createConversation(
-          title,
-          {
+        const { conversation, greeting: inlineGreeting } =
+          await client.createConversation(title, {
             bootstrapGreeting: true,
             lang: uiLanguage,
-          },
-        );
+          });
         const nextCutoffTs = Date.now();
         setConversations((prev) => [conversation, ...prev]);
         setActiveConversationId(conversation.id);
         activeConversationIdRef.current = conversation.id;
         setCompanionMessageCutoffTs(nextCutoffTs);
-        const greetingText = greeting?.text?.trim() || "";
+        // Try inline greeting first; fall back to dedicated greeting endpoint
+        let greetingText = inlineGreeting?.text?.trim() || "";
+        if (!greetingText) {
+          try {
+            const resp = await client.requestGreeting(
+              conversation.id,
+              uiLanguage,
+            );
+            greetingText = resp.text?.trim() || "";
+          } catch {
+            // Greeting generation failed — continue without greeting
+          }
+        }
 
         if (greetingText) {
           greetingFiredRef.current = true;
@@ -4878,8 +4888,7 @@ export function AppProvider({
       if (onboardingStep === "permissions") {
         if (options?.allowPermissionBypass) {
           if (options.skipTask) addDeferredOnboardingTask(options.skipTask);
-          await handleOnboardingFinish();
-          return;
+          // Don't finish yet — advance to identity step for avatar selection
         }
       }
 

--- a/packages/app-core/src/state/types.ts
+++ b/packages/app-core/src/state/types.ts
@@ -67,6 +67,7 @@ export type OnboardingStep =
   | "hosting"
   | "providers"
   | "permissions"
+  | "identity"
   | "launch";
 
 export interface OnboardingStepMeta {
@@ -96,6 +97,11 @@ export const ONBOARDING_STEPS: OnboardingStepMeta[] = [
     id: "permissions",
     name: "onboarding.stepName.permissions",
     subtitle: "onboarding.stepSub.permissions",
+  },
+  {
+    id: "identity",
+    name: "onboarding.stepName.identity",
+    subtitle: "onboarding.stepSub.identity",
   },
   {
     id: "launch",


### PR DESCRIPTION
## Summary
- Add "identity" (avatar/character) step to onboarding flow — users select their agent persona after permissions, before launch
- Fix companion mode UI not appearing on macOS 15 (WebGPU unavailable in WKWebView) — dispatch `vrm-teleport-complete` event on teleport failure fallback
- Fix new chat greeting not showing — fall back to dedicated `/greeting` endpoint when inline `bootstrapGreeting` returns empty
- Add hover edit/delete icon buttons to conversation list items (no right-click needed)
- Permissions bypass now advances to identity step instead of finishing onboarding

## Test plan
- [ ] Complete onboarding — verify Identity/Avatar step appears after Permissions
- [ ] Select different avatars in Identity step, verify VRM changes
- [ ] Click Continue in Identity step, verify Launch step appears
- [ ] Enter companion mode — verify header and chat UI appear (not blank avatar only)
- [ ] Create new chat — verify agent greeting message appears
- [ ] Hover over conversation in sidebar — verify edit (pencil) and delete (trash) icons appear
- [ ] Click edit icon — verify inline rename input appears
- [ ] Click delete icon — verify delete confirmation appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)