### PR TITLE
fix: prevent VRM camera zoom/drag from stealing scroll on character editor

### DIFF
--- a/packages/app-core/src/components/CharacterEditor.tsx
+++ b/packages/app-core/src/components/CharacterEditor.tsx
@@ -1047,6 +1047,8 @@ export function CharacterEditor({
   return (
     <div
       className="absolute inset-0 z-10 flex flex-col pointer-events-none pt-[4.5rem] px-6 pb-3 max-md:px-3 max-md:pb-2 max-md:pt-[4.5rem] [&>*]:pointer-events-auto"
+      data-no-camera-zoom="true"
+      data-no-camera-drag="true"
       onWheel={(e) => e.stopPropagation()}
     >
       <div

--- a/packages/app-core/src/components/avatar/VrmEngine.ts
+++ b/packages/app-core/src/components/avatar/VrmEngine.ts
@@ -2665,9 +2665,7 @@ export class VrmEngine {
         // Teleport animation failed (e.g. WebGPU unavailable) — still notify
         // the app so companion UI (header, chat) becomes visible.
         if (typeof window !== "undefined") {
-          window.dispatchEvent(
-            new CustomEvent("eliza:vrm-teleport-complete"),
-          );
+          window.dispatchEvent(new CustomEvent("eliza:vrm-teleport-complete"));
         }
       }
     }


### PR DESCRIPTION
## Summary

The VRM 3D scene captures wheel events for camera zoom, which prevents users from scrolling through voice options and other customization panels on the character editor page.

### Fix
Added `data-no-camera-zoom="true"` and `data-no-camera-drag="true"` to the CharacterEditor overlay container. `CompanionSceneHost` already checks these selectors via `shouldIgnoreCameraZoom()` and `shouldIgnoreCameraDrag()` — it skips camera manipulation when the event originates from a matching element.

### One-line change
```tsx
<div data-no-camera-zoom="true" data-no-camera-drag="true" ...>
```

## Test plan
- [x] Typecheck passes
- [x] Vite build succeeds
- [ ] Character editor panels scroll freely (voice picker, style options)
- [ ] VRM camera still works when clicking/scrolling directly on the 3D scene

🤖 Generated with [Claude Code](https://claude.com/claude-code)