### PR TITLE
docs: add missing connector pages, fix broken links, update plugin/pr…

### DIFF
--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -88,4 +88,4 @@ Use the `/model` slash command in the dashboard to switch models during a sessio
 
 - [milady configure](/cli/configure) -- print provider key guidance to the terminal
 - [Environment Variables](/cli/environment) -- complete environment variable reference
-- [Model Providers](/model-providers) -- detailed provider configuration and model IDs
+- [Model Providers](/runtime/models) -- detailed provider configuration and model IDs

--- a/docs/connectors/bluebubbles.md
+++ b/docs/connectors/bluebubbles.md
@@ -1,0 +1,152 @@
+---
+title: BlueBubbles Connector
+sidebarTitle: BlueBubbles
+description: Connect your agent to iMessage via BlueBubbles using the @elizaos/plugin-bluebubbles package.
+---
+
+Connect your agent to iMessage for private chats and group conversations via a BlueBubbles server (macOS only).
+
+## Overview
+
+The BlueBubbles connector is an external elizaOS plugin that bridges your agent to iMessage through a BlueBubbles server running on macOS. It is auto-enabled by the runtime when both a server URL and password are detected in your connector configuration.
+
+## Package Info
+
+| Field | Value |
+|-------|-------|
+| Package | `@elizaos/plugin-bluebubbles` |
+| Config key | `connectors.bluebubbles` |
+| Auto-enable trigger | `serverUrl` and `password` are both truthy in connector config |
+
+## Minimal Configuration
+
+In your character file:
+
+```json
+{
+  "connectors": {
+    "bluebubbles": {
+      "serverUrl": "http://localhost:1234",
+      "password": "your-password"
+    }
+  }
+}
+```
+
+## Disabling
+
+To explicitly disable the connector even when credentials are present:
+
+```json
+{
+  "connectors": {
+    "bluebubbles": {
+      "serverUrl": "http://localhost:1234",
+      "password": "your-password",
+      "enabled": false
+    }
+  }
+}
+```
+
+## Auto-Enable Mechanism
+
+The `plugin-auto-enable.ts` module checks `connectors.bluebubbles` in your character config. If both `serverUrl` and `password` are truthy (and `enabled` is not explicitly `false`), the runtime automatically loads `@elizaos/plugin-bluebubbles`.
+
+No environment variable is required to trigger auto-enable — it is driven entirely by the connector config object.
+
+## Full Configuration Reference
+
+All fields are defined under `connectors.bluebubbles` in your character file.
+
+### Core Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `serverUrl` | string | — | BlueBubbles server URL (e.g., `http://192.168.1.100:1234`) |
+| `password` | string | — | BlueBubbles server password |
+| `name` | string | — | Account display name |
+| `enabled` | boolean | — | Explicitly enable/disable |
+| `capabilities` | string[] | — | Capability flags |
+| `webhookPath` | string | — | Webhook endpoint path for incoming events |
+| `sendReadReceipts` | boolean | — | Send read receipts to senders |
+| `dmPolicy` | `"pairing"` \| `"allowlist"` \| `"open"` \| `"disabled"` | `"pairing"` | DM access policy. `"open"` requires `allowFrom` to include `"*"` |
+| `allowFrom` | (string\|number)[] | — | User IDs allowed to DM |
+| `groupPolicy` | `"open"` \| `"disabled"` \| `"allowlist"` | `"allowlist"` | Group join policy |
+| `groupAllowFrom` | (string\|number)[] | — | Allowed group IDs |
+| `historyLimit` | integer >= 0 | — | Max messages in context |
+| `dmHistoryLimit` | integer >= 0 | — | History limit for DMs |
+| `dms` | object | — | Per-DM history overrides keyed by DM ID. Each value: `{historyLimit?: int}` |
+| `textChunkLimit` | integer > 0 | — | Max characters per message chunk |
+| `chunkMode` | `"length"` \| `"newline"` | — | Long message splitting strategy |
+| `mediaMaxMb` | integer > 0 | — | Max media file size in MB |
+| `configWrites` | boolean | — | Allow config writes from BlueBubbles events |
+| `blockStreaming` | boolean | — | Disable streaming responses |
+| `blockStreamingCoalesce` | object | — | Coalescing settings: `minChars`, `maxChars`, `idleMs` |
+| `markdown` | object | — | Table rendering: `tables` can be `"off"`, `"bullets"`, or `"code"` |
+
+### Actions
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `actions.reactions` | boolean | React to messages with tapback emojis |
+| `actions.edit` | boolean | Edit previously sent messages |
+| `actions.unsend` | boolean | Unsend previously sent messages |
+| `actions.reply` | boolean | Reply to specific messages in threads |
+| `actions.sendWithEffect` | boolean | Send messages with iMessage effects (slam, loud, gentle, invisible ink, etc.) |
+| `actions.renameGroup` | boolean | Rename group conversations |
+| `actions.setGroupIcon` | boolean | Set group conversation icons |
+| `actions.addParticipant` | boolean | Add participants to group conversations |
+| `actions.removeParticipant` | boolean | Remove participants from group conversations |
+| `actions.leaveGroup` | boolean | Leave group conversations |
+| `actions.sendAttachment` | boolean | Send media attachments |
+
+### Group Configuration
+
+Per-group settings are defined under `groups.<group-id>`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `requireMention` | boolean | Only respond when @mentioned |
+| `tools` | ToolPolicySchema | Tool access policy |
+| `toolsBySender` | object | Per-sender tool policies (keyed by sender ID) |
+
+### Heartbeat
+
+```json
+{
+  "connectors": {
+    "bluebubbles": {
+      "heartbeat": {
+        "showOk": true,
+        "showAlerts": true,
+        "useIndicator": true
+      }
+    }
+  }
+}
+```
+
+### Multi-Account Support
+
+The `accounts` field allows running multiple BlueBubbles connections from a single agent:
+
+```json
+{
+  "connectors": {
+    "bluebubbles": {
+      "accounts": {
+        "home-mac": { "serverUrl": "http://192.168.1.100:1234", "password": "..." },
+        "office-mac": { "serverUrl": "http://192.168.1.200:1234", "password": "..." }
+      }
+    }
+  }
+}
+```
+
+## Related
+
+- [BlueBubbles plugin reference](/plugin-registry/platform/bluebubbles)
+- [iMessage connector reference](/connectors/imessage)
+- [Connectors overview](/guides/connectors)
+- [Configuration reference](/configuration)

--- a/docs/connectors/farcaster.md
+++ b/docs/connectors/farcaster.md
@@ -1,0 +1,125 @@
+---
+title: Farcaster Connector
+sidebarTitle: Farcaster
+description: Connect your agent to Farcaster using the @elizaos/plugin-farcaster package.
+---
+
+Connect your agent to the Farcaster decentralized social protocol for casting, replies, and channel participation.
+
+## Overview
+
+The Farcaster connector is an external elizaOS plugin that bridges your agent to the Farcaster network via the Neynar API. It is auto-enabled by the runtime when a valid API key is detected in your connector configuration.
+
+## Package Info
+
+| Field | Value |
+|-------|-------|
+| Package | `@elizaos/plugin-farcaster` |
+| Config key | `connectors.farcaster` |
+| Auto-enable trigger | `apiKey` is truthy in connector config |
+
+## Minimal Configuration
+
+In your character file:
+
+```json
+{
+  "connectors": {
+    "farcaster": {
+      "apiKey": "YOUR_NEYNAR_API_KEY",
+      "signerUuid": "YOUR_SIGNER_UUID",
+      "fid": 12345
+    }
+  }
+}
+```
+
+## Disabling
+
+To explicitly disable the connector even when an API key is present:
+
+```json
+{
+  "connectors": {
+    "farcaster": {
+      "apiKey": "YOUR_NEYNAR_API_KEY",
+      "signerUuid": "YOUR_SIGNER_UUID",
+      "fid": 12345,
+      "enabled": false
+    }
+  }
+}
+```
+
+## Auto-Enable Mechanism
+
+The `plugin-auto-enable.ts` module checks `connectors.farcaster` in your character config. If the `apiKey` field is truthy (and `enabled` is not explicitly `false`), the runtime automatically loads `@elizaos/plugin-farcaster`.
+
+No environment variable is required to trigger auto-enable — it is driven entirely by the connector config object.
+
+## Full Configuration Reference
+
+All fields are defined under `connectors.farcaster` in your character file.
+
+### Core Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `apiKey` | string | — | Neynar API key (required) |
+| `signerUuid` | string | — | Neynar signer UUID for the agent account (required) |
+| `fid` | number | — | Farcaster ID of the agent account (required) |
+| `enabled` | boolean | — | Explicitly enable/disable |
+| `channels` | string[] | — | Farcaster channel names to monitor and participate in |
+| `pollInterval` | number | `60` | Seconds between mention checks |
+
+### Autonomous Casting
+
+The agent can post casts autonomously at random intervals. The LLM generates cast content based on the character's personality and current context.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `castIntervalMin` | number | `120` | Minimum minutes between autonomous casts |
+| `castIntervalMax` | number | `240` | Maximum minutes between autonomous casts |
+
+```json
+{
+  "connectors": {
+    "farcaster": {
+      "apiKey": "...",
+      "signerUuid": "...",
+      "fid": 12345,
+      "channels": ["ai", "agents"],
+      "castIntervalMin": 90,
+      "castIntervalMax": 180
+    }
+  }
+}
+```
+
+### Cast Limits
+
+Casts are limited to 320 characters. Longer responses are automatically split into cast threads.
+
+### DM Policy
+
+Farcaster supports direct casts (private messages via Warpcast). The connector handles incoming direct casts as DM conversations.
+
+## Features
+
+- **Autonomous casting** — Posts in the agent's voice at configurable intervals
+- **Replies** — Responds to @mentions and replies to the agent's casts
+- **Reactions** — Likes and recasts
+- **Channel monitoring** — Participates in Farcaster channels
+- **Direct casts** — Private DM-like messages (Warpcast feature)
+- **On-chain identity** — Agent identity is tied to an Ethereum address
+- **Thread splitting** — Messages over 320 characters are split into cast threads
+
+## Multi-Account Support
+
+Farcaster does not support multi-account configuration. Each agent runs a single Farcaster account.
+
+## Related
+
+- [Farcaster plugin reference](/plugin-registry/platform/farcaster)
+- [Connectors overview](/guides/connectors)
+- [Configuration reference](/configuration)

--- a/docs/connectors/googlechat.md
+++ b/docs/connectors/googlechat.md
@@ -1,0 +1,157 @@
+---
+title: Google Chat Connector
+sidebarTitle: Google Chat
+description: Connect your agent to Google Chat using the @elizaos/plugin-google-chat package.
+---
+
+Connect your agent to Google Chat for DMs and space conversations.
+
+## Overview
+
+The Google Chat connector is an external elizaOS plugin that bridges your agent to Google Chat via a Google Cloud service account. It is auto-enabled by the runtime when a valid token or service account configuration is detected in your connector configuration.
+
+## Package Info
+
+| Field | Value |
+|-------|-------|
+| Package | `@elizaos/plugin-google-chat` |
+| Config key | `connectors.googlechat` |
+| Auto-enable trigger | `botToken`, `token`, or `apiKey` is truthy in connector config |
+
+## Minimal Configuration
+
+In your character file:
+
+```json
+{
+  "connectors": {
+    "googlechat": {
+      "serviceAccountFile": "./service-account.json",
+      "audienceType": "project-number",
+      "audience": "123456789",
+      "webhookPath": "/google-chat"
+    }
+  }
+}
+```
+
+## Disabling
+
+To explicitly disable the connector even when credentials are present:
+
+```json
+{
+  "connectors": {
+    "googlechat": {
+      "serviceAccountFile": "./service-account.json",
+      "audienceType": "project-number",
+      "audience": "123456789",
+      "enabled": false
+    }
+  }
+}
+```
+
+## Auto-Enable Mechanism
+
+The `plugin-auto-enable.ts` module checks `connectors.googlechat` in your character config. If any of the fields `botToken`, `token`, or `apiKey` is truthy (and `enabled` is not explicitly `false`), the runtime automatically loads `@elizaos/plugin-google-chat`.
+
+No environment variable is required to trigger auto-enable — it is driven entirely by the connector config object.
+
+## Full Configuration Reference
+
+All fields are defined under `connectors.googlechat` in your character file.
+
+### Core Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `serviceAccountFile` | string | — | Path to service account JSON key file |
+| `serviceAccount` | string \| object | — | Inline service account JSON (alternative to file) |
+| `audienceType` | `"app-url"` \| `"project-number"` | — | Authentication audience type |
+| `audience` | string | — | App URL or project number (matches `audienceType`) |
+| `name` | string | — | Account display name |
+| `enabled` | boolean | — | Explicitly enable/disable |
+| `capabilities` | string[] | — | Capability flags |
+| `webhookPath` | string | — | Webhook endpoint path (e.g., `/google-chat`) |
+| `webhookUrl` | string | — | Full webhook URL override |
+| `botUser` | string | — | Bot user identifier |
+| `configWrites` | boolean | — | Allow config writes from Google Chat events |
+| `allowBots` | boolean | — | Allow interactions from other bots |
+| `requireMention` | boolean | — | Only respond when @mentioned |
+| `dmPolicy` | `"pairing"` \| `"allowlist"` \| `"open"` \| `"disabled"` | `"pairing"` | DM access policy |
+| `groupPolicy` | `"open"` \| `"disabled"` \| `"allowlist"` | `"allowlist"` | Group join policy |
+| `groupAllowFrom` | (string\|number)[] | — | Allowed group/space IDs |
+| `historyLimit` | integer >= 0 | — | Max messages in context |
+| `dmHistoryLimit` | integer >= 0 | — | History limit for DMs |
+| `dms` | object | — | Per-DM history overrides keyed by DM ID. Each value: `{historyLimit?: int}` |
+| `textChunkLimit` | integer > 0 | — | Max characters per message chunk |
+| `chunkMode` | `"length"` \| `"newline"` | — | Long message splitting strategy |
+| `mediaMaxMb` | number > 0 | — | Max media file size in MB |
+| `blockStreaming` | boolean | — | Disable streaming responses |
+| `blockStreamingCoalesce` | object | — | Coalescing settings: `minChars`, `maxChars`, `idleMs` |
+| `replyToMode` | `"off"` \| `"first"` \| `"all"` | — | Reply threading mode |
+| `typingIndicator` | `"none"` \| `"message"` \| `"reaction"` | `"none"` | Typing indicator mode |
+
+### Actions
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `actions.reactions` | boolean | Send reactions to messages |
+
+### DM Configuration
+
+The `dm` sub-object provides additional DM-level policy:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `dm.enabled` | boolean | — | Enable/disable DMs |
+| `dm.policy` | `"pairing"` \| `"allowlist"` \| `"open"` \| `"disabled"` | `"pairing"` | DM access policy. `"open"` requires `dm.allowFrom` to include `"*"` |
+| `dm.allowFrom` | (string\|number)[] | — | User IDs allowed to DM |
+
+### Group Configuration
+
+Per-group settings are defined under `groups.<group-id>`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `enabled` | boolean | Enable/disable this group |
+| `allow` | boolean | Allow messages in this group |
+| `requireMention` | boolean | Only respond when @mentioned |
+| `users` | (string\|number)[] | Allowed user IDs in this group |
+| `systemPrompt` | string | Group-specific system prompt |
+
+### Multi-Account Support
+
+The `accounts` field allows running multiple Google Chat bots from a single agent:
+
+```json
+{
+  "connectors": {
+    "googlechat": {
+      "accounts": {
+        "workspace-1": {
+          "serviceAccountFile": "./sa-1.json",
+          "audienceType": "project-number",
+          "audience": "111111111"
+        },
+        "workspace-2": {
+          "serviceAccountFile": "./sa-2.json",
+          "audienceType": "project-number",
+          "audience": "222222222"
+        }
+      },
+      "defaultAccount": "workspace-1"
+    }
+  }
+}
+```
+
+Account-level settings override the base connector settings. Use `defaultAccount` to specify which account is used when none is explicitly selected.
+
+## Related
+
+- [Google Chat plugin reference](/plugin-registry/platform/googlechat)
+- [MS Teams connector reference](/connectors/msteams)
+- [Connectors overview](/guides/connectors)
+- [Configuration reference](/configuration)

--- a/docs/connectors/imessage.md
+++ b/docs/connectors/imessage.md
@@ -1,0 +1,194 @@
+---
+title: iMessage Connector
+sidebarTitle: iMessage
+description: Connect your agent to iMessage using the @elizaos/plugin-imessage package.
+---
+
+Connect your agent to iMessage for private chats and group conversations on macOS.
+
+## Overview
+
+The iMessage connector is an external elizaOS plugin that bridges your agent to iMessage and SMS on macOS. It accesses the native iMessage database directly and supports remote host connectivity via SSH. It is auto-enabled by the runtime when a CLI path is detected in your connector configuration.
+
+## Package Info
+
+| Field | Value |
+|-------|-------|
+| Package | `@elizaos/plugin-imessage` |
+| Config key | `connectors.imessage` |
+| Auto-enable trigger | `cliPath` is truthy in connector config |
+
+## Prerequisites
+
+- macOS with iMessage configured and signed in
+- Full Disk Access granted to the terminal or application running Milady (for chat database access at `~/Library/Messages/chat.db`)
+- A CLI tool for iMessage access (e.g., `imessage-exporter`)
+
+## Minimal Configuration
+
+In your character file:
+
+```json
+{
+  "connectors": {
+    "imessage": {
+      "cliPath": "/usr/local/bin/imessage",
+      "service": "auto",
+      "dmPolicy": "pairing"
+    }
+  }
+}
+```
+
+## Disabling
+
+To explicitly disable the connector even when a CLI path is present:
+
+```json
+{
+  "connectors": {
+    "imessage": {
+      "cliPath": "/usr/local/bin/imessage",
+      "enabled": false
+    }
+  }
+}
+```
+
+## Auto-Enable Mechanism
+
+The `plugin-auto-enable.ts` module checks `connectors.imessage` in your character config. If the `cliPath` field is truthy (and `enabled` is not explicitly `false`), the runtime automatically loads `@elizaos/plugin-imessage`.
+
+No environment variable is required to trigger auto-enable — it is driven entirely by the connector config object.
+
+## Full Configuration Reference
+
+All fields are defined under `connectors.imessage` in your character file.
+
+### Core Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `cliPath` | string | — | Path to the iMessage CLI tool executable |
+| `dbPath` | string | — | Path to the iMessage database (default: `~/Library/Messages/chat.db`) |
+| `remoteHost` | string | — | Remote Mac hostname for SSH-based iMessage access |
+| `service` | `"imessage"` \| `"sms"` \| `"auto"` | — | Message service selection. `"auto"` detects the appropriate service |
+| `region` | string | — | Region configuration for phone number formatting |
+| `name` | string | — | Account display name |
+| `enabled` | boolean | — | Explicitly enable/disable |
+| `capabilities` | string[] | — | Capability flags |
+| `includeAttachments` | boolean | — | Include attachments in messages |
+| `configWrites` | boolean | — | Allow config writes from iMessage events |
+| `dmPolicy` | `"pairing"` \| `"allowlist"` \| `"open"` \| `"disabled"` | `"pairing"` | DM access policy. `"open"` requires `allowFrom` to include `"*"` |
+| `allowFrom` | (string\|number)[] | — | User IDs allowed to DM |
+| `groupPolicy` | `"open"` \| `"disabled"` \| `"allowlist"` | `"allowlist"` | Group join policy |
+| `groupAllowFrom` | (string\|number)[] | — | User IDs allowed in groups |
+| `historyLimit` | integer >= 0 | — | Max messages in context |
+| `dmHistoryLimit` | integer >= 0 | — | History limit for DMs |
+| `dms` | object | — | Per-DM history overrides keyed by DM ID. Each value: `{historyLimit?: int}` |
+| `textChunkLimit` | integer > 0 | — | Max characters per message chunk |
+| `chunkMode` | `"length"` \| `"newline"` | — | Long message splitting strategy |
+| `mediaMaxMb` | integer > 0 | — | Max media file size in MB |
+| `markdown` | object | — | Table rendering: `tables` can be `"off"`, `"bullets"`, or `"code"` |
+
+### Streaming Configuration
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `blockStreaming` | boolean | — | Disable streaming entirely |
+| `blockStreamingCoalesce` | object | — | Coalescing settings: `minChars`, `maxChars`, `idleMs` |
+
+### Group Configuration
+
+Per-group settings are defined under `groups.<group-id>`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `requireMention` | boolean | Only respond when @mentioned |
+| `tools` | ToolPolicySchema | Tool access policy |
+| `toolsBySender` | object | Per-sender tool policies (keyed by sender ID) |
+
+### Heartbeat
+
+```json
+{
+  "connectors": {
+    "imessage": {
+      "heartbeat": {
+        "showOk": true,
+        "showAlerts": true,
+        "useIndicator": true
+      }
+    }
+  }
+}
+```
+
+### Multi-Account Support
+
+The `accounts` field allows running multiple iMessage accounts from a single agent:
+
+```json
+{
+  "connectors": {
+    "imessage": {
+      "accounts": {
+        "personal": {
+          "cliPath": "/usr/local/bin/imessage",
+          "service": "imessage",
+          "groups": {}
+        },
+        "work": {
+          "cliPath": "/usr/local/bin/imessage",
+          "remoteHost": "work-mac.local",
+          "service": "auto",
+          "groups": {}
+        }
+      }
+    }
+  }
+}
+```
+
+Each account entry supports the same fields as the top-level `connectors.imessage` configuration (excluding the `accounts` field itself).
+
+## Remote Host Access
+
+To connect to iMessage on a remote Mac via SSH, set the `remoteHost` field:
+
+```json
+{
+  "connectors": {
+    "imessage": {
+      "cliPath": "/usr/local/bin/imessage",
+      "remoteHost": "mac-mini.local"
+    }
+  }
+}
+```
+
+Ensure SSH key-based authentication is configured between the local machine and the remote host.
+
+## Troubleshooting
+
+### Full Disk Access
+
+If message retrieval fails, ensure Full Disk Access is granted:
+
+1. Open **System Settings > Privacy & Security > Full Disk Access**
+2. Add the terminal application or Milady process
+
+### Database Path
+
+The default iMessage database is at `~/Library/Messages/chat.db`. If using a non-standard location, set `dbPath` explicitly.
+
+### macOS Only
+
+The iMessage connector requires macOS. It will not function on Linux or Windows.
+
+## Related
+
+- [iMessage plugin reference](/plugin-registry/platform/imessage)
+- [BlueBubbles plugin reference](/plugin-registry/platform/bluebubbles) — iMessage bridge via BlueBubbles
+- [Connectors overview](/guides/connectors)
+- [Configuration reference](/configuration)

--- a/docs/connectors/mattermost.md
+++ b/docs/connectors/mattermost.md
@@ -1,0 +1,119 @@
+---
+title: Mattermost Connector
+sidebarTitle: Mattermost
+description: Connect your agent to Mattermost using the @elizaos/plugin-mattermost package.
+---
+
+Connect your agent to a self-hosted Mattermost server for channel and DM conversations.
+
+## Overview
+
+The Mattermost connector is an external elizaOS plugin that bridges your agent to a Mattermost server as a bot. It is auto-enabled by the runtime when a valid bot token is detected in your connector configuration.
+
+## Package Info
+
+| Field | Value |
+|-------|-------|
+| Package | `@elizaos/plugin-mattermost` |
+| Config key | `connectors.mattermost` |
+| Auto-enable trigger | `botToken` is truthy in connector config |
+
+## Minimal Configuration
+
+In your character file:
+
+```json
+{
+  "connectors": {
+    "mattermost": {
+      "botToken": "YOUR_BOT_TOKEN",
+      "baseUrl": "https://chat.example.com"
+    }
+  }
+}
+```
+
+## Disabling
+
+To explicitly disable the connector even when a token is present:
+
+```json
+{
+  "connectors": {
+    "mattermost": {
+      "botToken": "YOUR_BOT_TOKEN",
+      "baseUrl": "https://chat.example.com",
+      "enabled": false
+    }
+  }
+}
+```
+
+## Auto-Enable Mechanism
+
+The `plugin-auto-enable.ts` module checks `connectors.mattermost` in your character config. If the `botToken` field is truthy (and `enabled` is not explicitly `false`), the runtime automatically loads `@elizaos/plugin-mattermost`.
+
+No environment variable is required to trigger auto-enable — it is driven entirely by the connector config object.
+
+## Environment Variables
+
+When the connector is loaded, the runtime pushes the following secrets from your config into `process.env` for the plugin to consume:
+
+| Variable | Source | Description |
+|----------|--------|-------------|
+| `MATTERMOST_BOT_TOKEN` | `botToken` | Bot token from Mattermost System Console |
+| `MATTERMOST_BASE_URL` | `baseUrl` | Base URL for the Mattermost server |
+
+## Full Configuration Reference
+
+All fields are defined under `connectors.mattermost` in your character file.
+
+### Core Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `botToken` | string | — | Bot token from Mattermost System Console (required) |
+| `baseUrl` | string | — | Base URL for your Mattermost server (required) |
+| `enabled` | boolean | — | Explicitly enable/disable |
+| `chatmode` | `"dm-only"` \| `"channel-only"` \| `"all"` | `"all"` | Restrict which chat types the bot responds in |
+| `requireMention` | boolean | `false` | Only respond when @mentioned |
+| `oncharPrefixes` | string[] | — | Custom command prefixes that trigger agent responses |
+| `configWrites` | boolean | `true` | Allow config writes from channel events |
+
+### Chat Mode
+
+The `chatmode` field controls where the bot responds:
+
+| Mode | Behavior |
+|------|----------|
+| `"all"` | Responds in both DMs and channels (default) |
+| `"dm-only"` | Responds only in direct messages |
+| `"channel-only"` | Responds only in channels |
+
+```json
+{
+  "connectors": {
+    "mattermost": {
+      "botToken": "YOUR_BOT_TOKEN",
+      "baseUrl": "https://chat.example.com",
+      "chatmode": "all",
+      "requireMention": true,
+      "oncharPrefixes": ["!", "/ask"]
+    }
+  }
+}
+```
+
+### Self-Hosted Server Support
+
+The Mattermost connector works with any Mattermost server deployment, including self-hosted instances. Set `baseUrl` to your server's URL and ensure the Milady host can reach it over the network.
+
+## Multi-Account Support
+
+Mattermost does not support multi-account configuration. Each agent runs a single Mattermost bot.
+
+## Related
+
+- [Mattermost plugin reference](/plugin-registry/platform/mattermost)
+- [Connectors overview](/guides/connectors)
+- [Configuration reference](/configuration)

--- a/docs/connectors/msteams.md
+++ b/docs/connectors/msteams.md
@@ -1,0 +1,158 @@
+---
+title: Microsoft Teams Connector
+sidebarTitle: MS Teams
+description: Connect your agent to Microsoft Teams using the @elizaos/plugin-msteams package.
+---
+
+Connect your agent to Microsoft Teams for DMs, team channels, and threaded conversations.
+
+## Overview
+
+The Microsoft Teams connector is an external elizaOS plugin that bridges your agent to Teams as an Azure Bot. It is auto-enabled by the runtime when a valid token is detected in your connector configuration.
+
+## Package Info
+
+| Field | Value |
+|-------|-------|
+| Package | `@elizaos/plugin-msteams` |
+| Config key | `connectors.msteams` |
+| Auto-enable trigger | `botToken`, `token`, or `apiKey` is truthy in connector config |
+
+## Minimal Configuration
+
+In your character file:
+
+```json
+{
+  "connectors": {
+    "msteams": {
+      "appId": "YOUR_APP_ID",
+      "appPassword": "YOUR_APP_PASSWORD",
+      "tenantId": "YOUR_TENANT_ID"
+    }
+  }
+}
+```
+
+## Disabling
+
+To explicitly disable the connector even when credentials are present:
+
+```json
+{
+  "connectors": {
+    "msteams": {
+      "appId": "YOUR_APP_ID",
+      "appPassword": "YOUR_APP_PASSWORD",
+      "tenantId": "YOUR_TENANT_ID",
+      "enabled": false
+    }
+  }
+}
+```
+
+## Auto-Enable Mechanism
+
+The `plugin-auto-enable.ts` module checks `connectors.msteams` in your character config. If any of the fields `botToken`, `token`, or `apiKey` is truthy (and `enabled` is not explicitly `false`), the runtime automatically loads `@elizaos/plugin-msteams`.
+
+No environment variable is required to trigger auto-enable — it is driven entirely by the connector config object.
+
+## Environment Variables
+
+When the connector is loaded, the runtime can consume the following secrets from environment variables as an alternative to inline config:
+
+| Variable | Source | Description |
+|----------|--------|-------------|
+| `MSTEAMS_APP_ID` | `appId` | Azure Bot App ID |
+| `MSTEAMS_APP_PASSWORD` | `appPassword` | Azure Bot App Password (client secret) |
+| `MSTEAMS_TENANT_ID` | `tenantId` | Azure AD Tenant ID |
+
+## Full Configuration Reference
+
+All fields are defined under `connectors.msteams` in your character file.
+
+### Core Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `appId` | string | — | Azure Bot App ID (Microsoft App ID) |
+| `appPassword` | string | — | Azure Bot App Password (client secret) |
+| `tenantId` | string | — | Azure AD Tenant ID |
+| `enabled` | boolean | — | Explicitly enable/disable |
+| `capabilities` | string[] | — | Capability flags |
+| `configWrites` | boolean | — | Allow config writes from Teams events |
+| `requireMention` | boolean | — | Only respond when @mentioned |
+| `dmPolicy` | `"pairing"` \| `"allowlist"` \| `"open"` \| `"disabled"` | `"pairing"` | DM access policy. `"open"` requires `allowFrom` to include `"*"` |
+| `allowFrom` | string[] | — | User IDs allowed to DM |
+| `groupPolicy` | `"open"` \| `"disabled"` \| `"allowlist"` | `"allowlist"` | Group join policy |
+| `groupAllowFrom` | string[] | — | Allowed group/team IDs |
+| `historyLimit` | integer >= 0 | — | Max messages in context |
+| `dmHistoryLimit` | integer >= 0 | — | History limit for DMs |
+| `dms` | object | — | Per-DM history overrides keyed by DM ID. Each value: `{historyLimit?: int}` |
+| `textChunkLimit` | integer > 0 | — | Max characters per message chunk |
+| `chunkMode` | `"length"` \| `"newline"` | — | Long message splitting strategy |
+| `mediaMaxMb` | number > 0 | — | Max media file size in MB (up to 100MB via OneDrive upload) |
+| `blockStreamingCoalesce` | object | — | Coalescing settings: `minChars`, `maxChars`, `idleMs` |
+| `replyStyle` | `"thread"` \| `"top-level"` | `"thread"` | Reply threading mode |
+| `markdown` | object | — | Table rendering: `tables` can be `"off"`, `"bullets"`, or `"code"` |
+
+### Webhook Configuration
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `webhook.port` | integer > 0 | Port for incoming webhook events |
+| `webhook.path` | string | Path for webhook endpoint (e.g., `/api/msteams/webhook`) |
+
+### Media Configuration
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `mediaAllowHosts` | string[] | Allowlist of hosts from which media can be downloaded |
+| `mediaAuthAllowHosts` | string[] | Hosts that require authentication headers for media downloads |
+| `sharePointSiteId` | string | SharePoint site ID for file uploads in group chats (e.g., `"contoso.sharepoint.com,guid1,guid2"`) |
+
+### Team Configuration
+
+Per-team settings are defined under `teams.<team-id>`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `requireMention` | boolean | Only respond when @mentioned |
+| `tools` | ToolPolicySchema | Tool access policy |
+| `toolsBySender` | object | Per-sender tool policies (keyed by sender ID) |
+| `replyStyle` | `"thread"` \| `"top-level"` | Override reply style for this team |
+| `channels` | object | Per-channel configuration (see below) |
+
+### Channel Configuration
+
+Per-channel settings are defined within a team under `teams.<team-id>.channels.<channel-id>`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `requireMention` | boolean | Only respond when @mentioned |
+| `tools` | ToolPolicySchema | Tool access policy |
+| `toolsBySender` | object | Per-sender tool policies (keyed by sender ID) |
+| `replyStyle` | `"thread"` \| `"top-level"` | Override reply style for this channel |
+
+### Heartbeat
+
+```json
+{
+  "connectors": {
+    "msteams": {
+      "heartbeat": {
+        "showOk": true,
+        "showAlerts": true,
+        "useIndicator": true
+      }
+    }
+  }
+}
+```
+
+## Related
+
+- [MS Teams plugin reference](/plugin-registry/platform/msteams)
+- [Google Chat connector reference](/connectors/googlechat)
+- [Connectors overview](/guides/connectors)
+- [Configuration reference](/configuration)

--- a/docs/connectors/signal.md
+++ b/docs/connectors/signal.md
@@ -1,0 +1,203 @@
+---
+title: Signal Connector
+sidebarTitle: Signal
+description: Connect your agent to Signal using the @elizaos/plugin-signal package.
+---
+
+Connect your agent to Signal for private and group messaging via signal-cli.
+
+## Overview
+
+The Signal connector is an external elizaOS plugin that bridges your agent to Signal via signal-cli running in HTTP or JSON-RPC mode. It is auto-enabled by the runtime when a valid account configuration is detected.
+
+## Package Info
+
+| Field | Value |
+|-------|-------|
+| Package | `@elizaos/plugin-signal` |
+| Config key | `connectors.signal` |
+| Auto-enable trigger | `account` with `httpUrl`, OR `cliPath`, OR `accounts` with configured entries |
+
+## Minimal Configuration
+
+In your character file:
+
+```json
+{
+  "connectors": {
+    "signal": {
+      "account": "+1234567890",
+      "httpUrl": "http://localhost:8080",
+      "dmPolicy": "pairing"
+    }
+  }
+}
+```
+
+## Setup
+
+### 1. Install signal-cli
+
+Install [signal-cli](https://github.com/AsamK/signal-cli) and register or link a Signal account:
+
+```bash
+signal-cli -a +1234567890 register
+signal-cli -a +1234567890 verify CODE
+```
+
+### 2. Start signal-cli in HTTP Mode
+
+```bash
+signal-cli -a +1234567890 daemon --http localhost:8080
+```
+
+### 3. Configure Milady
+
+Add the `connectors.signal` block to your character file as shown in the minimal configuration above.
+
+## Disabling
+
+To explicitly disable the connector even when an account is configured:
+
+```json
+{
+  "connectors": {
+    "signal": {
+      "account": "+1234567890",
+      "httpUrl": "http://localhost:8080",
+      "enabled": false
+    }
+  }
+}
+```
+
+## Auto-Enable Mechanism
+
+The `plugin-auto-enable.ts` module checks `connectors.signal` in your character config. The plugin auto-enables when any of the following conditions are met (and `enabled` is not explicitly `false`):
+
+- `account` is set together with `httpUrl`
+- `cliPath` is set (signal-cli binary path for auto-start)
+- `accounts` contains at least one configured entry
+
+No environment variable is required to trigger auto-enable — it is driven entirely by the connector config object.
+
+## Full Configuration Reference
+
+All fields are defined under `connectors.signal` in your character file.
+
+### Core Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `account` | string | — | Signal phone number in E.164 format (e.g. `+1234567890`) |
+| `httpUrl` | string | — | HTTP URL for signal-cli daemon (e.g. `http://localhost:8080`) |
+| `httpHost` | string | — | Hostname alternative to `httpUrl` |
+| `httpPort` | integer > 0 | — | Port alternative to `httpUrl` |
+| `cliPath` | string | — | Path to signal-cli binary for auto-start |
+| `autoStart` | boolean | — | Auto-start signal-cli when the connector loads |
+| `startupTimeoutMs` | integer (1000-120000) | — | Milliseconds to wait for CLI startup (1-120 seconds) |
+| `receiveMode` | `"on-start"` \| `"manual"` | `"on-start"` | When to begin receiving messages |
+| `name` | string | — | Account display name |
+| `enabled` | boolean | — | Explicitly enable/disable |
+| `capabilities` | string[] | — | Capability flags |
+| `configWrites` | boolean | — | Allow config writes from Signal events |
+
+### Message Handling
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `ignoreAttachments` | boolean | — | Ignore incoming attachments (default behaviour includes them) |
+| `ignoreStories` | boolean | — | Ignore story messages (default behaviour excludes them) |
+| `sendReadReceipts` | boolean | — | Send read receipts for received messages |
+| `historyLimit` | integer >= 0 | — | Max messages in context |
+| `dmHistoryLimit` | integer >= 0 | — | History limit for DMs |
+| `dms` | object | — | Per-DM history overrides keyed by DM ID. Each value: `{historyLimit?: int}` |
+| `textChunkLimit` | integer > 0 | — | Max characters per message chunk |
+| `chunkMode` | `"length"` \| `"newline"` | — | Long message splitting strategy |
+| `mediaMaxMb` | integer > 0 | — | Max media file size in MB |
+| `markdown` | object | — | Table rendering: `tables` can be `"off"`, `"bullets"`, or `"code"` |
+
+### Access Policies
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `dmPolicy` | `"pairing"` \| `"allowlist"` \| `"open"` \| `"disabled"` | `"pairing"` | DM access policy. `"open"` requires `allowFrom` to include `"*"` |
+| `allowFrom` | (string\|number)[] | — | User IDs allowed to DM |
+| `groupPolicy` | `"open"` \| `"disabled"` \| `"allowlist"` | `"allowlist"` | Group join policy |
+| `groupAllowFrom` | (string\|number)[] | — | User IDs allowed in groups |
+
+### Streaming Configuration
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `blockStreaming` | boolean | — | Disable streaming entirely |
+| `blockStreamingCoalesce` | object | — | Coalescing settings: `minChars`, `maxChars`, `idleMs` |
+
+### Actions
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `actions.reactions` | boolean | Send reactions |
+
+### Reaction Notifications
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `reactionNotifications` | `"off"` \| `"own"` \| `"all"` \| `"allowlist"` | Which reactions trigger notifications |
+| `reactionAllowlist` | (string\|number)[] | User IDs whose reactions trigger notifications (when `reactionNotifications` is `"allowlist"`) |
+| `reactionLevel` | `"off"` \| `"ack"` \| `"minimal"` \| `"extensive"` | Reaction response verbosity |
+
+### Heartbeat
+
+```json
+{
+  "connectors": {
+    "signal": {
+      "heartbeat": {
+        "showOk": true,
+        "showAlerts": true,
+        "useIndicator": true
+      }
+    }
+  }
+}
+```
+
+### Multi-Account Support
+
+The `accounts` field allows running multiple Signal accounts from a single agent:
+
+```json
+{
+  "connectors": {
+    "signal": {
+      "accounts": {
+        "personal": {
+          "account": "+1234567890",
+          "httpUrl": "http://localhost:8080",
+          "dmPolicy": "pairing"
+        },
+        "work": {
+          "account": "+0987654321",
+          "httpUrl": "http://localhost:8081",
+          "dmPolicy": "allowlist",
+          "allowFrom": ["+1111111111"]
+        }
+      }
+    }
+  }
+}
+```
+
+Each account entry accepts all the same fields as the top-level `connectors.signal` configuration. Top-level fields act as defaults that individual accounts can override.
+
+## Validation
+
+- When `dmPolicy` is `"open"`, the `allowFrom` array must include `"*"`.
+- `startupTimeoutMs` must be between 1000 and 120000 (1-120 seconds).
+
+## Related
+
+- [Signal plugin reference](/plugin-registry/platform/signal)
+- [Connectors overview](/guides/connectors)
+- [Configuration reference](/configuration)

--- a/docs/connectors/wechat.md
+++ b/docs/connectors/wechat.md
@@ -1,0 +1,159 @@
+---
+title: WeChat Connector
+sidebarTitle: WeChat
+description: Connect your agent to WeChat using the @miladyai/plugin-wechat package.
+---
+
+Connect your agent to WeChat for personal and group messaging via a third-party proxy service.
+
+## Overview
+
+The WeChat connector is a Milady-local plugin that bridges your agent to WeChat via a user-supplied proxy service. Unlike most connectors which use official platform APIs, the WeChat connector relies on a third-party proxy that bridges WeChat's protocol. Your agent authenticates by scanning a QR code displayed in the terminal on first startup.
+
+## Privacy Notice
+
+The WeChat connector sends your API key and message payloads through the configured proxy service. Only point `proxyUrl` at infrastructure you operate yourself or explicitly trust for that message flow.
+
+## Package Info
+
+| Field | Value |
+|-------|-------|
+| Package | `@miladyai/plugin-wechat` |
+| Config key | `connectors.wechat` |
+| Auto-enable trigger | `apiKey` is truthy at top level, or an `accounts` entry has a truthy `apiKey` |
+
+## Minimal Configuration
+
+In your character file:
+
+```json
+{
+  "connectors": {
+    "wechat": {
+      "apiKey": "YOUR_API_KEY",
+      "proxyUrl": "https://your-proxy-service.example.com"
+    }
+  }
+}
+```
+
+## Disabling
+
+To explicitly disable the connector even when an API key is present:
+
+```json
+{
+  "connectors": {
+    "wechat": {
+      "apiKey": "YOUR_API_KEY",
+      "proxyUrl": "https://your-proxy-service.example.com",
+      "enabled": false
+    }
+  }
+}
+```
+
+## Auto-Enable Mechanism
+
+The `plugin-auto-enable.ts` module checks `connectors.wechat` in your character config. The plugin auto-enables when:
+
+- A top-level `apiKey` is truthy, OR
+- An `accounts` map contains at least one enabled account with a truthy `apiKey`
+
+Setting `enabled: false` at the connector or account level disables auto-enable. No environment variable is required to trigger auto-enable — it is driven entirely by the connector config object.
+
+## Environment Variables
+
+| Variable | Source | Description |
+|----------|--------|-------------|
+| `WECHAT_API_KEY` | `apiKey` | Proxy service API key |
+
+## Full Configuration Reference
+
+All fields are defined under `connectors.wechat` in your character file.
+
+### Core Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `apiKey` | string | — | Proxy service API key (required) |
+| `proxyUrl` | string | — | Proxy service URL (required) |
+| `webhookPort` | number | `18790` | Webhook listener port for incoming messages |
+| `deviceType` | `"ipad"` \| `"mac"` | `"ipad"` | Device emulation type |
+| `enabled` | boolean | — | Explicitly enable/disable |
+
+### Feature Toggles
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `features.images` | boolean | `false` | Enable image send/receive |
+| `features.groups` | boolean | `false` | Enable group chat support |
+
+```json
+{
+  "connectors": {
+    "wechat": {
+      "apiKey": "YOUR_API_KEY",
+      "proxyUrl": "https://your-proxy.example.com",
+      "webhookPort": 18790,
+      "deviceType": "ipad",
+      "features": {
+        "images": true,
+        "groups": true
+      }
+    }
+  }
+}
+```
+
+### QR Code Login
+
+On first start, the plugin displays a QR code in the terminal. Scan it with WeChat on your phone to link the session. Sessions persist automatically — subsequent starts reuse the existing session unless it has expired.
+
+If a session expires after extended inactivity, the plugin attempts to re-login automatically. If re-login fails, a new QR code is displayed for scanning.
+
+### Multi-Account Support
+
+Run multiple WeChat accounts using the `accounts` map:
+
+```json
+{
+  "connectors": {
+    "wechat": {
+      "accounts": {
+        "personal": {
+          "apiKey": "KEY_1",
+          "proxyUrl": "https://proxy.example.com",
+          "deviceType": "ipad"
+        },
+        "work": {
+          "apiKey": "KEY_2",
+          "proxyUrl": "https://proxy.example.com",
+          "deviceType": "mac",
+          "enabled": false
+        }
+      },
+      "features": {
+        "groups": true
+      }
+    }
+  }
+}
+```
+
+Each account has its own API key, proxy URL, and session. Per-account fields override top-level settings.
+
+## Features
+
+- **Text messaging** — DM conversations enabled by default
+- **Group chats** — Participate in group conversations (enable with `features.groups: true`)
+- **Image support** — Send and receive images (enable with `features.images: true`)
+- **QR code login** — Authenticate by scanning a QR code, with automatic session persistence
+- **Multi-account** — Run multiple WeChat accounts from a single agent via the `accounts` map
+- **Device emulation** — Choose between iPad or Mac client emulation
+
+## Related
+
+- [WeChat plugin reference](/plugin-registry/platform/wechat)
+- [Connectors overview](/guides/connectors)
+- [Configuration reference](/configuration)

--- a/docs/connectors/whatsapp.md
+++ b/docs/connectors/whatsapp.md
@@ -1,0 +1,270 @@
+---
+title: WhatsApp Connector
+sidebarTitle: WhatsApp
+description: Connect your agent to WhatsApp using the @elizaos/plugin-whatsapp package.
+---
+
+Connect your agent to WhatsApp for private chats and group conversations via personal or business accounts.
+
+## Overview
+
+The WhatsApp connector is an external elizaOS plugin that bridges your agent to WhatsApp. It supports two authentication methods: **Baileys** (QR code scan, personal accounts) and **Cloud API** (WhatsApp Business API). The connector is auto-enabled by the runtime when a valid auth configuration is detected.
+
+## Package Info
+
+| Field | Value |
+|-------|-------|
+| Package | `@elizaos/plugin-whatsapp` |
+| Config key | `connectors.whatsapp` |
+| Auto-enable trigger | `authDir`, `authState`, `sessionPath`, or `accounts` with at least one account having `authDir` |
+
+## Minimal Configuration
+
+In your character file (Baileys / QR code):
+
+```json
+{
+  "connectors": {
+    "whatsapp": {
+      "accounts": {
+        "default": {
+          "enabled": true,
+          "authDir": "./auth/whatsapp"
+        }
+      }
+    }
+  }
+}
+```
+
+Or with a top-level `authDir` (single account shorthand):
+
+```json
+{
+  "connectors": {
+    "whatsapp": {
+      "authDir": "./whatsapp-auth"
+    }
+  }
+}
+```
+
+## Disabling
+
+To explicitly disable the connector even when auth config is present:
+
+```json
+{
+  "connectors": {
+    "whatsapp": {
+      "authDir": "./whatsapp-auth",
+      "enabled": false
+    }
+  }
+}
+```
+
+## Auto-Enable Mechanism
+
+The `plugin-auto-enable.ts` module checks `connectors.whatsapp` in your character config. The plugin is loaded when any of the following is truthy (and `enabled` is not explicitly `false`):
+
+- `authDir` is set at the top level
+- `authState` is set at the top level
+- `sessionPath` is set at the top level
+- `accounts` contains at least one account with `authDir` set
+
+No environment variable is required to trigger auto-enable -- it is driven entirely by the connector config object.
+
+## Authentication Methods
+
+### Baileys (QR Code)
+
+Baileys connects via the WhatsApp Web multi-device protocol. No API keys or business accounts are needed. On first start, a QR code is printed to the terminal. Scan it with your phone (WhatsApp > Settings > Linked Devices > Link a Device) to authenticate.
+
+**Pros**: No API costs, works with personal accounts, full feature access.
+**Cons**: Requires a phone with WhatsApp linked, session can expire if phone disconnects.
+
+### Cloud API (Business)
+
+The WhatsApp Business Cloud API is Meta's official API. Requires a WhatsApp Business Account and access tokens from the Meta Developer Dashboard.
+
+**Pros**: Official API, reliable uptime, webhook-based.
+**Cons**: Requires business account, per-message costs may apply, approval process.
+
+## Environment Variables
+
+For Cloud API authentication, the following environment variables are used:
+
+| Variable | Description |
+|----------|-------------|
+| `WHATSAPP_ACCESS_TOKEN` | WhatsApp Business API access token |
+| `WHATSAPP_PHONE_NUMBER_ID` | Phone number ID from Meta Developer Dashboard |
+| `WHATSAPP_WEBHOOK_VERIFY_TOKEN` | Webhook verification token |
+| `WHATSAPP_BUSINESS_ACCOUNT_ID` | WhatsApp Business Account ID |
+
+These can also be placed in the `env` section of your config file. Baileys mode does not require any environment variables.
+
+## Full Configuration Reference
+
+All fields are defined under `connectors.whatsapp` in your character file.
+
+### Core Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `accounts` | object | -- | Named account configurations (see Multi-Account below) |
+| `authDir` | string | -- | Directory for Baileys session files (single-account shorthand) |
+| `enabled` | boolean | -- | Explicitly enable/disable |
+| `dmPolicy` | `"pairing"` \| `"open"` \| `"closed"` | `"pairing"` | DM acceptance policy. `"open"` requires `allowFrom` to include `"*"` |
+| `allowFrom` | string[] | -- | Allowlist of phone numbers (required when `dmPolicy: "open"`) |
+| `groupPolicy` | `"open"` \| `"disabled"` \| `"allowlist"` | `"allowlist"` | Group message policy |
+| `groupAllowFrom` | string[] | -- | Allowlist of group JIDs |
+| `historyLimit` | number | -- | Max messages to load from conversation history |
+| `dmHistoryLimit` | number | -- | Max messages for DM history |
+| `textChunkLimit` | number | -- | Max characters per outgoing message chunk |
+| `chunkMode` | `"length"` \| `"newline"` | -- | Long message splitting strategy |
+| `mediaMaxMb` | number | `50` | Max media attachment size in MB |
+| `sendReadReceipts` | boolean | -- | Send read receipts for incoming messages |
+| `selfChatMode` | boolean | -- | Respond to your own messages (for testing; avoid in production) |
+| `messagePrefix` | string | -- | Text prefix added to all outgoing messages |
+| `debounceMs` | number | `0` | Delay in ms before responding, to allow message batching |
+| `blockStreaming` | boolean | -- | Disable streaming responses |
+| `groups` | object | -- | Per-group configuration overrides |
+
+### Acknowledgment Reactions
+
+Configure emoji reactions sent as message acknowledgments:
+
+```json
+{
+  "connectors": {
+    "whatsapp": {
+      "ackReaction": {
+        "emoji": "eyes",
+        "direct": true,
+        "group": "mentions"
+      }
+    }
+  }
+}
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `ackReaction.emoji` | string | -- | Reaction emoji to send as acknowledgment |
+| `ackReaction.direct` | boolean | `true` | Send ack reactions in DMs |
+| `ackReaction.group` | string | `"mentions"` | Group ack behavior: `"always"`, `"mentions"`, or `"never"` |
+
+### Multi-Account Support
+
+The `accounts` field allows running multiple WhatsApp sessions from a single agent. Each account gets its own Baileys auth directory and QR code pairing flow.
+
+```json
+{
+  "connectors": {
+    "whatsapp": {
+      "accounts": {
+        "account-1": {
+          "enabled": true,
+          "authDir": "./auth/whatsapp-1"
+        },
+        "account-2": {
+          "enabled": true,
+          "authDir": "./auth/whatsapp-2"
+        }
+      }
+    }
+  }
+}
+```
+
+Each account under `accounts.<name>` supports all top-level fields plus:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `enabled` | boolean | Enable or disable this account |
+| `authDir` | string | Directory for Baileys session files (required per account) |
+| `name` | string | Display name for this account |
+
+### Self-Chat Mode
+
+When `selfChatMode` is `true`, the agent responds to messages you send to yourself (the "Message Yourself" chat). This is useful for testing without involving other contacts. Avoid enabling in production.
+
+```json
+{
+  "connectors": {
+    "whatsapp": {
+      "selfChatMode": true
+    }
+  }
+}
+```
+
+## Session Persistence
+
+Baileys saves its session state to the directory specified by `authDir`. This includes:
+
+- Encryption credentials
+- Device registration info
+- Authentication keys
+
+The session persists across restarts. A new QR code is only generated when:
+
+- The session files in `authDir` are deleted or corrupted
+- Your phone revokes the linked device (Settings > Linked Devices > remove)
+- The session expires due to prolonged disconnection
+
+**Security considerations**:
+
+- Never commit the auth directory to version control (`auth/` should be in `.gitignore`)
+- Back up the auth directory to avoid re-scanning on a new machine
+- The auth directory contents grant full access to the linked WhatsApp session
+
+## Troubleshooting
+
+### Plugin Not Loading
+
+Verify that at least one of the auto-enable triggers is present in your config:
+
+- `authDir` at the top level, or
+- At least one account under `accounts` with `authDir` set and `enabled: true`
+
+### QR Code Expires
+
+QR codes have a short TTL (typically around 20 seconds). The connector automatically generates a new QR code when the previous one expires. Make sure your phone has internet access when scanning.
+
+### Session Expired
+
+If reconnection fails with a session error:
+
+1. Delete the contents of your `authDir` directory
+2. Restart Milady
+3. Scan the new QR code
+
+### `dmPolicy: "open"` Validation Error
+
+When setting `dmPolicy` to `"open"`, you must also set `allowFrom: ["*"]`. This is a safety requirement enforced by the config validator:
+
+```json
+{
+  "dmPolicy": "open",
+  "allowFrom": ["*"]
+}
+```
+
+### Rate Limits
+
+WhatsApp has undocumented rate limits. If the agent sends messages too rapidly, the connection may be throttled or temporarily banned. Use `debounceMs` to add delays:
+
+```json
+{
+  "debounceMs": 1000
+}
+```
+
+## Related
+
+- [WhatsApp setup guide](/guides/whatsapp)
+- [WhatsApp plugin reference](/plugin-registry/platform/whatsapp)
+- [Connectors overview](/guides/connectors)
+- [Configuration reference](/configuration)

--- a/docs/guides/beginners-user-guide.md
+++ b/docs/guides/beginners-user-guide.md
@@ -283,7 +283,7 @@ Use this staged path so you do not get overwhelmed.
 2. **Core configuration**
    - `/configuration`
    - `/config-schema`
-   - `/model-providers`
+   - `/runtime/models`
 3. **Everyday commands and interfaces**
    - `/chat-commands`
    - `/apps/dashboard`

--- a/docs/guides/connectors.md
+++ b/docs/guides/connectors.md
@@ -20,9 +20,12 @@ Connectors are platform bridges that allow your agent to communicate across mess
 10. [Microsoft Teams](#microsoft-teams)
 11. [Google Chat](#google-chat)
 12. [Twitter](#twitter)
-13. [Connector Lifecycle](#connector-lifecycle)
-14. [Multi-Account Support](#multi-account-support)
-15. [Session Management](#session-management)
+13. [Farcaster](#farcaster)
+14. [Mattermost](#mattermost)
+15. [WeChat](#wechat)
+16. [Connector Lifecycle](#connector-lifecycle)
+17. [Multi-Account Support](#multi-account-support)
+18. [Session Management](#session-management)
 
 ---
 
@@ -40,6 +43,8 @@ Connectors are platform bridges that allow your agent to communicate across mess
 | Microsoft Teams | App ID + password | Yes | Yes (teams/channels) | No |
 | Google Chat | Service account | Yes | Yes (spaces) | Yes |
 | Twitter | API keys + tokens | DMs | N/A | No |
+| Farcaster | Neynar API key + signer | Casts | Yes (channels) | No |
+| Mattermost | Bot token | Yes | Yes (channels) | No |
 | WeChat | Proxy API key + QR code | Yes | Yes | Yes |
 
 ---
@@ -446,6 +451,79 @@ See the [WhatsApp Integration Guide](/guides/whatsapp) for detailed setup instru
 - Action processing toggle
 - Dry run mode for testing
 - Configurable max tweet length (default: 4000)
+
+---
+
+## Farcaster
+
+### Setup Requirements
+
+- Neynar API key (from [neynar.com](https://neynar.com))
+- Farcaster account with a Neynar signer UUID
+- Farcaster ID (FID) of the agent account
+
+### Key Configuration
+
+```json
+{
+  "connectors": {
+    "farcaster": {
+      "enabled": true,
+      "apiKey": "YOUR_NEYNAR_API_KEY",
+      "signerUuid": "YOUR_SIGNER_UUID",
+      "fid": 12345,
+      "channels": ["ai", "agents"],
+      "castIntervalMin": 120,
+      "castIntervalMax": 240
+    }
+  }
+}
+```
+
+### Features
+
+- Autonomous casting (posting) at configurable intervals
+- Reply to @mentions and cast replies
+- Channel monitoring and participation
+- Reactions (likes and recasts)
+- Direct casts (private messages)
+- On-chain identity tied to Ethereum address
+- Cast thread splitting for messages over 320 characters
+
+---
+
+## Mattermost
+
+### Setup Requirements
+
+- Mattermost bot token (from System Console > Integrations > Bot Accounts)
+- Mattermost server URL
+
+### Key Configuration
+
+```json
+{
+  "connectors": {
+    "mattermost": {
+      "enabled": true,
+      "botToken": "YOUR_BOT_TOKEN",
+      "baseUrl": "https://chat.example.com",
+      "chatmode": "all",
+      "requireMention": false
+    }
+  }
+}
+```
+
+**Environment variables:** `MATTERMOST_BOT_TOKEN`, `MATTERMOST_BASE_URL`
+
+### Features
+
+- Channel and DM messaging
+- Chat mode restriction (`dm-only`, `channel-only`, or `all`)
+- Mention filtering (optionally require @mentions)
+- Custom command prefix triggers
+- Self-hosted server support
 
 ---
 

--- a/docs/guides/learning-paths.md
+++ b/docs/guides/learning-paths.md
@@ -23,7 +23,7 @@ Outcome: you can install Milady and run a basic conversation loop.
 ### Phase 2: Daily productivity
 
 - `/configuration`
-- `/model-providers`
+- `/runtime/models`
 - `/apps/dashboard/settings`
 
 Outcome: you can tune model/provider behavior and navigate day-to-day controls.

--- a/docs/guides/local-models.md
+++ b/docs/guides/local-models.md
@@ -115,6 +115,6 @@ const statuses = getLocalModelStatuses("embedding");
 
 ## Related
 
-- [Model Providers](/model-providers)
+- [Model Providers](/runtime/models)
 - [Environment variables](/cli/environment) — `OLLAMA_BASE_URL`, `LOCAL_EMBEDDING_*`
 - [`milady models`](/cli/models) — check configured providers

--- a/docs/plugin-registry/llm/anthropic.md
+++ b/docs/plugin-registry/llm/anthropic.md
@@ -1,10 +1,10 @@
 ---
 title: "Anthropic Plugin"
 sidebarTitle: "Anthropic"
-description: "Anthropic Claude model provider for Milady — Claude Opus 4, Sonnet 4.5, Haiku, and the extended thinking models."
+description: "Anthropic Claude model provider for Milady — Claude Opus 4.6, Sonnet 4.6, Haiku 4.5, and the extended thinking models."
 ---
 
-The Anthropic plugin connects Milady agents to Anthropic's Claude API, providing access to the Claude 4 and Claude 3 model families including Opus, Sonnet, and Haiku variants.
+The Anthropic plugin connects Milady agents to Anthropic's Claude API, providing access to the Claude 4.6, 4.5, 4, and 3 model families including Opus, Sonnet, and Haiku variants.
 
 **Package:** `@elizaos/plugin-anthropic`
 
@@ -49,14 +49,22 @@ export ANTHROPIC_API_KEY=sk-ant-...
 
 ## Supported Models
 
+### Claude 4.5/4.6 Family
+
+| Model | Context | Best For |
+|-------|---------|---------|
+| `claude-opus-4-6` | 200k | Most capable, complex reasoning, 1M context available |
+| `claude-sonnet-4-6` | 200k | Latest Sonnet, balanced performance and cost |
+| `claude-haiku-4-5-20251001` | 200k | Fast, lightweight tasks |
+
 ### Claude 4 Family
 
 | Model | Context | Best For |
 |-------|---------|---------|
-| `claude-opus-4-20250514` | 200k | Most capable, complex reasoning |
+| `claude-opus-4-20250514` | 200k | Complex reasoning |
 | `claude-sonnet-4-20250514` | 200k | Balanced performance and cost |
-| `claude-sonnet-4.5` | 200k | Latest Sonnet, improved coding |
-| `claude-3-5-haiku-20241022` | 200k | Fast, lightweight tasks |
+| `claude-sonnet-4.5` | 200k | Improved coding |
+| `claude-3-5-haiku-20241022` | 200k | Fast responses |
 
 ### Claude 3.7 Family
 
@@ -93,7 +101,7 @@ export ANTHROPIC_API_KEY=sk-ant-...
 - Streaming responses
 - Tool use (function calling)
 - Vision (image input on all models)
-- Extended thinking (claude-3-7-sonnet, claude-opus-4-20250514)
+- Extended thinking (claude-3-7-sonnet, claude-opus-4-6)
 - Structured JSON output via tool use
 - 200k token context window on all models
 - Prompt caching for cost reduction on repeated context
@@ -119,4 +127,4 @@ Pricing: [anthropic.com/pricing](https://www.anthropic.com/pricing)
 
 - [OpenAI Plugin](/plugin-registry/llm/openai) — GPT-4o and reasoning models
 - [OpenRouter Plugin](/plugin-registry/llm/openrouter) — Route between providers including Anthropic
-- [Model Providers Guide](/model-providers) — Compare all providers
+- [Model Providers](/runtime/models) — Compare all providers

--- a/docs/plugin-registry/llm/deepseek.md
+++ b/docs/plugin-registry/llm/deepseek.md
@@ -106,4 +106,4 @@ DeepSeek-V3 costs a fraction of GPT-4o at comparable quality for most tasks.
 - [OpenRouter Plugin](/plugin-registry/llm/openrouter) — Access DeepSeek via OpenRouter
 - [Groq Plugin](/plugin-registry/llm/groq) — Fast inference alternative
 - [Ollama Plugin](/plugin-registry/llm/ollama) — Run DeepSeek locally
-- [Model Providers Guide](/model-providers) — Compare all providers
+- [Model Providers](/runtime/models) — Compare all providers

--- a/docs/plugin-registry/llm/google-genai.md
+++ b/docs/plugin-registry/llm/google-genai.md
@@ -115,4 +115,4 @@ See [ai.google.dev/pricing](https://ai.google.dev/pricing) for current rates.
 
 - [OpenAI Plugin](/plugin-registry/llm/openai) — GPT-4o family
 - [Groq Plugin](/plugin-registry/llm/groq) — Fast inference for smaller models
-- [Model Providers Guide](/model-providers) — Compare all providers
+- [Model Providers](/runtime/models) — Compare all providers

--- a/docs/plugin-registry/llm/groq.md
+++ b/docs/plugin-registry/llm/groq.md
@@ -102,4 +102,4 @@ See [groq.com/pricing](https://groq.com/pricing) for current rates.
 
 - [Ollama Plugin](/plugin-registry/llm/ollama) — Local model inference (no API key needed)
 - [OpenRouter Plugin](/plugin-registry/llm/openrouter) — Route between Groq and other providers
-- [Model Providers Guide](/model-providers) — Compare all providers
+- [Model Providers](/runtime/models) — Compare all providers

--- a/docs/plugin-registry/llm/ollama.md
+++ b/docs/plugin-registry/llm/ollama.md
@@ -196,4 +196,4 @@ If Milady doesn't detect your Ollama instance:
 
 - [Groq Plugin](/plugin-registry/llm/groq) — Fast cloud inference for Llama models
 - [OpenRouter Plugin](/plugin-registry/llm/openrouter) — Multi-provider gateway
-- [Model Providers Guide](/model-providers) — Compare all providers
+- [Model Providers](/runtime/models) — Compare all providers

--- a/docs/plugin-registry/llm/openai.md
+++ b/docs/plugin-registry/llm/openai.md
@@ -130,4 +130,4 @@ Pricing: [openai.com/pricing](https://openai.com/pricing)
 
 - [Anthropic Plugin](/plugin-registry/llm/anthropic) — Claude model family
 - [OpenRouter Plugin](/plugin-registry/llm/openrouter) — Route between providers
-- [Model Providers Guide](/model-providers) — Compare all providers
+- [Model Providers](/runtime/models) — Compare all providers

--- a/docs/plugin-registry/llm/openrouter.md
+++ b/docs/plugin-registry/llm/openrouter.md
@@ -138,4 +138,4 @@ See [openrouter.ai/docs#limits](https://openrouter.ai/docs#limits) for rate limi
 
 - [OpenAI Plugin](/plugin-registry/llm/openai) — Direct OpenAI integration
 - [Anthropic Plugin](/plugin-registry/llm/anthropic) — Direct Anthropic integration
-- [Model Providers Guide](/model-providers) — Compare all providers
+- [Model Providers](/runtime/models) — Compare all providers

--- a/docs/plugin-registry/platform/wechat.md
+++ b/docs/plugin-registry/platform/wechat.md
@@ -1,0 +1,174 @@
+---
+title: "WeChat Plugin"
+sidebarTitle: "WeChat"
+description: "WeChat connector for Milady — personal and group messaging via a third-party proxy API."
+---
+
+The WeChat plugin connects Milady agents to WeChat via a user-supplied proxy service, enabling text messaging and optional image and group chat support from personal WeChat accounts.
+
+**Package:** `@miladyai/plugin-wechat`
+
+## Overview
+
+Unlike most connectors which use official platform APIs, the WeChat connector relies on a third-party proxy service that bridges WeChat's protocol. Your agent authenticates by scanning a QR code displayed in the terminal on first startup.
+
+**Privacy Notice:** The WeChat connector sends your API key and message payloads through the configured proxy service. Only point `proxyUrl` at infrastructure you operate yourself or explicitly trust.
+
+## Installation
+
+The WeChat plugin ships as a local Milady package (`@miladyai/plugin-wechat`) and does not need to be installed separately. It is available out of the box.
+
+## Setup
+
+### 1. Obtain a Proxy API Key
+
+Get an API key from your WeChat proxy service provider.
+
+### 2. Configure Milady
+
+```json
+{
+  "connectors": {
+    "wechat": {
+      "apiKey": "YOUR_API_KEY",
+      "proxyUrl": "https://your-proxy-service.example.com"
+    }
+  }
+}
+```
+
+Or set the environment variable:
+
+```bash
+export WECHAT_API_KEY=YOUR_API_KEY
+```
+
+### 3. Scan the QR Code
+
+On first start, the plugin displays a QR code in the terminal. Scan it with WeChat on your phone to link the session.
+
+## Configuration
+
+### Single Account
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `apiKey` | Yes | — | Proxy service API key |
+| `proxyUrl` | Yes | — | Proxy service URL |
+| `webhookPort` | No | `18790` | Webhook listener port for incoming messages |
+| `deviceType` | No | `"ipad"` | Device emulation type: `"ipad"` or `"mac"` |
+| `enabled` | No | `true` | Enable or disable the connector |
+| `features.images` | No | `false` | Enable image send/receive |
+| `features.groups` | No | `false` | Enable group chat support |
+
+```json
+{
+  "connectors": {
+    "wechat": {
+      "apiKey": "YOUR_API_KEY",
+      "proxyUrl": "https://your-proxy.example.com",
+      "webhookPort": 18790,
+      "deviceType": "ipad",
+      "features": {
+        "images": true,
+        "groups": true
+      }
+    }
+  }
+}
+```
+
+### Multi-Account Support
+
+Run multiple WeChat accounts using the `accounts` map:
+
+```json
+{
+  "connectors": {
+    "wechat": {
+      "accounts": {
+        "personal": {
+          "apiKey": "KEY_1",
+          "proxyUrl": "https://proxy.example.com",
+          "deviceType": "ipad"
+        },
+        "work": {
+          "apiKey": "KEY_2",
+          "proxyUrl": "https://proxy.example.com",
+          "deviceType": "mac",
+          "enabled": false
+        }
+      },
+      "features": {
+        "groups": true
+      }
+    }
+  }
+}
+```
+
+Each account has its own API key, proxy URL, and session. Per-account fields override top-level settings.
+
+## Features
+
+- **Text messaging** — DM conversations enabled by default
+- **Group chats** — Participate in group conversations (enable with `features.groups: true`)
+- **Image support** — Send and receive images (enable with `features.images: true`)
+- **QR code login** — Authenticate by scanning a QR code, with automatic session persistence
+- **Multi-account** — Run multiple WeChat accounts from a single agent
+- **Device emulation** — Choose between iPad or Mac client emulation
+- **Health checks** — Automatic periodic health checks with reconnection on failure
+
+## Message Flow
+
+```
+Proxy webhook delivers incoming message
+       ↓
+Plugin filters by message type and features config
+       ↓
+AgentRuntime processes the message
+       ↓
+Response sent via proxy API
+```
+
+## Auto-Enable
+
+The plugin auto-enables when `connectors.wechat` contains:
+- A top-level `apiKey`, OR
+- An `accounts` map with at least one enabled account that has an `apiKey`
+
+Setting `enabled: false` at the connector or account level disables auto-enable.
+
+## Supported Message Types
+
+The plugin handles these incoming message types:
+
+| Type | Description |
+|------|-------------|
+| `text` | Plain text messages |
+| `image` | Image attachments (requires `features.images`) |
+| `video` | Video messages |
+| `file` | File attachments |
+| `voice` | Voice messages |
+
+## Troubleshooting
+
+### QR Code Not Displaying
+
+Ensure the proxy service URL is reachable and the API key is valid. The plugin logs errors to the console if the proxy returns an error during login.
+
+### Session Expired
+
+WeChat sessions can expire after extended inactivity. The plugin automatically attempts to re-login. If re-login fails, a new QR code is displayed for scanning.
+
+### Messages Not Arriving
+
+- Check that the `webhookPort` (default: 18790) is not blocked by a firewall
+- Verify `features.groups` is enabled if you expect group messages
+- Confirm the proxy service is running and forwarding webhooks
+
+## Related
+
+- [Connectors Overview](/guides/connectors) — All connector options
+- [Telegram Plugin](/plugin-registry/platform/telegram) — Telegram bot integration
+- [WhatsApp Plugin](/plugin-registry/platform/whatsapp) — WhatsApp integration via Baileys

--- a/docs/plugin-setup-guide.md
+++ b/docs/plugin-setup-guide.md
@@ -259,6 +259,23 @@ where to get the credentials, minimum required fields, and tips for optional fie
 3. Get your API key from Neynar dashboard
 **Tips:** Neynar is required — it's the indexer that makes Farcaster data accessible via API.
 
+### WeChat
+**Get credentials:** From your WeChat proxy service provider
+**Minimum required:** `WECHAT_API_KEY` + proxy URL in config
+**Variables:**
+- `WECHAT_API_KEY` — Proxy service API key
+**Config-only fields** (set in `connectors.wechat`, not env vars):
+- `proxyUrl` — **Required** — Your WeChat proxy service URL
+- `webhookPort` — Webhook listener port (default: 18790)
+- `deviceType` — Device emulation: `ipad` (default) or `mac`
+- `features.images` — Enable image send/receive (default: false)
+- `features.groups` — Enable group chat support (default: false)
+**Setup steps:**
+1. Get API key from your WeChat proxy service
+2. Configure `connectors.wechat` in milady.json with `apiKey` and `proxyUrl`
+3. Start Milady — scan the QR code displayed in terminal with WeChat
+**Tips:** WeChat uses a third-party proxy service, not an official API. Only use a proxy you trust — it sees all message traffic. Multi-account supported via `accounts` map. Package: `@miladyai/plugin-wechat`.
+
 ### GitHub
 **Get credentials:** https://github.com/settings/tokens → Fine-grained or Classic
 **Minimum required:** `GITHUB_API_TOKEN`

--- a/docs/plugins/architecture.md
+++ b/docs/plugins/architecture.md
@@ -254,4 +254,4 @@ interface PluginModuleShape {
 - [Create a Plugin](/plugins/create-a-plugin) — Build a plugin from scratch
 - [Plugin Patterns](/plugins/patterns) — Common implementation patterns
 - [Plugin Schemas](/plugins/schemas) — Full schema reference
-- [Plugin Registry](/plugin-registry/bootstrap) — Core plugin documentation
+- [Plugin Registry](/plugins/registry) — Browse available plugins

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -19,16 +19,16 @@ A plugin is a self-contained module that registers one or more of:
 
 <CardGroup cols={2}>
 
-<Card title="Core Plugins" icon="cube" href="/plugin-registry/bootstrap">
-  Essential plugins that ship with every Milady installation — message processing, knowledge, database, and secrets.
+<Card title="Core Plugins" icon="cube" href="/plugin-registry/knowledge">
+  Essential plugins that ship with every Milady installation — knowledge, database, secrets, cron, and shell.
 </Card>
 
 <Card title="Model Providers" icon="brain" href="/plugin-registry/llm/openai">
-  LLM integrations for OpenAI, Anthropic, Google, Groq, Ollama, OpenRouter, and DeepSeek.
+  LLM integrations for OpenAI, Anthropic, Google Gemini, Groq, Ollama, OpenRouter, DeepSeek, xAI, Mistral, Cohere, Together, Qwen, Minimax, and Pi AI.
 </Card>
 
 <Card title="Platform Connectors" icon="plug" href="/plugin-registry/platform/discord">
-  Bridges to messaging platforms — Discord, Telegram, Twitter, Slack, WhatsApp, and Farcaster.
+  Bridges to messaging platforms — Discord, Telegram, Twitter, Slack, WhatsApp, Signal, iMessage, BlueBubbles, MS Teams, Google Chat, Mattermost, Farcaster, and WeChat.
 </Card>
 
 <Card title="DeFi & Blockchain" icon="wallet" href="/plugin-registry/defi/evm">

--- a/docs/rest/models.md
+++ b/docs/rest/models.md
@@ -117,6 +117,6 @@ List available AI models. Optionally filter by a specific provider or refresh th
 
 ## Related
 
-- [Model Providers](/model-providers) — configuring model providers
+- [Model Providers](/runtime/models) — configuring model providers
 - [Environment variables](/cli/environment) — API key variables
 - [`milady models`](/cli/models) — CLI command for checking models


### PR DESCRIPTION
…ovider listings

- Create 9 missing docs/connectors/ reference pages (WhatsApp, Signal, iMessage, BlueBubbles, Google Chat, MS Teams, WeChat, Farcaster, Mattermost)
- Create docs/plugin-registry/platform/wechat.md for the local WeChat plugin
- Add Farcaster and Mattermost sections to docs/guides/connectors.md
- Update plugins overview to list all 13 platform connectors and 14 LLM providers
- Fix broken /model-providers links across 12 docs → /runtime/models
- Fix broken /plugin-registry/bootstrap link → /plugins/registry
- Update Anthropic plugin doc with Claude 4.6 model family
- Add WeChat setup section to plugin-setup-guide.md

https://claude.ai/code/session_01QUC4DYbezui4P9mP1Rn4p1

This PR will be reviewed by an AI agent. Provide clear context to help it assess your changes.

Aesthetic/UI changes that don't improve agent capability are out of scope and will be rejected.

## Category
- [ ] Bug fix
- [ ] Security fix
- [ ] Performance improvement
- [ ] New feature
- [ ] Documentation
- [ ] Test coverage
- [ ] Other

## What
(brief description)

## Why
(motivation)

## How
(implementation approach)

## Testing
(what was tested, how to verify)
