### PR TITLE
fix: character editor shows wrong preset when VRM doesn't match saved character

### DIFF
--- a/packages/app-core/src/components/CharacterEditor.tsx
+++ b/packages/app-core/src/components/CharacterEditor.tsx
@@ -9,6 +9,7 @@ import type { StylePreset } from "@miladyai/shared/contracts/onboarding";
 import { getStylePresets } from "@miladyai/shared/onboarding-presets";
 import { Button, Input, Textarea, ThemedSelect } from "@miladyai/ui";
 import { client } from "../api/client";
+import { shouldApplyPresetDefaults } from "./character-editor-helpers";
 import {
   APP_EMOTE_EVENT,
   dispatchWindowEvent,
@@ -689,13 +690,11 @@ export function CharacterEditor({
 
     // Apply preset defaults if: no saved content, OR the active VRM character
     // differs from what's saved (name mismatch means user switched presets).
-    const savedName =
-      typeof currentCharacter.name === "string"
-        ? currentCharacter.name.trim().toLowerCase()
-        : null;
-    const isMatchingSavedCharacter =
-      savedName !== null && savedName === entry.name.toLowerCase();
-    const applyDefaults = !hasMeaningfulContent || !isMatchingSavedCharacter;
+    const applyDefaults = shouldApplyPresetDefaults(
+      hasMeaningfulContent,
+      currentCharacter.name,
+      entry.name,
+    );
 
     // Suppress dirty-tracking during programmatic auto-select
     suppressDirtyRef.current = true;

--- a/packages/app-core/src/components/character-editor-helpers.test.ts
+++ b/packages/app-core/src/components/character-editor-helpers.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  replaceNameTokens,
+  shouldApplyPresetDefaults,
+} from "./character-editor-helpers";
+
+describe("replaceNameTokens", () => {
+  it("replaces {{name}} with the character name", () => {
+    expect(replaceNameTokens("Hello {{name}}, welcome!", "Momo")).toBe(
+      "Hello Momo, welcome!",
+    );
+  });
+
+  it("replaces {{agentName}} with the character name", () => {
+    expect(replaceNameTokens("I am {{agentName}}", "Chen")).toBe("I am Chen");
+  });
+
+  it("replaces multiple occurrences of both tokens", () => {
+    const input = "{{name}} here. Call me {{name}} or {{agentName}}.";
+    expect(replaceNameTokens(input, "Momo")).toBe(
+      "Momo here. Call me Momo or Momo.",
+    );
+  });
+
+  it("returns the string unchanged when no tokens present", () => {
+    expect(replaceNameTokens("Just a normal bio", "Momo")).toBe(
+      "Just a normal bio",
+    );
+  });
+
+  it("handles empty name gracefully", () => {
+    expect(replaceNameTokens("Hi {{name}}", "")).toBe("Hi ");
+  });
+
+  it("handles empty input string", () => {
+    expect(replaceNameTokens("", "Momo")).toBe("");
+  });
+});
+
+describe("shouldApplyPresetDefaults", () => {
+  it("returns true when there is no meaningful content", () => {
+    expect(shouldApplyPresetDefaults(false, "Chen", "Momo")).toBe(true);
+  });
+
+  it("returns true when saved name is null (no saved character)", () => {
+    expect(shouldApplyPresetDefaults(true, null, "Momo")).toBe(true);
+  });
+
+  it("returns true when saved name is undefined", () => {
+    expect(shouldApplyPresetDefaults(true, undefined, "Momo")).toBe(true);
+  });
+
+  it("returns true when saved name differs from roster entry (preset switch)", () => {
+    expect(shouldApplyPresetDefaults(true, "Chen", "Momo")).toBe(true);
+  });
+
+  it("returns false when saved name matches roster entry (same character)", () => {
+    expect(shouldApplyPresetDefaults(true, "Chen", "Chen")).toBe(false);
+  });
+
+  it("is case-insensitive when comparing names", () => {
+    expect(shouldApplyPresetDefaults(true, "chen", "Chen")).toBe(false);
+    expect(shouldApplyPresetDefaults(true, "MOMO", "momo")).toBe(false);
+  });
+
+  it("trims whitespace when comparing names", () => {
+    expect(shouldApplyPresetDefaults(true, "  Chen  ", "Chen")).toBe(false);
+    expect(shouldApplyPresetDefaults(true, "Chen", "  Chen  ")).toBe(false);
+  });
+});

--- a/packages/app-core/src/components/character-editor-helpers.ts
+++ b/packages/app-core/src/components/character-editor-helpers.ts
@@ -1,0 +1,40 @@
+/**
+ * Pure helpers extracted from CharacterEditor and AppContext
+ * for testability and reuse.
+ */
+
+/**
+ * Replace un-substituted `{{name}}` / `{{agentName}}` tokens with the
+ * actual character name. Handles legacy persisted templates from onboarding.
+ */
+export function replaceNameTokens(text: string, name: string): string {
+  return text
+    .replace(/\{\{name\}\}/g, name)
+    .replace(/\{\{agentName\}\}/g, name);
+}
+
+/**
+ * Decide whether the character editor should apply preset defaults when
+ * auto-selecting a roster entry.
+ *
+ * Returns `true` when:
+ * - The saved character has no meaningful content (fresh state), OR
+ * - The active roster entry name differs from the saved character name
+ *   (user switched presets — e.g. selected Momo but Chen is saved).
+ */
+export function shouldApplyPresetDefaults(
+  hasMeaningfulContent: boolean,
+  savedCharacterName: string | null | undefined,
+  rosterEntryName: string,
+): boolean {
+  if (!hasMeaningfulContent) return true;
+
+  const savedNorm =
+    typeof savedCharacterName === "string"
+      ? savedCharacterName.trim().toLowerCase()
+      : null;
+  const entryNorm = rosterEntryName.trim().toLowerCase();
+
+  // Name mismatch means the user navigated to a different preset
+  return savedNorm === null || savedNorm !== entryNorm;
+}

--- a/packages/app-core/src/state/AppContext.tsx
+++ b/packages/app-core/src/state/AppContext.tsx
@@ -5,6 +5,7 @@
  */
 
 import { ONBOARDING_PROVIDER_CATALOG } from "@miladyai/shared/contracts/onboarding";
+import { replaceNameTokens } from "../components/character-editor-helpers";
 import {
   getDefaultStylePreset,
   getStylePresets,
@@ -2021,15 +2022,14 @@ function AppProviderInner({
       // Replace any un-substituted {{name}} tokens that may have been persisted
       // to the server before the fix (onboarding saved raw templates).
       const savedName = character.name ?? "";
-      const replaceNameToken = (s: string) =>
-        s.replace(/\{\{name\}\}/g, savedName).replace(/\{\{agentName\}\}/g, savedName);
+      const clean = (s: string) => replaceNameTokens(s, savedName);
       setCharacterDraft({
         name: savedName,
         username: character.username ?? "",
         bio: Array.isArray(character.bio)
-          ? character.bio.map(replaceNameToken).join("\n")
-          : replaceNameToken(character.bio ?? ""),
-        system: replaceNameToken(character.system ?? ""),
+          ? character.bio.map(clean).join("\n")
+          : clean(character.bio ?? ""),
+        system: clean(character.system ?? ""),
         adjectives: character.adjectives ?? [],
         topics: character.topics ?? [],
         style: {


### PR DESCRIPTION
## Summary

- **Wrong character data on Customize**: Selecting Momo (or any avatar) and clicking Customize showed the *saved* character's name/bio/system (e.g. Chen) instead of the selected preset. Auto-select set the VRM correctly but skipped `applyDefaults` whenever any saved character content existed. Fix: compare the active roster entry name against the saved character name — if they differ, apply the preset defaults so the right data appears immediately.

- **`{{name}}` tokens showing raw**: Characters saved during onboarding retained literal `{{name}}` / `{{agentName}}` in their bio and system prompt (the replacement happened locally for display but the raw template was persisted). Fix: replace tokens with the saved character name in `loadCharacter()` before populating the draft — cleans up all existing affected saves automatically on next load.

## Test plan

- [ ] Select a non-default avatar (e.g. Momo) from the character roster and click Customize — form should show Momo's name, bio, and system prompt, not Chen's
- [ ] Verify clicking between different presets in the editor roster updates all form fields correctly
- [ ] Verify a user with an existing saved character (Chen) still sees their saved data when they open the editor with Chen selected
- [ ] Confirm `{{name}}` no longer appears literally in bio or system prompt after loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)