### PR TITLE
fix(api): auth-gate onboarding status route

### DIFF
--- a/packages/app-core/src/api/server.onboarding-status.test.ts
+++ b/packages/app-core/src/api/server.onboarding-status.test.ts
@@ -42,6 +42,8 @@ describe("GET /api/onboarding/status", () => {
     "ELIZA_STATE_DIR",
     "MILADY_STATE_DIR",
     "MILADY_CONFIG_PATH",
+    "MILADY_API_TOKEN",
+    "ELIZA_API_TOKEN",
     "EVM_PRIVATE_KEY",
     "SOLANA_PRIVATE_KEY",
   ] as const;
@@ -99,6 +101,39 @@ describe("GET /api/onboarding/status", () => {
 
       expect(status).toBe(200);
       expect(data.complete).toBe(false);
+    } finally {
+      await server.close();
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  it("requires auth when an API token is configured", async () => {
+    const tempDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "eliza-onboarding-status-"),
+    );
+    process.env.ELIZA_STATE_DIR = tempDir;
+    process.env.MILADY_STATE_DIR = tempDir;
+    process.env.ELIZA_API_TOKEN = "test-onboarding-token";
+    await fs.writeFile(
+      path.join(tempDir, "eliza.json"),
+      JSON.stringify({ logging: { level: "error" } }),
+    );
+
+    const server = await startApiServer({ port: 0, runtime: RUNTIME_STUB });
+
+    try {
+      const unauth = await req(server.port, "GET", "/api/onboarding/status");
+      expect(unauth.status).toBe(401);
+
+      const authed = await req(
+        server.port,
+        "GET",
+        "/api/onboarding/status",
+        undefined,
+        { Authorization: "Bearer test-onboarding-token" },
+      );
+      expect(authed.status).toBe(200);
+      expect(typeof authed.data.complete).toBe("boolean");
     } finally {
       await server.close();
       await cleanupTempDir(tempDir);

--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -2125,6 +2125,10 @@ async function handleMiladyCompatRoute(
   // Cloud-provisioned containers skip onboarding — the platform handles setup.
   // Return { complete: true } so the frontend goes directly to chat.
   if (method === "GET" && url.pathname === "/api/onboarding/status") {
+    if (!ensureCompatApiAuthorized(req, res)) {
+      return true;
+    }
+
     if (_isCloudProvisioned()) {
       sendJsonResponse(res, 200, { complete: true });
       return true;
@@ -3128,18 +3132,6 @@ async function handleMiladyCompatRoute(
     req.push(replayBody);
     req.push(null);
     return false;
-  }
-
-  if (method === "GET" && url.pathname === "/api/onboarding/status") {
-    if (!ensureCompatApiAuthorized(req, res)) {
-      return true;
-    }
-
-    const config = loadElizaConfig();
-    sendJsonResponse(res, 200, {
-      complete: hasCompatPersistedOnboardingState(config),
-    });
-    return true;
   }
 
   if (method === "GET" && url.pathname === "/api/config") {


### PR DESCRIPTION
## Summary
- auth-gate the live GET /api/onboarding/status handler in compat API
- preserve cloud-provisioned behavior ({ complete: true }), now behind auth when a token is configured
- remove the duplicate later onboarding-status handler that was shadowed and effectively dead
- add regression test coverage for token-protected onboarding-status access

## Validation
- un test packages/app-core/src/api/server.onboarding-status.test.ts
