### PR TITLE
fix: address 8 UX audit issues — credentials guard, a11y, CSS fallbacks

### DIFF
--- a/apps/app/electrobun/src/bridge/electrobun-direct-rpc.ts
+++ b/apps/app/electrobun/src/bridge/electrobun-direct-rpc.ts
@@ -33,7 +33,12 @@ function dispatchMessage(messageName: string, payload: unknown): void {
     const apiBaseUpdate = payload as { base: string; token?: string };
     window.__MILADY_API_BASE__ = apiBaseUpdate.base;
     if (apiBaseUpdate.token) {
-      window.__MILADY_API_TOKEN__ = apiBaseUpdate.token;
+      Object.defineProperty(window, "__MILADY_API_TOKEN__", {
+        value: apiBaseUpdate.token,
+        configurable: true,
+        writable: true,
+        enumerable: false,
+      });
     }
   }
 

--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -335,6 +335,9 @@ function handleDeepLink(url: string): void {
       });
       break;
     }
+    default:
+      console.warn("[Milady] Unknown deep link path:", path);
+      break;
   }
 }
 

--- a/packages/app-core/src/components/BrowserSurfaceWindow.tsx
+++ b/packages/app-core/src/components/BrowserSurfaceWindow.tsx
@@ -253,6 +253,7 @@ export function BrowserSurfaceWindow() {
 
       <div className="flex min-w-0 items-center gap-3 px-0.5 text-[0.82rem] text-[color:var(--text-muted,#a1a1aa)]">
         <span
+          aria-live="polite"
           className={`shrink-0 rounded-full border border-[rgba(94,97,102,0.72)] bg-[rgba(30,31,35,0.9)] px-[0.55rem] py-[0.2rem] ${isLoading ? "border-[rgba(232,217,168,0.42)] text-[color:var(--highlight-gold,#f2d27a)]" : ""}`}
         >
           {isLoading ? "Loading" : "Ready"}

--- a/packages/app-core/src/components/onboarding/OnboardingStepNav.tsx
+++ b/packages/app-core/src/components/onboarding/OnboardingStepNav.tsx
@@ -26,7 +26,7 @@ export function OnboardingStepNav() {
 
   return (
     <div className="relative z-10 flex flex-col justify-center py-[48px] pl-[40px] pr-0 max-md:items-center max-md:px-4 max-md:pt-4 max-md:pb-2">
-      <div className="w-[248px] rounded-[28px] border border-[var(--onboarding-nav-border)] [background:var(--onboarding-nav-scrim)] px-[26px] py-[30px] shadow-[var(--onboarding-nav-shadow)] backdrop-blur-[22px] backdrop-saturate-[1.2] max-md:w-fit max-md:max-w-[calc(100vw-32px)] max-md:rounded-[22px] max-md:px-4 max-md:py-3">
+      <div className="w-[248px] rounded-[28px] border border-[var(--onboarding-nav-border,rgba(201,204,209,0.12))] [background:var(--onboarding-nav-scrim,rgba(18,18,20,0.72))] px-[26px] py-[30px] shadow-[var(--onboarding-nav-shadow,0_16px_40px_rgba(0,0,0,0.24))] backdrop-blur-[22px] backdrop-saturate-[1.2] max-md:w-fit max-md:max-w-[calc(100vw-32px)] max-md:rounded-[22px] max-md:px-4 max-md:py-3">
         <div
           role="list"
           aria-label={t("onboarding.stepNavigation")}
@@ -48,10 +48,10 @@ export function OnboardingStepNav() {
 
             // Dot classes
             let dotClass =
-              "w-[14px] h-[14px] border border-[var(--onboarding-nav-card-border)] rotate-45 shrink-0 relative z-10 bg-[var(--onboarding-nav-card-bg)] transition-all duration-500 ease-[cubic-bezier(0.25,0.46,0.45,0.94)]";
+              "w-[14px] h-[14px] border border-[var(--onboarding-nav-card-border,rgba(201,204,209,0.18))] rotate-45 shrink-0 relative z-10 bg-[var(--onboarding-nav-card-bg,rgba(30,31,35,0.88))] transition-all duration-500 ease-[cubic-bezier(0.25,0.46,0.45,0.94)]";
             if (isDone) {
               dotClass +=
-                " !bg-[var(--onboarding-accent-bg)] !border-[var(--onboarding-accent-border-hover)]";
+                " !bg-[var(--onboarding-accent-bg,rgba(207,175,90,0.22))] !border-[var(--onboarding-accent-border-hover,rgba(242,210,122,0.4))]";
             } else if (isActive) {
               dotClass +=
                 " !bg-accent !border-[rgba(255,248,220,0.9)] shadow-[0_0_12px_rgba(240,185,11,0.5)] animate-[onboarding-dot-pulse_2s_ease-in-out_infinite]";
@@ -62,12 +62,12 @@ export function OnboardingStepNav() {
               "text-[15px] tracking-[0.08em] font-medium drop-shadow-[0_2px_10px_rgba(3,5,10,0.65)] transition-all duration-500";
             if (isDone) {
               nameClass +=
-                " text-[var(--onboarding-nav-link)] group-hover:text-[var(--onboarding-nav-link-hover)]";
+                " text-[var(--onboarding-nav-link,rgba(207,175,90,0.85))] group-hover:text-[var(--onboarding-nav-link-hover,#f2d27a)]";
             } else if (isActive) {
               nameClass +=
-                " text-[var(--onboarding-nav-text-primary)] font-semibold";
+                " text-[var(--onboarding-nav-text-primary,#e8e8ec)] font-semibold";
             } else {
-              nameClass += " text-[var(--onboarding-nav-text-subtle)]";
+              nameClass += " text-[var(--onboarding-nav-text-subtle,#a1a1aa)]";
             }
 
             // Subtitle classes
@@ -75,11 +75,11 @@ export function OnboardingStepNav() {
               "text-[13px] tracking-[0.05em] drop-shadow-[0_2px_10px_rgba(3,5,10,0.55)] transition-all duration-500";
             if (isDone) {
               subClass +=
-                " text-[var(--onboarding-nav-text-subtle)] group-hover:text-[var(--onboarding-nav-text-primary)]";
+                " text-[var(--onboarding-nav-text-subtle,#a1a1aa)] group-hover:text-[var(--onboarding-nav-text-primary,#e8e8ec)]";
             } else if (isActive) {
               subClass += " text-accent";
             } else {
-              subClass += " text-[var(--onboarding-nav-text-faint)]";
+              subClass += " text-[var(--onboarding-nav-text-faint,#6b6b78)]";
             }
 
             if (isClickable) {

--- a/packages/app-core/src/components/onboarding/connection/ConnectionProviderDetailScreen.tsx
+++ b/packages/app-core/src/components/onboarding/connection/ConnectionProviderDetailScreen.tsx
@@ -17,7 +17,10 @@ import type {
 } from "../../../api";
 import { client } from "../../../api";
 import { useBranding } from "../../../config";
-import type { ConnectionEvent } from "../../../onboarding/connection-flow";
+import {
+  type ConnectionEvent,
+  isProviderConfirmDisabled,
+} from "../../../onboarding/connection-flow";
 import { getProviderLogo } from "../../../providers";
 import { useApp } from "../../../state";
 import { openExternalUrl } from "../../../utils";
@@ -242,10 +245,13 @@ export function ConnectionProviderDetailScreen({
     handleOnboardingNext,
   });
 
-  const isConfirmDisabled =
-    onboardingProvider === "elizacloud" &&
-    ((onboardingElizaCloudTab === "login" && !elizaCloudConnected) ||
-      (onboardingElizaCloudTab === "apikey" && !onboardingApiKey.trim()));
+  const isConfirmDisabled = isProviderConfirmDisabled({
+    provider: onboardingProvider,
+    apiKey: onboardingApiKey,
+    elizaCloudTab: onboardingElizaCloudTab,
+    elizaCloudConnected,
+    subscriptionTab: onboardingSubscriptionTab,
+  });
 
   return (
     <>
@@ -354,6 +360,7 @@ export function ConnectionProviderDetailScreen({
                   }
                   return (
                     <p
+                      aria-live="assertive"
                       style={{
                         color: "var(--danger)",
                         fontSize: "0.8125rem",
@@ -526,7 +533,10 @@ export function ConnectionProviderDetailScreen({
                 {t("onboarding.requiresClaudeSub")}
               </p>
               {anthropicError && (
-                <p style={{ fontSize: "0.75rem", color: "var(--danger)" }}>
+                <p
+                  aria-live="assertive"
+                  style={{ fontSize: "0.75rem", color: "var(--danger)" }}
+                >
                   {anthropicError}
                 </p>
               )}
@@ -565,7 +575,10 @@ export function ConnectionProviderDetailScreen({
                 style={{ textAlign: "center" }}
               />
               {anthropicError && (
-                <p style={{ fontSize: "0.75rem", color: "var(--danger)" }}>
+                <p
+                  aria-live="assertive"
+                  style={{ fontSize: "0.75rem", color: "var(--danger)" }}
+                >
                   {anthropicError}
                 </p>
               )}
@@ -734,7 +747,10 @@ export function ConnectionProviderDetailScreen({
                 }}
               />
               {openaiError && (
-                <p style={{ fontSize: "0.75rem", color: "var(--danger)" }}>
+                <p
+                  aria-live="assertive"
+                  style={{ fontSize: "0.75rem", color: "var(--danger)" }}
+                >
                   {openaiError}
                 </p>
               )}
@@ -811,6 +827,7 @@ export function ConnectionProviderDetailScreen({
             />
             {apiKeyFormatWarning && (
               <p
+                aria-live="assertive"
                 style={{
                   fontSize: "0.75rem",
                   color: "var(--danger)",

--- a/packages/app-core/src/onboarding/connection-flow.ts
+++ b/packages/app-core/src/onboarding/connection-flow.ts
@@ -291,7 +291,51 @@ export function applyConnectionTransition(
         kind: "patch",
         patch: { onboardingSubscriptionTab: event.tab },
       };
+    default: {
+      const _exhaustive: never = event;
+      console.warn(
+        "[connection-flow] Unhandled connection event:",
+        (_exhaustive as ConnectionEvent).type,
+      );
+      return null;
+    }
   }
+}
+
+/** Providers that do not require an API key to proceed. */
+const NO_KEY_REQUIRED = new Set(["ollama", "pi-ai"]);
+
+/**
+ * Pure predicate: should the CONFIRM button be disabled on the provider-detail screen?
+ * Extracted so tests can cover every provider path without rendering React.
+ */
+export function isProviderConfirmDisabled(opts: {
+  provider: string;
+  apiKey: string;
+  elizaCloudTab: "login" | "apikey";
+  elizaCloudConnected: boolean;
+  subscriptionTab: "token" | "oauth";
+}): boolean {
+  const {
+    provider,
+    apiKey,
+    elizaCloudTab,
+    elizaCloudConnected,
+    subscriptionTab,
+  } = opts;
+  if (!provider) return true;
+  if (provider === "elizacloud") {
+    return (
+      (elizaCloudTab === "login" && !elizaCloudConnected) ||
+      (elizaCloudTab === "apikey" && !apiKey.trim())
+    );
+  }
+  if (provider === "anthropic-subscription") {
+    return subscriptionTab === "token" && !apiKey.trim();
+  }
+  if (NO_KEY_REQUIRED.has(provider)) return false;
+  // All other providers require an API key
+  return !apiKey.trim();
 }
 
 /**

--- a/packages/app-core/src/onboarding/tests/connection-flow.test.ts
+++ b/packages/app-core/src/onboarding/tests/connection-flow.test.ts
@@ -2,13 +2,14 @@
  * Locks `deriveConnectionScreen`, `resolveConnectionUiSpec`, and `applyConnectionTransition` together.
  * **Why merge + derive in tests:** patches alone do not prove the user lands on the right screen after an event.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   applyConnectionTransition,
   type ConnectionFlowSnapshot,
   computeShowProviderSelection,
   deriveConnectionScreen,
   getEffectiveRunMode,
+  isProviderConfirmDisabled,
   mergeConnectionSnapshot,
   resolveConnectionUiSpec,
 } from "../connection-flow";
@@ -250,6 +251,186 @@ describe("connection-flow", () => {
       if (r?.kind !== "patch") return;
       const s1 = mergeConnectionSnapshot(s0, r.patch);
       expect(deriveConnectionScreen(s1)).toBe("providerDetail");
+    });
+
+    it("all known event types are handled (no null for valid events)", () => {
+      const validEvents = [
+        { type: "selectLocalHosting" as const },
+        { type: "selectRemoteHosting" as const },
+        { type: "selectElizaCloudHosting" as const },
+        { type: "backElizaCloudPreProvider" as const },
+        { type: "clearProvider" as const },
+        { type: "setElizaCloudTab" as const, tab: "apikey" as const },
+        { type: "setSubscriptionTab" as const, tab: "oauth" as const },
+        {
+          type: "selectProvider" as const,
+          providerId: "openai",
+        },
+      ];
+      for (const event of validEvents) {
+        const r = applyConnectionTransition(baseSnap(), event);
+        expect(r).not.toBeNull();
+      }
+    });
+
+    it("unknown event type returns null via exhaustive default", () => {
+      const s0 = baseSnap();
+      const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      // Force an unknown event type to exercise the default branch
+      const r = applyConnectionTransition(s0, {
+        type: "totally_unknown",
+      } as never);
+      expect(r).toBeNull();
+      expect(spy).toHaveBeenCalledWith(
+        "[connection-flow] Unhandled connection event:",
+        "totally_unknown",
+      );
+      spy.mockRestore();
+    });
+  });
+
+  describe("isProviderConfirmDisabled", () => {
+    const defaults = {
+      provider: "",
+      apiKey: "",
+      elizaCloudTab: "login" as const,
+      elizaCloudConnected: false,
+      subscriptionTab: "token" as const,
+    };
+
+    it("disabled when no provider selected", () => {
+      expect(isProviderConfirmDisabled(defaults)).toBe(true);
+    });
+
+    it("elizacloud: disabled when login tab and not connected", () => {
+      expect(
+        isProviderConfirmDisabled({
+          ...defaults,
+          provider: "elizacloud",
+          elizaCloudTab: "login",
+          elizaCloudConnected: false,
+        }),
+      ).toBe(true);
+    });
+
+    it("elizacloud: enabled when login tab and connected", () => {
+      expect(
+        isProviderConfirmDisabled({
+          ...defaults,
+          provider: "elizacloud",
+          elizaCloudTab: "login",
+          elizaCloudConnected: true,
+        }),
+      ).toBe(false);
+    });
+
+    it("elizacloud: disabled when apikey tab and empty key", () => {
+      expect(
+        isProviderConfirmDisabled({
+          ...defaults,
+          provider: "elizacloud",
+          elizaCloudTab: "apikey",
+          apiKey: "  ",
+        }),
+      ).toBe(true);
+    });
+
+    it("elizacloud: enabled when apikey tab and key provided", () => {
+      expect(
+        isProviderConfirmDisabled({
+          ...defaults,
+          provider: "elizacloud",
+          elizaCloudTab: "apikey",
+          apiKey: "ec-test-key",
+        }),
+      ).toBe(false);
+    });
+
+    it("anthropic-subscription: disabled when token tab and empty key", () => {
+      expect(
+        isProviderConfirmDisabled({
+          ...defaults,
+          provider: "anthropic-subscription",
+          subscriptionTab: "token",
+          apiKey: "",
+        }),
+      ).toBe(true);
+    });
+
+    it("anthropic-subscription: enabled when token tab and key provided", () => {
+      expect(
+        isProviderConfirmDisabled({
+          ...defaults,
+          provider: "anthropic-subscription",
+          subscriptionTab: "token",
+          apiKey: "sk-ant-oat01-test",
+        }),
+      ).toBe(false);
+    });
+
+    it("anthropic-subscription: enabled on oauth tab regardless of key", () => {
+      expect(
+        isProviderConfirmDisabled({
+          ...defaults,
+          provider: "anthropic-subscription",
+          subscriptionTab: "oauth",
+          apiKey: "",
+        }),
+      ).toBe(false);
+    });
+
+    it("ollama: enabled without API key", () => {
+      expect(
+        isProviderConfirmDisabled({ ...defaults, provider: "ollama" }),
+      ).toBe(false);
+    });
+
+    it("pi-ai: enabled without API key", () => {
+      expect(
+        isProviderConfirmDisabled({ ...defaults, provider: "pi-ai" }),
+      ).toBe(false);
+    });
+
+    it.each([
+      "openai",
+      "anthropic",
+      "openrouter",
+      "gemini",
+      "grok",
+      "groq",
+      "deepseek",
+      "mistral",
+      "together",
+      "zai",
+    ])("%s: disabled when API key empty", (providerId) => {
+      expect(
+        isProviderConfirmDisabled({
+          ...defaults,
+          provider: providerId,
+          apiKey: "",
+        }),
+      ).toBe(true);
+    });
+
+    it.each([
+      "openai",
+      "anthropic",
+      "openrouter",
+      "gemini",
+      "grok",
+      "groq",
+      "deepseek",
+      "mistral",
+      "together",
+      "zai",
+    ])("%s: enabled when API key provided", (providerId) => {
+      expect(
+        isProviderConfirmDisabled({
+          ...defaults,
+          provider: providerId,
+          apiKey: "sk-test-key-12345",
+        }),
+      ).toBe(false);
     });
   });
 });

--- a/packages/app-core/src/styles/styles.css
+++ b/packages/app-core/src/styles/styles.css
@@ -277,7 +277,12 @@ kbd {
   background-color: hsl(240 4.8% 10%);
 }
 
-/* Focus visible improvements for dark mode */
+/* Focus visible improvements */
+:focus-visible {
+  outline: 2px solid hsl(217 91% 50%);
+  outline-offset: 2px;
+}
+
 [data-theme="dark"] :focus-visible {
   outline: 2px solid hsl(217 91% 60%);
   outline-offset: 2px;


### PR DESCRIPTION
## Summary

Fixes from UX Persona Audits #1278, #1282, #1284.

### P0
- **OnboardingStepNav CSS variables**: 9 `--onboarding-nav-*` variables were referenced but never defined. Added `var(--name, fallback)` pattern with brand-gold defaults.

### P1
- **CONFIRM button credential guard**: Extracted `isProviderConfirmDisabled()` — now disables Connect button when required credentials are empty for all provider types (elizacloud, anthropic, openai, etc.)
- **API token non-enumerable**: Changed `window.__MILADY_API_TOKEN__` from plain assignment to `Object.defineProperty` with `enumerable: false`
- **Light mode focus-visible**: Added `:focus-visible` outline style for light mode (blue `hsl(217 91% 50%)`)

### P2
- **BrowserSurfaceWindow**: Added `aria-live="polite"` to loading status indicator
- **ConnectionProviderDetailScreen**: Added `aria-live="assertive"` to all error message containers

### P3
- **handleDeepLink**: Added `default` case logging unknown deep link paths
- **applyConnectionTransition**: Added exhaustive `default` with `never` typing

### Tests (30 new)
- `isProviderConfirmDisabled`: 14 cases covering every provider type and tab
- Connection transition: all events return non-null, unknown returns null

Closes #1278 Closes #1282 Closes #1284

🤖 Generated with [Claude Code](https://claude.com/claude-code)