### PR TITLE
fix: prevent CompanionSceneHost re-rendering on every keystroke

### DIFF
--- a/packages/app-core/src/components/CompanionSceneHost.tsx
+++ b/packages/app-core/src/components/CompanionSceneHost.tsx
@@ -583,7 +583,27 @@ function CompanionSceneSurface({
   );
 }
 
-export const CompanionSceneHost = memo(CompanionSceneSurface);
+// Custom comparator ignores `children` — children are overlaid via CSS
+// absolute positioning and never affect the 3D canvas.  Without this,
+// every App re-render (e.g. chat input keystrokes) recreates the children
+// JSX tree, breaking memo and causing 20+ renders/sec on the WebGL scene.
+//
+// Safety: children (shellContent in App.tsx) include ViewRouter which receives
+// characterSceneVisible as a prop. This is safe because when companionShellVisible
+// is true, shellContent is <CompanionShell/> — ViewRouter only renders in the
+// non-companion branch and is never a child of CompanionSceneHost in that case.
+// The `interactive` prop already tracks `companionShellVisible || characterSceneVisible`,
+// so scene-relevant visibility changes always trigger re-renders.
+export const companionSceneHostAreEqual = (
+  prev: { active: boolean; interactive?: boolean },
+  next: { active: boolean; interactive?: boolean },
+): boolean =>
+  prev.active === next.active && prev.interactive === next.interactive;
+
+export const CompanionSceneHost = memo(
+  CompanionSceneSurface,
+  companionSceneHostAreEqual,
+);
 
 export function SharedCompanionScene({
   active,

--- a/packages/app-core/src/components/__tests__/companion-scene-memo.test.ts
+++ b/packages/app-core/src/components/__tests__/companion-scene-memo.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Tests that CompanionSceneHost's custom memo comparator only
+ * re-renders when `active` or `interactive` change, not when
+ * `children` change (which happens on every App re-render due
+ * to chat input keystrokes recreating the JSX tree).
+ */
+import { describe, expect, it } from "vitest";
+import { companionSceneHostAreEqual } from "../CompanionSceneHost";
+
+describe("CompanionSceneHost memo comparator", () => {
+  it("returns true when only children change (no re-render)", () => {
+    const prev = { active: true, interactive: true };
+    const next = { active: true, interactive: true };
+    expect(companionSceneHostAreEqual(prev, next)).toBe(true);
+  });
+
+  it("returns false when active changes", () => {
+    const prev = { active: true, interactive: true };
+    const next = { active: false, interactive: true };
+    expect(companionSceneHostAreEqual(prev, next)).toBe(false);
+  });
+
+  it("returns false when interactive changes", () => {
+    const prev = { active: true, interactive: true };
+    const next = { active: true, interactive: false };
+    expect(companionSceneHostAreEqual(prev, next)).toBe(false);
+  });
+
+  it("returns true when all scene-relevant props are equal", () => {
+    const prev = { active: false, interactive: false };
+    const next = { active: false, interactive: false };
+    expect(companionSceneHostAreEqual(prev, next)).toBe(true);
+  });
+
+  it("handles undefined interactive (default param)", () => {
+    const prev = { active: true };
+    const next = { active: true };
+    expect(companionSceneHostAreEqual(prev, next)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- CompanionSceneHost (3D VRM scene) was re-rendering 20+ times/sec when typing in the chat input
- Root cause: `App` subscribes to `useApp()` context, re-renders on every `chatInput` state change, recreates `shellContent` JSX tree, passes new `children` reference to `SharedCompanionScene` → `CompanionSceneHost`
- `memo(CompanionSceneSurface)` couldn't help because shallow comparison sees new `children` reference each time
- Fix: custom memo comparator that only checks `active` and `interactive`, ignoring `children` — children are CSS absolute-positioned overlays that never affect the 3D canvas

## Test plan
- [x] 5 unit tests for the memo comparator (children-only change, active change, interactive change, all equal, undefined interactive)
- [ ] Open companion mode, type in chat input — no `[RenderGuard] "CompanionSceneHost"` warnings in devtools console
- [ ] VRM avatar still responds to `active`/`interactive` prop changes (tab switch, scene toggle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)