### PR TITLE
refactor: centralize module interop for Bun CJS/ESM compatibility

### DIFF
--- a/scripts/dev-ui-json5-interop.test.ts
+++ b/scripts/dev-ui-json5-interop.test.ts
@@ -1,9 +1,0 @@
-import * as JSON5Module from "json5";
-import { describe, expect, it } from "vitest";
-
-describe("dev-ui json5 interop", () => {
-  it("resolves a parse function from default-or-namespace shape", () => {
-    const JSON5 = JSON5Module.default ?? JSON5Module;
-    expect(typeof JSON5.parse).toBe("function");
-  });
-});

--- a/scripts/dev-ui.mjs
+++ b/scripts/dev-ui.mjs
@@ -35,9 +35,10 @@ import {
 } from "./lib/dev-ui-onchain.mjs";
 import { buildVisionDepsFailureMessage } from "./lib/dev-ui-vision.mjs";
 import { signalSpawnedProcessTree } from "./lib/kill-process-tree.mjs";
+import { resolveModuleDefault } from "./lib/module-interop.mjs";
 
 const API_PORT = Number(process.env.MILADY_API_PORT) || 31337;
-const JSON5 = JSON5Module.default ?? JSON5Module;
+const JSON5 = resolveModuleDefault(JSON5Module);
 
 // --app=<name> selects which app to serve (default: "app" → apps/app)
 const appArgMatch = process.argv.find((a) => a.startsWith("--app="));

--- a/scripts/lib/module-interop.mjs
+++ b/scripts/lib/module-interop.mjs
@@ -1,0 +1,13 @@
+/**
+ * Resolve a module namespace to its default export when present.
+ * Falls back to the namespace itself for CJS/dual package interop.
+ *
+ * Bun canary sometimes exposes CJS modules as `{ default: { parse, ... } }`
+ * instead of directly as `{ parse, ... }`. This helper normalizes both shapes.
+ */
+export function resolveModuleDefault(namespace) {
+  if (namespace && typeof namespace === "object" && "default" in namespace) {
+    return namespace.default;
+  }
+  return namespace;
+}

--- a/scripts/lib/module-interop.test.ts
+++ b/scripts/lib/module-interop.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { resolveModuleDefault } from "./module-interop.mjs";
+
+describe("resolveModuleDefault", () => {
+  it("returns default export when present", () => {
+    const resolved = resolveModuleDefault({ default: { parse: () => "ok" } });
+    expect(typeof resolved.parse).toBe("function");
+  });
+
+  it("falls back to namespace object when default is absent", () => {
+    const namespace = { parse: () => "ok" };
+    expect(resolveModuleDefault(namespace)).toBe(namespace);
+  });
+
+  it("handles null/undefined gracefully", () => {
+    expect(resolveModuleDefault(null)).toBeNull();
+    expect(resolveModuleDefault(undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Cleans up and supersedes #1294 by @dutchiono.

Extracts the inline `JSON5Module.default ?? JSON5Module` pattern from `dev-ui.mjs` into a shared `resolveModuleDefault()` helper at `scripts/lib/module-interop.mjs`. This normalizes Bun canary's CJS namespace export quirk in one place.

### Changes
- **New**: `scripts/lib/module-interop.mjs` — `resolveModuleDefault(namespace)` helper
- **Updated**: `scripts/dev-ui.mjs` — uses the shared helper instead of inline fallback
- **Removed**: `scripts/dev-ui-json5-interop.test.ts` — replaced by generic helper test
- **New**: `scripts/lib/module-interop.test.ts` — 3 test cases (default present, absent, null)

### Credit
Based on #1294 by @dutchiono — rebased onto current develop, removed duplicate changes already landed in #1292, cleaned up old test file.

Supersedes #1294

🤖 Generated with [Claude Code](https://claude.com/claude-code)