### PR TITLE
feat: Bun version advisory + Windows CI smoke workflow

### DIFF
--- a/.github/workflows/windows-dev-smoke.yml
+++ b/.github/workflows/windows-dev-smoke.yml
@@ -1,0 +1,49 @@
+name: Windows Dev Smoke
+
+on:
+  pull_request:
+    branches: [develop]
+    paths:
+      - "scripts/**"
+      - "apps/app/electrobun/**"
+      - "package.json"
+      - "bun.lock"
+  workflow_dispatch:
+
+jobs:
+  dev-smoke:
+    name: Windows smoke (${{ matrix.bun-version }})
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        bun-version: ["1.3.10", "canary"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ matrix.bun-version }}
+
+      - name: Install dependencies
+        run: bun install --ignore-scripts
+
+      - name: Verify json5 interop
+        run: >
+          bun -e "import * as JSON5Module from 'json5';
+          const JSON5 = JSON5Module.default ?? JSON5Module;
+          if (typeof JSON5.parse !== 'function') throw new Error('JSON5.parse missing');
+          console.log('json5 interop ok');"
+
+      - name: Verify bun-version-guard
+        run: >
+          bun -e "import { getBunVersionAdvisory } from './scripts/lib/bun-version-guard.mjs';
+          const result = getBunVersionAdvisory();
+          console.log('bun-version-guard:', result ?? 'OK (no advisory)');"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,6 +13,11 @@ Most scripts here are invoked from **root `package.json`** (`bun run …`). This
 
 **Full guide (WHYs for signals, `detached`, HMR vs Rollup watch, multiple `bun` PIDs):** [Desktop local development](../docs/apps/desktop-local-development.md)
 
+### Bun Version (Windows)
+
+- Recommended: **Bun 1.3.x stable** for `dev:win` flows.
+- Canary builds can change ESM/CJS interop behavior. `dev-ui.mjs` prints a startup advisory when it detects canary or non-1.3 Bun.
+
 ### Supporting modules (`scripts/lib/`)
 
 | Module | Why it exists |

--- a/scripts/dev-ui.mjs
+++ b/scripts/dev-ui.mjs
@@ -28,6 +28,7 @@ import process from "node:process";
 import { ethers } from "ethers";
 import * as JSON5Module from "json5";
 import { CAPACITOR_PLUGIN_NAMES } from "../apps/app/scripts/capacitor-plugin-names.mjs";
+import { getBunVersionAdvisory } from "./lib/bun-version-guard.mjs";
 import { capacitorPluginsBuildNeeded } from "./lib/capacitor-plugin-build-needed.mjs";
 import {
   coerceBoolean,
@@ -87,6 +88,9 @@ function getCliName() {
 
 const cliName = getCliName();
 const logPrefix = `[${cliName}]`;
+
+const bunAdvisory = getBunVersionAdvisory();
+if (bunAdvisory) console.warn(`${logPrefix} ${bunAdvisory}`);
 
 const cwd = process.cwd();
 const uiOnly = process.argv.includes("--ui-only");

--- a/scripts/lib/bun-version-guard.mjs
+++ b/scripts/lib/bun-version-guard.mjs
@@ -1,0 +1,41 @@
+const RECOMMENDED_BUN_MAJOR = 1;
+const RECOMMENDED_BUN_MINOR = 3;
+
+function parseBunVersion(rawVersion) {
+  const trimmed = String(rawVersion ?? "").trim();
+  const match = /^(\d+)\.(\d+)\.(\d+)(.*)$/.exec(trimmed);
+  if (!match) return null;
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    suffix: match[4] ?? "",
+    raw: trimmed,
+  };
+}
+
+/**
+ * Returns a non-fatal advisory string if the current Bun version is
+ * canary or outside the recommended 1.3.x range. Returns null if OK.
+ */
+export function getBunVersionAdvisory() {
+  const raw = globalThis.Bun?.version;
+  if (!raw) return null;
+  const parsed = parseBunVersion(raw);
+  if (!parsed) {
+    return `Detected Bun ${raw}. Recommended: Bun ${RECOMMENDED_BUN_MAJOR}.${RECOMMENDED_BUN_MINOR}.x stable.`;
+  }
+
+  if (parsed.suffix.includes("canary")) {
+    return `Detected Bun ${parsed.raw} (canary). Canary can break module interop; prefer Bun ${RECOMMENDED_BUN_MAJOR}.${RECOMMENDED_BUN_MINOR}.x stable.`;
+  }
+
+  if (
+    parsed.major !== RECOMMENDED_BUN_MAJOR ||
+    parsed.minor !== RECOMMENDED_BUN_MINOR
+  ) {
+    return `Detected Bun ${parsed.raw}. Recommended: Bun ${RECOMMENDED_BUN_MAJOR}.${RECOMMENDED_BUN_MINOR}.x stable.`;
+  }
+
+  return null;
+}

--- a/scripts/lib/bun-version-guard.test.ts
+++ b/scripts/lib/bun-version-guard.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { getBunVersionAdvisory } from "./bun-version-guard.mjs";
+
+describe("bun-version-guard", () => {
+  const originalBun = globalThis.Bun;
+
+  const setBunVersion = (version: string) => {
+    Object.defineProperty(globalThis, "Bun", {
+      value: { version },
+      configurable: true,
+      writable: true,
+    });
+  };
+
+  afterEach(() => {
+    if (originalBun === undefined) {
+      delete (globalThis as Record<string, unknown>).Bun;
+    } else {
+      Object.defineProperty(globalThis, "Bun", {
+        value: originalBun,
+        configurable: true,
+        writable: true,
+      });
+    }
+  });
+
+  it("returns null for Bun 1.3.x stable", () => {
+    setBunVersion("1.3.11");
+    expect(getBunVersionAdvisory()).toBeNull();
+  });
+
+  it("warns for canary builds", () => {
+    setBunVersion("1.1.42-canary.8+1fa6d9e69");
+    expect(getBunVersionAdvisory()).toContain("canary");
+  });
+
+  it("warns for non-1.3 stable versions", () => {
+    setBunVersion("1.2.0");
+    expect(getBunVersionAdvisory()).toContain("Recommended");
+  });
+
+  it("returns null when Bun is not available", () => {
+    delete (globalThis as Record<string, unknown>).Bun;
+    expect(getBunVersionAdvisory()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Consolidates #1295 and #1296 by @dutchiono.

### Bun version advisory
- `scripts/lib/bun-version-guard.mjs` — warns at startup when running Bun canary or non-1.3 (non-fatal)
- Integrated into `dev-ui.mjs` startup log
- 4 test cases (stable OK, canary warns, non-1.3 warns, no Bun OK)

### Windows CI smoke
- `.github/workflows/windows-dev-smoke.yml` — runs on `windows-latest`
- Bun matrix: `1.3.10` (stable) + `canary`
- Verifies json5 interop shape and bun-version-guard
- Only triggers on scripts/electrobun/package changes (not every PR)

### Not included
- `module-interop.mjs` abstraction — per feedback, the inline `JSON5Module.default ?? JSON5Module` stays. The #1292 integration test (`dev-ui-json5-interop.test.ts`) is preserved as-is.

### Credit
Based on #1295 and #1296 by @dutchiono — consolidated and cleaned.

Supersedes #1295 #1296

🤖 Generated with [Claude Code](https://claude.com/claude-code)