### PR TITLE
fix: 3 bugs from code hunt — response leak, restart state, set iteration

### DIFF
--- a/packages/agent/src/api/stream-routes-mjpeg.test.ts
+++ b/packages/agent/src/api/stream-routes-mjpeg.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * Validates that MJPEG subscriber cleanup doesn't modify the Set
+ * during iteration — collects failures first, then deletes.
+ */
+describe("MJPEG subscriber cleanup pattern", () => {
+  it("collects failed subscribers before deleting from Set", async () => {
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+    const testDir = path.dirname(new URL(import.meta.url).pathname);
+    const source = fs.readFileSync(
+      path.resolve(testDir, "stream-routes.ts"),
+      "utf-8",
+    );
+
+    // Find pushFrameToSubscribers function
+    const fnIdx = source.indexOf("pushFrameToSubscribers");
+    expect(fnIdx).toBeGreaterThan(-1);
+
+    // Extract the function body (next ~600 chars)
+    const fnBody = source.slice(fnIdx, fnIdx + 600);
+
+    // Verify the pattern: collect in array, then delete after loop
+    expect(fnBody).toContain("failed.push(sub)");
+    expect(fnBody).toContain("for (const sub of failed)");
+
+    // Verify there's NO delete inside the iteration loop
+    const iterStart = fnBody.indexOf("for (const sub of mjpegSubscribers)");
+    const iterEnd = fnBody.indexOf("for (const sub of failed)");
+    expect(iterStart).toBeGreaterThan(-1);
+    expect(iterEnd).toBeGreaterThan(iterStart);
+    const iterBody = fnBody.slice(iterStart, iterEnd);
+    expect(iterBody).not.toContain("mjpegSubscribers.delete");
+  });
+});

--- a/packages/agent/src/api/stream-routes.ts
+++ b/packages/agent/src/api/stream-routes.ts
@@ -69,12 +69,16 @@ function pushFrameToSubscribers(frame: Buffer): void {
   const headerBuf = Buffer.from(header, "ascii");
   const trailer = Buffer.from("\r\n", "ascii");
   const chunk = Buffer.concat([headerBuf, frame, trailer]);
+  const failed: ServerResponse[] = [];
   for (const sub of mjpegSubscribers) {
     try {
       sub.write(chunk);
     } catch {
-      mjpegSubscribers.delete(sub);
+      failed.push(sub);
     }
+  }
+  for (const sub of failed) {
+    mjpegSubscribers.delete(sub);
   }
 }
 

--- a/packages/agent/src/services/stream-manager-restart.test.ts
+++ b/packages/agent/src/services/stream-manager-restart.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * Validates that FFmpeg auto-restart properly resets _running state
+ * when start() fails before spawning. This is a contract test —
+ * it verifies the fix is present in the source code.
+ */
+describe("stream-manager autoRestart error recovery", () => {
+  it("resets _running in the catch block of autoRestart", async () => {
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+    const testDir = path.dirname(new URL(import.meta.url).pathname);
+    const source = fs.readFileSync(
+      path.resolve(testDir, "stream-manager.ts"),
+      "utf-8",
+    );
+
+    // Find the autoRestart catch block
+    const catchIdx = source.indexOf("} catch (err) {", source.indexOf("autoRestart"));
+    expect(catchIdx).toBeGreaterThan(-1);
+
+    // Verify _running = false appears within 100 chars after the catch
+    const catchBlock = source.slice(catchIdx, catchIdx + 100);
+    expect(catchBlock).toContain("this._running = false");
+  });
+});

--- a/packages/agent/src/services/stream-manager.ts
+++ b/packages/agent/src/services/stream-manager.ts
@@ -504,9 +504,8 @@ class StreamManager {
         this._frameCount = savedFrameCount;
         logger.info(`${TAG} Auto-restart successful`);
       } catch (err) {
-        logger.error(
-          `${TAG} Auto-restart failed: ${String(err)}`,
-        );
+        this._running = false;
+        logger.error(`${TAG} Auto-restart failed: ${String(err)}`);
         // start() failed before spawning FFmpeg — no exit event will fire,
         // so manually chain the next restart attempt if retries remain.
         if (!this._intentionalStop && this._config) {

--- a/packages/plugin-wechat/src/proxy-client-429.test.ts
+++ b/packages/plugin-wechat/src/proxy-client-429.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+describe("proxy-client 429 body consumption", () => {
+  it("consumes response body before retry on 429", () => {
+    const source = readFileSync(path.join(__dirname, "proxy-client.ts"), "utf-8");
+
+    const idx = source.indexOf("res.status === 429");
+    expect(idx).toBeGreaterThan(-1);
+
+    const block = source.slice(idx, idx + 500);
+    expect(block).toContain("res.text()");
+    expect(block.indexOf("res.text()")).toBeLessThan(
+      block.indexOf("continue;"),
+    );
+  });
+});

--- a/packages/plugin-wechat/src/proxy-client.ts
+++ b/packages/plugin-wechat/src/proxy-client.ts
@@ -48,6 +48,8 @@ export class ProxyClient {
           const delay = retryAfter
             ? Number.parseInt(retryAfter, 10) * 1000
             : Math.min(1000 * 2 ** attempt, 8000);
+          // Consume the response body to release the connection
+          await res.text().catch(() => {});
           await sleep(delay);
           continue;
         }


### PR DESCRIPTION
## Summary

Bugs found via systematic code hunt across API, frontend, and plugin code.

### 1. WeChat 429 response body leak (HIGH)
**File:** `packages/plugin-wechat/src/proxy-client.ts:46-52`

On HTTP 429, the response body was never consumed before retrying. Under sustained rate limiting, unconsumed response bodies accumulate and leak connections/memory.

**Fix:** Added `await res.text().catch(() => {})` before the retry sleep.

### 2. FFmpeg auto-restart state inconsistency (MED)
**File:** `packages/agent/src/services/stream-manager.ts:506`

When `start()` threw before spawning FFmpeg, `_running` was never reset to `false`. Subsequent `writeFrame()` calls would check stale state and could behave incorrectly.

**Fix:** Added `this._running = false` in the catch block.

### 3. MJPEG Set modified during iteration (LOW)
**File:** `packages/agent/src/api/stream-routes.ts:72-78`

Failed MJPEG subscribers were deleted from the Set during iteration. While JS Set iteration handles this safely, the pattern is fragile and non-obvious.

**Fix:** Collect failed subscribers in an array, delete after iteration completes.

### Also investigated (no bugs found)
- Frontend React components — clean. Proper cleanup, abort controllers, mounted checks throughout.
- process.env race on wallet writes — confirmed but requires architectural refactor (mutex/lock pattern). Documented, not fixed here.

### Tests (3 new)
Each fix has a contract test verifying the fix is present in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)