### PR TITLE
fix: correct config paths, plugin names, and CLI docs across repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,9 +76,9 @@ The try/catch blocks in `apps/app/electrobun/src/native/agent.ts` keep the deskt
 
 ## Config
 
-- **Runtime config**: `~/.eliza/eliza.json` (or `ELIZA_CONFIG_PATH` / `ELIZA_STATE_DIR`)
-- **Env secrets**: `~/.eliza/.env` or project `.env`
-- **Namespace**: The CLI auto-detects "milady" from package.json name
+- **Runtime config**: `~/.milady/milady.json` (override with `MILADY_CONFIG_PATH` or `MILADY_STATE_DIR`; falls back to `ELIZA_CONFIG_PATH` / `ELIZA_STATE_DIR`)
+- **Env secrets**: `~/.milady/.env` or project `.env`
+- **Namespace**: The CLI sets `ELIZA_NAMESPACE=milady` (via `run-node.mjs` and `dev-ui.mjs`), so the state dir is `~/.milady/` and the config file is `milady.json`
 
 ## Code Standards
 
@@ -117,7 +117,7 @@ All `@elizaos/*` packages use the `alpha` dist-tag. When developing locally, `bu
 - **Plugin not found at runtime**: Ensure NODE_PATH is set. Run `bun run repair` to re-run postinstall.
 - **Stale Vite cache after patching deps**: run `MILADY_VITE_FORCE=1 bun run dev` (or delete `apps/app/.vite/`). Dev no longer passes `--force` by default so dependency pre-bundling can cache between runs.
 - **Cold rebuild / stuck artifacts**: `bun run clean` removes root `dist`, UI + Capacitor plugin `dist`, `apps/app/.vite`, Turbo, Foundry test `out/`/`cache`, Playwright output, and `node_modules/.cache` under main workspaces. `bun run clean:deep` also removes Electrobun `build/`/`artifacts/` and generated `preload.js`, plus Electron pack dirs. For a global Bun store wipe (affects all projects): `MILADY_CLEAN_GLOBAL_TOOL_CACHE=1 bun run clean`.
-- **Config file not found**: The actual path is `~/.eliza/eliza.json`, not `~/.milady/milady.json`.
+- **Config file not found**: The actual path is `~/.milady/milady.json` (because `ELIZA_NAMESPACE=milady`). The generic eliza default `~/.eliza/eliza.json` does not apply when running as Milady.
 - **Lock file blocking install**: If postinstall times out with a lock error, delete `.eliza-repo-setup.lock` in the repo root.
 
 ## Setup Environment Variables

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Milady ships with native **BNB Smart Chain (BSC)** support — your agent can tr
 
 The built-in `EXECUTE_TRADE` action lets your agent swap tokens on BSC via PancakeSwap. Supports buy/sell with configurable slippage.
 
-To enable BSC trading, add to your `.env` or `~/.eliza/.env`:
+To enable BSC trading, add to your `.env` or `~/.milady/.env`:
 
 ```bash
 EVM_PRIVATE_KEY=0x...                    # wallet private key (hex, 0x-prefixed)
@@ -235,7 +235,7 @@ Recommended server environment:
 export MILADY_API_BIND=0.0.0.0
 export MILADY_API_TOKEN="$(openssl rand -hex 32)"
 export MILADY_ALLOWED_ORIGINS="https://app.milady.ai,https://milady.ai,https://elizacloud.ai,https://www.elizacloud.ai"
-milady start --headless
+milady start
 ```
 
 The access key the user enters in onboarding is the value of `MILADY_API_TOKEN`.
@@ -286,10 +286,10 @@ The implementation and proxy runbook lives in [docs/eliza-cloud-deployment.md](d
 ## Terminal Commands
 
 ```bash
-milady                    # start (default)
-milady start              # same thing
-milady start --headless   # no browser popup
-milady start --verbose    # debug mode for when things break
+milady                    # start (interactive, opens dashboard)
+milady start              # server-only mode (API server, no interactive chat loop)
+milady --verbose          # enable informational runtime logs
+milady --debug            # enable debug-level runtime logs
 ```
 
 ### Setup & Config
@@ -375,15 +375,15 @@ When running, milady shows a live terminal interface:
 | `?` | show help |
 | `↑/↓` | scroll activity |
 
-### Headless mode
+### Server-only mode
 
-Don't want the TUI? Run headless:
+Don't want the interactive TUI? Use the `start` command, which runs in server-only mode (API server, no interactive chat loop):
 
 ```bash
-milady start --headless
+milady start
 ```
 
-Logs go to `stdout/stderr (or configure LOG_FILE)`. Daemonize with your favorite process manager.
+Logs go to `stdout/stderr`. Daemonize with your favorite process manager.
 
 ---
 
@@ -423,7 +423,7 @@ MILADY_GATEWAY_PORT=19000 MILADY_PORT=3000 milady start
 
 ## Config
 
-Lives at `~/.eliza/eliza.json` (override with `ELIZA_CONFIG_PATH` or `ELIZA_STATE_DIR`)
+Lives at `~/.milady/milady.json` (override with `MILADY_CONFIG_PATH` or `MILADY_STATE_DIR`)
 
 ```json5
 {
@@ -437,7 +437,7 @@ Lives at `~/.eliza/eliza.json` (override with `ELIZA_CONFIG_PATH` or `ELIZA_STAT
 }
 ```
 
-Or use `~/.eliza/.env` for secrets.
+Or use `~/.milady/.env` for secrets.
 
 ---
 
@@ -475,7 +475,7 @@ ollama pull gemma3:4b
 
 > **⚠️ Known issue:** The `@elizaos/plugin-ollama` has an SDK version incompatibility with the current AI SDK. Use Ollama's **OpenAI-compatible endpoint** as a workaround:
 
-Edit `~/.eliza/eliza.json`:
+Edit `~/.milady/milady.json`:
 
 ```json5
 {

--- a/docs/agents/memory-and-state.md
+++ b/docs/agents/memory-and-state.md
@@ -74,7 +74,7 @@ A full `connectionString` can be used instead of individual fields:
 nomic-embed-text-v1.5.Q5_K_M.gguf
 ```
 
-Models are stored in `~/.eliza/models/` by default.
+Models are stored in `~/.milady/models/` by default.
 
 ### Embedding Configuration
 

--- a/docs/cli/configure.md
+++ b/docs/cli/configure.md
@@ -52,7 +52,7 @@ Common environment variables:
 
 ## Common Environment Variables
 
-The following environment variables configure AI model provider access. Set them in your shell profile (e.g. `~/.zshrc` or `~/.bashrc`) or in a `.env` file in your working directory.
+The following environment variables configure AI model provider access. Set them in your shell profile (e.g. `~/.zshrc` or `~/.bashrc`), in `~/.milady/.env`, or in a `.env` file in your working directory.
 
 | Environment Variable | Provider |
 |---------------------|----------|
@@ -60,6 +60,15 @@ The following environment variables configure AI model provider access. Set them
 | `OPENAI_API_KEY` | OpenAI (GPT) |
 | `AI_GATEWAY_API_KEY` | Vercel AI Gateway |
 | `GOOGLE_API_KEY` | Google (Gemini) |
+| `GROQ_API_KEY` | Groq |
+| `XAI_API_KEY` | xAI (Grok) |
+| `OPENROUTER_API_KEY` | OpenRouter |
+| `DEEPSEEK_API_KEY` | DeepSeek |
+| `TOGETHER_API_KEY` | Together AI |
+| `MISTRAL_API_KEY` | Mistral |
+| `COHERE_API_KEY` | Cohere |
+| `PERPLEXITY_API_KEY` | Perplexity |
+| `OLLAMA_BASE_URL` | Ollama (local, no API key) |
 
 For a complete list of supported providers and their environment variables, see [milady models](/cli/models) and [Environment Variables](/cli/environment).
 

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -24,11 +24,11 @@ A plugin is a self-contained module that registers one or more of:
 </Card>
 
 <Card title="Model Providers" icon="brain" href="/plugin-registry/llm/openai">
-  LLM integrations for OpenAI, Anthropic, Google Gemini, Google Antigravity, Groq, Ollama, OpenRouter, DeepSeek, xAI, Mistral, Cohere, Together, Qwen, Minimax, Pi AI, Perplexity, Zai, and Vercel AI Gateway.
+  LLM integrations for OpenAI, Anthropic, Google Gemini, Google Antigravity, Groq, Ollama, OpenRouter, DeepSeek, xAI, Mistral, Cohere, Together, Qwen, Minimax, Pi AI, Perplexity, Zai, Vercel AI Gateway, and Eliza Cloud.
 </Card>
 
 <Card title="Platform Connectors" icon="plug" href="/plugin-registry/platform/discord">
-  Bridges to 30+ messaging platforms — Discord, Telegram, Twitter, Slack, WhatsApp, Signal, iMessage, BlueBubbles, Blooio, MS Teams, Google Chat, Mattermost, Farcaster, Bluesky, Instagram, Twitch, WeChat, Feishu, Matrix, Nostr, LINE, Zalo, Twilio, GitHub, Gmail Watch, Nextcloud Talk, Tlon, Lens, Retake, and more.
+  Bridges to 19 messaging platforms — Discord, Telegram, Twitter, Slack, WhatsApp, Signal, iMessage, BlueBubbles, Blooio, MS Teams, Google Chat, Mattermost, Farcaster, Twitch, WeChat, Feishu, Matrix, Nostr, Lens, and Retake.
 </Card>
 
 <Card title="DeFi & Blockchain" icon="wallet" href="/plugin-registry/defi/evm">

--- a/docs/runtime/memory.md
+++ b/docs/runtime/memory.md
@@ -63,7 +63,7 @@ For production or shared deployments, set `database.provider = "postgres"`. The 
 ```
 nomic-embed-text-v1.5.Q5_K_M.gguf
 Dimensions: 768
-Model directory: ~/.eliza/models/
+Model directory: ~/.milady/models/
 ```
 
 ### Environment Variables
@@ -78,7 +78,7 @@ The embedding plugin reads configuration from environment variables set by `conf
 | `LOCAL_EMBEDDING_CONTEXT_SIZE` | auto | Context window size |
 | `LOCAL_EMBEDDING_GPU_LAYERS` | `"auto"` (Apple Silicon) / `"0"` (other) | GPU acceleration |
 | `LOCAL_EMBEDDING_USE_MMAP` | `"false"` (Apple Silicon) / `"true"` (other) | Memory-mapped model loading |
-| `MODELS_DIR` | `~/.eliza/models` | Directory for model storage |
+| `MODELS_DIR` | `~/.milady/models` | Directory for model storage |
 
 ## Memory Config
 

--- a/packages/agent/src/config/plugin-auto-enable.ts
+++ b/packages/agent/src/config/plugin-auto-enable.ts
@@ -46,7 +46,7 @@ export const STREAMING_PLUGINS: Record<string, string> = {
 
 const PROVIDER_PLUGINS: Record<string, string> = {
   "google-antigravity": "@elizaos/plugin-google-antigravity",
-  "google-gemini": "@elizaos/plugin-google-gemini",
+  "google-genai": "@elizaos/plugin-google-genai",
   "vercel-ai-gateway": "@elizaos/plugin-vercel-ai-gateway",
   openai: "@elizaos/plugin-openai",
   anthropic: "@elizaos/plugin-anthropic",
@@ -71,8 +71,8 @@ export const AUTH_PROVIDER_PLUGINS: Record<string, string> = {
   OPENAI_API_KEY: "@elizaos/plugin-openai",
   AI_GATEWAY_API_KEY: "@elizaos/plugin-vercel-ai-gateway",
   AIGATEWAY_API_KEY: "@elizaos/plugin-vercel-ai-gateway",
-  GOOGLE_API_KEY: "@elizaos/plugin-google-gemini",
-  GOOGLE_GENERATIVE_AI_API_KEY: "@elizaos/plugin-google-gemini",
+  GOOGLE_API_KEY: "@elizaos/plugin-google-genai",
+  GOOGLE_GENERATIVE_AI_API_KEY: "@elizaos/plugin-google-genai",
   GOOGLE_CLOUD_API_KEY: "@elizaos/plugin-google-antigravity",
   GROQ_API_KEY: "@elizaos/plugin-groq",
   XAI_API_KEY: "@elizaos/plugin-xai",

--- a/packages/app-core/src/cli/program/register.configure.ts
+++ b/packages/app-core/src/cli/program/register.configure.ts
@@ -12,12 +12,12 @@ export function registerConfigureCommand(program: Command) {
         `\n${theme.muted("Docs:")} ${formatDocsLink("/configuration", "docs.eliza.ai/configuration")}\n`,
     )
     .action(() => {
-      console.log(`\n${theme.heading("Eliza Configuration")}\n`);
+      console.log(`\n${theme.heading("Milady Configuration")}\n`);
       console.log("Set values with:");
       console.log(
-        `  ${theme.command("eliza config get <key>")}     Read a config value`,
+        `  ${theme.command("milady config get <key>")}     Read a config value`,
       );
-      console.log(`  Edit ~/.eliza/eliza.json directly for full control.\n`);
+      console.log(`  Edit ~/.milady/milady.json directly for full control.\n`);
       console.log("Common environment variables:");
       console.log(
         `  ${theme.command("ANTHROPIC_API_KEY")}    Anthropic (Claude)`,
@@ -27,7 +27,7 @@ export function registerConfigureCommand(program: Command) {
         `  ${theme.command("AI_GATEWAY_API_KEY")}   Vercel AI Gateway`,
       );
       console.log(
-        `  ${theme.command("GEMINI_API_KEY")}       Google (Gemini)\n`,
+        `  ${theme.command("GOOGLE_API_KEY")}       Google (Gemini)\n`,
       );
     });
 }


### PR DESCRIPTION
- Fix ~/.eliza/eliza.json → ~/.milady/milady.json in CLAUDE.md, README.md, and runtime docs (namespace is "milady" via run-node.mjs)
- Fix google-gemini → google-genai in plugin-auto-enable.ts to match actual npm package @elizaos/plugin-google-genai
- Fix register.configure.ts: eliza → milady branding, GEMINI → GOOGLE_API_KEY
- Remove non-existent --headless CLI flag from README.md
- Correct "30+" platform count to 19 in plugins overview
- Add missing model providers to cli/configure.md env var table

https://claude.ai/code/session_01Lzi799fRZifbvsG3oejHx7

This PR will be reviewed by an AI agent. Provide clear context to help it assess your changes.

Aesthetic/UI changes that don't improve agent capability are out of scope and will be rejected.

## Category
- [ ] Bug fix
- [ ] Security fix
- [ ] Performance improvement
- [ ] New feature
- [ ] Documentation
- [ ] Test coverage
- [ ] Other

## What
(brief description)

## Why
(motivation)

## How
(implementation approach)

## Testing
(what was tested, how to verify)
