### PR TITLE
docs: fix project paths, add missing connector pages, update plugin c…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,11 +23,13 @@
 
 ## Project Structure
 
-- **Source code:** `src/` — runtime in `src/runtime/`, CLI wiring in `src/cli/`, config in `src/config/`, providers in `src/providers/`, hooks in `src/hooks/`, utils in `src/utils/`, types in `src/types/`
+- **Source code:** `packages/app-core/src/` — runtime in `src/runtime/`, CLI wiring in `src/cli/`, config in `src/config/`, API in `src/api/`, connectors in `src/connectors/`, providers in `src/providers/`, hooks in `src/hooks/`, utils in `src/utils/`, types in `src/types/`
+- **Agent upstream:** `packages/agent/` — elizaOS agent runtime, core plugins, plugin auto-enable maps
 - **Tests:** colocated `*.test.ts` alongside source files
 - **Build output:** `dist/` (via `tsdown`)
-- **Entry points:** `src/entry.ts` (CLI), `src/index.ts` (library), `src/runtime/eliza.ts` (elizaOS runtime)
+- **Entry points:** `packages/app-core/src/entry.ts` (CLI), `packages/app-core/src/index.ts` (library), `packages/app-core/src/runtime/eliza.ts` (elizaOS runtime)
 - **Apps:** `apps/app/` (Capacitor mobile/desktop, includes React UI), `apps/chrome-extension/`
+- **Internal packages:** `packages/ui/`, `packages/shared/`, `packages/vrm-utils/`, `packages/plugin-wechat/`
 - **Deployment:** `deploy/` (Docker configs)
 - **Scripts:** `scripts/` (build, dev, release tooling)
 - **Tests:** `test/` (setup, helpers, mocks, e2e scripts)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,18 +35,26 @@ bun run db:check     # database security + readonly tests
 ## Project Layout
 
 ```
-src/
-  entry.ts              CLI bootstrap (env, log level)
-  cli/                  Commander CLI (milady command)
-  runtime/
-    eliza.ts            Agent loader — sets NODE_PATH, loads plugins dynamically
-    dev-server.ts       Dev mode entry point (started by dev-ui.mjs)
-  api/                  Dashboard API (port 31337 in dev, 2138 in prod)
-  plugins/              Milady-specific plugins
-  services/             Business logic
+packages/
+  app-core/             Main application package (source of truth for runtime)
+    src/
+      entry.ts          CLI bootstrap (env, log level)
+      cli/              Commander CLI (milady command)
+      runtime/
+        eliza.ts        Agent loader — sets NODE_PATH, loads plugins dynamically
+        dev-server.ts   Dev mode entry point (started by dev-ui.mjs)
+      api/              Dashboard API (port 31337 in dev, 2138 in prod)
+      config/           Plugin auto-enable, config schemas
+      connectors/       Connector integration code
+      services/         Business logic
+  agent/                Upstream elizaOS agent (core plugins, auto-enable maps)
+  plugin-wechat/        WeChat connector plugin (@miladyai/plugin-wechat)
+  ui/                   Shared UI component library
+  shared/               Shared utilities
+  vrm-utils/            VRM avatar utilities
 apps/
   app/                  Main web + desktop UI (Vite + React)
-  home/                 Home dashboard
+    electrobun/         Electrobun desktop shell
   homepage/             Marketing site
 scripts/
   dev-ui.mjs            Dev orchestrator (API + Vite)
@@ -54,15 +62,13 @@ scripts/
   run-repo-setup.mjs    Postinstall sequencer
   setup-eliza-workspace.mjs   Clone + link ../eliza packages
   patch-deps.mjs        Post-install patches for broken upstream exports
-plugins/                Workspace plugins (plugin-*)
-packages/               Internal packages
 ```
 
 ## Key Architecture Decisions
 
 ### NODE_PATH (do not remove)
 Dynamic plugin imports (`import("@elizaos/plugin-foo")`) need NODE_PATH set to the repo root's `node_modules`. This is set in three places — all three are required:
-1. `src/runtime/eliza.ts` — module-level, before dynamic imports
+1. `packages/agent/src/runtime/eliza.ts` — module-level, before dynamic imports
 2. `scripts/run-node.mjs` — child process env
 3. `apps/app/electrobun/src/native/agent.ts` — Electrobun main process
 

--- a/docs/connectors/bluesky.md
+++ b/docs/connectors/bluesky.md
@@ -1,0 +1,60 @@
+---
+title: Bluesky Connector
+sidebarTitle: Bluesky
+description: Connect your agent to Bluesky using the @elizaos/plugin-bluesky package.
+---
+
+Connect your agent to Bluesky for social posting and engagement on the AT Protocol network.
+
+## Overview
+
+The Bluesky connector is an elizaOS plugin that bridges your agent to Bluesky via the AT Protocol. It supports automated posting, mention monitoring, and reply handling. This connector is available from the plugin registry.
+
+## Package Info
+
+| Field | Value |
+|-------|-------|
+| Package | `@elizaos/plugin-bluesky` |
+| Config key | `connectors.bluesky` |
+| Install | `milady plugins install bluesky` |
+
+## Setup Requirements
+
+- Bluesky account credentials (handle and app password)
+- Generate an app password at [bsky.app/settings/app-passwords](https://bsky.app/settings/app-passwords)
+
+## Configuration
+
+```json
+{
+  "connectors": {
+    "bluesky": {
+      "enabled": true,
+      "postEnable": true,
+      "postIntervalMin": 90,
+      "postIntervalMax": 180
+    }
+  }
+}
+```
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `BLUESKY_USERNAME` | Bluesky username/email |
+| `BLUESKY_PASSWORD` | App password (not your main password) |
+| `BLUESKY_HANDLE` | Bluesky handle (e.g., `yourname.bsky.social`) |
+| `BLUESKY_ENABLED` | Set to `true` to enable |
+| `BLUESKY_DRY_RUN` | Set to `true` for testing without posting |
+
+## Features
+
+- Post creation at configurable intervals
+- Mention and reply monitoring
+- Dry run mode for testing
+- AT Protocol-based decentralized social networking
+
+## Related
+
+- [Connectors overview](/guides/connectors#bluesky)

--- a/docs/connectors/github.md
+++ b/docs/connectors/github.md
@@ -1,0 +1,54 @@
+---
+title: GitHub Connector
+sidebarTitle: GitHub
+description: Connect your agent to GitHub using the @elizaos/plugin-github package.
+---
+
+Connect your agent to GitHub for repository management, issue tracking, and pull request workflows.
+
+## Overview
+
+The GitHub connector is an elizaOS plugin that bridges your agent to the GitHub API. It supports repository management, issue tracking, pull request creation and review, and code search. This connector is available from the plugin registry.
+
+## Package Info
+
+| Field | Value |
+|-------|-------|
+| Package | `@elizaos/plugin-github` |
+| Config key | `connectors.github` |
+| Install | `milady plugins install github` |
+
+## Setup Requirements
+
+- GitHub API token (personal access token or fine-grained token)
+
+## Configuration
+
+```json
+{
+  "connectors": {
+    "github": {
+      "enabled": true
+    }
+  }
+}
+```
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `GITHUB_API_TOKEN` | Personal access token or fine-grained token |
+| `GITHUB_OWNER` | Default repository owner |
+| `GITHUB_REPO` | Default repository name |
+
+## Features
+
+- Repository management
+- Issue tracking and creation
+- Pull request workflows (create, review, merge)
+- Code search and file access
+
+## Related
+
+- [Connectors overview](/guides/connectors#github)

--- a/docs/connectors/gmail-watch.md
+++ b/docs/connectors/gmail-watch.md
@@ -1,0 +1,46 @@
+---
+title: Gmail Watch Connector
+sidebarTitle: Gmail Watch
+description: Monitor Gmail inboxes using the @elizaos/plugin-gmail-watch package.
+---
+
+Monitor Gmail inboxes for incoming messages using Pub/Sub.
+
+## Overview
+
+The Gmail Watch connector is an elizaOS plugin that monitors Gmail inboxes via Google Cloud Pub/Sub. It watches for new messages and triggers agent events. This connector is enabled via feature flags rather than the `connectors` section. Available from the plugin registry.
+
+## Package Info
+
+| Field | Value |
+|-------|-------|
+| Package | `@elizaos/plugin-gmail-watch` |
+| Feature flag | `features.gmailWatch` |
+| Install | `milady plugins install gmail-watch` |
+
+## Setup Requirements
+
+- Google Cloud service account or OAuth credentials with Gmail API access
+- Pub/Sub topic configured for Gmail push notifications
+
+## Configuration
+
+Gmail Watch is enabled via the `features` section:
+
+```json
+{
+  "features": {
+    "gmailWatch": true
+  }
+}
+```
+
+## Features
+
+- Gmail Pub/Sub message watching
+- Auto-renewal of watch subscriptions
+- Inbound email event handling
+
+## Related
+
+- [Connectors overview](/guides/connectors#gmail-watch)

--- a/docs/connectors/instagram.md
+++ b/docs/connectors/instagram.md
@@ -1,0 +1,58 @@
+---
+title: Instagram Connector
+sidebarTitle: Instagram
+description: Connect your agent to Instagram using the @elizaos/plugin-instagram package.
+---
+
+Connect your agent to Instagram for media posting, comment monitoring, and DM handling.
+
+## Overview
+
+The Instagram connector is an elizaOS plugin that bridges your agent to Instagram. It supports media posting with caption generation, comment response, and direct message handling. This connector is available from the plugin registry.
+
+## Package Info
+
+| Field | Value |
+|-------|-------|
+| Package | `@elizaos/plugin-instagram` |
+| Config key | `connectors.instagram` |
+| Install | `milady plugins install instagram` |
+
+## Setup Requirements
+
+- Instagram account credentials (username and password)
+
+## Configuration
+
+```json
+{
+  "connectors": {
+    "instagram": {
+      "enabled": true
+    }
+  }
+}
+```
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `INSTAGRAM_USERNAME` | Instagram username |
+| `INSTAGRAM_PASSWORD` | Instagram password |
+| `INSTAGRAM_DRY_RUN` | Set to `true` for testing without posting |
+| `INSTAGRAM_POLL_INTERVAL` | Polling interval in ms |
+| `INSTAGRAM_POST_INTERVAL_MIN` | Min seconds between posts |
+| `INSTAGRAM_POST_INTERVAL_MAX` | Max seconds between posts |
+
+## Features
+
+- Media posting with caption generation
+- Comment monitoring and response
+- DM handling
+- Dry run mode for testing
+- Configurable posting and polling intervals
+
+## Related
+
+- [Connectors overview](/guides/connectors#instagram)

--- a/docs/connectors/line.md
+++ b/docs/connectors/line.md
@@ -1,0 +1,56 @@
+---
+title: LINE Connector
+sidebarTitle: LINE
+description: Connect your agent to LINE using the @elizaos/plugin-line package.
+---
+
+Connect your agent to LINE for bot messaging and customer conversations.
+
+## Overview
+
+The LINE connector is an elizaOS plugin that bridges your agent to LINE Messaging API. It supports rich message types, group chat, and webhook-based event handling. This connector is available from the plugin registry.
+
+## Package Info
+
+| Field | Value |
+|-------|-------|
+| Package | `@elizaos/plugin-line` |
+| Config key | `connectors.line` |
+| Install | `milady plugins install line` |
+
+## Setup Requirements
+
+- LINE Channel access token
+- LINE Channel secret
+- Create a Messaging API channel at [developers.line.biz](https://developers.line.biz)
+
+## Configuration
+
+```json
+{
+  "connectors": {
+    "line": {
+      "enabled": true
+    }
+  }
+}
+```
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `LINE_CHANNEL_ACCESS_TOKEN` | Channel access token from LINE Developer Console |
+| `LINE_CHANNEL_SECRET` | Channel secret for webhook verification |
+| `LINE_CUSTOM_GREETING` | Custom greeting message for new users |
+
+## Features
+
+- Bot messaging and customer conversations
+- Rich message types (text, sticker, image, video)
+- Group chat support
+- Webhook-based event handling
+
+## Related
+
+- [Connectors overview](/guides/connectors#line)

--- a/docs/connectors/nextcloud-talk.md
+++ b/docs/connectors/nextcloud-talk.md
@@ -1,0 +1,45 @@
+---
+title: Nextcloud Talk Connector
+sidebarTitle: Nextcloud Talk
+description: Connect your agent to Nextcloud Talk using the @elizaos/plugin-nextcloud-talk package.
+---
+
+Connect your agent to Nextcloud Talk for self-hosted collaboration messaging.
+
+## Overview
+
+The Nextcloud Talk connector is an elizaOS plugin that bridges your agent to Nextcloud Talk rooms. It supports DM and group conversations on self-hosted Nextcloud instances. This connector is available from the plugin registry.
+
+## Package Info
+
+| Field | Value |
+|-------|-------|
+| Package | `@elizaos/plugin-nextcloud-talk` |
+| Config key | `connectors.nextcloud-talk` |
+| Install | `milady plugins install nextcloud-talk` |
+
+## Setup Requirements
+
+- Nextcloud server URL and credentials
+
+## Configuration
+
+```json
+{
+  "connectors": {
+    "nextcloud-talk": {
+      "enabled": true
+    }
+  }
+}
+```
+
+## Features
+
+- Room-based messaging
+- DM and group conversation support
+- Self-hosted collaboration platform integration
+
+## Related
+
+- [Connectors overview](/guides/connectors#nextcloud-talk)

--- a/docs/connectors/tlon.md
+++ b/docs/connectors/tlon.md
@@ -1,0 +1,53 @@
+---
+title: Tlon Connector
+sidebarTitle: Tlon
+description: Connect your agent to Tlon/Urbit using the @elizaos/plugin-tlon package.
+---
+
+Connect your agent to the Urbit network via Tlon for ship-to-ship messaging.
+
+## Overview
+
+The Tlon connector is an elizaOS plugin that bridges your agent to the Urbit network. It supports ship-to-ship messaging and group chat participation. This connector is available from the plugin registry.
+
+## Package Info
+
+| Field | Value |
+|-------|-------|
+| Package | `@elizaos/plugin-tlon` |
+| Config key | `connectors.tlon` |
+| Install | `milady plugins install tlon` |
+
+## Setup Requirements
+
+- Tlon ship credentials (Urbit ship name and access code)
+
+## Configuration
+
+```json
+{
+  "connectors": {
+    "tlon": {
+      "enabled": true
+    }
+  }
+}
+```
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `TLON_SHIP` | Urbit ship name |
+| `TLON_CODE` | Ship access code |
+| `TLON_URL` | Ship URL |
+
+## Features
+
+- Urbit-based chat and social interactions
+- Ship-to-ship messaging
+- Group chat participation
+
+## Related
+
+- [Connectors overview](/guides/connectors#tlon)

--- a/docs/connectors/twilio.md
+++ b/docs/connectors/twilio.md
@@ -1,0 +1,54 @@
+---
+title: Twilio Connector
+sidebarTitle: Twilio
+description: Connect your agent to Twilio for SMS and voice using the @elizaos/plugin-twilio package.
+---
+
+Connect your agent to Twilio for SMS messaging and voice call capabilities.
+
+## Overview
+
+The Twilio connector is an elizaOS plugin that bridges your agent to Twilio's communication APIs. It supports inbound and outbound SMS, as well as voice call capabilities. This connector is available from the plugin registry.
+
+## Package Info
+
+| Field | Value |
+|-------|-------|
+| Package | `@elizaos/plugin-twilio` |
+| Config key | `connectors.twilio` |
+| Install | `milady plugins install twilio` |
+
+## Setup Requirements
+
+- Twilio Account SID and Auth Token
+- A Twilio phone number
+
+## Configuration
+
+```json
+{
+  "connectors": {
+    "twilio": {
+      "enabled": true
+    }
+  }
+}
+```
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `TWILIO_ACCOUNT_SID` | Twilio Account SID |
+| `TWILIO_AUTH_TOKEN` | Twilio Auth Token |
+| `TWILIO_PHONE_NUMBER` | Twilio phone number for sending/receiving |
+
+## Features
+
+- SMS messaging (send and receive)
+- Voice call capabilities
+- Webhook-based inbound message handling
+
+## Related
+
+- [Connectors overview](/guides/connectors#twilio)

--- a/docs/connectors/zalo.md
+++ b/docs/connectors/zalo.md
@@ -1,0 +1,54 @@
+---
+title: Zalo Connector
+sidebarTitle: Zalo
+description: Connect your agent to Zalo using the @elizaos/plugin-zalo package.
+---
+
+Connect your agent to Zalo for Official Account messaging and support workflows.
+
+## Overview
+
+The Zalo connector is an elizaOS plugin that bridges your agent to the Zalo platform via the Official Account API. This connector is available from the plugin registry. A personal-account variant is also available as `@elizaos/plugin-zalouser`.
+
+## Package Info
+
+| Field | Value |
+|-------|-------|
+| Package | `@elizaos/plugin-zalo` |
+| Config key | `connectors.zalo` |
+| Install | `milady plugins install zalo` |
+
+## Setup Requirements
+
+- Zalo Official Account (OA) access token
+
+## Configuration
+
+```json
+{
+  "connectors": {
+    "zalo": {
+      "enabled": true
+    }
+  }
+}
+```
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `ZALO_ACCESS_TOKEN` | OA access token |
+| `ZALO_REFRESH_TOKEN` | Token refresh credential |
+| `ZALO_APP_ID` | Application ID |
+| `ZALO_APP_SECRET` | Application secret |
+
+## Features
+
+- Official Account messaging and support workflows
+- Webhook-based message handling
+- Customer interaction management
+
+## Related
+
+- [Connectors overview](/guides/connectors#zalo)

--- a/docs/plugin-registry/platform/bluesky.md
+++ b/docs/plugin-registry/platform/bluesky.md
@@ -1,0 +1,66 @@
+---
+title: "Bluesky Plugin"
+sidebarTitle: "Bluesky"
+description: "Bluesky connector for Milady — post, reply, and interact on the AT Protocol network."
+---
+
+The Bluesky plugin connects Milady agents to the Bluesky social network via the AT Protocol, enabling posting, replying, and social interactions.
+
+**Package:** `@elizaos/plugin-bluesky`
+
+## Installation
+
+```bash
+milady plugins install bluesky
+```
+
+## Setup
+
+### 1. Get Your Bluesky Credentials
+
+1. Go to [bsky.app](https://bsky.app) and create an account (or use an existing one)
+2. Note your handle (e.g., `yourname.bsky.social`)
+3. Use your account username and password (or generate an app password in Settings → App Passwords)
+
+### 2. Configure Milady
+
+```json
+{
+  "connectors": {
+    "bluesky": {
+      "username": "YOUR_USERNAME",
+      "password": "YOUR_PASSWORD",
+      "handle": "YOUR_HANDLE"
+    }
+  }
+}
+```
+
+Or via environment variables:
+
+```bash
+export BLUESKY_USERNAME=YOUR_USERNAME
+export BLUESKY_PASSWORD=YOUR_PASSWORD
+export BLUESKY_HANDLE=YOUR_HANDLE
+```
+
+## Configuration
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `username` | Yes | Bluesky account username |
+| `password` | Yes | Bluesky account password or app password |
+| `handle` | Yes | Bluesky handle (e.g., `yourname.bsky.social`) |
+| `enabled` | No | Set `false` to disable (default: `true`) |
+
+## Environment Variables
+
+```bash
+export BLUESKY_USERNAME=YOUR_USERNAME
+export BLUESKY_PASSWORD=YOUR_PASSWORD
+export BLUESKY_HANDLE=YOUR_HANDLE
+```
+
+## Related
+
+- [Connectors Guide](/guides/connectors) — General connector documentation

--- a/docs/plugin-registry/platform/github.md
+++ b/docs/plugin-registry/platform/github.md
@@ -1,0 +1,67 @@
+---
+title: "GitHub Plugin"
+sidebarTitle: "GitHub"
+description: "GitHub connector for Milady — interact with repositories, issues, and pull requests."
+---
+
+The GitHub plugin connects Milady agents to GitHub, enabling interactions with repositories, issues, pull requests, and other GitHub resources.
+
+**Package:** `@elizaos/plugin-github`
+
+## Installation
+
+```bash
+milady plugins install github
+```
+
+## Setup
+
+### 1. Create a GitHub Personal Access Token
+
+1. Go to [github.com/settings/tokens](https://github.com/settings/tokens)
+2. Click **Generate new token** (classic) or **Fine-grained token**
+3. Select the scopes needed for your use case (e.g., `repo`, `issues`, `pull_requests`)
+4. Copy the generated token
+
+### 2. Configure Milady
+
+```json
+{
+  "connectors": {
+    "github": {
+      "apiToken": "YOUR_API_TOKEN",
+      "owner": "YOUR_GITHUB_OWNER",
+      "repo": "YOUR_GITHUB_REPO"
+    }
+  }
+}
+```
+
+Or via environment variables:
+
+```bash
+export GITHUB_API_TOKEN=YOUR_API_TOKEN
+export GITHUB_OWNER=YOUR_GITHUB_OWNER
+export GITHUB_REPO=YOUR_GITHUB_REPO
+```
+
+## Configuration
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `apiToken` | Yes | GitHub personal access token |
+| `owner` | Yes | GitHub repository owner (user or organization) |
+| `repo` | Yes | GitHub repository name |
+| `enabled` | No | Set `false` to disable (default: `true`) |
+
+## Environment Variables
+
+```bash
+export GITHUB_API_TOKEN=YOUR_API_TOKEN
+export GITHUB_OWNER=YOUR_GITHUB_OWNER
+export GITHUB_REPO=YOUR_GITHUB_REPO
+```
+
+## Related
+
+- [Connectors Guide](/guides/connectors) — General connector documentation

--- a/docs/plugin-registry/platform/gmail-watch.md
+++ b/docs/plugin-registry/platform/gmail-watch.md
@@ -1,0 +1,51 @@
+---
+title: "Gmail Watch Plugin"
+sidebarTitle: "Gmail Watch"
+description: "Gmail Watch connector for Milady — monitor Gmail inboxes and respond to incoming emails."
+---
+
+The Gmail Watch plugin connects Milady agents to Gmail, enabling monitoring of incoming emails and automated responses.
+
+**Package:** `@elizaos/plugin-gmail-watch`
+
+## Installation
+
+```bash
+milady plugins install gmail-watch
+```
+
+## Setup
+
+### 1. Enable the Feature Flag
+
+The Gmail Watch plugin is activated via the `features.gmailWatch` flag in your Milady configuration:
+
+```json
+{
+  "features": {
+    "gmailWatch": true
+  }
+}
+```
+
+### 2. Configure Gmail API Access
+
+Follow the Google Cloud Console setup to enable the Gmail API and obtain OAuth credentials for your agent.
+
+## Configuration
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `features.gmailWatch` | Yes | Set `true` to enable the Gmail Watch plugin |
+
+```json
+{
+  "features": {
+    "gmailWatch": true
+  }
+}
+```
+
+## Related
+
+- [Connectors Guide](/guides/connectors) — General connector documentation

--- a/docs/plugin-registry/platform/instagram.md
+++ b/docs/plugin-registry/platform/instagram.md
@@ -1,0 +1,61 @@
+---
+title: "Instagram Plugin"
+sidebarTitle: "Instagram"
+description: "Instagram connector for Milady — interact with Instagram messaging and content."
+---
+
+The Instagram plugin connects Milady agents to Instagram, enabling message handling and content interactions.
+
+**Package:** `@elizaos/plugin-instagram`
+
+## Installation
+
+```bash
+milady plugins install instagram
+```
+
+## Setup
+
+### 1. Get Your Instagram Credentials
+
+1. Use your Instagram account username and password
+2. For automation, consider creating a dedicated account for your agent
+
+### 2. Configure Milady
+
+```json
+{
+  "connectors": {
+    "instagram": {
+      "username": "YOUR_USERNAME",
+      "password": "YOUR_PASSWORD"
+    }
+  }
+}
+```
+
+Or via environment variables:
+
+```bash
+export INSTAGRAM_USERNAME=YOUR_USERNAME
+export INSTAGRAM_PASSWORD=YOUR_PASSWORD
+```
+
+## Configuration
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `username` | Yes | Instagram account username |
+| `password` | Yes | Instagram account password |
+| `enabled` | No | Set `false` to disable (default: `true`) |
+
+## Environment Variables
+
+```bash
+export INSTAGRAM_USERNAME=YOUR_USERNAME
+export INSTAGRAM_PASSWORD=YOUR_PASSWORD
+```
+
+## Related
+
+- [Connectors Guide](/guides/connectors) — General connector documentation

--- a/docs/plugin-registry/platform/line.md
+++ b/docs/plugin-registry/platform/line.md
@@ -1,0 +1,64 @@
+---
+title: "LINE Plugin"
+sidebarTitle: "LINE"
+description: "LINE connector for Milady — bot integration with the LINE messaging platform."
+---
+
+The LINE plugin connects Milady agents to LINE as a bot, enabling message handling in chats and groups.
+
+**Package:** `@elizaos/plugin-line`
+
+## Installation
+
+```bash
+milady plugins install line
+```
+
+## Setup
+
+### 1. Create a LINE Messaging API Channel
+
+1. Go to [LINE Developers Console](https://developers.line.biz/console/)
+2. Create a new provider (or use an existing one)
+3. Create a new **Messaging API** channel
+4. Under the **Messaging API** tab, issue a **Channel access token**
+5. Note the **Channel secret** from the **Basic settings** tab
+
+### 2. Configure Milady
+
+```json
+{
+  "connectors": {
+    "line": {
+      "channelAccessToken": "YOUR_CHANNEL_ACCESS_TOKEN",
+      "channelSecret": "YOUR_CHANNEL_SECRET"
+    }
+  }
+}
+```
+
+Or via environment variables:
+
+```bash
+export LINE_CHANNEL_ACCESS_TOKEN=YOUR_CHANNEL_ACCESS_TOKEN
+export LINE_CHANNEL_SECRET=YOUR_CHANNEL_SECRET
+```
+
+## Configuration
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `channelAccessToken` | Yes | LINE Messaging API channel access token |
+| `channelSecret` | Yes | LINE channel secret |
+| `enabled` | No | Set `false` to disable (default: `true`) |
+
+## Environment Variables
+
+```bash
+export LINE_CHANNEL_ACCESS_TOKEN=YOUR_CHANNEL_ACCESS_TOKEN
+export LINE_CHANNEL_SECRET=YOUR_CHANNEL_SECRET
+```
+
+## Related
+
+- [Connectors Guide](/guides/connectors) — General connector documentation

--- a/docs/plugin-registry/platform/nextcloud-talk.md
+++ b/docs/plugin-registry/platform/nextcloud-talk.md
@@ -1,0 +1,56 @@
+---
+title: "Nextcloud Talk Plugin"
+sidebarTitle: "Nextcloud Talk"
+description: "Nextcloud Talk connector for Milady — bot integration with Nextcloud Talk chat."
+---
+
+The Nextcloud Talk plugin connects Milady agents to Nextcloud Talk, enabling message handling in Nextcloud Talk conversations.
+
+**Package:** `@elizaos/plugin-nextcloud-talk`
+
+## Installation
+
+```bash
+milady plugins install nextcloud-talk
+```
+
+## Setup
+
+### 1. Configure Your Nextcloud Instance
+
+1. Ensure Nextcloud Talk is installed and enabled on your Nextcloud instance
+2. Create a bot user or use an existing account for the agent
+3. Note the Nextcloud server URL and credentials
+
+### 2. Configure Milady
+
+```json
+{
+  "connectors": {
+    "nextcloud-talk": {
+      "enabled": true
+    }
+  }
+}
+```
+
+## Configuration
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `connectors.nextcloud-talk` | Yes | Config block for Nextcloud Talk |
+| `enabled` | No | Set `false` to disable (default: `true`) |
+
+```json
+{
+  "connectors": {
+    "nextcloud-talk": {
+      "enabled": true
+    }
+  }
+}
+```
+
+## Related
+
+- [Connectors Guide](/guides/connectors) — General connector documentation

--- a/docs/plugin-registry/platform/tlon.md
+++ b/docs/plugin-registry/platform/tlon.md
@@ -1,0 +1,67 @@
+---
+title: "Tlon Plugin"
+sidebarTitle: "Tlon"
+description: "Tlon connector for Milady — bot integration with the Tlon (Urbit) messaging platform."
+---
+
+The Tlon plugin connects Milady agents to Tlon (Urbit), enabling message handling through a connected Urbit ship.
+
+**Package:** `@elizaos/plugin-tlon`
+
+## Installation
+
+```bash
+milady plugins install tlon
+```
+
+## Setup
+
+### 1. Get Your Urbit Ship Credentials
+
+1. Have a running Urbit ship (planet, star, or comet)
+2. Note the ship name (e.g., `~zod`)
+3. Obtain the access code from your ship's web interface (Settings → Access Key)
+4. Note the ship's URL (e.g., `http://localhost:8080`)
+
+### 2. Configure Milady
+
+```json
+{
+  "connectors": {
+    "tlon": {
+      "ship": "YOUR_SHIP",
+      "code": "YOUR_CODE",
+      "url": "YOUR_URL"
+    }
+  }
+}
+```
+
+Or via environment variables:
+
+```bash
+export TLON_SHIP=YOUR_SHIP
+export TLON_CODE=YOUR_CODE
+export TLON_URL=YOUR_URL
+```
+
+## Configuration
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `ship` | Yes | Urbit ship name (e.g., `~zod`) |
+| `code` | Yes | Urbit ship access code |
+| `url` | Yes | Urbit ship URL |
+| `enabled` | No | Set `false` to disable (default: `true`) |
+
+## Environment Variables
+
+```bash
+export TLON_SHIP=YOUR_SHIP
+export TLON_CODE=YOUR_CODE
+export TLON_URL=YOUR_URL
+```
+
+## Related
+
+- [Connectors Guide](/guides/connectors) — General connector documentation

--- a/docs/plugin-registry/platform/twilio.md
+++ b/docs/plugin-registry/platform/twilio.md
@@ -1,0 +1,66 @@
+---
+title: "Twilio Plugin"
+sidebarTitle: "Twilio"
+description: "Twilio connector for Milady — SMS and voice integration via the Twilio API."
+---
+
+The Twilio plugin connects Milady agents to Twilio, enabling SMS messaging and voice interactions through Twilio phone numbers.
+
+**Package:** `@elizaos/plugin-twilio`
+
+## Installation
+
+```bash
+milady plugins install twilio
+```
+
+## Setup
+
+### 1. Get Your Twilio Credentials
+
+1. Sign up at [twilio.com](https://www.twilio.com/)
+2. From the Twilio Console dashboard, copy your **Account SID** and **Auth Token**
+3. Purchase or configure a Twilio phone number
+
+### 2. Configure Milady
+
+```json
+{
+  "connectors": {
+    "twilio": {
+      "accountSid": "YOUR_ACCOUNT_SID",
+      "authToken": "YOUR_AUTH_TOKEN",
+      "phoneNumber": "YOUR_PHONE_NUMBER"
+    }
+  }
+}
+```
+
+Or via environment variables:
+
+```bash
+export TWILIO_ACCOUNT_SID=YOUR_ACCOUNT_SID
+export TWILIO_AUTH_TOKEN=YOUR_AUTH_TOKEN
+export TWILIO_PHONE_NUMBER=YOUR_PHONE_NUMBER
+```
+
+## Configuration
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `accountSid` | Yes | Twilio Account SID |
+| `authToken` | Yes | Twilio Auth Token |
+| `phoneNumber` | Yes | Twilio phone number (E.164 format) |
+| `enabled` | No | Set `false` to disable (default: `true`) |
+
+## Environment Variables
+
+```bash
+export TWILIO_ACCOUNT_SID=YOUR_ACCOUNT_SID
+export TWILIO_AUTH_TOKEN=YOUR_AUTH_TOKEN
+export TWILIO_PHONE_NUMBER=YOUR_PHONE_NUMBER
+```
+
+## Related
+
+- [Connectors Guide](/guides/connectors) — General connector documentation

--- a/docs/plugin-registry/platform/zalo.md
+++ b/docs/plugin-registry/platform/zalo.md
@@ -1,0 +1,70 @@
+---
+title: "Zalo Plugin"
+sidebarTitle: "Zalo"
+description: "Zalo connector for Milady — bot integration with the Zalo messaging platform."
+---
+
+The Zalo plugin connects Milady agents to Zalo, enabling message handling through the Zalo Official Account API.
+
+**Package:** `@elizaos/plugin-zalo`
+
+## Installation
+
+```bash
+milady plugins install zalo
+```
+
+## Setup
+
+### 1. Create a Zalo Official Account
+
+1. Go to the [Zalo Developers portal](https://developers.zalo.me/)
+2. Create an application and obtain your App ID and App Secret
+3. Generate an access token and refresh token for API access
+
+### 2. Configure Milady
+
+```json
+{
+  "connectors": {
+    "zalo": {
+      "accessToken": "YOUR_ACCESS_TOKEN",
+      "refreshToken": "YOUR_REFRESH_TOKEN",
+      "appId": "YOUR_APP_ID",
+      "appSecret": "YOUR_APP_SECRET"
+    }
+  }
+}
+```
+
+Or via environment variables:
+
+```bash
+export ZALO_ACCESS_TOKEN=YOUR_ACCESS_TOKEN
+export ZALO_REFRESH_TOKEN=YOUR_REFRESH_TOKEN
+export ZALO_APP_ID=YOUR_APP_ID
+export ZALO_APP_SECRET=YOUR_APP_SECRET
+```
+
+## Configuration
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `accessToken` | Yes | Zalo API access token |
+| `refreshToken` | Yes | Zalo API refresh token |
+| `appId` | Yes | Zalo application ID |
+| `appSecret` | Yes | Zalo application secret |
+| `enabled` | No | Set `false` to disable (default: `true`) |
+
+## Environment Variables
+
+```bash
+export ZALO_ACCESS_TOKEN=YOUR_ACCESS_TOKEN
+export ZALO_REFRESH_TOKEN=YOUR_REFRESH_TOKEN
+export ZALO_APP_ID=YOUR_APP_ID
+export ZALO_APP_SECRET=YOUR_APP_SECRET
+```
+
+## Related
+
+- [Connectors Guide](/guides/connectors) — General connector documentation

--- a/docs/plugins/architecture.md
+++ b/docs/plugins/architecture.md
@@ -18,7 +18,7 @@ AgentRuntime
 └── Local            (from plugins/ directory)
 ```
 
-The source of truth for which plugins are always loaded lives in `src/runtime/core-plugins.ts`:
+The source of truth for which plugins are always loaded lives in `packages/agent/src/runtime/core-plugins.ts` (re-exported by `packages/app-core/src/runtime/core-plugins.ts`):
 
 ```typescript
 export const CORE_PLUGINS: readonly string[] = [
@@ -38,7 +38,7 @@ export const CORE_PLUGINS: readonly string[] = [
 
 ### Optional Core Plugins
 
-A separate list of optional core plugins can be enabled from the admin panel. These are not loaded by default due to packaging or specification constraints. The list lives in `src/runtime/core-plugins.ts`:
+A separate list of optional core plugins can be enabled from the admin panel. These are not loaded by default due to packaging or specification constraints. The list lives in `packages/agent/src/runtime/core-plugins.ts`:
 
 ```typescript
 export const OPTIONAL_CORE_PLUGINS: readonly string[] = [
@@ -117,7 +117,7 @@ interface Plugin {
 
 ## Auto-Enable Mechanism
 
-Plugins are automatically enabled when their required configuration is detected. This logic lives in `src/config/plugin-auto-enable.ts` and runs before runtime initialization.
+Plugins are automatically enabled when their required configuration is detected. This logic lives in `packages/agent/src/config/plugin-auto-enable.ts` (extended by `packages/app-core/src/config/plugin-auto-enable.ts` for Milady-specific connectors like WeChat) and runs before runtime initialization.
 
 ### Trigger Sources
 
@@ -178,8 +178,11 @@ const CONNECTOR_PLUGINS = {
   retake:      "@elizaos/plugin-retake",
   blooio:      "@elizaos/plugin-blooio",
   twitch:      "@elizaos/plugin-twitch",
+  wechat:      "@miladyai/plugin-wechat",  // Milady-specific (added in app-core)
 };
 ```
+
+> **Note:** The upstream `packages/agent` defines all `@elizaos/*` connectors. Milady's `packages/app-core` extends this map with the `wechat` entry pointing to `@miladyai/plugin-wechat`.
 
 **Feature flags** — The `features` section of `milady.json` auto-enables feature plugins. A feature can be enabled with `features.<name>: true` or `features.<name>.enabled: true`:
 

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -28,7 +28,7 @@ A plugin is a self-contained module that registers one or more of:
 </Card>
 
 <Card title="Platform Connectors" icon="plug" href="/plugin-registry/platform/discord">
-  Bridges to 19 messaging platforms — Discord, Telegram, Twitter, Slack, WhatsApp, Signal, iMessage, BlueBubbles, Blooio, MS Teams, Google Chat, Mattermost, Farcaster, Twitch, WeChat, Feishu, Matrix, Nostr, Lens, and Retake.
+  Bridges to 30+ messaging platforms — Discord, Telegram, Twitter, Slack, WhatsApp, Signal, iMessage, BlueBubbles, Blooio, MS Teams, Google Chat, Mattermost, Farcaster, Bluesky, Instagram, Twitch, WeChat, Feishu, Matrix, Nostr, Lens, LINE, Zalo, Twilio, GitHub, Gmail Watch, Nextcloud Talk, Tlon, Retake, and more.
 </Card>
 
 <Card title="DeFi & Blockchain" icon="wallet" href="/plugin-registry/defi/evm">
@@ -36,7 +36,7 @@ A plugin is a self-contained module that registers one or more of:
 </Card>
 
 <Card title="Feature Plugins" icon="wand-magic-sparkles" href="/plugin-registry/browser">
-  Extended capabilities — browser control, image generation, text-to-speech, speech-to-text, computer use, cron scheduling, vision, shell, webhooks, FAL media generation, Suno music, and more.
+  Extended capabilities — browser control, image generation, text-to-speech, speech-to-text, computer use, cron scheduling, vision, shell, webhooks, FAL media generation, Suno music, OpenTelemetry diagnostics, x402 payments, and more.
 </Card>
 
 </CardGroup>
@@ -47,7 +47,7 @@ Plugins are loaded during runtime initialization in this order:
 
 1. **Milady plugin** — The bridge plugin (`createMiladyPlugin()`) providing workspace context, session keys, emotes, custom actions, and lifecycle actions. Always first in the plugins array.
 2. **Pre-registered plugins** — `@elizaos/plugin-sql` and `@elizaos/plugin-local-embedding` are pre-registered before `runtime.initialize()` to prevent race conditions.
-3. **Core plugins** — Always loaded: `sql`, `local-embedding`, `form`, `knowledge`, `trajectory-logger`, `agent-orchestrator`, `cron`, `shell`, `agent-skills` (see `src/runtime/core-plugins.ts`). Additional plugins like `pdf`, `browser`, `computeruse`, `obsidian`, `vision`, `edge-tts`, and `elevenlabs` are optional and loaded when their feature flags or environment variables are configured.
+3. **Core plugins** — Always loaded: `sql`, `local-embedding`, `form`, `knowledge`, `trajectory-logger`, `agent-orchestrator`, `cron`, `shell`, `agent-skills` (see `packages/agent/src/runtime/core-plugins.ts`). Additional plugins like `pdf`, `browser`, `computeruse`, `obsidian`, `code`, `repoprompt`, `claude-code-workbench`, `vision`, `cli`, `edge-tts`, and `elevenlabs` are optional and loaded when their feature flags or environment variables are configured.
 4. **Auto-enabled plugins** — Connector, provider, feature, and streaming plugins are auto-enabled based on config and environment variables (see [Architecture](/plugins/architecture) for the full maps).
 5. **Ejected plugins** — Local overrides discovered from `~/.milady/plugins/ejected/`. When an ejected copy exists, it takes priority over the npm-published version.
 6. **User-installed plugins** — Tracked in `plugins.installs` in `milady.json`. Collected before drop-in plugins; any plugin name already present here takes precedence.


### PR DESCRIPTION
…ounts

- Fix CLAUDE.md and AGENTS.md project layout to reflect actual monorepo structure (packages/app-core/src/ instead of top-level src/)
- Fix NODE_PATH reference to packages/agent/src/runtime/eliza.ts
- Update plugin overview connector count from 19 to 30+
- Add wechat to CONNECTOR_PLUGINS map in architecture docs
- Fix source file path references in plugin architecture docs
- Add 9 missing individual connector docs (Bluesky, Instagram, LINE, Zalo, Twilio, GitHub, Gmail Watch, Nextcloud Talk, Tlon)
- Add 9 corresponding plugin-registry platform pages

https://claude.ai/code/session_011vKDCknibvSp5YHvs9UndU

This PR will be reviewed by an AI agent. Provide clear context to help it assess your changes.

Aesthetic/UI changes that don't improve agent capability are out of scope and will be rejected.

## Category
- [ ] Bug fix
- [ ] Security fix
- [ ] Performance improvement
- [ ] New feature
- [ ] Documentation
- [ ] Test coverage
- [ ] Other

## What
(brief description)

## Why
(motivation)

## How
(implementation approach)

## Testing
(what was tested, how to verify)
