### PR TITLE
fix: homepage sign-in broken — bare domain redirect drops POST body

### DIFF
--- a/apps/homepage/src/App.tsx
+++ b/apps/homepage/src/App.tsx
@@ -135,7 +135,8 @@ function DownloadDropdown() {
         <ChevronDown />
       </button>
       {open && (
-        <div className="absolute bottom-full left-0 mb-2 w-72 border border-text-subtle/20 bg-dark/95 backdrop-blur-md z-[100]">
+        <div className="absolute bottom-full left-0 pb-2 w-72 z-[100]">
+        <div className="border border-text-subtle/20 bg-dark/95 backdrop-blur-md">
           {downloads.map((d) => (
             <a
               key={d.id}
@@ -164,6 +165,7 @@ function DownloadDropdown() {
               All Releases
             </span>
           </a>
+        </div>
         </div>
       )}
     </fieldset>

--- a/apps/homepage/src/App.tsx
+++ b/apps/homepage/src/App.tsx
@@ -136,36 +136,36 @@ function DownloadDropdown() {
       </button>
       {open && (
         <div className="absolute bottom-full left-0 pb-2 w-72 z-[100]">
-        <div className="border border-text-subtle/20 bg-dark/95 backdrop-blur-md">
-          {downloads.map((d) => (
+          <div className="border border-text-subtle/20 bg-dark/95 backdrop-blur-md">
+            {downloads.map((d) => (
+              <a
+                key={d.id}
+                href={d.url}
+                target="_blank"
+                rel="noreferrer"
+                className="flex items-center gap-3 px-4 py-3 hover:bg-white/5 transition-colors border-b border-text-subtle/10 last:border-b-0"
+              >
+                {platformIcon(d.id)}
+                <span className="flex-1 font-mono text-[11px] tracking-wider uppercase text-text-light">
+                  {d.label}
+                </span>
+                <span className="font-mono text-[10px] text-text-subtle">
+                  {d.sizeLabel}
+                </span>
+              </a>
+            ))}
             <a
-              key={d.id}
-              href={d.url}
+              href={releaseData.release.url}
               target="_blank"
               rel="noreferrer"
-              className="flex items-center gap-3 px-4 py-3 hover:bg-white/5 transition-colors border-b border-text-subtle/10 last:border-b-0"
+              className="flex items-center gap-3 px-4 py-3 hover:bg-white/5 transition-colors border-t border-text-subtle/20"
             >
-              {platformIcon(d.id)}
-              <span className="flex-1 font-mono text-[11px] tracking-wider uppercase text-text-light">
-                {d.label}
-              </span>
-              <span className="font-mono text-[10px] text-text-subtle">
-                {d.sizeLabel}
+              <GithubIcon />
+              <span className="font-mono text-[11px] tracking-wider uppercase text-text-muted">
+                All Releases
               </span>
             </a>
-          ))}
-          <a
-            href={releaseData.release.url}
-            target="_blank"
-            rel="noreferrer"
-            className="flex items-center gap-3 px-4 py-3 hover:bg-white/5 transition-colors border-t border-text-subtle/20"
-          >
-            <GithubIcon />
-            <span className="font-mono text-[11px] tracking-wider uppercase text-text-muted">
-              All Releases
-            </span>
-          </a>
-        </div>
+          </div>
         </div>
       )}
     </fieldset>

--- a/apps/homepage/src/__tests__/pricing-regression.test.tsx
+++ b/apps/homepage/src/__tests__/pricing-regression.test.tsx
@@ -1,0 +1,152 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentGrid } from "../components/dashboard/AgentGrid";
+import { CreateAgentForm } from "../components/dashboard/CreateAgentForm";
+import { CreditsPanel } from "../components/dashboard/CreditsPanel";
+import { CloudClient } from "../lib/cloud-api";
+
+const useAgentsMock = vi.fn();
+const useAuthMock = vi.fn();
+const useCloudLoginMock = vi.fn();
+
+vi.mock("../lib/AgentProvider", () => ({
+  useAgents: () => useAgentsMock(),
+}));
+
+vi.mock("../lib/useAuth", () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+vi.mock("../components/dashboard/useCloudLogin", () => ({
+  useCloudLogin: () => useCloudLoginMock(),
+}));
+
+describe("homepage pricing regression coverage", () => {
+  beforeEach(() => {
+    useAgentsMock.mockReturnValue({
+      agents: [],
+      filteredAgents: [],
+      loading: false,
+      isRefreshing: false,
+      error: null,
+      clearError: vi.fn(),
+      refresh: vi.fn(),
+    });
+    useAuthMock.mockReturnValue({
+      isAuthenticated: false,
+      token: null,
+      signOut: vi.fn(),
+    });
+    useCloudLoginMock.mockReturnValue({
+      error: null,
+      isAuthenticated: true,
+      manualLoginUrl: null,
+      signIn: vi.fn(),
+      state: "idle",
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders the credits panel pricing breakdown for hosted costs", async () => {
+    useAgentsMock.mockReturnValue({
+      agents: [
+        {
+          id: "cloud-1",
+          source: "cloud",
+          billing: { costPerHour: 0.01 },
+        },
+      ],
+    });
+    useAuthMock.mockReturnValue({
+      isAuthenticated: true,
+      token: "test-token",
+      signOut: vi.fn(),
+    });
+
+    vi.spyOn(CloudClient.prototype, "getCreditsBalance").mockResolvedValue({
+      balance: 500,
+      currency: "credits",
+    });
+    vi.spyOn(CloudClient.prototype, "getCurrentSession").mockResolvedValue({
+      credits: 12,
+      requests: 34,
+      tokens: 56,
+    });
+    vi.spyOn(CloudClient.prototype, "getBillingSettings").mockResolvedValue({
+      settings: {
+        autoTopUp: {
+          enabled: true,
+          hasPaymentMethod: true,
+          threshold: 5,
+          amount: 10,
+        },
+        limits: {
+          minAmount: 5,
+          maxAmount: 100,
+        },
+      },
+    });
+    vi.spyOn(CloudClient.prototype, "getCreditsSummary").mockResolvedValue({
+      organization: {
+        creditBalance: 500,
+        autoTopUpEnabled: true,
+        autoTopUpThreshold: 5,
+        autoTopUpAmount: 10,
+        hasPaymentMethod: true,
+      },
+      agentsSummary: {
+        total: 1,
+        totalAllocated: 25,
+        totalSpent: 10,
+        totalAvailable: 15,
+        withBudget: 1,
+        paused: 0,
+      },
+      pricing: {
+        creditsPerDollar: 100,
+        minimumTopUp: 5,
+      },
+    });
+
+    render(<CreditsPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText("PRICING")).toBeTruthy();
+    });
+
+    expect(screen.getByText("RUNNING AGENT")).toBeTruthy();
+    expect(screen.getByText("IDLE AGENT")).toBeTruthy();
+    expect(screen.getByText("CREDIT PACKS")).toBeTruthy();
+    expect(screen.getByText(/Minimum deposit: \$5\.00/)).toBeTruthy();
+    expect(screen.getByText("SMALL")).toBeTruthy();
+    expect(screen.getByText("MEDIUM")).toBeTruthy();
+    expect(screen.getByText("LARGE")).toBeTruthy();
+  });
+
+  it("shows the pricing note in the authenticated create form", () => {
+    render(<CreateAgentForm onCreated={vi.fn()} onCancel={vi.fn()} />);
+
+    expect(screen.getByText(/HOSTING/)).toBeTruthy();
+    expect(screen.getByText(/\$0\.01\/hr running/)).toBeTruthy();
+    expect(screen.getByText(/\$0\.0025\/hr idle/)).toBeTruthy();
+    expect(screen.getByText(/min\. balance \$5\.00/)).toBeTruthy();
+    expect(screen.getByText("DEPLOY")).toBeTruthy();
+  });
+
+  it("shows the pricing preview in the empty agents state", () => {
+    render(<AgentGrid />);
+
+    expect(screen.getByText("NO AGENTS FOUND")).toBeTruthy();
+    expect(screen.getByText("RUNNING")).toBeTruthy();
+    expect(screen.getByText("IDLE")).toBeTruthy();
+    expect(screen.getByText("MIN. DEPOSIT")).toBeTruthy();
+    expect(screen.getByText("$0.01/hr")).toBeTruthy();
+    expect(screen.getByText("$0.0025/hr")).toBeTruthy();
+    expect(screen.getByText("$5.00")).toBeTruthy();
+    expect(screen.getByText("+ CREATE CLOUD AGENT")).toBeTruthy();
+  });
+});

--- a/apps/homepage/src/components/dashboard/AgentGrid.tsx
+++ b/apps/homepage/src/components/dashboard/AgentGrid.tsx
@@ -322,13 +322,43 @@ function EmptyState({ onCreateClick }: { onCreateClick: () => void }) {
         <h3 className="font-mono text-sm text-text-light mb-2">
           NO AGENTS FOUND
         </h3>
-        <p className="font-mono text-xs text-text-muted max-w-sm mx-auto leading-relaxed mb-6">
+        <p className="font-mono text-xs text-text-muted max-w-sm mx-auto leading-relaxed mb-4">
           Start Milady locally to see your agents here.
           <br />
           {authed
             ? "Or create a cloud agent for hosted infrastructure."
             : "Sign in to Eliza Cloud for hosted options."}
         </p>
+
+        {/* Pricing preview */}
+        <div className="max-w-xs mx-auto mb-6">
+          <div className="grid grid-cols-3 gap-px bg-border-subtle text-center">
+            <div className="bg-dark-secondary/50 px-3 py-2.5">
+              <p className="font-mono text-[9px] tracking-wider text-text-subtle mb-1">
+                RUNNING
+              </p>
+              <p className="font-mono text-xs font-semibold text-brand tabular-nums">
+                $0.01/hr
+              </p>
+            </div>
+            <div className="bg-dark-secondary/50 px-3 py-2.5">
+              <p className="font-mono text-[9px] tracking-wider text-text-subtle mb-1">
+                IDLE
+              </p>
+              <p className="font-mono text-xs font-semibold text-text-light tabular-nums">
+                $0.0025/hr
+              </p>
+            </div>
+            <div className="bg-dark-secondary/50 px-3 py-2.5">
+              <p className="font-mono text-[9px] tracking-wider text-text-subtle mb-1">
+                MIN. DEPOSIT
+              </p>
+              <p className="font-mono text-xs font-semibold text-text-light tabular-nums">
+                $5.00
+              </p>
+            </div>
+          </div>
+        </div>
 
         <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
           <a

--- a/apps/homepage/src/components/dashboard/CreateAgentForm.tsx
+++ b/apps/homepage/src/components/dashboard/CreateAgentForm.tsx
@@ -521,6 +521,14 @@ export function CreateAgentForm({
           )}
         </div>
 
+        {/* Pricing note */}
+        <div className="mb-5 px-3 py-2.5 border-l-2 border-brand/30 bg-brand/5">
+          <p className="font-mono text-[10px] text-text-muted leading-relaxed">
+            <span className="text-brand">HOSTING</span> $0.01/hr running ·
+            $0.0025/hr idle · min. balance $5.00
+          </p>
+        </div>
+
         {/* Error message */}
         {error && (
           <div className="mb-5 font-mono text-sm text-red-400">

--- a/apps/homepage/src/components/dashboard/CreditsPanel.tsx
+++ b/apps/homepage/src/components/dashboard/CreditsPanel.tsx
@@ -133,6 +133,93 @@ export function CreditsPanel() {
         </p>
       </div>
 
+      {/* Pricing breakdown */}
+      <div className="border border-border bg-surface">
+        <div className="px-4 py-2 bg-dark-secondary border-b border-border flex items-center justify-between">
+          <span className="font-mono text-[10px] tracking-wider text-text-subtle">
+            PRICING
+          </span>
+          <span className="font-mono text-[10px] tracking-wider text-text-subtle">
+            $ milady pricing --show
+          </span>
+        </div>
+        <div className="p-4 space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <p className="font-mono text-[9px] tracking-wider text-text-subtle mb-1.5">
+                RUNNING AGENT
+              </p>
+              <p className="font-mono text-lg font-semibold text-brand tabular-nums">
+                $0.01
+                <span className="text-xs font-normal text-text-muted">/hr</span>
+              </p>
+              <p className="font-mono text-[10px] text-text-subtle mt-0.5">
+                ≈ $7.20/month
+              </p>
+            </div>
+            <div>
+              <p className="font-mono text-[9px] tracking-wider text-text-subtle mb-1.5">
+                IDLE AGENT
+              </p>
+              <p className="font-mono text-lg font-semibold text-text-light tabular-nums">
+                $0.0025
+                <span className="text-xs font-normal text-text-muted">/hr</span>
+              </p>
+              <p className="font-mono text-[10px] text-text-subtle mt-0.5">
+                ≈ $1.80/month
+              </p>
+            </div>
+          </div>
+
+          <div className="border-t border-border-subtle" />
+
+          <div>
+            <p className="font-mono text-[9px] tracking-wider text-text-subtle mb-3">
+              CREDIT PACKS
+            </p>
+            <div className="grid grid-cols-3 gap-3">
+              <div className="border border-border-subtle bg-dark p-3">
+                <p className="font-mono text-[9px] tracking-wider text-text-subtle mb-1">
+                  SMALL
+                </p>
+                <p className="font-mono text-sm font-semibold text-text-light tabular-nums">
+                  $5
+                </p>
+                <p className="font-mono text-[10px] text-text-subtle mt-0.5">
+                  500 credits
+                </p>
+              </div>
+              <div className="border border-brand/20 bg-brand/5 p-3">
+                <p className="font-mono text-[9px] tracking-wider text-text-subtle mb-1">
+                  MEDIUM
+                </p>
+                <p className="font-mono text-sm font-semibold text-text-light tabular-nums">
+                  $13
+                </p>
+                <p className="font-mono text-[10px] text-brand mt-0.5">
+                  $15 value <span className="text-emerald-400">+15%</span>
+                </p>
+              </div>
+              <div className="border border-brand/20 bg-brand/5 p-3">
+                <p className="font-mono text-[9px] tracking-wider text-text-subtle mb-1">
+                  LARGE
+                </p>
+                <p className="font-mono text-sm font-semibold text-text-light tabular-nums">
+                  $40
+                </p>
+                <p className="font-mono text-[10px] text-brand mt-0.5">
+                  $50 value <span className="text-emerald-400">+25%</span>
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <p className="font-mono text-[10px] text-text-subtle pt-1">
+            Minimum deposit: $5.00
+          </p>
+        </div>
+      </div>
+
       {/* Stats grid */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-px bg-border">
         <DataCell

--- a/apps/homepage/src/lib/runtime-config.ts
+++ b/apps/homepage/src/lib/runtime-config.ts
@@ -10,7 +10,7 @@ function normalizeCloudHost(hostname: string): string {
 
 function resolveDefaultCloudBase(): string {
   if (typeof window === "undefined") {
-    return "https://elizacloud.ai";
+    return "https://www.elizacloud.ai";
   }
 
   const hostname = normalizeCloudHost(window.location.hostname);
@@ -22,7 +22,8 @@ function resolveDefaultCloudBase(): string {
     return `${window.location.protocol}//${window.location.host}`;
   }
 
-  return "https://elizacloud.ai";
+  // Use www to avoid bare-domain redirect dropping POST bodies
+  return "https://www.elizacloud.ai";
 }
 
 const DEFAULT_CLOUD_BASE = resolveDefaultCloudBase();

--- a/packages/app-core/src/platform/browser-launch.test.ts
+++ b/packages/app-core/src/platform/browser-launch.test.ts
@@ -56,7 +56,7 @@ describe("applyLaunchConnectionFromUrl", () => {
     await expect(applyLaunchConnectionFromUrl()).resolves.toBe(true);
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://elizacloud.ai/api/v1/eliza/launch-sessions/session-123",
+      "https://elizacloud.ai/api/v1/milady/launch-sessions/session-123",
       expect.objectContaining({
         method: "GET",
         redirect: "manual",
@@ -67,6 +67,54 @@ describe("applyLaunchConnectionFromUrl", () => {
     );
     expect(mockClient.setToken).toHaveBeenCalledWith("managed-backend-token");
     expect(window.location.search).toBe("");
+  });
+
+  it("falls back to the legacy eliza launch-session path when milady path is unavailable", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: "not found" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            success: true,
+            data: {
+              connection: {
+                apiBase: "https://agent-legacy.containers.elizacloud.ai",
+                token: "legacy-token",
+              },
+            },
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      );
+
+    setUrl(
+      "/?cloudLaunchSession=session-legacy&cloudLaunchBase=https%3A%2F%2Felizacloud.ai",
+    );
+
+    await expect(applyLaunchConnectionFromUrl()).resolves.toBe(true);
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://elizacloud.ai/api/v1/milady/launch-sessions/session-legacy",
+      expect.objectContaining({ method: "GET", redirect: "manual" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://elizacloud.ai/api/v1/eliza/launch-sessions/session-legacy",
+      expect.objectContaining({ method: "GET", redirect: "manual" }),
+    );
+    expect(mockClient.setBaseUrl).toHaveBeenCalledWith(
+      "https://agent-legacy.containers.elizacloud.ai",
+    );
+    expect(mockClient.setToken).toHaveBeenCalledWith("legacy-token");
   });
 
   it("falls back to direct launch params and strips them after applying", async () => {

--- a/packages/app-core/src/platform/browser-launch.ts
+++ b/packages/app-core/src/platform/browser-launch.ts
@@ -97,7 +97,8 @@ async function exchangeCloudLaunchSession(
         error?: string;
       };
       lastError = new Error(
-        payload.error || `Launch session exchange failed (HTTP ${response.status})`,
+        payload.error ||
+          `Launch session exchange failed (HTTP ${response.status})`,
       );
 
       if (response.status === 404) {

--- a/packages/app-core/src/platform/browser-launch.ts
+++ b/packages/app-core/src/platform/browser-launch.ts
@@ -77,46 +77,59 @@ async function exchangeCloudLaunchSession(
   cloudBaseUrl: string,
   sessionId: string,
 ): Promise<{ apiBase: string; token: string }> {
-  const response = await fetch(
-    `${cloudBaseUrl}/api/v1/eliza/launch-sessions/${encodeURIComponent(sessionId)}`,
-    {
+  const sessionPath = encodeURIComponent(sessionId);
+  const launchSessionUrls = [
+    `${cloudBaseUrl}/api/v1/milady/launch-sessions/${sessionPath}`,
+    `${cloudBaseUrl}/api/v1/eliza/launch-sessions/${sessionPath}`,
+  ];
+
+  let lastError: Error | null = null;
+
+  for (const url of launchSessionUrls) {
+    const response = await fetch(url, {
       method: "GET",
       headers: { Accept: "application/json" },
       redirect: "manual",
-    },
-  );
+    });
 
-  if (!response.ok) {
-    const payload = (await response.json().catch(() => ({}))) as {
+    if (!response.ok) {
+      const payload = (await response.json().catch(() => ({}))) as {
+        error?: string;
+      };
+      lastError = new Error(
+        payload.error || `Launch session exchange failed (HTTP ${response.status})`,
+      );
+
+      if (response.status === 404) {
+        continue;
+      }
+      throw lastError;
+    }
+
+    const payload = (await response.json()) as {
+      success?: boolean;
+      data?: {
+        connection?: { apiBase?: string; token?: string };
+      };
       error?: string;
     };
-    throw new Error(
-      payload.error ||
-        `Launch session exchange failed (HTTP ${response.status})`,
-    );
-  }
 
-  const payload = (await response.json()) as {
-    success?: boolean;
-    data?: {
-      connection?: { apiBase?: string; token?: string };
+    if (!payload.success || !payload.data?.connection?.apiBase) {
+      throw new Error(payload.error || "Launch session payload is invalid");
+    }
+
+    const token = payload.data.connection.token?.trim();
+    if (!token) {
+      throw new Error("Launch session did not include an access token");
+    }
+
+    return {
+      apiBase: normalizeLaunchApiBase(payload.data.connection.apiBase),
+      token,
     };
-    error?: string;
-  };
-
-  if (!payload.success || !payload.data?.connection?.apiBase) {
-    throw new Error(payload.error || "Launch session payload is invalid");
   }
 
-  const token = payload.data.connection.token?.trim();
-  if (!token) {
-    throw new Error("Launch session did not include an access token");
-  }
-
-  return {
-    apiBase: normalizeLaunchApiBase(payload.data.connection.apiBase),
-    token,
-  };
+  throw lastError ?? new Error("Launch session exchange failed");
 }
 
 export async function applyLaunchConnectionFromUrl(): Promise<boolean> {


### PR DESCRIPTION
The cloud base URL defaulted to `elizacloud.ai` (no www) when running on milady.ai. The bare domain does a 307 redirect to `www.elizacloud.ai`, which drops the POST body on the cli-session auth flow, breaking sign-in.

Fix: default to `https://www.elizacloud.ai` explicitly.