### PR TITLE
fix: homepage mobile font overflow and download dropdown hover

### DIFF
--- a/apps/homepage/src/App.tsx
+++ b/apps/homepage/src/App.tsx
@@ -142,7 +142,10 @@ function DownloadDropdown() {
         type="button"
         className="flex items-center gap-2 px-6 py-3 border border-text-subtle/30 text-text-muted font-mono text-[11px] tracking-[0.15em] uppercase hover:border-text-muted/50 hover:text-text-light transition-all"
         onClick={() => setOpen((v) => !v)}
-        onMouseEnter={() => { cancelClose(); setOpen(true); }}
+        onMouseEnter={() => {
+          cancelClose();
+          setOpen(true);
+        }}
       >
         <DownloadIcon />
         Download

--- a/apps/homepage/src/App.tsx
+++ b/apps/homepage/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { HeroBackground } from "./components/Hero";
 import { releaseData } from "./generated/release-data";
 
@@ -109,7 +109,20 @@ function ChevronDown() {
 
 function DownloadDropdown() {
   const [open, setOpen] = useState(false);
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const downloads = releaseData.release.downloads;
+
+  const cancelClose = () => {
+    if (closeTimer.current) {
+      clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
+  };
+
+  const scheduleClose = () => {
+    cancelClose();
+    closeTimer.current = setTimeout(() => setOpen(false), 150);
+  };
 
   const platformIcon = (id: string) => {
     const cls = "w-5 h-5 text-text-muted";
@@ -122,13 +135,14 @@ function DownloadDropdown() {
   return (
     <fieldset
       className="relative border-0 p-0 m-0"
-      onMouseLeave={() => setOpen(false)}
+      onMouseLeave={scheduleClose}
+      onMouseEnter={cancelClose}
     >
       <button
         type="button"
         className="flex items-center gap-2 px-6 py-3 border border-text-subtle/30 text-text-muted font-mono text-[11px] tracking-[0.15em] uppercase hover:border-text-muted/50 hover:text-text-light transition-all"
-        onClick={() => setOpen(!open)}
-        onMouseEnter={() => setOpen(true)}
+        onClick={() => setOpen((v) => !v)}
+        onMouseEnter={() => { cancelClose(); setOpen(true); }}
       >
         <DownloadIcon />
         Download

--- a/apps/homepage/src/components/Hero.tsx
+++ b/apps/homepage/src/components/Hero.tsx
@@ -82,7 +82,7 @@ export function HeroBackground() {
   };
 
   return (
-    <section className="absolute inset-x-0 top-0 bottom-[45%] sm:bottom-0 flex flex-col items-center justify-start sm:justify-center px-4 sm:px-6 md:px-12 pt-24 sm:pt-12 pointer-events-none overflow-hidden">
+    <section className="absolute inset-x-0 top-0 bottom-[30%] sm:bottom-0 flex flex-col items-center justify-start sm:justify-center px-4 sm:px-6 md:px-12 pt-24 sm:pt-12 pointer-events-none overflow-visible sm:overflow-hidden">
       {/* Corner accents — sharp, terminal-like */}
       <div className="hidden sm:block absolute top-12 left-12 w-6 h-6 border-t border-l border-brand/30" />
       <div className="hidden sm:block absolute top-12 right-12 w-6 h-6 border-t border-r border-brand/30" />
@@ -97,10 +97,10 @@ export function HeroBackground() {
       >
         <motion.h1
           variants={itemVariants}
-          className="text-[28vw] sm:text-[11vw] lg:text-[13vw] font-black leading-[0.76] tracking-tighter uppercase text-white/95 flex flex-col items-center pointer-events-none select-none mt-16 sm:mt-12 max-w-[10ch] sm:max-w-none"
+          className="text-[13vw] sm:text-[11vw] lg:text-[13vw] font-black leading-[0.76] tracking-tighter uppercase text-white/95 flex flex-col items-center pointer-events-none select-none mt-16 sm:mt-12 max-w-none"
         >
           <span>MILADY</span>
-          <span className="text-brand drop-shadow-lg text-[28vw] sm:text-[9vw] lg:text-[11vw] break-words hyphens-none text-center w-full">
+          <span className="text-brand drop-shadow-lg text-[11vw] sm:text-[9vw] lg:text-[11vw] break-words hyphens-none text-center w-full">
             <TypewriterLoop />
           </span>
         </motion.h1>

--- a/packages/app-core/src/api/client.ts
+++ b/packages/app-core/src/api/client.ts
@@ -2282,12 +2282,15 @@ export class MiladyClient {
     if (!res.ok && !options?.allowNonOk) {
       const body = (await res
         .json()
-        .catch(() => ({ error: res.statusText }))) as Record<string, string>;
+        .catch(() => ({ error: res.statusText }))) as Record<
+        string,
+        string
+      > | null;
       throw new ApiError({
         kind: "http",
         path,
         status: res.status,
-        message: body.error ?? `HTTP ${res.status}`,
+        message: body?.error ?? `HTTP ${res.status}`,
       });
     }
     return res;
@@ -3068,8 +3071,11 @@ export class MiladyClient {
     if (!res.ok) {
       const body = (await res
         .json()
-        .catch(() => ({ error: res.statusText }))) as Record<string, string>;
-      const err = new Error(body.error ?? `HTTP ${res.status}`);
+        .catch(() => ({ error: res.statusText }))) as Record<
+        string,
+        string
+      > | null;
+      const err = new Error(body?.error ?? `HTTP ${res.status}`);
       (err as Error & { status?: number }).status = res.status;
       throw err;
     }


### PR DESCRIPTION
## Summary
- Scale down hero text on mobile (`13vw`/`11vw` from `28vw`) so long phrases fit without clipping
- Fix mobile hero container `overflow-hidden` cutting off text
- Fix download dropdown closing when cursor moves from button to dropdown list (delayed close with cancel-on-reenter)
- Guard against null JSON body in API client error handling (fixes "null is not an object" crash on billing page)

## Test plan
- [ ] Verify homepage hero text fits on mobile screens for all typewriter phrases
- [ ] Verify download dropdown stays open when hovering from button to list
- [ ] Verify download dropdown toggles on click (mobile)
- [ ] Verify billing page no longer crashes with "null is not an object" when cloud returns null body

🤖 Generated with [Claude Code](https://claude.com/claude-code)