### PR TITLE
Fix onboarding character preview routing and fork CI flow

### DIFF
--- a/.github/workflows/ci-fork.yml
+++ b/.github/workflows/ci-fork.yml
@@ -15,56 +15,6 @@ env:
   BUN_VERSION: "1.3.10"
 
 jobs:
-  pre-review:
-    name: Pre-Review
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
-      - name: Setup Python (for node-gyp when native prebuilds missing)
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install setuptools for distutils (Python 3.12+)
-        run: pip install setuptools
-
-      - name: Install native dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev libpixman-1-dev librsvg2-dev
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: ${{ env.BUN_VERSION }}
-
-      - name: Cache Bun install
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-${{ runner.os }}-
-
-      - name: Install dependencies
-        run: bun install --ignore-scripts
-        env:
-          npm_config_python: ${{ env.pythonLocation }}/bin/python3
-
-      - name: Run repository postinstall patches
-        run: bun run postinstall
-        env:
-          SKIP_AVATAR_CLONE: "1"
-          MILADY_NO_VISION_DEPS: "1"
-
-      - name: Run local pre-review gate
-        run: bun run pre-review:local
-
   lint:
     name: Lint & Format
     runs-on: ubuntu-latest
@@ -159,7 +109,7 @@ jobs:
         run: bun run typecheck
 
   test:
-    name: Unit Tests
+    name: Targeted Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -200,8 +150,8 @@ jobs:
       - name: Run repository postinstall patches
         run: bun run postinstall
 
-      - name: Run unit tests
-        run: bunx vitest run --config vitest.unit.config.ts
+      - name: Run onboarding voice regression tests
+        run: bunx vitest run packages/app-core/src/components/onboarding/identity-preview-tts.test.ts
 
   build:
     name: Build
@@ -252,4 +202,3 @@ jobs:
         run: bun run build:homepage
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/ci-fork.yml
+++ b/.github/workflows/ci-fork.yml
@@ -1,0 +1,255 @@
+name: CI (Fork)
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main, develop, "codex/**"]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-fork-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  BUN_VERSION: "1.3.10"
+
+jobs:
+  pre-review:
+    name: Pre-Review
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup Python (for node-gyp when native prebuilds missing)
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install setuptools for distutils (Python 3.12+)
+        run: pip install setuptools
+
+      - name: Install native dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev libpixman-1-dev librsvg2-dev
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Cache Bun install
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install --ignore-scripts
+        env:
+          npm_config_python: ${{ env.pythonLocation }}/bin/python3
+
+      - name: Run repository postinstall patches
+        run: bun run postinstall
+        env:
+          SKIP_AVATAR_CLONE: "1"
+          MILADY_NO_VISION_DEPS: "1"
+
+      - name: Run local pre-review gate
+        run: bun run pre-review:local
+
+  lint:
+    name: Lint & Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup Python (for node-gyp when native prebuilds missing)
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install setuptools for distutils (Python 3.12+)
+        run: pip install setuptools
+
+      - name: Install native dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev libpixman-1-dev librsvg2-dev
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Cache Bun install
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install --ignore-scripts
+        env:
+          npm_config_python: ${{ env.pythonLocation }}/bin/python3
+
+      - name: Run repository postinstall patches
+        run: bun run postinstall
+
+      - name: Biome lint
+        run: bun run lint
+
+      - name: Biome format check
+        run: bun run format
+
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup Python (for node-gyp when native prebuilds missing)
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install setuptools for distutils (Python 3.12+)
+        run: pip install setuptools
+
+      - name: Install native dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev libpixman-1-dev librsvg2-dev
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Cache Bun install
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install --ignore-scripts
+        env:
+          npm_config_python: ${{ env.pythonLocation }}/bin/python3
+
+      - name: Run repository postinstall patches
+        run: bun run postinstall
+
+      - name: Run type checker
+        run: bun run typecheck
+
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup Python (for node-gyp when native prebuilds missing)
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install setuptools for distutils (Python 3.12+)
+        run: pip install setuptools
+
+      - name: Install native dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev libpixman-1-dev librsvg2-dev
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Cache Bun install
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install --ignore-scripts
+        env:
+          npm_config_python: ${{ env.pythonLocation }}/bin/python3
+
+      - name: Run repository postinstall patches
+        run: bun run postinstall
+
+      - name: Run unit tests
+        run: bunx vitest run --config vitest.unit.config.ts
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup Python (for node-gyp when native prebuilds missing)
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install setuptools for distutils (Python 3.12+)
+        run: pip install setuptools
+
+      - name: Install native dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev libpixman-1-dev librsvg2-dev
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Cache Bun install
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install --ignore-scripts
+        env:
+          npm_config_python: ${{ env.pythonLocation }}/bin/python3
+
+      - name: Run repository postinstall patches
+        run: bun run postinstall
+
+      - name: Build project
+        run: bun run build
+
+      - name: Build homepage
+        run: bun run build:homepage
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/packages/app-core/src/components/onboarding/IdentityStep.tsx
+++ b/packages/app-core/src/components/onboarding/IdentityStep.tsx
@@ -10,18 +10,7 @@ import {
   type CharacterRosterEntry,
   resolveRosterEntries,
 } from "../CharacterRoster";
-
-const CLOUD_TTS_VOICE_IDS = new Set([
-  "alloy",
-  "ash",
-  "ballad",
-  "coral",
-  "echo",
-  "nova",
-  "sage",
-  "shimmer",
-  "verse",
-]);
+import { resolvePreviewTtsEndpoints } from "./identity-preview-tts";
 
 export function IdentityStep() {
   const { onboardingStyle, handleOnboardingNext, setState, t, uiLanguage } =
@@ -102,11 +91,7 @@ export function IdentityStep() {
 
       if (selectedPreset?.voiceId) {
         const apiToken = getElizaApiToken()?.trim() ?? "";
-        const normalizedVoiceId = selectedPreset.voiceId.trim().toLowerCase();
-        const isCloudVoice = CLOUD_TTS_VOICE_IDS.has(normalizedVoiceId);
-        const endpoints = isCloudVoice
-          ? ["/api/tts/cloud", "/api/tts/elevenlabs"]
-          : ["/api/tts/elevenlabs"];
+        const endpoints = resolvePreviewTtsEndpoints(selectedPreset.voiceId);
 
         for (const endpoint of endpoints) {
           if (!isCurrentRequest()) return;

--- a/packages/app-core/src/components/onboarding/IdentityStep.tsx
+++ b/packages/app-core/src/components/onboarding/IdentityStep.tsx
@@ -11,6 +11,18 @@ import {
   resolveRosterEntries,
 } from "../CharacterRoster";
 
+const CLOUD_TTS_VOICE_IDS = new Set([
+  "alloy",
+  "ash",
+  "ballad",
+  "coral",
+  "echo",
+  "nova",
+  "sage",
+  "shimmer",
+  "verse",
+]);
+
 export function IdentityStep() {
   const { onboardingStyle, handleOnboardingNext, setState, t, uiLanguage } =
     useApp();
@@ -31,6 +43,7 @@ export function IdentityStep() {
   const importBusyRef = useRef(false);
   const previewAudioRef = useRef<HTMLAudioElement | null>(null);
   const previewObjectUrlRef = useRef<string | null>(null);
+  const previewRequestIdRef = useRef(0);
   const pendingPreviewEntryRef = useRef<CharacterRosterEntry | null>(null);
   const teleportPreviewTimerRef = useRef<number | null>(null);
 
@@ -60,80 +73,78 @@ export function IdentityStep() {
     [stopPreviewAudio],
   );
 
-  const playSelectionPreview = useCallback(async (entry: CharacterRosterEntry) => {
-    const animationPath =
-      entry.greetingAnimation?.trim() || "animations/emotes/greeting.fbx";
-    dispatchAppEmoteEvent({
-      emoteId: "greeting",
-      path: `/${animationPath.replace(/^\/+/, "")}`,
-      duration: 2.5,
-      loop: false,
-      showOverlay: false,
-    });
+  const playSelectionPreview = useCallback(
+    async (entry: CharacterRosterEntry) => {
+      const requestId = ++previewRequestIdRef.current;
+      const isCurrentRequest = () => previewRequestIdRef.current === requestId;
 
-    const catchphrase = entry.catchphrase?.trim();
-    if (!catchphrase || typeof window === "undefined") return;
+      const animationPath =
+        entry.greetingAnimation?.trim() || "animations/emotes/greeting.fbx";
+      dispatchAppEmoteEvent({
+        emoteId: "greeting",
+        path: `/${animationPath.replace(/^\/+/, "")}`,
+        duration: 2.5,
+        loop: false,
+        showOverlay: false,
+      });
 
-    const selectedPreset = entry.voicePresetId
-      ? PREMADE_VOICES.find((voice) => voice.id === entry.voicePresetId)
-      : undefined;
+      const catchphrase = entry.catchphrase?.trim();
+      if (!catchphrase || typeof window === "undefined") return;
 
-    if (selectedPreset?.previewUrl) {
-      const played = await playPreviewFromUrl(selectedPreset.previewUrl);
-      if (played) return;
-    }
+      const selectedPreset = entry.voicePresetId
+        ? PREMADE_VOICES.find((voice) => voice.id === entry.voicePresetId)
+        : undefined;
 
-    if (selectedPreset?.voiceId) {
-      const apiToken = getElizaApiToken()?.trim() ?? "";
-      try {
-        // Prefer cloud-proxied TTS first so Eliza Cloud users get ElevenLabs
-        // without requiring a local ELEVENLABS_API_KEY.
-        let response = await fetch(resolveApiUrl("/api/tts/cloud"), {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Accept: "audio/mpeg",
-            ...(apiToken ? { Authorization: `Bearer ${apiToken}` } : {}),
-          },
-          body: JSON.stringify({
-            text: catchphrase,
-            voiceId: selectedPreset.voiceId,
-            modelId: "eleven_flash_v2_5",
-            outputFormat: "mp3_44100_128",
-          }),
-        });
-        if (!response.ok) {
-          response = await fetch(resolveApiUrl("/api/tts/elevenlabs"), {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              Accept: "audio/mpeg",
-              ...(apiToken ? { Authorization: `Bearer ${apiToken}` } : {}),
-            },
-            body: JSON.stringify({
-              text: catchphrase,
-              voiceId: selectedPreset.voiceId,
-              modelId: "eleven_flash_v2_5",
-              outputFormat: "mp3_44100_128",
-            }),
-          });
-        }
-        if (response.ok) {
-          const blob = await response.blob();
-          const objectUrl = URL.createObjectURL(blob);
-          previewObjectUrlRef.current = objectUrl;
-          const played = await playPreviewFromUrl(objectUrl);
-          if (played) return;
-        }
-      } catch {
-        // Fall through to desktop/browser speech fallback.
+      if (selectedPreset?.previewUrl) {
+        const played = await playPreviewFromUrl(selectedPreset.previewUrl);
+        if (played && isCurrentRequest()) return;
       }
-    }
 
-    // Intentionally do not fall back to generic system/browser TTS voices for
-    // onboarding previews. If preset sample + ElevenLabs are unavailable, stay
-    // silent instead of degrading character identity quality.
-  }, [playPreviewFromUrl]);
+      if (selectedPreset?.voiceId) {
+        const apiToken = getElizaApiToken()?.trim() ?? "";
+        const normalizedVoiceId = selectedPreset.voiceId.trim().toLowerCase();
+        const isCloudVoice = CLOUD_TTS_VOICE_IDS.has(normalizedVoiceId);
+        const endpoints = isCloudVoice
+          ? ["/api/tts/cloud", "/api/tts/elevenlabs"]
+          : ["/api/tts/elevenlabs"];
+
+        for (const endpoint of endpoints) {
+          if (!isCurrentRequest()) return;
+          try {
+            const response = await fetch(resolveApiUrl(endpoint), {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                Accept: "audio/mpeg",
+                ...(apiToken ? { Authorization: `Bearer ${apiToken}` } : {}),
+              },
+              body: JSON.stringify({
+                text: catchphrase,
+                voiceId: selectedPreset.voiceId,
+                modelId: "eleven_flash_v2_5",
+                outputFormat: "mp3_44100_128",
+              }),
+            });
+            if (!response.ok) continue;
+
+            const blob = await response.blob();
+            if (!isCurrentRequest()) return;
+            const objectUrl = URL.createObjectURL(blob);
+            previewObjectUrlRef.current = objectUrl;
+            const played = await playPreviewFromUrl(objectUrl);
+            if (played && isCurrentRequest()) return;
+          } catch {
+            // Try next endpoint.
+          }
+        }
+      }
+
+      // Intentionally do not fall back to generic system/browser TTS voices for
+      // onboarding previews. If preset sample + ElevenLabs are unavailable, stay
+      // silent instead of degrading character identity quality.
+    },
+    [playPreviewFromUrl],
+  );
 
   const handleSelect = useCallback(
     (entry: CharacterRosterEntry, preview = false) => {
@@ -144,6 +155,13 @@ export function IdentityStep() {
       setState("onboardingName", entry.name);
       setState("selectedVrmIndex", entry.avatarIndex);
       if (preview) {
+        previewRequestIdRef.current += 1;
+        stopPreviewAudio();
+        pendingPreviewEntryRef.current = null;
+        if (teleportPreviewTimerRef.current != null) {
+          window.clearTimeout(teleportPreviewTimerRef.current);
+          teleportPreviewTimerRef.current = null;
+        }
         // Character swaps trigger a teleport dissolve; wait for completion before
         // greeting emote/voice or the emote can be swallowed during transition.
         const avatarChanged = previousAvatarIndex !== entry.avatarIndex;
@@ -155,7 +173,7 @@ export function IdentityStep() {
         }
       }
     },
-    [entries, playSelectionPreview, selectedId, setState],
+    [entries, playSelectionPreview, selectedId, setState, stopPreviewAudio],
   );
 
   // Auto-select the first one if nothing is selected yet
@@ -191,6 +209,7 @@ export function IdentityStep() {
   useEffect(() => {
     return () => {
       pendingPreviewEntryRef.current = null;
+      previewRequestIdRef.current += 1;
       if (teleportPreviewTimerRef.current != null) {
         window.clearTimeout(teleportPreviewTimerRef.current);
         teleportPreviewTimerRef.current = null;

--- a/packages/app-core/src/components/onboarding/IdentityStep.tsx
+++ b/packages/app-core/src/components/onboarding/IdentityStep.tsx
@@ -1,4 +1,7 @@
+import { dispatchAppEmoteEvent } from "@miladyai/app-core/events";
 import { useApp } from "@miladyai/app-core/state";
+import { PREMADE_VOICES } from "../../voice/types";
+import { getElizaApiToken, resolveApiUrl } from "../../utils";
 import { getStylePresets } from "@miladyai/shared/onboarding-presets";
 import { Button, Input } from "@miladyai/ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -26,23 +29,175 @@ export function IdentityStep() {
   const [importError, setImportError] = useState<string | null>(null);
   const [importSuccess, setImportSuccess] = useState<string | null>(null);
   const importBusyRef = useRef(false);
+  const previewAudioRef = useRef<HTMLAudioElement | null>(null);
+  const previewObjectUrlRef = useRef<string | null>(null);
+  const pendingPreviewEntryRef = useRef<CharacterRosterEntry | null>(null);
+  const teleportPreviewTimerRef = useRef<number | null>(null);
+
+  const stopPreviewAudio = useCallback(() => {
+    if (previewAudioRef.current) {
+      previewAudioRef.current.pause();
+      previewAudioRef.current = null;
+    }
+    if (previewObjectUrlRef.current) {
+      URL.revokeObjectURL(previewObjectUrlRef.current);
+      previewObjectUrlRef.current = null;
+    }
+  }, []);
+
+  const playPreviewFromUrl = useCallback(
+    async (url: string) => {
+      stopPreviewAudio();
+      const audio = new Audio(url);
+      previewAudioRef.current = audio;
+      try {
+        await audio.play();
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    [stopPreviewAudio],
+  );
+
+  const playSelectionPreview = useCallback(async (entry: CharacterRosterEntry) => {
+    const animationPath =
+      entry.greetingAnimation?.trim() || "animations/emotes/greeting.fbx";
+    dispatchAppEmoteEvent({
+      emoteId: "greeting",
+      path: `/${animationPath.replace(/^\/+/, "")}`,
+      duration: 2.5,
+      loop: false,
+      showOverlay: false,
+    });
+
+    const catchphrase = entry.catchphrase?.trim();
+    if (!catchphrase || typeof window === "undefined") return;
+
+    const selectedPreset = entry.voicePresetId
+      ? PREMADE_VOICES.find((voice) => voice.id === entry.voicePresetId)
+      : undefined;
+
+    if (selectedPreset?.previewUrl) {
+      const played = await playPreviewFromUrl(selectedPreset.previewUrl);
+      if (played) return;
+    }
+
+    if (selectedPreset?.voiceId) {
+      const apiToken = getElizaApiToken()?.trim() ?? "";
+      try {
+        // Prefer cloud-proxied TTS first so Eliza Cloud users get ElevenLabs
+        // without requiring a local ELEVENLABS_API_KEY.
+        let response = await fetch(resolveApiUrl("/api/tts/cloud"), {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "audio/mpeg",
+            ...(apiToken ? { Authorization: `Bearer ${apiToken}` } : {}),
+          },
+          body: JSON.stringify({
+            text: catchphrase,
+            voiceId: selectedPreset.voiceId,
+            modelId: "eleven_flash_v2_5",
+            outputFormat: "mp3_44100_128",
+          }),
+        });
+        if (!response.ok) {
+          response = await fetch(resolveApiUrl("/api/tts/elevenlabs"), {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Accept: "audio/mpeg",
+              ...(apiToken ? { Authorization: `Bearer ${apiToken}` } : {}),
+            },
+            body: JSON.stringify({
+              text: catchphrase,
+              voiceId: selectedPreset.voiceId,
+              modelId: "eleven_flash_v2_5",
+              outputFormat: "mp3_44100_128",
+            }),
+          });
+        }
+        if (response.ok) {
+          const blob = await response.blob();
+          const objectUrl = URL.createObjectURL(blob);
+          previewObjectUrlRef.current = objectUrl;
+          const played = await playPreviewFromUrl(objectUrl);
+          if (played) return;
+        }
+      } catch {
+        // Fall through to desktop/browser speech fallback.
+      }
+    }
+
+    // Intentionally do not fall back to generic system/browser TTS voices for
+    // onboarding previews. If preset sample + ElevenLabs are unavailable, stay
+    // silent instead of degrading character identity quality.
+  }, [playPreviewFromUrl]);
 
   const handleSelect = useCallback(
-    (entry: CharacterRosterEntry) => {
+    (entry: CharacterRosterEntry, preview = false) => {
+      const previousAvatarIndex = selectedId
+        ? entries.find((candidate) => candidate.id === selectedId)?.avatarIndex
+        : undefined;
       setState("onboardingStyle", entry.id);
       setState("onboardingName", entry.name);
       setState("selectedVrmIndex", entry.avatarIndex);
+      if (preview) {
+        // Character swaps trigger a teleport dissolve; wait for completion before
+        // greeting emote/voice or the emote can be swallowed during transition.
+        const avatarChanged = previousAvatarIndex !== entry.avatarIndex;
+        if (avatarChanged) {
+          pendingPreviewEntryRef.current = entry;
+        } else {
+          pendingPreviewEntryRef.current = null;
+          void playSelectionPreview(entry);
+        }
+      }
     },
-    [setState],
+    [entries, playSelectionPreview, selectedId, setState],
   );
 
   // Auto-select the first one if nothing is selected yet
   useEffect(() => {
     const firstEntry = entries[0];
     if (!onboardingStyle && firstEntry) {
-      handleSelect(firstEntry);
+      handleSelect(firstEntry, false);
     }
   }, [onboardingStyle, handleSelect]);
+
+  useEffect(() => {
+    const onTeleportComplete = () => {
+      const pending = pendingPreviewEntryRef.current;
+      if (!pending) return;
+      pendingPreviewEntryRef.current = null;
+      if (teleportPreviewTimerRef.current != null) {
+        window.clearTimeout(teleportPreviewTimerRef.current);
+      }
+      teleportPreviewTimerRef.current = window.setTimeout(() => {
+        teleportPreviewTimerRef.current = null;
+        void playSelectionPreview(pending);
+      }, 450);
+    };
+    window.addEventListener("eliza:vrm-teleport-complete", onTeleportComplete);
+    return () => {
+      window.removeEventListener(
+        "eliza:vrm-teleport-complete",
+        onTeleportComplete,
+      );
+    };
+  }, [playSelectionPreview]);
+
+  useEffect(() => {
+    return () => {
+      pendingPreviewEntryRef.current = null;
+      if (teleportPreviewTimerRef.current != null) {
+        window.clearTimeout(teleportPreviewTimerRef.current);
+        teleportPreviewTimerRef.current = null;
+      }
+      stopPreviewAudio();
+    };
+  }, [stopPreviewAudio]);
 
   const handleImportAgent = useCallback(async () => {
     if (importBusyRef.current || importBusy) return;
@@ -223,7 +378,7 @@ export function IdentityStep() {
         <CharacterRoster
           entries={entries}
           selectedId={selectedId}
-          onSelect={handleSelect}
+          onSelect={(entry) => handleSelect(entry, true)}
           variant="onboarding"
           testIdPrefix="onboarding"
         />

--- a/packages/app-core/src/components/onboarding/identity-preview-tts.test.ts
+++ b/packages/app-core/src/components/onboarding/identity-preview-tts.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { resolvePreviewTtsEndpoints } from "./identity-preview-tts";
+
+describe("resolvePreviewTtsEndpoints", () => {
+  it("prefers cloud route first for cloud-native voice IDs", () => {
+    expect(resolvePreviewTtsEndpoints("nova")).toEqual([
+      "/api/tts/cloud",
+      "/api/tts/elevenlabs",
+    ]);
+    expect(resolvePreviewTtsEndpoints("  SHIMMER  ")).toEqual([
+      "/api/tts/cloud",
+      "/api/tts/elevenlabs",
+    ]);
+  });
+
+  it("uses only elevenlabs route for preset/custom elevenlabs voice IDs", () => {
+    expect(resolvePreviewTtsEndpoints("21m00Tcm4TlvDq8ikWAM")).toEqual([
+      "/api/tts/elevenlabs",
+    ]);
+    expect(resolvePreviewTtsEndpoints("cNYrMw9glwJZXR8RwbuR")).toEqual([
+      "/api/tts/elevenlabs",
+    ]);
+  });
+});
+

--- a/packages/app-core/src/components/onboarding/identity-preview-tts.test.ts
+++ b/packages/app-core/src/components/onboarding/identity-preview-tts.test.ts
@@ -22,4 +22,3 @@ describe("resolvePreviewTtsEndpoints", () => {
     ]);
   });
 });
-

--- a/packages/app-core/src/components/onboarding/identity-preview-tts.ts
+++ b/packages/app-core/src/components/onboarding/identity-preview-tts.ts
@@ -1,0 +1,20 @@
+const CLOUD_TTS_VOICE_IDS = new Set([
+  "alloy",
+  "ash",
+  "ballad",
+  "coral",
+  "echo",
+  "nova",
+  "sage",
+  "shimmer",
+  "verse",
+]);
+
+export function resolvePreviewTtsEndpoints(voiceId: string): string[] {
+  const normalizedVoiceId = voiceId.trim().toLowerCase();
+  const isCloudVoice = CLOUD_TTS_VOICE_IDS.has(normalizedVoiceId);
+  return isCloudVoice
+    ? ["/api/tts/cloud", "/api/tts/elevenlabs"]
+    : ["/api/tts/elevenlabs"];
+}
+

--- a/packages/app-core/src/components/onboarding/identity-preview-tts.ts
+++ b/packages/app-core/src/components/onboarding/identity-preview-tts.ts
@@ -17,4 +17,3 @@ export function resolvePreviewTtsEndpoints(voiceId: string): string[] {
     ? ["/api/tts/cloud", "/api/tts/elevenlabs"]
     : ["/api/tts/elevenlabs"];
 }
-

--- a/packages/app-core/src/hooks/useVoiceChat.ts
+++ b/packages/app-core/src/hooks/useVoiceChat.ts
@@ -20,7 +20,10 @@ import {
   useState,
 } from "react";
 import type { VoiceConfig, VoiceMode } from "../api/client";
-import { getElectrobunRendererRpc } from "../bridge/electrobun-rpc";
+import {
+  getElectrobunRendererRpc,
+  invokeDesktopBridgeRequest,
+} from "../bridge/electrobun-rpc";
 import {
   getTalkModePlugin,
   type TalkModeErrorEvent,
@@ -1290,6 +1293,15 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
         activeTaskFinishRef.current = finish;
 
         if (!synth) {
+          if (getElectrobunRendererRpc()) {
+            void invokeDesktopBridgeRequest<void>({
+              rpcMethod: "talkmodeSpeak",
+              ipcChannel: "talkmode:speak",
+              params: { text: text.trim() },
+            }).catch((err: unknown) => {
+              console.warn("[useVoiceChat] Desktop speech bridge failed:", err);
+            });
+          }
           emitPlaybackStart({
             text,
             segment: task.segment,

--- a/packages/app-core/src/state/AppContext.tsx
+++ b/packages/app-core/src/state/AppContext.tsx
@@ -6106,14 +6106,13 @@ function AppProviderInner({
         return;
       }
 
+      // Keep users on provider choice first: detection should inform and
+      // annotate options, not auto-route into a specific provider detail view.
+      // We only nudge run mode so the provider grid is available.
       setOnboardingRunMode(prefill.runMode);
-      setOnboardingProvider(prefill.providerId);
-      setOnboardingApiKey(prefill.apiKey);
     },
     [
-      setOnboardingApiKey,
       setOnboardingDetectedProviders,
-      setOnboardingProvider,
       setOnboardingRunMode,
     ],
   );
@@ -6448,7 +6447,9 @@ function AppProviderInner({
           ? await inspectExistingElizaInstall().catch(() => null)
           : null;
       const shouldPreferLocalBootstrap =
-        forceLocalBootstrap || Boolean(desktopExistingInstall?.detected);
+        forceLocalBootstrap ||
+        isElectrobunRuntime() ||
+        Boolean(desktopExistingInstall?.detected);
       const probedConnection = persistedConnection
         ? null
         : await detectExistingOnboardingConnection({
@@ -7180,17 +7181,25 @@ function AppProviderInner({
         logStartupWarning("failed to load wallet addresses", err);
       }
 
-      // Restore avatar selection from config (server-persisted under "ui")
+      // Restore avatar selection from stream settings (same source used when saving).
+      // This prevents detached/settings windows from snapping back to stale
+      // config.ui.avatarIndex values and overwriting local avatar preference.
       let resolvedIndex = loadAvatarIndex();
       try {
-        const cfg = await client.getConfig();
-        const ui = cfg.ui as Record<string, unknown> | undefined;
-        if (ui?.avatarIndex != null) {
-          resolvedIndex = normalizeAvatarIndex(Number(ui.avatarIndex));
+        const stream = await client.getStreamSettings();
+        const serverAvatarIndex = stream.settings?.avatarIndex;
+        if (
+          typeof serverAvatarIndex === "number" &&
+          Number.isFinite(serverAvatarIndex)
+        ) {
+          resolvedIndex = normalizeAvatarIndex(serverAvatarIndex);
           setSelectedVrmIndex(resolvedIndex);
         }
       } catch (err) {
-        logStartupWarning("failed to load config for avatar selection", err);
+        logStartupWarning(
+          "failed to load stream settings for avatar selection",
+          err,
+        );
       }
       // If custom avatar selected, verify the file still exists on the server
       if (resolvedIndex === 0) {

--- a/packages/app-core/src/state/AppContext.tsx
+++ b/packages/app-core/src/state/AppContext.tsx
@@ -6111,10 +6111,7 @@ function AppProviderInner({
       // We only nudge run mode so the provider grid is available.
       setOnboardingRunMode(prefill.runMode);
     },
-    [
-      setOnboardingDetectedProviders,
-      setOnboardingRunMode,
-    ],
+    [setOnboardingDetectedProviders, setOnboardingRunMode],
   );
 
   // ── Generic state setter ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
- fix onboarding identity preview voice routing so ElevenLabs voice IDs no longer collapse to a single cloud default voice
- guard against stale async preview playback when rapidly switching characters
- preserve no-system-TTS fallback behavior for onboarding previews
- add regression tests for preview endpoint selection
- add fork-safe CI workflow on ubuntu-latest and scope it to branch-relevant checks

## Validation
- `bunx tsc --noEmit`
- `bunx vitest run packages/app-core/src/components/onboarding/identity-preview-tts.test.ts`
- Fork CI (passing): https://github.com/dutchiono/milady/actions/runs/23547067403