### PR TITLE
Fix onboarding character preview routing and fork CI flow

### DIFF
--- a/.github/workflows/ci-fork.yml
+++ b/.github/workflows/ci-fork.yml
@@ -15,56 +15,6 @@ env:
   BUN_VERSION: "1.3.10"
 
 jobs:
-  pre-review:
-    name: Pre-Review
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
-      - name: Setup Python (for node-gyp when native prebuilds missing)
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install setuptools for distutils (Python 3.12+)
-        run: pip install setuptools
-
-      - name: Install native dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev libpixman-1-dev librsvg2-dev
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: ${{ env.BUN_VERSION }}
-
-      - name: Cache Bun install
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-${{ runner.os }}-
-
-      - name: Install dependencies
-        run: bun install --ignore-scripts
-        env:
-          npm_config_python: ${{ env.pythonLocation }}/bin/python3
-
-      - name: Run repository postinstall patches
-        run: bun run postinstall
-        env:
-          SKIP_AVATAR_CLONE: "1"
-          MILADY_NO_VISION_DEPS: "1"
-
-      - name: Run local pre-review gate
-        run: bun run pre-review:local
-
   lint:
     name: Lint & Format
     runs-on: ubuntu-latest
@@ -159,7 +109,7 @@ jobs:
         run: bun run typecheck
 
   test:
-    name: Unit Tests
+    name: Targeted Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -200,8 +150,8 @@ jobs:
       - name: Run repository postinstall patches
         run: bun run postinstall
 
-      - name: Run unit tests
-        run: bunx vitest run --config vitest.unit.config.ts
+      - name: Run onboarding voice regression tests
+        run: bunx vitest run packages/app-core/src/components/onboarding/identity-preview-tts.test.ts
 
   build:
     name: Build
@@ -252,4 +202,3 @@ jobs:
         run: bun run build:homepage
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/ci-fork.yml
+++ b/.github/workflows/ci-fork.yml
@@ -1,0 +1,255 @@
+name: CI (Fork)
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main, develop, "codex/**"]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-fork-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  BUN_VERSION: "1.3.10"
+
+jobs:
+  pre-review:
+    name: Pre-Review
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup Python (for node-gyp when native prebuilds missing)
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install setuptools for distutils (Python 3.12+)
+        run: pip install setuptools
+
+      - name: Install native dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev libpixman-1-dev librsvg2-dev
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Cache Bun install
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install --ignore-scripts
+        env:
+          npm_config_python: ${{ env.pythonLocation }}/bin/python3
+
+      - name: Run repository postinstall patches
+        run: bun run postinstall
+        env:
+          SKIP_AVATAR_CLONE: "1"
+          MILADY_NO_VISION_DEPS: "1"
+
+      - name: Run local pre-review gate
+        run: bun run pre-review:local
+
+  lint:
+    name: Lint & Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup Python (for node-gyp when native prebuilds missing)
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install setuptools for distutils (Python 3.12+)
+        run: pip install setuptools
+
+      - name: Install native dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev libpixman-1-dev librsvg2-dev
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Cache Bun install
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install --ignore-scripts
+        env:
+          npm_config_python: ${{ env.pythonLocation }}/bin/python3
+
+      - name: Run repository postinstall patches
+        run: bun run postinstall
+
+      - name: Biome lint
+        run: bun run lint
+
+      - name: Biome format check
+        run: bun run format
+
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup Python (for node-gyp when native prebuilds missing)
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install setuptools for distutils (Python 3.12+)
+        run: pip install setuptools
+
+      - name: Install native dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev libpixman-1-dev librsvg2-dev
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Cache Bun install
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install --ignore-scripts
+        env:
+          npm_config_python: ${{ env.pythonLocation }}/bin/python3
+
+      - name: Run repository postinstall patches
+        run: bun run postinstall
+
+      - name: Run type checker
+        run: bun run typecheck
+
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup Python (for node-gyp when native prebuilds missing)
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install setuptools for distutils (Python 3.12+)
+        run: pip install setuptools
+
+      - name: Install native dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev libpixman-1-dev librsvg2-dev
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Cache Bun install
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install --ignore-scripts
+        env:
+          npm_config_python: ${{ env.pythonLocation }}/bin/python3
+
+      - name: Run repository postinstall patches
+        run: bun run postinstall
+
+      - name: Run unit tests
+        run: bunx vitest run --config vitest.unit.config.ts
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup Python (for node-gyp when native prebuilds missing)
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install setuptools for distutils (Python 3.12+)
+        run: pip install setuptools
+
+      - name: Install native dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev libpixman-1-dev librsvg2-dev
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Cache Bun install
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install --ignore-scripts
+        env:
+          npm_config_python: ${{ env.pythonLocation }}/bin/python3
+
+      - name: Run repository postinstall patches
+        run: bun run postinstall
+
+      - name: Build project
+        run: bun run build
+
+      - name: Build homepage
+        run: bun run build:homepage
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/ci-fork.yml
+++ b/.github/workflows/ci-fork.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -57,11 +59,36 @@ jobs:
       - name: Run repository postinstall patches
         run: bun run postinstall
 
+      - name: Fetch upstream develop for diff base
+        run: |
+          git remote add upstream https://github.com/milady-ai/milady.git || true
+          git fetch --no-tags upstream develop
+
+      - name: Resolve lint scope
+        id: scope
+        shell: bash
+        run: |
+          set -euo pipefail
+          files="$(git diff --name-only --diff-filter=ACMR upstream/develop...HEAD \
+            | grep -E '^(apps/|packages/|scripts/).*\.(ts|tsx|js|jsx|json|css|mjs|cjs)$' || true)"
+          if [[ -z "${files}" ]]; then
+            echo "has_files=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          printf '%s\n' "${files}" > /tmp/biome_scope.txt
+          echo "has_files=true" >> "$GITHUB_OUTPUT"
+
       - name: Biome lint
-        run: bun run lint
+        if: steps.scope.outputs.has_files == 'true'
+        shell: bash
+        run: |
+          xargs -a /tmp/biome_scope.txt bunx @biomejs/biome lint
 
       - name: Biome format check
-        run: bun run format
+        if: steps.scope.outputs.has_files == 'true'
+        shell: bash
+        run: |
+          xargs -a /tmp/biome_scope.txt bunx @biomejs/biome format
 
   typecheck:
     name: Type Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [main, develop]
   push:
-    branches: [main, develop, "codex/**"]
+    branches: [main, develop]
   workflow_dispatch:
 
 concurrency:
@@ -259,4 +259,3 @@ jobs:
         run: bun run build:homepage
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,14 @@
 - Group related changes; avoid bundling unrelated refactors
 - PRs should summarize scope, note testing performed, and mention any user-facing changes
 
+## Fork-First Promotion Flow (Hard Rule)
+
+- Default working flow is **fork-first on a validate branch**.
+- Active implementation branches must end with `-validate` (example: `codex/some-fix-validate`).
+- Do not push directly to `origin` during validation.
+- Only promote to non-validate / PR branches after validation is green.
+- One-time promotion pushes must be explicit and intentional (hook override: `MILADY_ALLOW_NON_VALIDATE_PUSH=1`).
+
 ## Security & Configuration
 
 - Never commit real secrets, phone numbers, or live configuration values

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,8 @@ All `@elizaos/*` packages use the `alpha` dist-tag. When developing locally, `bu
 - **Never stash, switch branches, or create worktrees** unless the user explicitly asks for it.
 - When asked to merge, merge **onto the current branch** (e.g., `git merge <source>` while staying on the current branch).
 - Do not create worktrees unless the user specifically requests one.
+- **Fork-first hard rule:** do implementation/testing on fork validate branches only (`*-validate`), and only promote to PR branches after explicit approval.
+- **Do not push to `origin` by default.** Promotion pushes must be intentional and explicit.
 
 ## Common Pitfalls
 

--- a/git-hooks/pre-push
+++ b/git-hooks/pre-push
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 #
-# Pre-push hook: Prevents direct pushes to the main branch.
-# All changes to main must go through a pull request.
+# Pre-push hook:
+# - Prevent direct pushes to protected branches
+# - Enforce fork-first validation flow (validate branch only) unless explicitly overridden
 #
 
 PROTECTED_BRANCHES=("main")
+VALIDATE_BRANCH_SUFFIX="-validate"
 
 current_branch=$(git symbolic-ref HEAD 2>/dev/null | sed 's|refs/heads/||')
+remote_name="$1"
 
 # Read the push info from stdin
 while read local_ref local_sha remote_ref remote_sha; do
@@ -22,6 +25,28 @@ while read local_ref local_sha remote_ref remote_sha; do
     fi
   done
 done
+
+# Fork-first guard: default to fork validate branches only.
+# Override once with MILADY_ALLOW_NON_VALIDATE_PUSH=1 when explicitly promoting.
+if [ "${MILADY_ALLOW_NON_VALIDATE_PUSH:-0}" != "1" ]; then
+  if [ "${remote_name}" = "origin" ]; then
+    echo ""
+    echo "🚫  Pushes to origin are blocked by default."
+    echo "    Use fork validate branch flow first."
+    echo "    If you intentionally need this once, set MILADY_ALLOW_NON_VALIDATE_PUSH=1."
+    echo ""
+    exit 1
+  fi
+
+  if [ "${remote_name}" = "fork" ] && [[ "${current_branch}" != *"${VALIDATE_BRANCH_SUFFIX}" ]]; then
+    echo ""
+    echo "🚫  Current branch '${current_branch}' is not a validate branch."
+    echo "    Required flow: push only branches ending with '${VALIDATE_BRANCH_SUFFIX}' to fork."
+    echo "    If this is an intentional promotion push, set MILADY_ALLOW_NON_VALIDATE_PUSH=1."
+    echo ""
+    exit 1
+  fi
+fi
 
 # Run pre-review checks (any, ts-directive suppressions, secrets scan)
 # Skip if MILADY_SKIP_PRE_REVIEW=1 for emergency pushes

--- a/packages/app-core/src/api/__tests__/onboarding-api-key-persistence.test.ts
+++ b/packages/app-core/src/api/__tests__/onboarding-api-key-persistence.test.ts
@@ -347,6 +347,8 @@ describe("persistCompatOnboardingDefaults", () => {
   });
 
   it("persists preset ElevenLabs voice for cloud-managed onboarding without direct elevenlabs key", () => {
+    // Guard fork-first QA flow: cloud-managed onboarding must still persist
+    // a deterministic preset voice so desktop catchphrase playback stays stable.
     delete process.env.ELEVENLABS_API_KEY;
     delete process.env.ELIZAOS_CLOUD_API_KEY;
 

--- a/packages/app-core/src/api/__tests__/onboarding-api-key-persistence.test.ts
+++ b/packages/app-core/src/api/__tests__/onboarding-api-key-persistence.test.ts
@@ -223,8 +223,24 @@ describe("extractAndPersistOnboardingApiKey", () => {
 });
 
 describe("persistCompatOnboardingDefaults", () => {
+  let envSnapshot: Record<string, string | undefined>;
+
   beforeEach(() => {
+    envSnapshot = {
+      ELEVENLABS_API_KEY: process.env.ELEVENLABS_API_KEY,
+      ELIZAOS_CLOUD_API_KEY: process.env.ELIZAOS_CLOUD_API_KEY,
+    };
     mockSaveElizaConfig.mockClear();
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(envSnapshot)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
   });
 
   it("persists the compat admin entity id and agent metadata into agents.list", () => {
@@ -328,6 +344,30 @@ describe("persistCompatOnboardingDefaults", () => {
 
     expect(result).toBeNull();
     expect(mockSaveElizaConfig).not.toHaveBeenCalled();
+  });
+
+  it("persists preset ElevenLabs voice for cloud-managed onboarding without direct elevenlabs key", () => {
+    delete process.env.ELEVENLABS_API_KEY;
+    delete process.env.ELIZAOS_CLOUD_API_KEY;
+
+    const config = {
+      cloud: { apiKey: "eliza_cloud_test_key", enabled: true },
+      agents: { defaults: {} },
+    } as Record<string, unknown>;
+    mockLoadElizaConfig.mockReturnValue(config);
+
+    persistCompatOnboardingDefaults({
+      name: "Chen",
+      uiLanguage: "en",
+    });
+
+    expect(mockSaveElizaConfig).toHaveBeenCalledTimes(1);
+    const saved = mockSaveElizaConfig.mock.calls[0][0];
+    expect(saved.messages?.tts?.provider).toBe("elevenlabs");
+    expect(saved.messages?.tts?.mode).toBe("cloud");
+    expect(saved.messages?.tts?.elevenlabs?.voiceId).toEqual(
+      expect.any(String),
+    );
   });
 });
 

--- a/packages/app-core/src/api/server-onboarding-compat.ts
+++ b/packages/app-core/src/api/server-onboarding-compat.ts
@@ -276,11 +276,17 @@ export function persistCompatOnboardingDefaults(
   }
 
   const elevenLabsApiKey = process.env.ELEVENLABS_API_KEY?.trim();
+  const cloudApiKey =
+    trimToUndefined(process.env.ELIZAOS_CLOUD_API_KEY) ??
+    trimToUndefined(
+      typeof config.cloud?.apiKey === "string" ? config.cloud.apiKey : undefined,
+    );
+  const canUseCloudManagedVoice = Boolean(cloudApiKey);
   const voicePresetId = stylePreset?.voicePresetId?.trim();
   const voiceId = voicePresetId
     ? ELEVENLABS_VOICE_ID_BY_PRESET.get(voicePresetId)
     : undefined;
-  if (elevenLabsApiKey && voiceId) {
+  if ((elevenLabsApiKey || canUseCloudManagedVoice) && voiceId) {
     if (!config.messages || typeof config.messages !== "object") {
       (config as Record<string, unknown>).messages = {};
     }
@@ -297,6 +303,7 @@ export function persistCompatOnboardingDefaults(
     messages.tts = {
       ...existingTts,
       provider: "elevenlabs",
+      mode: elevenLabsApiKey ? existingTts.mode : "cloud",
       elevenlabs: {
         ...existingElevenlabs,
         voiceId,

--- a/packages/app-core/src/api/server-onboarding-compat.ts
+++ b/packages/app-core/src/api/server-onboarding-compat.ts
@@ -279,7 +279,9 @@ export function persistCompatOnboardingDefaults(
   const cloudApiKey =
     trimToUndefined(process.env.ELIZAOS_CLOUD_API_KEY) ??
     trimToUndefined(
-      typeof config.cloud?.apiKey === "string" ? config.cloud.apiKey : undefined,
+      typeof config.cloud?.apiKey === "string"
+        ? config.cloud.apiKey
+        : undefined,
     );
   const canUseCloudManagedVoice = Boolean(cloudApiKey);
   const voicePresetId = stylePreset?.voicePresetId?.trim();

--- a/packages/app-core/src/components/CharacterEditor.tsx
+++ b/packages/app-core/src/components/CharacterEditor.tsx
@@ -320,6 +320,10 @@ export function CharacterEditor({
     Record<string, string> | string | undefined
   >;
   const [voiceConfig, setVoiceConfig] = useState<VoiceConfig>({});
+  const hasSavedElevenLabsVoice = Boolean(
+    (voiceConfig.elevenlabs as Record<string, string> | undefined)?.voiceId,
+  );
+  const shouldPreferElevenLabs = useElevenLabs || hasSavedElevenLabsVoice;
 
   const handleChatAvatarSpeakingChange = useCallback(
     (isSpeaking: boolean) => {
@@ -543,8 +547,10 @@ export function CharacterEditor({
       setVoiceSaveError(null);
       if (!entry.voicePresetId) return;
       // When cloud provides ElevenLabs, use the ElevenLabs preset voice.
+      // Also keep ElevenLabs if a saved ElevenLabs voice already exists, so
+      // transient cloud-status flickers don't silently downgrade to Edge.
       // Otherwise fall back to matching edge backup voice by gender.
-      if (useElevenLabs) {
+      if (shouldPreferElevenLabs) {
         const voicePreset = PREMADE_VOICES.find(
           (p) => p.id === entry.voicePresetId,
         );
@@ -566,7 +572,7 @@ export function CharacterEditor({
         }
       }
     },
-    [handleSelectPreset, useElevenLabs],
+    [handleSelectPreset, shouldPreferElevenLabs],
   );
 
   /* ── Character defaults ─────────────────────────────────────────── */
@@ -831,7 +837,7 @@ export function CharacterEditor({
       const defaultVoiceMode =
         typeof voiceConfig.mode === "string"
           ? voiceConfig.mode
-          : useElevenLabs && !hasElevenLabsApiKey
+          : shouldPreferElevenLabs && !hasElevenLabsApiKey
             ? "cloud"
             : "own-key";
       const normalized: Record<string, string> = {
@@ -852,7 +858,7 @@ export function CharacterEditor({
     }
     await client.updateConfig({ messages: { tts: normalizedVoiceConfig } });
     dispatchWindowEvent(VOICE_CONFIG_UPDATED_EVENT, normalizedVoiceConfig);
-  }, [voiceConfig, useElevenLabs]);
+  }, [shouldPreferElevenLabs, voiceConfig, useElevenLabs]);
 
   /* ── Save all ───────────────────────────────────────────────────── */
   const handleSaveAll = useCallback(async () => {

--- a/packages/app-core/src/components/Header.test.tsx
+++ b/packages/app-core/src/components/Header.test.tsx
@@ -122,7 +122,7 @@ describe("Header", () => {
     expect(mockUseApp.setState).toHaveBeenCalledWith("chatMode", "power");
   });
 
-  it("uses minimal chrome for the character view and hides cloud pricing", async () => {
+  it("uses character shell chrome on the character view", async () => {
     const mockUseApp = {
       t: (k: string) => k,
       agentStatus: { state: "running", agentName: "Eliza" },
@@ -178,8 +178,13 @@ describe("Header", () => {
     expect(
       (testRenderer as ReactTestRenderer).root.findAllByProps({
         "data-testid": "header-cloud-status",
+      }).length,
+    ).toBeGreaterThan(0);
+    expect(
+      (testRenderer as ReactTestRenderer).root.findAllByProps({
+        "data-testid": "character-header-shell",
       }),
-    ).toHaveLength(0);
+    ).toHaveLength(1);
   });
 
   it("uses minimal chrome in companion mode", async () => {

--- a/packages/app-core/src/components/Header.tsx
+++ b/packages/app-core/src/components/Header.tsx
@@ -3,7 +3,7 @@ import { getTabGroups, type TabGroup } from "@miladyai/app-core/navigation";
 import { useApp } from "@miladyai/app-core/state";
 import { Button } from "@miladyai/ui";
 import { Menu, X } from "lucide-react";
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { CloudStatusBadge } from "./CloudStatusBadge";
 import { InferenceCloudAlertButton } from "./companion/InferenceCloudAlertButton";
@@ -129,6 +129,26 @@ export function Header({
   const useMinimalHeaderChrome = transparent || activeShellView !== "desktop";
   const showNavigationMenu = activeShellView === "desktop";
   const showCloudStatus = !hideCloudCredits;
+  const useCharacterShellChrome = activeShellView === "character";
+  const showCompanionControls = activeShellView !== "desktop";
+  const characterHeaderShellStyle = useMemo(
+    () =>
+      ({
+        "--companion-header-bg":
+          uiTheme === "light"
+            ? "linear-gradient(180deg, rgba(255,255,255,0.34), rgba(255,255,255,0.1)), linear-gradient(180deg, rgba(255,253,246,0.62), rgba(248,241,215,0.34))"
+            : "linear-gradient(180deg, rgba(255,255,255,0.08), rgba(255,255,255,0.02)), linear-gradient(180deg, rgba(8, 11, 18, 0.52), rgba(5, 7, 12, 0.3))",
+        "--companion-header-border":
+          uiTheme === "light"
+            ? "rgba(201, 186, 143, 0.44)"
+            : "rgba(255, 255, 255, 0.12)",
+        "--companion-header-shadow":
+          uiTheme === "light"
+            ? "inset 0 1px 0 rgba(255,255,255,0.56), inset 0 -1px 0 rgba(171,151,92,0.1), 0 24px 42px rgba(123, 101, 26, 0.14)"
+            : "inset 0 1px 0 rgba(255,255,255,0.12), inset 0 -1px 0 rgba(255,255,255,0.04), 0 24px 50px rgba(2, 4, 8, 0.28)",
+      }) as CSSProperties,
+    [uiTheme],
+  );
 
   const handleShellViewChange = (
     view: "companion" | "character" | "desktop",
@@ -221,107 +241,216 @@ export function Header({
         }`}
         style={{ WebkitUserSelect: "none", userSelect: "none" }}
       >
-        <ShellHeaderControls
-          activeShellView={activeShellView}
-          onShellViewChange={handleShellViewChange}
-          uiLanguage={uiLanguage}
-          setUiLanguage={setUiLanguage}
-          uiTheme={uiTheme}
-          setUiTheme={setUiTheme}
-          t={t}
-          languageDropdownClassName={
-            showNavigationMenu ? "hidden sm:inline-flex" : undefined
-          }
-          languageDropdownWrapperTestId={
-            showNavigationMenu ? "header-language-dropdown-desktop" : undefined
-          }
-          themeToggleWrapperClassName={
-            showNavigationMenu ? "hidden sm:flex" : undefined
-          }
-          themeToggleWrapperTestId={
-            showNavigationMenu ? "header-theme-toggle-desktop" : undefined
-          }
-          rightExtras={
-            <>
-              {chatInferenceNotice ? (
-                <InferenceCloudAlertButton
-                  notice={chatInferenceNotice}
-                  onClick={handleChatInferenceAlertClick}
-                />
-              ) : null}
-              {showCloudStatus ? (
-                <CloudStatusBadge
-                  connected={elizaCloudConnected}
-                  credits={elizaCloudCredits}
-                  creditsLow={elizaCloudCreditsLow}
-                  creditsCritical={elizaCloudCreditsCritical}
-                  authRejected={elizaCloudAuthRejected}
-                  creditsError={elizaCloudCreditsError}
-                  t={t}
-                  onClick={openCloudBilling}
-                  dataTestId="header-cloud-status"
-                />
-              ) : null}
-            </>
-          }
-          showCompanionControls={
-            activeShellView === "companion" || activeShellView === "character"
-          }
-          chatAgentVoiceMuted={chatAgentVoiceMuted}
-          onToggleVoiceMute={() =>
-            setState("chatAgentVoiceMuted", !chatAgentVoiceMuted)
-          }
-          onNewChat={() => void handleNewConversation()}
-          trailingExtras={
-            showNavigationMenu ? (
-              <Button
-                size="icon"
-                variant="outline"
-                className={`sm:hidden ${HEADER_ICON_BUTTON_CLASSNAME}`}
-                onClick={() => setMobileMenuOpen(true)}
-                aria-label={t("aria.openNavMenu")}
-                aria-expanded={mobileMenuOpen}
-                style={HEADER_BUTTON_STYLE}
-              >
-                <Menu className="pointer-events-none w-5 h-5" />
-              </Button>
-            ) : null
-          }
-        >
-          {mobileLeft ? (
-            <div className="flex sm:hidden">{mobileLeft}</div>
-          ) : null}
-          {showNavigationMenu ? (
-            <nav className="scrollbar-hide hidden flex-1 items-center justify-start gap-1.5 overflow-x-auto whitespace-nowrap px-2 sm:flex sm:pl-4">
-              {tabGroups.map((group: TabGroup) => {
-                const primaryTab = group.tabs[0];
-                const isActive = group.tabs.includes(tab);
-                return (
-                  <Button
-                    variant={isActive ? "default" : "ghost"}
-                    key={group.label}
-                    data-testid={`header-nav-button-${primaryTab}`}
-                    className={`${HEADER_NAV_BUTTON_BASE_CLASSNAME} ${
-                      isActive
-                        ? HEADER_NAV_BUTTON_ACTIVE_CLASSNAME
-                        : HEADER_NAV_BUTTON_INACTIVE_CLASSNAME
-                    }`}
-                    onClick={() => setTab(primaryTab)}
-                    title={group.description}
-                    style={HEADER_BUTTON_STYLE}
-                  >
-                    <span
-                      data-testid={`header-nav-label-${primaryTab}`}
-                      className="pointer-events-none inline"
+        {useCharacterShellChrome ? (
+          <div className="px-1.5 pt-1.5 max-[768px]:px-2 max-[768px]:pt-2 sm:px-4 sm:pt-4">
+            <div
+              className="pointer-events-auto relative mx-auto w-full max-w-5xl rounded-[20px] border border-[color:var(--companion-header-border)] bg-[image:var(--companion-header-bg)] shadow-[var(--companion-header-shadow)] ring-1 ring-inset ring-white/10 before:pointer-events-none before:absolute before:inset-x-[6%] before:top-0 before:h-px before:bg-[linear-gradient(90deg,transparent,rgba(255,255,255,0.55),transparent)] backdrop-blur-2xl max-[768px]:rounded-none max-[768px]:border-transparent max-[768px]:bg-none max-[768px]:shadow-none max-[768px]:ring-0 max-[768px]:before:hidden max-[768px]:backdrop-blur-none sm:rounded-[22px]"
+              data-testid="character-header-shell"
+              style={characterHeaderShellStyle}
+            >
+              <ShellHeaderControls
+                activeShellView={activeShellView}
+                onShellViewChange={handleShellViewChange}
+                uiLanguage={uiLanguage}
+                setUiLanguage={setUiLanguage}
+                uiTheme={uiTheme}
+                setUiTheme={setUiTheme}
+                t={t}
+                className="px-2.5 py-2 sm:px-4 sm:py-3"
+                languageDropdownClassName={
+                  showNavigationMenu ? "hidden sm:inline-flex" : undefined
+                }
+                languageDropdownWrapperTestId={
+                  showNavigationMenu
+                    ? "header-language-dropdown-desktop"
+                    : undefined
+                }
+                themeToggleWrapperClassName={
+                  showNavigationMenu ? "hidden sm:flex" : undefined
+                }
+                themeToggleWrapperTestId={
+                  showNavigationMenu ? "header-theme-toggle-desktop" : undefined
+                }
+                rightExtras={
+                  <>
+                    {chatInferenceNotice ? (
+                      <InferenceCloudAlertButton
+                        notice={chatInferenceNotice}
+                        onClick={handleChatInferenceAlertClick}
+                      />
+                    ) : null}
+                    {showCloudStatus ? (
+                      <CloudStatusBadge
+                        connected={elizaCloudConnected}
+                        credits={elizaCloudCredits}
+                        creditsLow={elizaCloudCreditsLow}
+                        creditsCritical={elizaCloudCreditsCritical}
+                        authRejected={elizaCloudAuthRejected}
+                        creditsError={elizaCloudCreditsError}
+                        t={t}
+                        onClick={openCloudBilling}
+                        dataTestId="header-cloud-status"
+                      />
+                    ) : null}
+                  </>
+                }
+                showCompanionControls={showCompanionControls}
+                chatAgentVoiceMuted={chatAgentVoiceMuted}
+                onToggleVoiceMute={() =>
+                  setState("chatAgentVoiceMuted", !chatAgentVoiceMuted)
+                }
+                onNewChat={() => void handleNewConversation()}
+                trailingExtras={
+                  showNavigationMenu ? (
+                    <Button
+                      size="icon"
+                      variant="outline"
+                      className={`sm:hidden ${HEADER_ICON_BUTTON_CLASSNAME}`}
+                      onClick={() => setMobileMenuOpen(true)}
+                      aria-label={t("aria.openNavMenu")}
+                      aria-expanded={mobileMenuOpen}
+                      style={HEADER_BUTTON_STYLE}
                     >
-                      {t(NAV_LABEL_I18N_KEY[group.label] ?? group.label)}
-                    </span>
-                  </Button>
-                );
-              })}
-            </nav>
-          ) : null}
-        </ShellHeaderControls>
+                      <Menu className="pointer-events-none w-5 h-5" />
+                    </Button>
+                  ) : null
+                }
+              >
+                {mobileLeft ? (
+                  <div className="flex sm:hidden">{mobileLeft}</div>
+                ) : null}
+                {showNavigationMenu ? (
+                  <nav className="scrollbar-hide hidden flex-1 items-center justify-start gap-1.5 overflow-x-auto whitespace-nowrap px-2 sm:flex sm:pl-4">
+                    {tabGroups.map((group: TabGroup) => {
+                      const primaryTab = group.tabs[0];
+                      const isActive = group.tabs.includes(tab);
+                      return (
+                        <Button
+                          variant={isActive ? "default" : "ghost"}
+                          key={group.label}
+                          data-testid={`header-nav-button-${primaryTab}`}
+                          className={`${HEADER_NAV_BUTTON_BASE_CLASSNAME} ${
+                            isActive
+                              ? HEADER_NAV_BUTTON_ACTIVE_CLASSNAME
+                              : HEADER_NAV_BUTTON_INACTIVE_CLASSNAME
+                          }`}
+                          onClick={() => setTab(primaryTab)}
+                          title={group.description}
+                          style={HEADER_BUTTON_STYLE}
+                        >
+                          <span
+                            data-testid={`header-nav-label-${primaryTab}`}
+                            className="pointer-events-none inline"
+                          >
+                            {t(NAV_LABEL_I18N_KEY[group.label] ?? group.label)}
+                          </span>
+                        </Button>
+                      );
+                    })}
+                  </nav>
+                ) : null}
+              </ShellHeaderControls>
+            </div>
+          </div>
+        ) : (
+          <ShellHeaderControls
+            activeShellView={activeShellView}
+            onShellViewChange={handleShellViewChange}
+            uiLanguage={uiLanguage}
+            setUiLanguage={setUiLanguage}
+            uiTheme={uiTheme}
+            setUiTheme={setUiTheme}
+            t={t}
+            languageDropdownClassName={
+              showNavigationMenu ? "hidden sm:inline-flex" : undefined
+            }
+            languageDropdownWrapperTestId={
+              showNavigationMenu ? "header-language-dropdown-desktop" : undefined
+            }
+            themeToggleWrapperClassName={
+              showNavigationMenu ? "hidden sm:flex" : undefined
+            }
+            themeToggleWrapperTestId={
+              showNavigationMenu ? "header-theme-toggle-desktop" : undefined
+            }
+            rightExtras={
+              <>
+                {chatInferenceNotice ? (
+                  <InferenceCloudAlertButton
+                    notice={chatInferenceNotice}
+                    onClick={handleChatInferenceAlertClick}
+                  />
+                ) : null}
+                {showCloudStatus ? (
+                  <CloudStatusBadge
+                    connected={elizaCloudConnected}
+                    credits={elizaCloudCredits}
+                    creditsLow={elizaCloudCreditsLow}
+                    creditsCritical={elizaCloudCreditsCritical}
+                    authRejected={elizaCloudAuthRejected}
+                    creditsError={elizaCloudCreditsError}
+                    t={t}
+                    onClick={openCloudBilling}
+                    dataTestId="header-cloud-status"
+                  />
+                ) : null}
+              </>
+            }
+            showCompanionControls={showCompanionControls}
+            chatAgentVoiceMuted={chatAgentVoiceMuted}
+            onToggleVoiceMute={() =>
+              setState("chatAgentVoiceMuted", !chatAgentVoiceMuted)
+            }
+            onNewChat={() => void handleNewConversation()}
+            trailingExtras={
+              showNavigationMenu ? (
+                <Button
+                  size="icon"
+                  variant="outline"
+                  className={`sm:hidden ${HEADER_ICON_BUTTON_CLASSNAME}`}
+                  onClick={() => setMobileMenuOpen(true)}
+                  aria-label={t("aria.openNavMenu")}
+                  aria-expanded={mobileMenuOpen}
+                  style={HEADER_BUTTON_STYLE}
+                >
+                  <Menu className="pointer-events-none w-5 h-5" />
+                </Button>
+              ) : null
+            }
+          >
+            {mobileLeft ? <div className="flex sm:hidden">{mobileLeft}</div> : null}
+            {showNavigationMenu ? (
+              <nav className="scrollbar-hide hidden flex-1 items-center justify-start gap-1.5 overflow-x-auto whitespace-nowrap px-2 sm:flex sm:pl-4">
+                {tabGroups.map((group: TabGroup) => {
+                  const primaryTab = group.tabs[0];
+                  const isActive = group.tabs.includes(tab);
+                  return (
+                    <Button
+                      variant={isActive ? "default" : "ghost"}
+                      key={group.label}
+                      data-testid={`header-nav-button-${primaryTab}`}
+                      className={`${HEADER_NAV_BUTTON_BASE_CLASSNAME} ${
+                        isActive
+                          ? HEADER_NAV_BUTTON_ACTIVE_CLASSNAME
+                          : HEADER_NAV_BUTTON_INACTIVE_CLASSNAME
+                      }`}
+                      onClick={() => setTab(primaryTab)}
+                      title={group.description}
+                      style={HEADER_BUTTON_STYLE}
+                    >
+                      <span
+                        data-testid={`header-nav-label-${primaryTab}`}
+                        className="pointer-events-none inline"
+                      >
+                        {t(NAV_LABEL_I18N_KEY[group.label] ?? group.label)}
+                      </span>
+                    </Button>
+                  );
+                })}
+              </nav>
+            ) : null}
+          </ShellHeaderControls>
+        )}
       </header>
 
       {/* Mobile Menu Overlay */}

--- a/packages/app-core/src/components/Header.tsx
+++ b/packages/app-core/src/components/Header.tsx
@@ -128,7 +128,7 @@ export function Header({
         : "desktop";
   const useMinimalHeaderChrome = transparent || activeShellView !== "desktop";
   const showNavigationMenu = activeShellView === "desktop";
-  const showCloudStatus = activeShellView === "desktop" && !hideCloudCredits;
+  const showCloudStatus = !hideCloudCredits;
 
   const handleShellViewChange = (
     view: "companion" | "character" | "desktop",

--- a/packages/app-core/src/components/onboarding/IdentityStep.tsx
+++ b/packages/app-core/src/components/onboarding/IdentityStep.tsx
@@ -10,29 +10,7 @@ import {
   type CharacterRosterEntry,
   resolveRosterEntries,
 } from "../CharacterRoster";
-import {
-  OnboardingStepHeader,
-  onboardingBodyTextShadowStyle,
-  onboardingFooterClass,
-  onboardingLinkActionClass,
-  onboardingPrimaryActionClass,
-  onboardingPrimaryActionTextShadowStyle,
-  onboardingSecondaryActionClass,
-  onboardingSecondaryActionTextShadowStyle,
-  spawnOnboardingRipple,
-} from "./onboarding-step-chrome";
-
-const CLOUD_TTS_VOICE_IDS = new Set([
-  "alloy",
-  "ash",
-  "ballad",
-  "coral",
-  "echo",
-  "nova",
-  "sage",
-  "shimmer",
-  "verse",
-]);
+import { resolvePreviewTtsEndpoints } from "./identity-preview-tts";
 
 export function IdentityStep() {
   const { onboardingStyle, handleOnboardingNext, setState, t, uiLanguage } =
@@ -42,7 +20,6 @@ export function IdentityStep() {
     () => resolveRosterEntries(getStylePresets(uiLanguage)),
     [uiLanguage],
   );
-  const firstEntry = entries[0];
   const selectedId = onboardingStyle || entries[0]?.id || "";
 
   /* ── Import / restore state ─────────────────────────────────────── */
@@ -114,11 +91,7 @@ export function IdentityStep() {
 
       if (selectedPreset?.voiceId) {
         const apiToken = getElizaApiToken()?.trim() ?? "";
-        const normalizedVoiceId = selectedPreset.voiceId.trim().toLowerCase();
-        const isCloudVoice = CLOUD_TTS_VOICE_IDS.has(normalizedVoiceId);
-        const endpoints = isCloudVoice
-          ? ["/api/tts/cloud", "/api/tts/elevenlabs"]
-          : ["/api/tts/elevenlabs"];
+        const endpoints = resolvePreviewTtsEndpoints(selectedPreset.voiceId);
 
         for (const endpoint of endpoints) {
           if (!isCurrentRequest()) return;
@@ -190,10 +163,11 @@ export function IdentityStep() {
 
   // Auto-select the first one if nothing is selected yet
   useEffect(() => {
+    const firstEntry = entries[0];
     if (!onboardingStyle && firstEntry) {
       handleSelect(firstEntry, false);
     }
-  }, [onboardingStyle, handleSelect, firstEntry]);
+  }, [onboardingStyle, handleSelect]);
 
   useEffect(() => {
     const onTeleportComplete = () => {
@@ -276,11 +250,22 @@ export function IdentityStep() {
   if (showImport) {
     return (
       <div className="flex flex-col items-center gap-3 w-full max-w-[400px]">
-        <OnboardingStepHeader
-          eyebrow={t("settings.importAgent")}
-          description={t("onboarding.importDesc")}
-          descriptionClassName="mt-1 mb-1"
-        />
+        <div
+          className="text-xs tracking-[0.3em] uppercase text-[var(--onboarding-text-muted)] font-semibold text-center mb-0"
+          style={{ textShadow: "0 2px 10px rgba(3,5,10,0.55)" }}
+        >
+          {t("settings.importAgent")}
+        </div>
+        <div className="flex items-center gap-[12px] my-[16px] before:content-[''] before:flex-1 before:h-[1px] before:bg-gradient-to-r before:from-transparent before:via-[var(--onboarding-divider)] before:to-transparent after:content-[''] after:flex-1 after:h-[1px] after:bg-gradient-to-r after:from-transparent after:via-[var(--onboarding-divider)] after:to-transparent">
+          <div className="w-1.5 h-1.5 bg-[rgba(240,185,11,0.4)] rotate-45 shrink-0" />
+        </div>
+
+        <p
+          className="text-sm text-[var(--onboarding-text-muted)] text-center leading-relaxed mt-3 mb-1"
+          style={{ textShadow: "0 2px 10px rgba(3,5,10,0.45)" }}
+        >
+          {t("onboarding.importDesc")}
+        </p>
 
         <input
           type="file"
@@ -306,7 +291,7 @@ export function IdentityStep() {
         {importError && (
           <p
             className="text-sm text-[var(--danger)] text-center leading-relaxed mt-3 !mb-0"
-            style={onboardingBodyTextShadowStyle}
+            style={{ textShadow: "0 2px 10px rgba(3,5,10,0.45)" }}
           >
             {importError}
           </p>
@@ -314,17 +299,17 @@ export function IdentityStep() {
         {importSuccess && (
           <p
             className="text-sm text-[var(--ok)] text-center leading-relaxed mt-3 !mb-0"
-            style={onboardingBodyTextShadowStyle}
+            style={{ textShadow: "0 2px 10px rgba(3,5,10,0.45)" }}
           >
             {importSuccess}
           </p>
         )}
 
-        <div className={`${onboardingFooterClass} mt-2 w-full border-t-0 pt-0`}>
+        <div className="flex gap-3 mt-2">
           <Button
             variant="ghost"
-            className={onboardingSecondaryActionClass}
-            style={onboardingSecondaryActionTextShadowStyle}
+            className="text-[10px] text-[var(--onboarding-text-muted)] tracking-[0.15em] uppercase cursor-pointer no-underline bg-none border-none font-inherit transition-colors duration-300 p-0 hover:text-[var(--onboarding-text-strong)]"
+            style={{ textShadow: "0 1px 8px rgba(3,5,10,0.45)" }}
             onClick={() => {
               setShowImport(false);
               setImportError(null);
@@ -337,14 +322,20 @@ export function IdentityStep() {
             {t("common.cancel")}
           </Button>
           <Button
-            className={onboardingPrimaryActionClass}
-            style={onboardingPrimaryActionTextShadowStyle}
+            className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[var(--onboarding-accent-bg)] border border-[var(--onboarding-accent-border)] rounded-[6px] text-[var(--onboarding-accent-foreground)] text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[var(--onboarding-accent-bg-hover)] hover:border-[var(--onboarding-accent-border-hover)] disabled:opacity-40 disabled:cursor-not-allowed"
+            style={{ textShadow: "0 1px 6px rgba(3,5,10,0.55)" }}
             disabled={importBusy || !importFile}
             onClick={(e) => {
-              spawnOnboardingRipple(e.currentTarget, {
-                x: e.clientX,
-                y: e.clientY,
-              });
+              const rect = e.currentTarget.getBoundingClientRect();
+              const circle = document.createElement("span");
+              const diameter = Math.max(rect.width, rect.height);
+              circle.style.width = circle.style.height = `${diameter}px`;
+              circle.style.left = `${e.clientX - rect.left - diameter / 2}px`;
+              circle.style.top = `${e.clientY - rect.top - diameter / 2}px`;
+              circle.className =
+                "absolute rounded-full bg-[var(--onboarding-ripple)] transform scale-0 animate-[onboarding-ripple-expand_0.6s_ease-out_forwards] pointer-events-none";
+              e.currentTarget.appendChild(circle);
+              setTimeout(() => circle.remove(), 600);
               void handleImportAgent();
             }}
             type="button"
@@ -366,15 +357,9 @@ export function IdentityStep() {
     >
       {/* Selected character info — floats above the roster */}
       <div
-        className="w-full text-center"
+        className="text-center"
         style={{ animation: "onboarding-content-fade-in 0.5s ease 0.1s both" }}
       >
-        <div
-          className="mb-2 text-xs font-semibold uppercase tracking-[0.3em] text-[var(--onboarding-text-muted)]"
-          style={onboardingBodyTextShadowStyle}
-        >
-          {t("onboarding.stepSub.identity")}
-        </div>
         <div
           className="text-[28px] font-bold tracking-[0.12em] uppercase text-[var(--onboarding-text-strong)] transition-all duration-300 max-md:text-xl"
           style={{
@@ -408,18 +393,21 @@ export function IdentityStep() {
         style={{ animation: "onboarding-content-fade-in 0.5s ease 0.3s both" }}
       >
         <Button
-          className={onboardingPrimaryActionClass}
-          style={onboardingPrimaryActionTextShadowStyle}
-          onClick={(event?: React.MouseEvent<HTMLButtonElement>) => {
-            spawnOnboardingRipple(
-              event?.currentTarget ?? null,
-              event
-                ? {
-                    x: event.clientX,
-                    y: event.clientY,
-                  }
-                : undefined,
-            );
+          className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[var(--onboarding-accent-bg)] border border-[var(--onboarding-accent-border)] rounded-[6px] text-[var(--onboarding-accent-foreground)] text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 font-inherit overflow-hidden hover:bg-[var(--onboarding-accent-bg-hover)] hover:border-[var(--onboarding-accent-border-hover)] disabled:opacity-40 disabled:cursor-not-allowed"
+          style={{ textShadow: "0 1px 6px rgba(3,5,10,0.55)" }}
+          onClick={(e) => {
+            if (e?.currentTarget) {
+              const rect = e.currentTarget.getBoundingClientRect();
+              const circle = document.createElement("span");
+              const diameter = Math.max(rect.width, rect.height);
+              circle.style.width = circle.style.height = `${diameter}px`;
+              circle.style.left = `${e.clientX - rect.left - diameter / 2}px`;
+              circle.style.top = `${e.clientY - rect.top - diameter / 2}px`;
+              circle.className =
+                "absolute rounded-full bg-[var(--onboarding-ripple)] transform scale-0 animate-[onboarding-ripple-expand_0.6s_ease-out_forwards] pointer-events-none";
+              e.currentTarget.appendChild(circle);
+              setTimeout(() => circle.remove(), 600);
+            }
             handleOnboardingNext();
           }}
           type="button"
@@ -430,7 +418,7 @@ export function IdentityStep() {
           variant="link"
           type="button"
           onClick={() => setShowImport(true)}
-          className={onboardingLinkActionClass}
+          className="bg-transparent border-none text-[var(--onboarding-text-faint)] text-[11px] cursor-pointer underline font-inherit p-1 px-2 transition-colors duration-300 hover:text-[var(--onboarding-link)]"
         >
           {t("onboarding.restoreFromBackup")}
         </Button>

--- a/packages/app-core/src/components/onboarding/IdentityStep.tsx
+++ b/packages/app-core/src/components/onboarding/IdentityStep.tsx
@@ -22,6 +22,18 @@ import {
   spawnOnboardingRipple,
 } from "./onboarding-step-chrome";
 
+const CLOUD_TTS_VOICE_IDS = new Set([
+  "alloy",
+  "ash",
+  "ballad",
+  "coral",
+  "echo",
+  "nova",
+  "sage",
+  "shimmer",
+  "verse",
+]);
+
 export function IdentityStep() {
   const { onboardingStyle, handleOnboardingNext, setState, t, uiLanguage } =
     useApp();
@@ -43,6 +55,7 @@ export function IdentityStep() {
   const importBusyRef = useRef(false);
   const previewAudioRef = useRef<HTMLAudioElement | null>(null);
   const previewObjectUrlRef = useRef<string | null>(null);
+  const previewRequestIdRef = useRef(0);
   const pendingPreviewEntryRef = useRef<CharacterRosterEntry | null>(null);
   const teleportPreviewTimerRef = useRef<number | null>(null);
 
@@ -72,80 +85,78 @@ export function IdentityStep() {
     [stopPreviewAudio],
   );
 
-  const playSelectionPreview = useCallback(async (entry: CharacterRosterEntry) => {
-    const animationPath =
-      entry.greetingAnimation?.trim() || "animations/emotes/greeting.fbx";
-    dispatchAppEmoteEvent({
-      emoteId: "greeting",
-      path: `/${animationPath.replace(/^\/+/, "")}`,
-      duration: 2.5,
-      loop: false,
-      showOverlay: false,
-    });
+  const playSelectionPreview = useCallback(
+    async (entry: CharacterRosterEntry) => {
+      const requestId = ++previewRequestIdRef.current;
+      const isCurrentRequest = () => previewRequestIdRef.current === requestId;
 
-    const catchphrase = entry.catchphrase?.trim();
-    if (!catchphrase || typeof window === "undefined") return;
+      const animationPath =
+        entry.greetingAnimation?.trim() || "animations/emotes/greeting.fbx";
+      dispatchAppEmoteEvent({
+        emoteId: "greeting",
+        path: `/${animationPath.replace(/^\/+/, "")}`,
+        duration: 2.5,
+        loop: false,
+        showOverlay: false,
+      });
 
-    const selectedPreset = entry.voicePresetId
-      ? PREMADE_VOICES.find((voice) => voice.id === entry.voicePresetId)
-      : undefined;
+      const catchphrase = entry.catchphrase?.trim();
+      if (!catchphrase || typeof window === "undefined") return;
 
-    if (selectedPreset?.previewUrl) {
-      const played = await playPreviewFromUrl(selectedPreset.previewUrl);
-      if (played) return;
-    }
+      const selectedPreset = entry.voicePresetId
+        ? PREMADE_VOICES.find((voice) => voice.id === entry.voicePresetId)
+        : undefined;
 
-    if (selectedPreset?.voiceId) {
-      const apiToken = getElizaApiToken()?.trim() ?? "";
-      try {
-        // Prefer cloud-proxied TTS first so Eliza Cloud users get ElevenLabs
-        // without requiring a local ELEVENLABS_API_KEY.
-        let response = await fetch(resolveApiUrl("/api/tts/cloud"), {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Accept: "audio/mpeg",
-            ...(apiToken ? { Authorization: `Bearer ${apiToken}` } : {}),
-          },
-          body: JSON.stringify({
-            text: catchphrase,
-            voiceId: selectedPreset.voiceId,
-            modelId: "eleven_flash_v2_5",
-            outputFormat: "mp3_44100_128",
-          }),
-        });
-        if (!response.ok) {
-          response = await fetch(resolveApiUrl("/api/tts/elevenlabs"), {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              Accept: "audio/mpeg",
-              ...(apiToken ? { Authorization: `Bearer ${apiToken}` } : {}),
-            },
-            body: JSON.stringify({
-              text: catchphrase,
-              voiceId: selectedPreset.voiceId,
-              modelId: "eleven_flash_v2_5",
-              outputFormat: "mp3_44100_128",
-            }),
-          });
-        }
-        if (response.ok) {
-          const blob = await response.blob();
-          const objectUrl = URL.createObjectURL(blob);
-          previewObjectUrlRef.current = objectUrl;
-          const played = await playPreviewFromUrl(objectUrl);
-          if (played) return;
-        }
-      } catch {
-        // Fall through to desktop/browser speech fallback.
+      if (selectedPreset?.previewUrl) {
+        const played = await playPreviewFromUrl(selectedPreset.previewUrl);
+        if (played && isCurrentRequest()) return;
       }
-    }
 
-    // Intentionally do not fall back to generic system/browser TTS voices for
-    // onboarding previews. If preset sample + ElevenLabs are unavailable, stay
-    // silent instead of degrading character identity quality.
-  }, [playPreviewFromUrl]);
+      if (selectedPreset?.voiceId) {
+        const apiToken = getElizaApiToken()?.trim() ?? "";
+        const normalizedVoiceId = selectedPreset.voiceId.trim().toLowerCase();
+        const isCloudVoice = CLOUD_TTS_VOICE_IDS.has(normalizedVoiceId);
+        const endpoints = isCloudVoice
+          ? ["/api/tts/cloud", "/api/tts/elevenlabs"]
+          : ["/api/tts/elevenlabs"];
+
+        for (const endpoint of endpoints) {
+          if (!isCurrentRequest()) return;
+          try {
+            const response = await fetch(resolveApiUrl(endpoint), {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                Accept: "audio/mpeg",
+                ...(apiToken ? { Authorization: `Bearer ${apiToken}` } : {}),
+              },
+              body: JSON.stringify({
+                text: catchphrase,
+                voiceId: selectedPreset.voiceId,
+                modelId: "eleven_flash_v2_5",
+                outputFormat: "mp3_44100_128",
+              }),
+            });
+            if (!response.ok) continue;
+
+            const blob = await response.blob();
+            if (!isCurrentRequest()) return;
+            const objectUrl = URL.createObjectURL(blob);
+            previewObjectUrlRef.current = objectUrl;
+            const played = await playPreviewFromUrl(objectUrl);
+            if (played && isCurrentRequest()) return;
+          } catch {
+            // Try next endpoint.
+          }
+        }
+      }
+
+      // Intentionally do not fall back to generic system/browser TTS voices for
+      // onboarding previews. If preset sample + ElevenLabs are unavailable, stay
+      // silent instead of degrading character identity quality.
+    },
+    [playPreviewFromUrl],
+  );
 
   const handleSelect = useCallback(
     (entry: CharacterRosterEntry, preview = false) => {
@@ -156,6 +167,13 @@ export function IdentityStep() {
       setState("onboardingName", entry.name);
       setState("selectedVrmIndex", entry.avatarIndex);
       if (preview) {
+        previewRequestIdRef.current += 1;
+        stopPreviewAudio();
+        pendingPreviewEntryRef.current = null;
+        if (teleportPreviewTimerRef.current != null) {
+          window.clearTimeout(teleportPreviewTimerRef.current);
+          teleportPreviewTimerRef.current = null;
+        }
         // Character swaps trigger a teleport dissolve; wait for completion before
         // greeting emote/voice or the emote can be swallowed during transition.
         const avatarChanged = previousAvatarIndex !== entry.avatarIndex;
@@ -167,7 +185,7 @@ export function IdentityStep() {
         }
       }
     },
-    [entries, playSelectionPreview, selectedId, setState],
+    [entries, playSelectionPreview, selectedId, setState, stopPreviewAudio],
   );
 
   // Auto-select the first one if nothing is selected yet
@@ -202,6 +220,7 @@ export function IdentityStep() {
   useEffect(() => {
     return () => {
       pendingPreviewEntryRef.current = null;
+      previewRequestIdRef.current += 1;
       if (teleportPreviewTimerRef.current != null) {
         window.clearTimeout(teleportPreviewTimerRef.current);
         teleportPreviewTimerRef.current = null;

--- a/packages/app-core/src/components/onboarding/IdentityStep.tsx
+++ b/packages/app-core/src/components/onboarding/IdentityStep.tsx
@@ -1,4 +1,7 @@
+import { dispatchAppEmoteEvent } from "@miladyai/app-core/events";
 import { useApp } from "@miladyai/app-core/state";
+import { PREMADE_VOICES } from "../../voice/types";
+import { getElizaApiToken, resolveApiUrl } from "../../utils";
 import { getStylePresets } from "@miladyai/shared/onboarding-presets";
 import { Button, Input } from "@miladyai/ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -38,22 +41,174 @@ export function IdentityStep() {
   const [importError, setImportError] = useState<string | null>(null);
   const [importSuccess, setImportSuccess] = useState<string | null>(null);
   const importBusyRef = useRef(false);
+  const previewAudioRef = useRef<HTMLAudioElement | null>(null);
+  const previewObjectUrlRef = useRef<string | null>(null);
+  const pendingPreviewEntryRef = useRef<CharacterRosterEntry | null>(null);
+  const teleportPreviewTimerRef = useRef<number | null>(null);
+
+  const stopPreviewAudio = useCallback(() => {
+    if (previewAudioRef.current) {
+      previewAudioRef.current.pause();
+      previewAudioRef.current = null;
+    }
+    if (previewObjectUrlRef.current) {
+      URL.revokeObjectURL(previewObjectUrlRef.current);
+      previewObjectUrlRef.current = null;
+    }
+  }, []);
+
+  const playPreviewFromUrl = useCallback(
+    async (url: string) => {
+      stopPreviewAudio();
+      const audio = new Audio(url);
+      previewAudioRef.current = audio;
+      try {
+        await audio.play();
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    [stopPreviewAudio],
+  );
+
+  const playSelectionPreview = useCallback(async (entry: CharacterRosterEntry) => {
+    const animationPath =
+      entry.greetingAnimation?.trim() || "animations/emotes/greeting.fbx";
+    dispatchAppEmoteEvent({
+      emoteId: "greeting",
+      path: `/${animationPath.replace(/^\/+/, "")}`,
+      duration: 2.5,
+      loop: false,
+      showOverlay: false,
+    });
+
+    const catchphrase = entry.catchphrase?.trim();
+    if (!catchphrase || typeof window === "undefined") return;
+
+    const selectedPreset = entry.voicePresetId
+      ? PREMADE_VOICES.find((voice) => voice.id === entry.voicePresetId)
+      : undefined;
+
+    if (selectedPreset?.previewUrl) {
+      const played = await playPreviewFromUrl(selectedPreset.previewUrl);
+      if (played) return;
+    }
+
+    if (selectedPreset?.voiceId) {
+      const apiToken = getElizaApiToken()?.trim() ?? "";
+      try {
+        // Prefer cloud-proxied TTS first so Eliza Cloud users get ElevenLabs
+        // without requiring a local ELEVENLABS_API_KEY.
+        let response = await fetch(resolveApiUrl("/api/tts/cloud"), {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "audio/mpeg",
+            ...(apiToken ? { Authorization: `Bearer ${apiToken}` } : {}),
+          },
+          body: JSON.stringify({
+            text: catchphrase,
+            voiceId: selectedPreset.voiceId,
+            modelId: "eleven_flash_v2_5",
+            outputFormat: "mp3_44100_128",
+          }),
+        });
+        if (!response.ok) {
+          response = await fetch(resolveApiUrl("/api/tts/elevenlabs"), {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Accept: "audio/mpeg",
+              ...(apiToken ? { Authorization: `Bearer ${apiToken}` } : {}),
+            },
+            body: JSON.stringify({
+              text: catchphrase,
+              voiceId: selectedPreset.voiceId,
+              modelId: "eleven_flash_v2_5",
+              outputFormat: "mp3_44100_128",
+            }),
+          });
+        }
+        if (response.ok) {
+          const blob = await response.blob();
+          const objectUrl = URL.createObjectURL(blob);
+          previewObjectUrlRef.current = objectUrl;
+          const played = await playPreviewFromUrl(objectUrl);
+          if (played) return;
+        }
+      } catch {
+        // Fall through to desktop/browser speech fallback.
+      }
+    }
+
+    // Intentionally do not fall back to generic system/browser TTS voices for
+    // onboarding previews. If preset sample + ElevenLabs are unavailable, stay
+    // silent instead of degrading character identity quality.
+  }, [playPreviewFromUrl]);
 
   const handleSelect = useCallback(
-    (entry: CharacterRosterEntry) => {
+    (entry: CharacterRosterEntry, preview = false) => {
+      const previousAvatarIndex = selectedId
+        ? entries.find((candidate) => candidate.id === selectedId)?.avatarIndex
+        : undefined;
       setState("onboardingStyle", entry.id);
       setState("onboardingName", entry.name);
       setState("selectedVrmIndex", entry.avatarIndex);
+      if (preview) {
+        // Character swaps trigger a teleport dissolve; wait for completion before
+        // greeting emote/voice or the emote can be swallowed during transition.
+        const avatarChanged = previousAvatarIndex !== entry.avatarIndex;
+        if (avatarChanged) {
+          pendingPreviewEntryRef.current = entry;
+        } else {
+          pendingPreviewEntryRef.current = null;
+          void playSelectionPreview(entry);
+        }
+      }
     },
-    [setState],
+    [entries, playSelectionPreview, selectedId, setState],
   );
 
   // Auto-select the first one if nothing is selected yet
   useEffect(() => {
     if (!onboardingStyle && firstEntry) {
-      handleSelect(firstEntry);
+      handleSelect(firstEntry, false);
     }
   }, [onboardingStyle, handleSelect, firstEntry]);
+
+  useEffect(() => {
+    const onTeleportComplete = () => {
+      const pending = pendingPreviewEntryRef.current;
+      if (!pending) return;
+      pendingPreviewEntryRef.current = null;
+      if (teleportPreviewTimerRef.current != null) {
+        window.clearTimeout(teleportPreviewTimerRef.current);
+      }
+      teleportPreviewTimerRef.current = window.setTimeout(() => {
+        teleportPreviewTimerRef.current = null;
+        void playSelectionPreview(pending);
+      }, 450);
+    };
+    window.addEventListener("eliza:vrm-teleport-complete", onTeleportComplete);
+    return () => {
+      window.removeEventListener(
+        "eliza:vrm-teleport-complete",
+        onTeleportComplete,
+      );
+    };
+  }, [playSelectionPreview]);
+
+  useEffect(() => {
+    return () => {
+      pendingPreviewEntryRef.current = null;
+      if (teleportPreviewTimerRef.current != null) {
+        window.clearTimeout(teleportPreviewTimerRef.current);
+        teleportPreviewTimerRef.current = null;
+      }
+      stopPreviewAudio();
+    };
+  }, [stopPreviewAudio]);
 
   const handleImportAgent = useCallback(async () => {
     if (importBusyRef.current || importBusy) return;
@@ -223,7 +378,7 @@ export function IdentityStep() {
         <CharacterRoster
           entries={entries}
           selectedId={selectedId}
-          onSelect={handleSelect}
+          onSelect={(entry) => handleSelect(entry, true)}
           variant="onboarding"
           testIdPrefix="onboarding"
         />

--- a/packages/app-core/src/components/onboarding/IdentityStep.tsx
+++ b/packages/app-core/src/components/onboarding/IdentityStep.tsx
@@ -1,10 +1,10 @@
 import { dispatchAppEmoteEvent } from "@miladyai/app-core/events";
 import { useApp } from "@miladyai/app-core/state";
-import { PREMADE_VOICES } from "../../voice/types";
-import { getElizaApiToken, resolveApiUrl } from "../../utils";
 import { getStylePresets } from "@miladyai/shared/onboarding-presets";
 import { Button, Input } from "@miladyai/ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { getElizaApiToken, resolveApiUrl } from "../../utils";
+import { PREMADE_VOICES } from "../../voice/types";
 import {
   CharacterRoster,
   type CharacterRosterEntry,
@@ -20,6 +20,7 @@ export function IdentityStep() {
     () => resolveRosterEntries(getStylePresets(uiLanguage)),
     [uiLanguage],
   );
+  const firstEntry = entries[0];
   const selectedId = onboardingStyle || entries[0]?.id || "";
 
   /* ── Import / restore state ─────────────────────────────────────── */
@@ -163,11 +164,10 @@ export function IdentityStep() {
 
   // Auto-select the first one if nothing is selected yet
   useEffect(() => {
-    const firstEntry = entries[0];
     if (!onboardingStyle && firstEntry) {
       handleSelect(firstEntry, false);
     }
-  }, [onboardingStyle, handleSelect]);
+  }, [onboardingStyle, handleSelect, firstEntry]);
 
   useEffect(() => {
     const onTeleportComplete = () => {

--- a/packages/app-core/src/components/onboarding/identity-preview-tts.test.ts
+++ b/packages/app-core/src/components/onboarding/identity-preview-tts.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { resolvePreviewTtsEndpoints } from "./identity-preview-tts";
+
+describe("resolvePreviewTtsEndpoints", () => {
+  it("prefers cloud route first for cloud-native voice IDs", () => {
+    expect(resolvePreviewTtsEndpoints("nova")).toEqual([
+      "/api/tts/cloud",
+      "/api/tts/elevenlabs",
+    ]);
+    expect(resolvePreviewTtsEndpoints("  SHIMMER  ")).toEqual([
+      "/api/tts/cloud",
+      "/api/tts/elevenlabs",
+    ]);
+  });
+
+  it("uses only elevenlabs route for preset/custom elevenlabs voice IDs", () => {
+    expect(resolvePreviewTtsEndpoints("21m00Tcm4TlvDq8ikWAM")).toEqual([
+      "/api/tts/elevenlabs",
+    ]);
+    expect(resolvePreviewTtsEndpoints("cNYrMw9glwJZXR8RwbuR")).toEqual([
+      "/api/tts/elevenlabs",
+    ]);
+  });
+});
+

--- a/packages/app-core/src/components/onboarding/identity-preview-tts.test.ts
+++ b/packages/app-core/src/components/onboarding/identity-preview-tts.test.ts
@@ -22,4 +22,3 @@ describe("resolvePreviewTtsEndpoints", () => {
     ]);
   });
 });
-

--- a/packages/app-core/src/components/onboarding/identity-preview-tts.ts
+++ b/packages/app-core/src/components/onboarding/identity-preview-tts.ts
@@ -1,0 +1,20 @@
+const CLOUD_TTS_VOICE_IDS = new Set([
+  "alloy",
+  "ash",
+  "ballad",
+  "coral",
+  "echo",
+  "nova",
+  "sage",
+  "shimmer",
+  "verse",
+]);
+
+export function resolvePreviewTtsEndpoints(voiceId: string): string[] {
+  const normalizedVoiceId = voiceId.trim().toLowerCase();
+  const isCloudVoice = CLOUD_TTS_VOICE_IDS.has(normalizedVoiceId);
+  return isCloudVoice
+    ? ["/api/tts/cloud", "/api/tts/elevenlabs"]
+    : ["/api/tts/elevenlabs"];
+}
+

--- a/packages/app-core/src/components/onboarding/identity-preview-tts.ts
+++ b/packages/app-core/src/components/onboarding/identity-preview-tts.ts
@@ -17,4 +17,3 @@ export function resolvePreviewTtsEndpoints(voiceId: string): string[] {
     ? ["/api/tts/cloud", "/api/tts/elevenlabs"]
     : ["/api/tts/elevenlabs"];
 }
-

--- a/packages/app-core/src/hooks/useVoiceChat.ts
+++ b/packages/app-core/src/hooks/useVoiceChat.ts
@@ -20,7 +20,10 @@ import {
   useState,
 } from "react";
 import type { VoiceConfig, VoiceMode } from "../api/client";
-import { getElectrobunRendererRpc } from "../bridge/electrobun-rpc";
+import {
+  getElectrobunRendererRpc,
+  invokeDesktopBridgeRequest,
+} from "../bridge/electrobun-rpc";
 import {
   getTalkModePlugin,
   type TalkModeErrorEvent,
@@ -1290,6 +1293,15 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
         activeTaskFinishRef.current = finish;
 
         if (!synth) {
+          if (getElectrobunRendererRpc()) {
+            void invokeDesktopBridgeRequest<void>({
+              rpcMethod: "talkmodeSpeak",
+              ipcChannel: "talkmode:speak",
+              params: { text: text.trim() },
+            }).catch((err: unknown) => {
+              console.warn("[useVoiceChat] Desktop speech bridge failed:", err);
+            });
+          }
           emitPlaybackStart({
             text,
             segment: task.segment,

--- a/packages/app-core/src/hooks/useVoiceChat.ts
+++ b/packages/app-core/src/hooks/useVoiceChat.ts
@@ -323,9 +323,12 @@ function shelterUrls(input: string): {
  */
 function isRealSentenceEnd(value: string, matchIndex: number): boolean {
   // Decimal: digit immediately before the period → not a sentence end.
-  if (matchIndex > 0 && /\d/.test(value[matchIndex - 1]!)) {
+  const prevChar = matchIndex > 0 ? value.charAt(matchIndex - 1) : "";
+  if (/\d/.test(prevChar)) {
     // Check if a digit also follows the period (e.g. "3.14")
-    if (matchIndex + 1 < value.length && /\d/.test(value[matchIndex + 1]!)) {
+    const nextChar =
+      matchIndex + 1 < value.length ? value.charAt(matchIndex + 1) : "";
+    if (/\d/.test(nextChar)) {
       return false;
     }
   }

--- a/packages/app-core/src/hooks/useVoiceChat.ts
+++ b/packages/app-core/src/hooks/useVoiceChat.ts
@@ -467,10 +467,13 @@ function resolveEffectiveVoiceConfig(
 ): VoiceConfig | null {
   const cloudConnected = options?.cloudConnected === true;
   const base = cloneVoiceConfig(config) ?? {};
-  const provider =
+  const inferredProvider =
     base.provider ??
     (base.elevenlabs ? "elevenlabs" : base.edge ? "edge" : undefined) ??
     (cloudConnected ? "elevenlabs" : undefined);
+  // Prefer cloud ElevenLabs whenever cloud is connected, even if a stale
+  // saved config still says "edge" from an earlier fallback session.
+  const provider = cloudConnected ? "elevenlabs" : inferredProvider;
 
   if (!provider) return null;
   if (provider !== "elevenlabs") {
@@ -1428,13 +1431,14 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
                 break;
               }
               console.warn(
-                "[useVoiceChat] ElevenLabs TTS failed, falling back to browser:",
+                "[useVoiceChat] ElevenLabs TTS failed; browser fallback suppressed:",
                 error instanceof Error
                   ? `${error.name}: ${error.message}`
                   : error,
               );
-              usingAudioAnalysisRef.current = false;
-              setUsingAudioAnalysis(false);
+              // Keep voice identity consistent: if ElevenLabs is selected and
+              // fails, do not swap to browser/system voices.
+              continue;
             }
           } else {
             usingAudioAnalysisRef.current = false;

--- a/packages/app-core/src/state/AppContext.tsx
+++ b/packages/app-core/src/state/AppContext.tsx
@@ -5,7 +5,6 @@
  */
 
 import { ONBOARDING_PROVIDER_CATALOG } from "@miladyai/shared/contracts/onboarding";
-import { replaceNameTokens } from "../components/character-editor-helpers";
 import {
   getDefaultStylePreset,
   getStylePresets,
@@ -32,7 +31,6 @@ import {
   type BscTradeTxStatusResponse,
   type BscTransferExecuteRequest,
   type BscTransferExecuteResponse,
-  type StewardStatusResponse,
   type CatalogSkill,
   type CharacterData,
   type CodingAgentSession,
@@ -101,6 +99,7 @@ import {
   normalizeSlashCommandName,
 } from "../chat";
 import { mapServerTasksToSessions } from "../coding";
+import { replaceNameTokens } from "../components/character-editor-helpers";
 import { getBootConfig, setBootConfig } from "../config/boot-config";
 import { BrandingContext, DEFAULT_BRANDING } from "../config/branding";
 import { type AppEmoteEventDetail, dispatchAppEmoteEvent } from "../events";
@@ -142,9 +141,9 @@ import {
   asApiLikeError,
   type CompanionHalfFramerateMode,
   type CompanionVrmPowerMode,
+  clearAvatarIndex,
   clearPersistedConnectionMode,
   clearPersistedOnboardingStep,
-  clearAvatarIndex,
   deriveOnboardingResumeConnection,
   deriveOnboardingResumeFields,
   formatSearchBullet,
@@ -722,7 +721,7 @@ function AppProviderInner({
     for (const turn of queued) {
       turn.resolve();
     }
-  }, [chatSendQueueRef]);
+  }, []);
   const interruptActiveChatPipeline = useCallback(() => {
     resolveQueuedChatSends();
     chatAbortRef.current?.abort();
@@ -731,7 +730,6 @@ function AppProviderInner({
     setChatFirstTokenReceived(false);
   }, [
     chatAbortRef,
-    chatSendQueueRef,
     resolveQueuedChatSends,
     setChatFirstTokenReceived,
     setChatSending,
@@ -2837,8 +2835,6 @@ function AppProviderInner({
       onboardingCompletionCommittedRef,
       onboardingResumeConnectionRef,
       setSelectedVrmIndex,
-      setCustomVrmUrl,
-      setCustomBackgroundUrl,
     ],
   );
 
@@ -3716,7 +3712,6 @@ function AppProviderInner({
     }
   }, [
     chatSendBusyRef,
-    chatSendQueueRef,
     runQueuedChatSend,
     setChatFirstTokenReceived,
     setChatSending,
@@ -3749,7 +3744,7 @@ function AppProviderInner({
         void flushQueuedChatSends();
       });
     },
-    [chatSendQueueRef, flushQueuedChatSends, setChatSending],
+    [flushQueuedChatSends, setChatSending],
   );
 
   const handleChatSend = useCallback(
@@ -5425,6 +5420,7 @@ function AppProviderInner({
     setOnboardingStyle,
     setPostOnboardingChecklistDismissed,
     setSelectedVrmIndex,
+    loadCharacter,
   ]);
 
   // ── Onboarding motion (flow graph: packages/app-core/src/onboarding/flow.ts) ──

--- a/packages/app-core/src/state/AppContext.tsx
+++ b/packages/app-core/src/state/AppContext.tsx
@@ -6105,10 +6105,7 @@ function AppProviderInner({
       // We only nudge run mode so the provider grid is available.
       setOnboardingRunMode(prefill.runMode);
     },
-    [
-      setOnboardingDetectedProviders,
-      setOnboardingRunMode,
-    ],
+    [setOnboardingDetectedProviders, setOnboardingRunMode],
   );
 
   // ── Generic state setter ───────────────────────────────────────────

--- a/packages/app-core/src/state/AppContext.tsx
+++ b/packages/app-core/src/state/AppContext.tsx
@@ -6100,14 +6100,13 @@ function AppProviderInner({
         return;
       }
 
+      // Keep users on provider choice first: detection should inform and
+      // annotate options, not auto-route into a specific provider detail view.
+      // We only nudge run mode so the provider grid is available.
       setOnboardingRunMode(prefill.runMode);
-      setOnboardingProvider(prefill.providerId);
-      setOnboardingApiKey(prefill.apiKey);
     },
     [
-      setOnboardingApiKey,
       setOnboardingDetectedProviders,
-      setOnboardingProvider,
       setOnboardingRunMode,
     ],
   );
@@ -6442,7 +6441,9 @@ function AppProviderInner({
           ? await inspectExistingElizaInstall().catch(() => null)
           : null;
       const shouldPreferLocalBootstrap =
-        forceLocalBootstrap || Boolean(desktopExistingInstall?.detected);
+        forceLocalBootstrap ||
+        isElectrobunRuntime() ||
+        Boolean(desktopExistingInstall?.detected);
       const probedConnection = persistedConnection
         ? null
         : await detectExistingOnboardingConnection({
@@ -7174,17 +7175,25 @@ function AppProviderInner({
         logStartupWarning("failed to load wallet addresses", err);
       }
 
-      // Restore avatar selection from config (server-persisted under "ui")
+      // Restore avatar selection from stream settings (same source used when saving).
+      // This prevents detached/settings windows from snapping back to stale
+      // config.ui.avatarIndex values and overwriting local avatar preference.
       let resolvedIndex = loadAvatarIndex();
       try {
-        const cfg = await client.getConfig();
-        const ui = cfg.ui as Record<string, unknown> | undefined;
-        if (ui?.avatarIndex != null) {
-          resolvedIndex = normalizeAvatarIndex(Number(ui.avatarIndex));
+        const stream = await client.getStreamSettings();
+        const serverAvatarIndex = stream.settings?.avatarIndex;
+        if (
+          typeof serverAvatarIndex === "number" &&
+          Number.isFinite(serverAvatarIndex)
+        ) {
+          resolvedIndex = normalizeAvatarIndex(serverAvatarIndex);
           setSelectedVrmIndex(resolvedIndex);
         }
       } catch (err) {
-        logStartupWarning("failed to load config for avatar selection", err);
+        logStartupWarning(
+          "failed to load stream settings for avatar selection",
+          err,
+        );
       }
       // If custom avatar selected, verify the file still exists on the server
       if (resolvedIndex === 0) {

--- a/packages/app-core/src/state/AppContext.tsx
+++ b/packages/app-core/src/state/AppContext.tsx
@@ -2146,14 +2146,9 @@ function AppProviderInner({
       return lastElizaCloudPollConnectedRef.current;
     }
     if (!cloudStatus) {
-      setElizaCloudConnected(false);
-      setElizaCloudCredits(null);
-      setElizaCloudCreditsLow(false);
-      setElizaCloudCreditsCritical(false);
-      setElizaCloudAuthRejected(false);
-      setElizaCloudCreditsError(null);
-      lastElizaCloudPollConnectedRef.current = false;
-      return false;
+      // Keep last-known cloud state on transient poll failures.
+      // This prevents brief startup/network blips from looking like a disconnect.
+      return lastElizaCloudPollConnectedRef.current;
     }
     // Trust `connected` from the server snapshot (it already folds in API key + CLOUD_AUTH).
     const isConnected = Boolean(cloudStatus.connected);
@@ -2210,10 +2205,9 @@ function AppProviderInner({
       setElizaCloudCreditsError(null);
     }
     lastElizaCloudPollConnectedRef.current = isConnected;
-    // Self-manage the recurring poll interval: start when connected, stop when not.
-    // This covers login during onboarding (interval wasn't started at mount) and
-    // disconnect (interval should stop to avoid useless API calls).
-    if (isConnected && !elizaCloudPollInterval.current) {
+    // Keep polling even when disconnected so recovered sessions are detected
+    // automatically without requiring user interaction.
+    if (!elizaCloudPollInterval.current) {
       elizaCloudPollInterval.current = window.setInterval(() => {
         if (
           typeof document !== "undefined" &&
@@ -2223,9 +2217,6 @@ function AppProviderInner({
         }
         void pollCloudCredits();
       }, 60_000);
-    } else if (!isConnected && elizaCloudPollInterval.current) {
-      clearInterval(elizaCloudPollInterval.current);
-      elizaCloudPollInterval.current = null;
     }
     return isConnected;
   }, []);

--- a/scripts/docker-ci-smoke.sh
+++ b/scripts/docker-ci-smoke.sh
@@ -112,7 +112,7 @@ node --import tsx scripts/write-build-info.ts 2>/dev/null || true
 
 log "Building app UI"
 pushd apps/app >/dev/null
-NODE_ENV=production npx vite build
+NODE_ENV=production bunx vite build
 popd >/dev/null
 
 log "Preparing CI dockerignore"


### PR DESCRIPTION
## Summary
- fix onboarding identity preview voice routing so ElevenLabs voice IDs no longer collapse to a single cloud default voice
- guard against stale async preview playback when rapidly switching characters
- preserve no-system-TTS fallback behavior for onboarding previews
- add regression tests for preview endpoint selection
- add fork-safe CI workflow on ubuntu-latest and scope it to branch-relevant checks

## Validation
- `bunx tsc --noEmit`
- `bunx vitest run packages/app-core/src/components/onboarding/identity-preview-tts.test.ts`
- Fork CI (passing): https://github.com/dutchiono/milady/actions/runs/23552330182