### PR TITLE
fix: stop recreating window on close — run in background instead

### DIFF
--- a/apps/app/electrobun/src/__tests__/close-to-background.test.ts
+++ b/apps/app/electrobun/src/__tests__/close-to-background.test.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const INDEX_PATH = path.resolve(import.meta.dirname, "..", "index.ts");
+const source = readFileSync(INDEX_PATH, "utf-8");
+
+describe("close-to-background behavior", () => {
+  it("ensureBackgroundWindow does NOT create a new BrowserWindow", () => {
+    // Find the ensureBackgroundWindow function body
+    const fnStart = source.indexOf("async function ensureBackgroundWindow");
+    expect(fnStart).toBeGreaterThan(-1);
+
+    // Get the function body (up to the next top-level function)
+    const fnBody = source.slice(fnStart, fnStart + 500);
+
+    // Must NOT contain createMainWindow — that was the bug
+    expect(fnBody).not.toContain("createMainWindow");
+    // Must NOT contain attachMainWindow
+    expect(fnBody).not.toContain("attachMainWindow");
+    // Should show the background notification
+    expect(fnBody).toContain("showBackgroundRunNoticeOnce");
+  });
+
+  it("restoreWindow function exists and creates window when needed", () => {
+    const fnStart = source.indexOf("async function restoreWindow");
+    expect(fnStart).toBeGreaterThan(-1);
+
+    const fnBody = source.slice(fnStart, fnStart + 600);
+
+    // Should handle existing window (unminimize + focus)
+    expect(fnBody).toContain("unminimize");
+    expect(fnBody).toContain("focus");
+    // Should create new window when none exists
+    expect(fnBody).toContain("createMainWindow");
+    expect(fnBody).toContain("attachMainWindow");
+    expect(fnBody).toContain("injectApiBase");
+  });
+
+  it("setupDockReopen wires the Electrobun reopen event", () => {
+    const fnStart = source.indexOf("function setupDockReopen");
+    expect(fnStart).toBeGreaterThan(-1);
+
+    const fnBody = source.slice(fnStart, fnStart + 200);
+    expect(fnBody).toContain('"reopen"');
+    expect(fnBody).toContain("restoreWindow");
+  });
+
+  it("setupDockReopen is called during initialization", () => {
+    expect(source).toContain("setupDockReopen();");
+  });
+
+  it("application-menu-clicked restores window when main window is gone", () => {
+    const menuHandler = source.indexOf('"application-menu-clicked"');
+    expect(menuHandler).toBeGreaterThan(-1);
+
+    const handlerBody = source.slice(menuHandler, menuHandler + 600);
+    expect(handlerBody).toContain("!currentWindow");
+    expect(handlerBody).toContain("restoreWindow");
+  });
+
+  it("showMainSurface restores window before sending renderer message", () => {
+    const fnStart = source.indexOf("async function showMainSurface");
+    expect(fnStart).toBeGreaterThan(-1);
+
+    const fnBody = source.slice(fnStart, fnStart + 300);
+    expect(fnBody).toContain("!currentWindow");
+    expect(fnBody).toContain("restoreWindow");
+    expect(fnBody).toContain("sendToActiveRenderer");
+  });
+
+  it("exitOnLastWindowClosed is false in electrobun config", () => {
+    const candidates = [
+      path.resolve(import.meta.dirname, "..", "electrobun.config.ts"),
+      path.resolve("apps/app/electrobun/electrobun.config.ts"),
+    ];
+    let configSource = "";
+    for (const p of candidates) {
+      try {
+        configSource = readFileSync(p, "utf-8");
+        break;
+      } catch {}
+    }
+    expect(configSource.length).toBeGreaterThan(0);
+    expect(configSource).toContain("exitOnLastWindowClosed: false");
+  });
+});

--- a/apps/app/electrobun/src/__tests__/startup-bootstrap.test.ts
+++ b/apps/app/electrobun/src/__tests__/startup-bootstrap.test.ts
@@ -70,14 +70,20 @@ describe("Electrobun startup bootstrap", () => {
     expect(source).toContain("MILADY_DESKTOP_API_BASE");
   });
 
-  it("shows a one-time background notice after recreating the minimized window", () => {
+  it("shows a one-time background notice when window closes to background", () => {
     const indexSource = fs.readFileSync(INDEX_PATH, "utf8");
     const noticeSource = fs.readFileSync(BACKGROUND_NOTICE_PATH, "utf8");
-    const minimizeIndex = indexSource.indexOf("replacementWindow.minimize();");
-    const noticeIndex = indexSource.indexOf("showBackgroundRunNoticeOnce();");
 
-    expect(minimizeIndex).toBeGreaterThan(-1);
-    expect(noticeIndex).toBeGreaterThan(minimizeIndex);
+    // ensureBackgroundWindow should call showBackgroundRunNoticeOnce
+    // without creating a new window (no replacementWindow.minimize)
+    const bgFnStart = indexSource.indexOf(
+      "async function ensureBackgroundWindow",
+    );
+    expect(bgFnStart).toBeGreaterThan(-1);
+    const bgFnBody = indexSource.slice(bgFnStart, bgFnStart + 500);
+    expect(bgFnBody).toContain("showBackgroundRunNoticeOnce");
+    expect(bgFnBody).not.toContain("createMainWindow");
+
     expect(noticeSource).toContain(
       'export const BACKGROUND_NOTICE_TITLE = "Milady Is Still Running";',
     );

--- a/apps/app/electrobun/src/index.ts
+++ b/apps/app/electrobun/src/index.ts
@@ -775,24 +775,39 @@ function attachMainWindow(win: BrowserWindow): BrowserWindow {
 }
 
 async function ensureBackgroundWindow(): Promise<void> {
-  if (isQuitting || currentWindow || backgroundWindowPromise) {
+  if (isQuitting || currentWindow) {
     return;
   }
 
-  backgroundWindowPromise = (async () => {
-    const replacementWindow = attachMainWindow(await createMainWindow());
+  // Don't recreate the window — just keep the process alive in the
+  // background (exitOnLastWindowClosed is false in electrobun.config.ts).
+  // The dock icon click fires the "reopen" event which restores the window.
+  console.log("[Main] Window closed — agent continues in background");
+  showBackgroundRunNoticeOnce();
+}
+
+/** Restore or recreate the main window (called on dock icon click). */
+async function restoreWindow(): Promise<void> {
+  if (currentWindow) {
     try {
-      replacementWindow.minimize();
-      console.log("[Main] Recreated minimized background window");
-      showBackgroundRunNoticeOnce();
-    } catch (err) {
-      console.warn("[Main] Failed to minimize background window:", err);
+      currentWindow.unminimize();
+      currentWindow.focus();
+    } catch {
+      // unminimize/focus may not be available
     }
-    injectApiBase(replacementWindow);
+    return;
+  }
+  if (backgroundWindowPromise) {
+    await backgroundWindowPromise;
+    return;
+  }
+  backgroundWindowPromise = (async () => {
+    const win = attachMainWindow(await createMainWindow());
+    injectApiBase(win);
+    console.log("[Main] Restored window from dock click");
   })().finally(() => {
     backgroundWindowPromise = null;
   });
-
   await backgroundWindowPromise;
 }
 
@@ -815,7 +830,10 @@ async function createSettingsWindow(tabHint?: string): Promise<void> {
   await surfaceWindowManager.openSettingsWindow(tabHint);
 }
 
-function showMainSurface(surface: string): void {
+async function showMainSurface(surface: string): Promise<void> {
+  if (!currentWindow) {
+    await restoreWindow();
+  }
   void getDesktopManager().showWindow();
   sendToActiveRenderer("desktopTrayMenuClick", {
     itemId: `show-main:${surface}`,
@@ -1191,8 +1209,13 @@ async function setupUpdater(): Promise<void> {
 
     Electrobun.events.on(
       "application-menu-clicked",
-      (e: { data?: { action?: string } }) => {
+      async (e: { data?: { action?: string } }) => {
         const action = e?.data?.action;
+
+        // If the main window is gone and the action targets it, restore first.
+        if (!currentWindow && action && !action.startsWith("focus-window:")) {
+          await restoreWindow();
+        }
         if (action === "check-for-updates") {
           triggerManualUpdateCheck();
         } else if (action === "export-config") {
@@ -1272,6 +1295,12 @@ async function setupUpdater(): Promise<void> {
 function setupDeepLinks(): void {
   Electrobun.events.on("open-url", (url: string) => {
     sendToActiveRenderer("shareTargetReceived", { url });
+  });
+}
+
+function setupDockReopen(): void {
+  Electrobun.events.on("reopen", () => {
+    void restoreWindow();
   });
 }
 
@@ -1526,6 +1555,7 @@ async function main(): Promise<void> {
   }
 
   setupDeepLinks();
+  setupDockReopen();
 
   const desktop = getDesktopManager();
   try {


### PR DESCRIPTION
## Summary

When the user closes the desktop window, `ensureBackgroundWindow()` was creating a new `BrowserWindow` and minimizing it. This caused a visible flash where the window would close then immediately reopen minimized.

### What changed
- **`ensureBackgroundWindow`** — no longer creates a replacement window. Just logs and shows the background notification. The process stays alive via `exitOnLastWindowClosed: false`.
- **`restoreWindow`** — new function that unminimizes an existing window or creates a new one. Used by dock click and menu actions.
- **`setupDockReopen`** — listens for Electrobun's `"reopen"` event (dock icon click) and calls `restoreWindow()`.
- **Menu handler** — restores the main window before executing any action that targets it, preventing blank white pages.
- **`showMainSurface`** — restores window before sending renderer messages.

### Behavior
1. Close window → stays closed, notification shows, agent runs in background
2. Click dock icon → window restores
3. Click menu/tray item → window restores first, then action executes

### Tests (7 new)
- ensureBackgroundWindow doesn't create new BrowserWindow
- restoreWindow handles both existing and missing window
- setupDockReopen wires the reopen event
- setupDockReopen called during init
- Menu handler restores window when missing
- showMainSurface restores before messaging
- exitOnLastWindowClosed config verified

## Verification
- [x] `npx tsc --noEmit` — clean
- [x] `bun run lint` — clean
- [x] Tests: 7/7 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)