### PR TITLE
[fix] fix desktop companion header glass bleed

### DIFF
--- a/packages/app-core/src/components/Header.test.tsx
+++ b/packages/app-core/src/components/Header.test.tsx
@@ -478,7 +478,7 @@ describe("Header", () => {
     ).toHaveLength(1);
   });
 
-  it("renders the glassmorphic pill container in all modes", async () => {
+  it("keeps desktop header chrome transparent so companion glass stays scoped", async () => {
     const mockUseApp = {
       elizaCloudEnabled: false,
       elizaCloudConnected: false,
@@ -514,9 +514,12 @@ describe("Header", () => {
     await act(async () => {
       tree = create(<Header />);
     });
-    const glassShell = tree?.root.findAll(
-      (node) => node.props["data-testid"] === "header-glass-shell",
+    const glassShell = tree?.root.findByProps({
+      "data-testid": "header-glass-shell",
+    });
+    expect(String(glassShell?.props.className)).toContain("bg-transparent");
+    expect(String(glassShell?.props.className)).toContain(
+      "backdrop-blur-none",
     );
-    expect(glassShell?.length).toBe(1);
   });
 });

--- a/packages/app-core/src/components/Header.test.tsx
+++ b/packages/app-core/src/components/Header.test.tsx
@@ -237,6 +237,58 @@ describe("Header", () => {
     ).toHaveLength(0);
   });
 
+  it("keeps desktop shell transparent when the header is explicitly transparent", async () => {
+    const mockUseApp = {
+      t: (k: string) => k,
+      agentStatus: { state: "running", agentName: "Eliza" },
+      elizaCloudEnabled: false,
+      elizaCloudConnected: false,
+      elizaCloudCredits: null,
+      elizaCloudCreditsCritical: false,
+      elizaCloudCreditsLow: false,
+      elizaCloudAuthRejected: false,
+      elizaCloudCreditsError: null,
+      elizaCloudTopUpUrl: "",
+      lifecycleBusy: false,
+      lifecycleAction: null,
+      handleRestart: vi.fn(),
+      handleStart: vi.fn(),
+      loadDropStatus: vi.fn().mockResolvedValue(undefined),
+      tab: "chat",
+      setTab: vi.fn(),
+      setState: vi.fn(),
+      plugins: [],
+      uiLanguage: "en",
+      setUiLanguage: vi.fn(),
+      uiTheme: "dark",
+      setUiTheme: vi.fn(),
+      uiShellMode: "native",
+      switchShellView: vi.fn(),
+    };
+
+    // @ts-expect-error - test uses a narrowed subset of the full app context type.
+    vi.spyOn(AppContext, "useApp").mockReturnValue(mockUseApp);
+
+    let testRenderer: ReactTestRenderer | null = null;
+    await act(async () => {
+      testRenderer = create(<Header transparent />);
+    });
+    if (!testRenderer) {
+      throw new Error("Failed to render Header");
+    }
+
+    const glassShell = (testRenderer as ReactTestRenderer).root.findByProps({
+      "data-testid": "header-glass-shell",
+    });
+    expect(String(glassShell.props.className)).toContain("bg-transparent");
+    expect(String(glassShell.props.className)).toContain("backdrop-blur-none");
+    expect(
+      (testRenderer as ReactTestRenderer).root.findAll(
+        (node) => node.props["data-testid"] === "header-nav-button-chat",
+      ),
+    ).not.toHaveLength(0);
+  });
+
   it("shows nothing when cloud is disconnected", async () => {
     const mockUseApp = {
       t: (k: string) => k,

--- a/packages/app-core/src/components/Header.test.tsx
+++ b/packages/app-core/src/components/Header.test.tsx
@@ -518,8 +518,6 @@ describe("Header", () => {
       "data-testid": "header-glass-shell",
     });
     expect(String(glassShell?.props.className)).toContain("bg-transparent");
-    expect(String(glassShell?.props.className)).toContain(
-      "backdrop-blur-none",
-    );
+    expect(String(glassShell?.props.className)).toContain("backdrop-blur-none");
   });
 });

--- a/packages/app-core/src/components/Header.tsx
+++ b/packages/app-core/src/components/Header.tsx
@@ -129,10 +129,11 @@ export function Header({
       : tab === "character" || tab === "character-select"
         ? "character"
         : "desktop";
-  const useMinimalHeaderChrome = transparent || activeShellView !== "desktop";
-  const showNavigationMenu = activeShellView === "desktop";
-  const showCloudStatus = activeShellView === "desktop" && !hideCloudCredits;
-  const headerShellClassName = showNavigationMenu
+  const isDesktopShell = activeShellView === "desktop";
+  const useMinimalHeaderChrome = transparent || !isDesktopShell;
+  const showNavigationMenu = isDesktopShell;
+  const showCloudStatus = isDesktopShell && !hideCloudCredits;
+  const headerShellClassName = isDesktopShell
     ? "border-transparent bg-transparent shadow-none ring-0 backdrop-blur-none"
     : "max-w-5xl border-[rgba(255,255,255,0.12)] bg-[image:linear-gradient(180deg,rgba(255,255,255,0.08),rgba(255,255,255,0.02)),linear-gradient(180deg,rgba(8,11,18,0.52),rgba(5,7,12,0.3))] shadow-[inset_0_1px_0_rgba(255,255,255,0.12),inset_0_-1px_0_rgba(255,255,255,0.04),0_24px_50px_rgba(2,4,8,0.28)] ring-1 ring-inset ring-white/10 backdrop-blur-2xl";
 

--- a/packages/app-core/src/components/Header.tsx
+++ b/packages/app-core/src/components/Header.tsx
@@ -132,6 +132,9 @@ export function Header({
   const useMinimalHeaderChrome = transparent || activeShellView !== "desktop";
   const showNavigationMenu = activeShellView === "desktop";
   const showCloudStatus = activeShellView === "desktop" && !hideCloudCredits;
+  const headerShellClassName = showNavigationMenu
+    ? "border-transparent bg-transparent shadow-none ring-0 backdrop-blur-none"
+    : "max-w-5xl border-[rgba(255,255,255,0.12)] bg-[image:linear-gradient(180deg,rgba(255,255,255,0.08),rgba(255,255,255,0.02)),linear-gradient(180deg,rgba(8,11,18,0.52),rgba(5,7,12,0.3))] shadow-[inset_0_1px_0_rgba(255,255,255,0.12),inset_0_-1px_0_rgba(255,255,255,0.04),0_24px_50px_rgba(2,4,8,0.28)] ring-1 ring-inset ring-white/10 backdrop-blur-2xl";
 
   const handleShellViewChange = (
     view: "companion" | "character" | "desktop",
@@ -225,11 +228,7 @@ export function Header({
           className={`px-1.5 pt-1.5 sm:px-4 sm:pt-3 ${useMinimalHeaderChrome ? "" : "pb-1.5 sm:pb-3"}`}
         >
           <div
-            className={`pointer-events-auto relative mx-auto w-full rounded-[20px] border bg-clip-padding shadow ring-1 ring-inset ring-white/10 backdrop-blur-2xl sm:rounded-[22px] transition-all ${
-              useMinimalHeaderChrome
-                ? "max-w-5xl border-[rgba(255,255,255,0.12)] bg-[image:linear-gradient(180deg,rgba(255,255,255,0.08),rgba(255,255,255,0.02)),linear-gradient(180deg,rgba(8,11,18,0.52),rgba(5,7,12,0.3))] shadow-[inset_0_1px_0_rgba(255,255,255,0.12),inset_0_-1px_0_rgba(255,255,255,0.04),0_24px_50px_rgba(2,4,8,0.28)]"
-                : "border-[rgba(255,255,255,0.12)] bg-[image:linear-gradient(180deg,rgba(255,255,255,0.08),rgba(255,255,255,0.02)),linear-gradient(180deg,rgba(8,11,18,0.52),rgba(5,7,12,0.3))] shadow-[inset_0_1px_0_rgba(255,255,255,0.12),inset_0_-1px_0_rgba(255,255,255,0.04),0_24px_50px_rgba(2,4,8,0.28)]"
-            }`}
+            className={`pointer-events-auto relative mx-auto w-full rounded-[20px] border bg-clip-padding transition-all sm:rounded-[22px] ${headerShellClassName}`}
             data-testid="header-glass-shell"
           >
             <ShellHeaderControls


### PR DESCRIPTION
## Summary
This fixes a desktop header regression where the companion glass shell styling leaked into the standard desktop header. On desktop, the top navigation was still wrapped in the same blurred glass bar intended for companion and character-facing header chrome, which made the full-width desktop header look like the companion overlay instead of the normal desktop surface.

## Root Cause
The shared `Header` component rendered the same outer shell treatment in both branches of its header chrome logic. Even when the active shell view was `desktop`, the wrapper still kept the blurred background, border, ring, and shadow classes, so the desktop header never actually dropped back to a transparent container.

## Fix
The desktop header path now uses a transparent shell wrapper, while the companion and character paths continue to use the dedicated glass treatment. This keeps the companion bar scoped to companion-oriented views and preserves the expected desktop header appearance without changing the separate `CompanionHeader` component.

## Validation
I ran the focused header test suite:

- `bun test packages/app-core/src/components/Header.test.tsx`

I also updated the header regression test so desktop explicitly asserts that the wrapper remains transparent and unblurred.
