### PR TITLE
fix: desktop header drops companion glass styling in desktop mode

### DIFF
--- a/packages/app-core/src/components/Header.test.tsx
+++ b/packages/app-core/src/components/Header.test.tsx
@@ -478,7 +478,7 @@ describe("Header", () => {
     ).toHaveLength(1);
   });
 
-  it("renders the glassmorphic pill container in all modes", async () => {
+  it("keeps desktop header chrome transparent so companion glass stays scoped", async () => {
     const mockUseApp = {
       elizaCloudEnabled: false,
       elizaCloudConnected: false,
@@ -514,9 +514,10 @@ describe("Header", () => {
     await act(async () => {
       tree = create(<Header />);
     });
-    const glassShell = tree?.root.findAll(
-      (node) => node.props["data-testid"] === "header-glass-shell",
-    );
-    expect(glassShell?.length).toBe(1);
+    const glassShell = tree?.root.findByProps({
+      "data-testid": "header-glass-shell",
+    });
+    expect(String(glassShell?.props.className)).toContain("bg-transparent");
+    expect(String(glassShell?.props.className)).toContain("backdrop-blur-none");
   });
 });

--- a/packages/app-core/src/components/Header.tsx
+++ b/packages/app-core/src/components/Header.tsx
@@ -132,6 +132,9 @@ export function Header({
   const useMinimalHeaderChrome = transparent || activeShellView !== "desktop";
   const showNavigationMenu = activeShellView === "desktop";
   const showCloudStatus = activeShellView === "desktop" && !hideCloudCredits;
+  const headerShellClassName = showNavigationMenu
+    ? "border-transparent bg-transparent shadow-none ring-0 backdrop-blur-none"
+    : "max-w-5xl border-[rgba(255,255,255,0.12)] bg-[image:linear-gradient(180deg,rgba(255,255,255,0.08),rgba(255,255,255,0.02)),linear-gradient(180deg,rgba(8,11,18,0.52),rgba(5,7,12,0.3))] shadow-[inset_0_1px_0_rgba(255,255,255,0.12),inset_0_-1px_0_rgba(255,255,255,0.04),0_24px_50px_rgba(2,4,8,0.28)] ring-1 ring-inset ring-white/10 backdrop-blur-2xl";
 
   const handleShellViewChange = (
     view: "companion" | "character" | "desktop",
@@ -225,11 +228,7 @@ export function Header({
           className={`px-1.5 pt-1.5 sm:px-4 sm:pt-3 ${useMinimalHeaderChrome ? "" : "pb-1.5 sm:pb-3"}`}
         >
           <div
-            className={`pointer-events-auto relative mx-auto w-full rounded-[20px] border bg-clip-padding shadow ring-1 ring-inset ring-white/10 backdrop-blur-2xl sm:rounded-[22px] transition-all ${
-              useMinimalHeaderChrome
-                ? "max-w-5xl border-[rgba(255,255,255,0.12)] bg-[image:linear-gradient(180deg,rgba(255,255,255,0.08),rgba(255,255,255,0.02)),linear-gradient(180deg,rgba(8,11,18,0.52),rgba(5,7,12,0.3))] shadow-[inset_0_1px_0_rgba(255,255,255,0.12),inset_0_-1px_0_rgba(255,255,255,0.04),0_24px_50px_rgba(2,4,8,0.28)]"
-                : "border-[rgba(255,255,255,0.12)] bg-[image:linear-gradient(180deg,rgba(255,255,255,0.08),rgba(255,255,255,0.02)),linear-gradient(180deg,rgba(8,11,18,0.52),rgba(5,7,12,0.3))] shadow-[inset_0_1px_0_rgba(255,255,255,0.12),inset_0_-1px_0_rgba(255,255,255,0.04),0_24px_50px_rgba(2,4,8,0.28)]"
-            }`}
+            className={`pointer-events-auto relative mx-auto w-full rounded-[20px] border bg-clip-padding transition-all sm:rounded-[22px] ${headerShellClassName}`}
             data-testid="header-glass-shell"
           >
             <ShellHeaderControls


### PR DESCRIPTION
## Summary

The companion glass shell (blur, border, shadow) was leaking into the standard desktop header. Desktop mode now uses a transparent shell wrapper while companion/character views keep the glass treatment.

### What changed
- Desktop mode: `border-transparent bg-transparent shadow-none ring-0 backdrop-blur-none`
- Companion/character mode: keeps the glass pill (`max-w-5xl`, blur, border, shadow)
- Test updated to assert desktop header is transparent

Based on #1346 by @SYMBaiEX — lint/format fixed.

Supersedes #1346

🤖 Generated with [Claude Code](https://claude.com/claude-code)