### PR TITLE
feat(win): automatic startup crash reports and diagnostics flow

### DIFF
--- a/apps/app/electrobun/src/__tests__/agent.test.ts
+++ b/apps/app/electrobun/src/__tests__/agent.test.ts
@@ -343,7 +343,8 @@ describe("AgentManager", () => {
       expect(writeFileSync).toHaveBeenCalled();
       expect(copyFileSync).toHaveBeenCalledTimes(2);
       const reportJsonWrite = writeFileSync.mock.calls.find(
-        (call) => typeof call[0] === "string" && call[0].endsWith("report.json"),
+        (call) =>
+          typeof call[0] === "string" && call[0].endsWith("report.json"),
       );
       expect(reportJsonWrite).toBeDefined();
       const parsed = JSON.parse(String(reportJsonWrite?.[1]));

--- a/apps/app/electrobun/src/__tests__/agent.test.ts
+++ b/apps/app/electrobun/src/__tests__/agent.test.ts
@@ -317,6 +317,21 @@ describe("AgentManager", () => {
     it("creates a local bug report bundle and copies diagnostics files", async () => {
       const writeFileSync = await getWriteFileSyncMock();
       const copyFileSync = await getCopyFileSyncMock();
+      const readFileSync = await getReadFileSyncMock();
+      readFileSync.mockImplementation((filePath: string) => {
+        if (String(filePath).endsWith("startup-status.json")) {
+          return JSON.stringify({
+            state: "error",
+            phase: "startup",
+            updatedAt: "2026-03-26T00:00:00.000Z",
+            logPath: "/tmp/milady-startup.log",
+            statusPath: "/tmp/startup-status.json",
+            platform: "win32",
+            arch: "x64",
+          });
+        }
+        return "Authorization: Bearer test-secret\nsafe line";
+      });
 
       const bundle = createBugReportBundle({
         reportMarkdown: "# Report",
@@ -327,6 +342,16 @@ describe("AgentManager", () => {
       expect(bundle.directory).toContain("canary-");
       expect(writeFileSync).toHaveBeenCalled();
       expect(copyFileSync).toHaveBeenCalledTimes(2);
+      const reportJsonWrite = writeFileSync.mock.calls.find(
+        (call) => typeof call[0] === "string" && call[0].endsWith("report.json"),
+      );
+      expect(reportJsonWrite).toBeDefined();
+      const parsed = JSON.parse(String(reportJsonWrite?.[1]));
+      expect(parsed.startupDiagnostics).toMatchObject({
+        state: "error",
+        phase: "startup",
+      });
+      expect(parsed.startupLogTail).toContain("[REDACTED]");
     });
 
     it("returns a default startup diagnostics snapshot when the status file is missing", async () => {

--- a/apps/app/electrobun/src/__tests__/agent.test.ts
+++ b/apps/app/electrobun/src/__tests__/agent.test.ts
@@ -22,17 +22,26 @@ const ORIGINAL_PLATFORM = process.platform;
 vi.mock("node:fs", () => {
   const existsSyncFn = vi.fn(() => true);
   const rmSyncFn = vi.fn();
+  const readFileSyncFn = vi.fn(() => "");
+  const writeFileSyncFn = vi.fn();
+  const copyFileSyncFn = vi.fn();
   return {
     default: {
       existsSync: existsSyncFn,
       mkdirSync: vi.fn(),
       appendFileSync: vi.fn(),
+      readFileSync: readFileSyncFn,
+      writeFileSync: writeFileSyncFn,
+      copyFileSync: copyFileSyncFn,
       readdirSync: vi.fn(() => ["entry.js"]),
       rmSync: rmSyncFn,
     },
     existsSync: existsSyncFn,
     mkdirSync: vi.fn(),
     appendFileSync: vi.fn(),
+    readFileSync: readFileSyncFn,
+    writeFileSync: writeFileSyncFn,
+    copyFileSync: copyFileSyncFn,
     readdirSync: vi.fn(() => ["entry.js"]),
     rmSync: rmSyncFn,
   };
@@ -141,13 +150,33 @@ async function getExistsSyncMock(): Promise<Mock> {
   return fs.default.existsSync as Mock;
 }
 
+async function getReadFileSyncMock(): Promise<Mock> {
+  const fs = await import("node:fs");
+  return fs.default.readFileSync as Mock;
+}
+
+async function getWriteFileSyncMock(): Promise<Mock> {
+  const fs = await import("node:fs");
+  return fs.default.writeFileSync as Mock;
+}
+
+async function getCopyFileSyncMock(): Promise<Mock> {
+  const fs = await import("node:fs");
+  return fs.default.copyFileSync as Mock;
+}
+
 // ---------------------------------------------------------------------------
 // Import AFTER mocks
 // ---------------------------------------------------------------------------
 import {
   AgentManager,
+  createBugReportBundle,
+  getDiagnosticLogPath,
   getHealthPollTimeoutMs,
   getMiladyDistFallbackCandidates,
+  getStartupDiagnosticLogTail,
+  getStartupDiagnosticsSnapshot,
+  getStartupStatusPath,
 } from "../native/agent";
 
 describe("AgentManager", () => {
@@ -264,6 +293,51 @@ describe("AgentManager", () => {
 
     it("getPort returns null initially", () => {
       expect(manager.getPort()).toBeNull();
+    });
+  });
+
+  describe("diagnostics helpers", () => {
+    it("resolves the startup status file beside the startup log", () => {
+      expect(getDiagnosticLogPath()).toContain("milady-startup.log");
+      expect(getStartupStatusPath()).toContain("startup-status.json");
+    });
+
+    it("redacts secrets from the startup log tail", async () => {
+      const readFileSync = await getReadFileSyncMock();
+      readFileSync.mockReturnValue(
+        "Authorization: Bearer super-secret-token\napiKey=abc123\nlast line",
+      );
+
+      const tail = getStartupDiagnosticLogTail();
+      expect(tail).toContain("[REDACTED]");
+      expect(tail).toContain("last line");
+      expect(tail).not.toContain("super-secret-token");
+    });
+
+    it("creates a local bug report bundle and copies diagnostics files", async () => {
+      const writeFileSync = await getWriteFileSyncMock();
+      const copyFileSync = await getCopyFileSyncMock();
+
+      const bundle = createBugReportBundle({
+        reportMarkdown: "# Report",
+        reportJson: { ok: true },
+        prefix: "canary",
+      });
+
+      expect(bundle.directory).toContain("canary-");
+      expect(writeFileSync).toHaveBeenCalled();
+      expect(copyFileSync).toHaveBeenCalledTimes(2);
+    });
+
+    it("returns a default startup diagnostics snapshot when the status file is missing", async () => {
+      const readFileSync = await getReadFileSyncMock();
+      readFileSync.mockImplementation(() => {
+        throw new Error("missing");
+      });
+
+      const snapshot = getStartupDiagnosticsSnapshot();
+      expect(snapshot.state).toBe("not_started");
+      expect(snapshot.statusPath).toContain("startup-status.json");
     });
   });
 

--- a/apps/app/electrobun/src/__tests__/startup-bootstrap.test.ts
+++ b/apps/app/electrobun/src/__tests__/startup-bootstrap.test.ts
@@ -59,6 +59,15 @@ describe("Electrobun startup bootstrap", () => {
     expect(source).toContain("[Main] Skipping embedded agent startup");
   });
 
+  it("prompts with startup crash report recovery instructions", () => {
+    const source = fs.readFileSync(INDEX_PATH, "utf8");
+
+    expect(source).toContain("maybePromptStartupCrashReport");
+    expect(source).toContain("Please send this in Discord and ping @iono.");
+    expect(source).toContain("Copy Report");
+    expect(source).toContain("startup-crash-report-latest.md");
+  });
+
   it("does not load repo or ~/.eliza env files in packaged desktop builds", () => {
     const source = fs.readFileSync(INDEX_PATH, "utf8");
 

--- a/apps/app/electrobun/src/__tests__/startup-bootstrap.test.ts
+++ b/apps/app/electrobun/src/__tests__/startup-bootstrap.test.ts
@@ -63,7 +63,10 @@ describe("Electrobun startup bootstrap", () => {
     const source = fs.readFileSync(INDEX_PATH, "utf8");
 
     expect(source).toContain("maybePromptStartupCrashReport");
-    expect(source).toContain("Please send this in Discord and ping @iono.");
+    expect(source).toContain("Share this report in Discord and ping @iono.");
+    expect(source).toContain("App Version:");
+    expect(source).toContain("Runtime:");
+    expect(source).toContain("Startup Log Tail:");
     expect(source).toContain("Copy Report");
     expect(source).toContain("startup-crash-report-latest.md");
   });

--- a/apps/app/electrobun/src/index.ts
+++ b/apps/app/electrobun/src/index.ts
@@ -30,7 +30,13 @@ import {
   pickReachableMenuResetApiBase,
   runMainMenuResetAfterApiBaseResolved,
 } from "./menu-reset-from-main";
-import { configureDesktopLocalApiAuth, getAgentManager } from "./native/agent";
+import {
+  configureDesktopLocalApiAuth,
+  getAgentManager,
+  getDiagnosticLogPath,
+  getStartupDiagnosticsSnapshot,
+  getStartupStatusPath,
+} from "./native/agent";
 import { getDesktopManager } from "./native/desktop";
 import { disposeNativeModules, initializeNativeModules } from "./native/index";
 import {
@@ -67,6 +73,8 @@ type HeartbeatMenuHealthResponse = {
 
 const HEARTBEAT_MENU_REFRESH_MS = 30_000;
 const CONFIG_EXPORT_FILE_NAME = "milady-config.json";
+const STARTUP_CRASH_REPORT_FILE = "startup-crash-report-latest.md";
+const STARTUP_CRASH_PROMPT_MARKER_FILE = "startup-crash-last-prompted.txt";
 // Browser surface ships enabled by default. Set
 // MILADY_ENABLE_BROWSER_SURFACE=0 to force-disable it for local debugging or
 // release triage.
@@ -1430,6 +1438,8 @@ async function main(): Promise<void> {
   console.log(
     `[Env] desktopRuntimeMode=${runtimeResolution.mode} externalApi=${runtimeResolution.externalApi.base ?? "none"}`,
   );
+
+  await maybePromptStartupCrashReport();
   // On Windows (CEF renderer), clear stale CEF profile data when the app
   // version changes.  A leftover Partitions/default profile from a previous
   // install causes "Cannot create profile at path" errors that cascade into
@@ -1643,19 +1653,158 @@ async function main(): Promise<void> {
   setupShutdown(cleanupFns);
 }
 
+function resolveStartupCrashReportPath(): string {
+  return path.join(
+    path.dirname(getDiagnosticLogPath()),
+    STARTUP_CRASH_REPORT_FILE,
+  );
+}
+
+function resolveStartupCrashPromptMarkerPath(): string {
+  return path.join(
+    path.dirname(getDiagnosticLogPath()),
+    STARTUP_CRASH_PROMPT_MARKER_FILE,
+  );
+}
+
+function buildStartupCrashDiscordReport(options: {
+  source: "startup-recovery" | "fatal-startup";
+  error: string | null;
+}): string {
+  const diagnostics = getStartupDiagnosticsSnapshot();
+  const reportLines = [
+    "Milady startup crash report",
+    "",
+    `Source: ${options.source}`,
+    `Timestamp: ${new Date().toISOString()}`,
+    `Platform: ${process.platform} ${process.arch}`,
+    `Bun: ${Bun.version}`,
+    `State: ${diagnostics.state}`,
+    `Phase: ${diagnostics.phase}`,
+    `Last Error: ${options.error ?? diagnostics.lastError ?? "unknown"}`,
+    `Updated At: ${diagnostics.updatedAt}`,
+    `Log Path: ${diagnostics.logPath}`,
+    `Status Path: ${diagnostics.statusPath}`,
+    "",
+    "Please send this in Discord and ping @iono.",
+  ];
+  return `${reportLines.join("\n")}\n`;
+}
+
+function persistStartupCrashReport(options: {
+  source: "startup-recovery" | "fatal-startup";
+  error: string | null;
+}): { report: string; reportPath: string } {
+  const report = buildStartupCrashDiscordReport(options);
+  const reportPath = resolveStartupCrashReportPath();
+  try {
+    fs.writeFileSync(reportPath, report, "utf8");
+  } catch (err) {
+    console.warn("[Main] Failed to write startup crash report:", err);
+  }
+  return { report, reportPath };
+}
+
+function wasStartupCrashAlreadyPrompted(updatedAt: string): boolean {
+  try {
+    const markerPath = resolveStartupCrashPromptMarkerPath();
+    return fs.readFileSync(markerPath, "utf8").trim() === updatedAt;
+  } catch {
+    return false;
+  }
+}
+
+function markStartupCrashPrompted(updatedAt: string): void {
+  try {
+    fs.writeFileSync(resolveStartupCrashPromptMarkerPath(), updatedAt, "utf8");
+  } catch {}
+}
+
+async function maybePromptStartupCrashReport(): Promise<void> {
+  const diagnostics = getStartupDiagnosticsSnapshot();
+  const looksLikeStartupFailure =
+    diagnostics.state === "error" &&
+    diagnostics.phase !== "ready" &&
+    diagnostics.phase !== "stopped";
+  if (!looksLikeStartupFailure) {
+    return;
+  }
+  if (wasStartupCrashAlreadyPrompted(diagnostics.updatedAt)) {
+    return;
+  }
+
+  const { report, reportPath } = persistStartupCrashReport({
+    source: "startup-recovery",
+    error: diagnostics.lastError,
+  });
+  markStartupCrashPrompted(diagnostics.updatedAt);
+
+  const dialog = await Utils.showMessageBox({
+    type: "warning",
+    title: "Milady recovered after a startup failure",
+    message:
+      "The previous launch failed. A crash report is ready to share with support.",
+    detail:
+      "Choose Copy Report, paste into Discord, and ping @iono. You can also open logs.",
+    buttons: ["Copy Report", "Open Logs Folder", "Continue"],
+    defaultId: 0,
+    cancelId: 2,
+  });
+  const response =
+    dialog && typeof dialog === "object" && "response" in dialog
+      ? (dialog as { response: number }).response
+      : typeof dialog === "number"
+        ? dialog
+        : 2;
+
+  if (response === 0) {
+    try {
+      Utils.clipboardWriteText(report);
+      Utils.showNotification({
+        title: "Crash report copied",
+        body: "Paste in Discord and ping @iono.",
+      });
+    } catch (err) {
+      console.warn("[Main] Failed to copy startup crash report:", err);
+    }
+  } else if (response === 1) {
+    try {
+      Utils.openPath(path.dirname(reportPath));
+    } catch (err) {
+      console.warn("[Main] Failed to open startup logs folder:", err);
+    }
+  }
+}
+
 main().catch((err) => {
   const msg = `[Main] Fatal error during startup: ${err?.stack ?? err}`;
   console.error(msg);
+  persistStartupCrashReport({
+    source: "fatal-startup",
+    error: msg,
+  });
   // Write to startup log so it's visible even without a console
   try {
-    const logDir =
-      process.platform === "win32"
-        ? path.join(process.env.APPDATA ?? "", "Milady")
-        : path.join(os.homedir(), ".config", "Milady");
-    fs.mkdirSync(logDir, { recursive: true });
-    fs.appendFileSync(
-      path.join(logDir, "milady-startup.log"),
-      `[${new Date().toISOString()}] ${msg}\n`,
+    const logPath = getDiagnosticLogPath();
+    fs.mkdirSync(path.dirname(logPath), { recursive: true });
+    fs.appendFileSync(logPath, `[${new Date().toISOString()}] ${msg}\n`);
+    fs.writeFileSync(
+      getStartupStatusPath(),
+      `${JSON.stringify(
+        {
+          state: "error",
+          phase: "fatal_startup",
+          updatedAt: new Date().toISOString(),
+          lastError: msg,
+          platform: process.platform,
+          arch: process.arch,
+          logPath,
+          statusPath: getStartupStatusPath(),
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
     );
   } catch {}
   process.exit(1);

--- a/apps/app/electrobun/src/index.ts
+++ b/apps/app/electrobun/src/index.ts
@@ -34,6 +34,7 @@ import {
   configureDesktopLocalApiAuth,
   getAgentManager,
   getDiagnosticLogPath,
+  getStartupDiagnosticLogTail,
   getStartupDiagnosticsSnapshot,
   getStartupStatusPath,
 } from "./native/agent";
@@ -1672,13 +1673,19 @@ function buildStartupCrashDiscordReport(options: {
   error: string | null;
 }): string {
   const diagnostics = getStartupDiagnosticsSnapshot();
+  const startupLogTail = getStartupDiagnosticLogTail(8_000).trim();
+  const appVersion = process.env.npm_package_version?.trim() || "unknown";
+  const appRuntime = `electrobun/${Bun.version}`;
   const reportLines = [
     "Milady startup crash report",
     "",
+    "Share this report in Discord and ping @iono.",
+    "",
     `Source: ${options.source}`,
     `Timestamp: ${new Date().toISOString()}`,
+    `App Version: ${appVersion}`,
+    `Runtime: ${appRuntime}`,
     `Platform: ${process.platform} ${process.arch}`,
-    `Bun: ${Bun.version}`,
     `State: ${diagnostics.state}`,
     `Phase: ${diagnostics.phase}`,
     `Last Error: ${options.error ?? diagnostics.lastError ?? "unknown"}`,
@@ -1686,8 +1693,14 @@ function buildStartupCrashDiscordReport(options: {
     `Log Path: ${diagnostics.logPath}`,
     `Status Path: ${diagnostics.statusPath}`,
     "",
-    "Please send this in Discord and ping @iono.",
+    startupLogTail ? "Startup Log Tail:" : "Startup Log Tail: unavailable",
   ];
+
+  if (startupLogTail) {
+    reportLines.push("```");
+    reportLines.push(startupLogTail);
+    reportLines.push("```");
+  }
   return `${reportLines.join("\n")}\n`;
 }
 
@@ -1696,11 +1709,24 @@ function persistStartupCrashReport(options: {
   error: string | null;
 }): { report: string; reportPath: string } {
   const report = buildStartupCrashDiscordReport(options);
-  const reportPath = resolveStartupCrashReportPath();
+  const primaryReportPath = resolveStartupCrashReportPath();
+  const fallbackReportPath = path.join(os.tmpdir(), STARTUP_CRASH_REPORT_FILE);
+  let reportPath = primaryReportPath;
   try {
-    fs.writeFileSync(reportPath, report, "utf8");
+    fs.mkdirSync(path.dirname(primaryReportPath), { recursive: true });
+    fs.writeFileSync(primaryReportPath, report, "utf8");
   } catch (err) {
     console.warn("[Main] Failed to write startup crash report:", err);
+    try {
+      fs.mkdirSync(path.dirname(fallbackReportPath), { recursive: true });
+      fs.writeFileSync(fallbackReportPath, report, "utf8");
+      reportPath = fallbackReportPath;
+    } catch (fallbackErr) {
+      console.warn(
+        "[Main] Failed to write fallback startup crash report:",
+        fallbackErr,
+      );
+    }
   }
   return { report, reportPath };
 }

--- a/apps/app/electrobun/src/native/agent.ts
+++ b/apps/app/electrobun/src/native/agent.ts
@@ -472,12 +472,23 @@ export function createBugReportBundle(options: {
   const statusPath = getStartupStatusPath();
   const startupLogTarget = path.join(directory, "milady-startup.log");
   const startupStatusTarget = path.join(directory, "startup-status.json");
+  const startupDiagnostics = getStartupDiagnosticsSnapshot();
+  const includeLogTail =
+    typeof options.reportJson.attachLogs === "boolean"
+      ? options.reportJson.attachLogs
+      : true;
+  const startupLogTail = includeLogTail ? getStartupDiagnosticLogTail() : "";
+  const normalizedReportJson = {
+    ...options.reportJson,
+    startupDiagnostics,
+    startupLogTail,
+  };
 
   fs.mkdirSync(directory, { recursive: true });
   fs.writeFileSync(reportMarkdownPath, options.reportMarkdown, "utf8");
   fs.writeFileSync(
     reportJsonPath,
-    `${JSON.stringify(options.reportJson, null, 2)}\n`,
+    `${JSON.stringify(normalizedReportJson, null, 2)}\n`,
     "utf8",
   );
 

--- a/apps/app/electrobun/src/native/agent.ts
+++ b/apps/app/electrobun/src/native/agent.ts
@@ -46,6 +46,29 @@ interface AgentStatus {
   error: string | null;
 }
 
+export interface StartupDiagnosticsSnapshot {
+  state: AgentStatus["state"];
+  phase: string;
+  updatedAt: string;
+  lastError: string | null;
+  agentName: string | null;
+  port: number | null;
+  startedAt: number | null;
+  platform: string;
+  arch: string;
+  configDir: string;
+  logPath: string;
+  statusPath: string;
+}
+
+export interface BugReportBundleResult {
+  directory: string;
+  reportMarkdownPath: string;
+  reportJsonPath: string;
+  startupLogPath: string | null;
+  startupStatusPath: string | null;
+}
+
 type ExistingElizaInstallSource =
   | "config-path-env"
   | "state-dir-env"
@@ -311,8 +334,9 @@ function getDesktopApiHeaders(
 }
 
 let diagnosticLogPath: string | null = null;
+let startupStatusPath: string | null = null;
 
-function getDiagnosticLogPath(): string {
+export function getDiagnosticLogPath(): string {
   if (diagnosticLogPath !== null) return diagnosticLogPath;
   try {
     const configDir = resolveConfigDir();
@@ -325,6 +349,20 @@ function getDiagnosticLogPath(): string {
     diagnosticLogPath = path.join(os.tmpdir(), "milady-startup.log");
   }
   return diagnosticLogPath;
+}
+
+export function getStartupStatusPath(): string {
+  if (startupStatusPath !== null) return startupStatusPath;
+  try {
+    const configDir = resolveConfigDir();
+    if (!fs.existsSync(configDir)) {
+      fs.mkdirSync(configDir, { recursive: true });
+    }
+    startupStatusPath = path.join(configDir, "startup-status.json");
+  } catch {
+    startupStatusPath = path.join(os.tmpdir(), "startup-status.json");
+  }
+  return startupStatusPath;
 }
 
 function diagnosticLog(message: string): void {
@@ -348,6 +386,120 @@ function shortError(err: unknown, maxLen = 280): string {
   const oneLine = raw.replace(/\s+/g, " ").trim();
   if (oneLine.length <= maxLen) return oneLine;
   return `${oneLine.slice(0, maxLen)}... (see logs for full details)`;
+}
+
+function redactSensitiveDiagnostics(input: string): string {
+  return input
+    .replace(
+      /(authorization\s*[:=]\s*bearer\s+)([a-z0-9._-]+)/gi,
+      "$1[REDACTED]",
+    )
+    .replace(
+      /((?:x-api-key|x-api-token|api[_-]?key|bearer[_-]?token|access[_-]?token|secret|password)\s*[:=]\s*)([^\s]+)/gi,
+      "$1[REDACTED]",
+    );
+}
+
+function readFileTail(filePath: string, maxChars = 16_000): string {
+  try {
+    const content = fs.readFileSync(filePath, "utf8");
+    return redactSensitiveDiagnostics(content.slice(-maxChars));
+  } catch {
+    return "";
+  }
+}
+
+function writeStartupDiagnosticsSnapshot(
+  snapshot: StartupDiagnosticsSnapshot,
+): void {
+  try {
+    fs.writeFileSync(
+      getStartupStatusPath(),
+      `${JSON.stringify(snapshot, null, 2)}\n`,
+      "utf8",
+    );
+  } catch {
+    // Ignore write errors
+  }
+}
+
+export function getStartupDiagnosticsSnapshot(): StartupDiagnosticsSnapshot {
+  let parsed: Partial<StartupDiagnosticsSnapshot> | null = null;
+  try {
+    parsed = JSON.parse(
+      fs.readFileSync(getStartupStatusPath(), "utf8"),
+    ) as Partial<StartupDiagnosticsSnapshot> | null;
+  } catch {
+    parsed = null;
+  }
+
+  return {
+    state: parsed?.state ?? "not_started",
+    phase: parsed?.phase ?? "unknown",
+    updatedAt: parsed?.updatedAt ?? new Date().toISOString(),
+    lastError: parsed?.lastError ?? null,
+    agentName: parsed?.agentName ?? null,
+    port: parsed?.port ?? null,
+    startedAt: parsed?.startedAt ?? null,
+    platform: parsed?.platform ?? process.platform,
+    arch: parsed?.arch ?? process.arch,
+    configDir: parsed?.configDir ?? resolveConfigDir(),
+    logPath: parsed?.logPath ?? getDiagnosticLogPath(),
+    statusPath: parsed?.statusPath ?? getStartupStatusPath(),
+  };
+}
+
+export function getStartupDiagnosticLogTail(maxChars = 16_000): string {
+  return readFileTail(getDiagnosticLogPath(), maxChars);
+}
+
+export function createBugReportBundle(options: {
+  reportMarkdown: string;
+  reportJson: Record<string, unknown>;
+  prefix?: string;
+}): BugReportBundleResult {
+  const configDir = resolveConfigDir();
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const prefix = options.prefix?.trim() || "bug-report";
+  const directory = path.join(
+    configDir,
+    "bug-reports",
+    `${prefix}-${timestamp}`,
+  );
+  const reportMarkdownPath = path.join(directory, "report.md");
+  const reportJsonPath = path.join(directory, "report.json");
+  const logPath = getDiagnosticLogPath();
+  const statusPath = getStartupStatusPath();
+  const startupLogTarget = path.join(directory, "milady-startup.log");
+  const startupStatusTarget = path.join(directory, "startup-status.json");
+
+  fs.mkdirSync(directory, { recursive: true });
+  fs.writeFileSync(reportMarkdownPath, options.reportMarkdown, "utf8");
+  fs.writeFileSync(
+    reportJsonPath,
+    `${JSON.stringify(options.reportJson, null, 2)}\n`,
+    "utf8",
+  );
+
+  let copiedLogPath: string | null = null;
+  let copiedStatusPath: string | null = null;
+
+  if (fs.existsSync(logPath)) {
+    fs.copyFileSync(logPath, startupLogTarget);
+    copiedLogPath = startupLogTarget;
+  }
+  if (fs.existsSync(statusPath)) {
+    fs.copyFileSync(statusPath, startupStatusTarget);
+    copiedStatusPath = startupStatusTarget;
+  }
+
+  return {
+    directory,
+    reportMarkdownPath,
+    reportJsonPath,
+    startupLogPath: copiedLogPath,
+    startupStatusPath: copiedStatusPath,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -728,6 +880,11 @@ export class AgentManager {
   private stdioAbortController: AbortController | null = null;
   private hasPgliteError = false;
   private pgliteRecoveryDone = false;
+  private startupPhase = "not_started";
+
+  constructor() {
+    this.persistStartupDiagnostics();
+  }
 
   setSendToWebview(fn: SendToWebview): void {
     this.sendToWebview = fn;
@@ -744,6 +901,7 @@ export class AgentManager {
 
   /** Start the agent runtime as a child process. Idempotent. */
   async start(): Promise<AgentStatus> {
+    this.setStartupPhase("start_requested");
     diagnosticLog(
       `[Agent] start() called, current state: ${this.status.state}`,
     );
@@ -762,6 +920,7 @@ export class AgentManager {
           ? `Embedded desktop runtime is disabled because ${runtimeMode.externalApi.source} points at ${runtimeMode.externalApi.base}.`
           : "Embedded desktop runtime is disabled by MILADY_DESKTOP_SKIP_EMBEDDED_AGENT=1.";
       diagnosticLog(`[Agent] ${reason}`);
+      this.setStartupPhase("startup_disabled", reason);
       throw new Error(reason);
     }
 
@@ -791,6 +950,7 @@ export class AgentManager {
         startedAt: null,
         error: msg,
       };
+      this.setStartupPhase("port_allocation_failed", msg);
       this.emitStatus();
       return this.status;
     }
@@ -807,10 +967,12 @@ export class AgentManager {
       startedAt: null,
       error: null,
     };
+    this.setStartupPhase("starting_runtime");
     this.emitStatus();
 
     try {
       // Resolve milady-dist path
+      this.setStartupPhase("resolving_runtime");
       const miladyDistPath = resolveMiladyDistPath();
       diagnosticLog(`[Agent] Resolved milady dist: ${miladyDistPath}`);
 
@@ -836,6 +998,7 @@ export class AgentManager {
           startedAt: null,
           error: errMsg,
         };
+        this.setStartupPhase("runtime_entry_missing", errMsg);
         this.emitStatus();
         return this.status;
       }
@@ -843,6 +1006,7 @@ export class AgentManager {
       diagnosticLog(`[Agent] runtime entry: exists (${runtimeEntryPath})`);
 
       diagnosticLog(`[Agent] Starting child process on port ${apiPort}...`);
+      this.setStartupPhase("spawning_runtime");
 
       // Build NODE_PATH so the child can find node_modules
       const nodePaths: string[] = [];
@@ -982,6 +1146,7 @@ export class AgentManager {
       diagnosticLog(
         `[Agent] Waiting for health endpoint at http://127.0.0.1:${apiPort}/api/health ...`,
       );
+      this.setStartupPhase("waiting_for_health");
       const healthPollTimeoutMs = getHealthPollTimeoutMs();
       const healthy = await waitForHealthy(
         () => apiPort,
@@ -1002,6 +1167,7 @@ export class AgentManager {
             startedAt: null,
             error: errMsg,
           };
+          this.setStartupPhase("startup_failed", errMsg);
           this.emitStatus();
           return this.status;
         }
@@ -1017,11 +1183,13 @@ export class AgentManager {
           startedAt: null,
           error: errMsg,
         };
+        this.setStartupPhase("startup_failed", errMsg);
         this.emitStatus();
         return this.status;
       }
 
       // Fetch agent name from the running server
+      this.setStartupPhase("fetching_agent_metadata");
       const agentName = await this.fetchAgentName(apiPort);
 
       this.status = {
@@ -1034,6 +1202,7 @@ export class AgentManager {
       process.env.MILADY_PORT = String(apiPort);
       process.env.MILADY_API_PORT = String(apiPort);
       process.env.ELIZA_PORT = String(apiPort);
+      this.setStartupPhase("ready", null);
       this.emitStatus();
       diagnosticLog(
         `[Agent] Runtime started -- agent: ${agentName}, port: ${apiPort}, pid: ${proc.pid}, startup_ms: ${Date.now() - spawnTime}`,
@@ -1056,6 +1225,7 @@ export class AgentManager {
         startedAt: null,
         error: shortError(err),
       };
+      this.setStartupPhase("startup_failed", shortError(err));
       this.emitStatus();
       return this.status;
     }
@@ -1068,6 +1238,7 @@ export class AgentManager {
     }
 
     diagnosticLog("[Agent] Stopping...");
+    this.setStartupPhase("stopping");
 
     // Abort stdio watchers
     if (this.stdioAbortController) {
@@ -1084,6 +1255,7 @@ export class AgentManager {
       startedAt: null,
       error: null,
     };
+    this.setStartupPhase("stopped", null);
     this.emitStatus();
     diagnosticLog("[Agent] Runtime stopped");
   }
@@ -1094,6 +1266,7 @@ export class AgentManager {
    */
   async restart(): Promise<AgentStatus> {
     diagnosticLog("[Agent] Restart requested -- stopping current runtime...");
+    this.setStartupPhase("restart_requested");
     await this.stop();
     diagnosticLog("[Agent] Restarting...");
     return this.start();
@@ -1166,6 +1339,7 @@ export class AgentManager {
   // -----------------------------------------------------------------------
 
   private emitStatus(): void {
+    this.persistStartupDiagnostics();
     if (this.sendToWebview) {
       this.sendToWebview("agentStatusUpdate", this.status);
     }
@@ -1177,6 +1351,28 @@ export class AgentManager {
         console.warn("[Agent] status listener failed:", err);
       }
     }
+  }
+
+  private setStartupPhase(phase: string, lastError?: string | null): void {
+    this.startupPhase = phase;
+    this.persistStartupDiagnostics(lastError);
+  }
+
+  private persistStartupDiagnostics(lastError?: string | null): void {
+    writeStartupDiagnosticsSnapshot({
+      state: this.status.state,
+      phase: this.startupPhase,
+      updatedAt: new Date().toISOString(),
+      lastError: lastError ?? this.status.error,
+      agentName: this.status.agentName,
+      port: this.status.port,
+      startedAt: this.status.startedAt,
+      platform: process.platform,
+      arch: process.arch,
+      configDir: resolveConfigDir(),
+      logPath: getDiagnosticLogPath(),
+      statusPath: getStartupStatusPath(),
+    });
   }
 
   /**
@@ -1213,6 +1409,7 @@ export class AgentManager {
               startedAt: null,
               error: null,
             };
+            this.setStartupPhase("recovering_pglite");
             // Delay slightly so OS releases file handles before respawn
             setTimeout(() => void this.start(), 500);
             return;
@@ -1225,6 +1422,10 @@ export class AgentManager {
             startedAt: null,
             error: `Process exited unexpectedly with code ${exitCode}`,
           };
+          this.setStartupPhase(
+            "process_exited_unexpectedly",
+            `Process exited unexpectedly with code ${exitCode}`,
+          );
           this.emitStatus();
         } else {
           // Expected exit (we called stop)
@@ -1248,6 +1449,7 @@ export class AgentManager {
             startedAt: null,
             error: shortError(err),
           };
+          this.setStartupPhase("process_exit_error", shortError(err));
           this.emitStatus();
         }
       });

--- a/apps/app/electrobun/src/native/desktop.ts
+++ b/apps/app/electrobun/src/native/desktop.ts
@@ -63,6 +63,11 @@ import type {
 } from "../rpc-schema";
 import type { SendToWebview } from "../types.js";
 import {
+  createBugReportBundle,
+  getStartupDiagnosticLogTail,
+  getStartupDiagnosticsSnapshot,
+} from "./agent";
+import {
   isAppActive,
   isKeyWindow,
   makeKeyAndOrderFront,
@@ -1164,6 +1169,59 @@ X-GNOME-Autostart-enabled=true
       `[DesktopManager] Unknown path name "${options.name}", falling back to userData`,
     );
     return { path: Utils.paths.userData };
+  }
+
+  async getStartupDiagnostics(): Promise<{
+    state: "not_started" | "starting" | "running" | "stopped" | "error";
+    phase: string;
+    updatedAt: string;
+    lastError: string | null;
+    agentName: string | null;
+    port: number | null;
+    startedAt: number | null;
+    platform: string;
+    arch: string;
+    configDir: string;
+    logPath: string;
+    statusPath: string;
+    logTail: string;
+    appVersion?: string;
+    appRuntime?: string;
+    packaged?: boolean;
+    locale?: string;
+  }> {
+    const snapshot = getStartupDiagnosticsSnapshot();
+    const version = await this.getVersion();
+    const packaged = await this.isPackaged();
+    const locale = Intl.DateTimeFormat().resolvedOptions().locale;
+    return {
+      ...snapshot,
+      logTail: getStartupDiagnosticLogTail(),
+      appVersion: version.version,
+      appRuntime: version.runtime,
+      packaged: packaged.packaged,
+      locale,
+    };
+  }
+
+  async openLogsFolder(): Promise<void> {
+    const diagnostics = getStartupDiagnosticsSnapshot();
+    const folderPath = path.dirname(diagnostics.logPath);
+    Utils.openPath(folderPath);
+  }
+
+  async createBugReportBundle(options: {
+    reportMarkdown: string;
+    reportJson: Record<string, unknown>;
+    prefix?: string;
+  }): Promise<{
+    directory: string;
+    reportMarkdownPath: string;
+    reportJsonPath: string;
+    startupLogPath: string | null;
+    startupStatusPath: string | null;
+  }> {
+    return createBugReportBundle(options);
   }
 
   async checkForUpdates(): Promise<DesktopUpdaterSnapshot> {

--- a/apps/app/electrobun/src/rpc-handlers.ts
+++ b/apps/app/electrobun/src/rpc-handlers.ts
@@ -269,6 +269,11 @@ export function registerRpcHandlers(
     ) => desktop.setDockIconVisibility(params),
     desktopGetPath: async (params: Parameters<typeof desktop.getPath>[0]) =>
       desktop.getPath(params),
+    desktopGetStartupDiagnostics: async () => desktop.getStartupDiagnostics(),
+    desktopOpenLogsFolder: async () => desktop.openLogsFolder(),
+    desktopCreateBugReportBundle: async (
+      params: Parameters<typeof desktop.createBugReportBundle>[0],
+    ) => desktop.createBugReportBundle(params),
     desktopBeep: async () => desktop.beep(),
     desktopShowSelectionContextMenu: async (
       params: Parameters<typeof desktop.showSelectionContextMenu>[0],

--- a/apps/app/electrobun/src/rpc-schema.ts
+++ b/apps/app/electrobun/src/rpc-schema.ts
@@ -358,6 +358,34 @@ export interface ExistingElizaInstallInfo {
   source: "config-path-env" | "state-dir-env" | "default-state-dir";
 }
 
+export interface DesktopStartupDiagnostics {
+  state: "not_started" | "starting" | "running" | "stopped" | "error";
+  phase: string;
+  updatedAt: string;
+  lastError: string | null;
+  agentName: string | null;
+  port: number | null;
+  startedAt: number | null;
+  platform: string;
+  arch: string;
+  configDir: string;
+  logPath: string;
+  statusPath: string;
+  logTail: string;
+  appVersion?: string;
+  appRuntime?: string;
+  packaged?: boolean;
+  locale?: string;
+}
+
+export interface DesktopBugReportBundleInfo {
+  directory: string;
+  reportMarkdownPath: string;
+  reportJsonPath: string;
+  startupLogPath: string | null;
+  startupStatusPath: string | null;
+}
+
 // ============================================================================
 // RPC Schema
 // ============================================================================
@@ -514,6 +542,19 @@ export type MiladyRPCSchema = {
       desktopGetPath: {
         params: { name: string };
         response: { path: string };
+      };
+      desktopGetStartupDiagnostics: {
+        params: undefined;
+        response: DesktopStartupDiagnostics;
+      };
+      desktopOpenLogsFolder: { params: undefined; response: undefined };
+      desktopCreateBugReportBundle: {
+        params: {
+          reportMarkdown: string;
+          reportJson: Record<string, unknown>;
+          prefix?: string;
+        };
+        response: DesktopBugReportBundleInfo;
       };
       desktopBeep: { params: undefined; response: undefined };
       desktopShowSelectionContextMenu: {
@@ -1196,6 +1237,9 @@ export const CHANNEL_TO_RPC_METHOD: Record<string, string> = {
   "desktop:getDockIconVisibility": "desktopGetDockIconVisibility",
   "desktop:setDockIconVisibility": "desktopSetDockIconVisibility",
   "desktop:getPath": "desktopGetPath",
+  "desktop:getStartupDiagnostics": "desktopGetStartupDiagnostics",
+  "desktop:openLogsFolder": "desktopOpenLogsFolder",
+  "desktop:createBugReportBundle": "desktopCreateBugReportBundle",
   "desktop:beep": "desktopBeep",
   "desktop:showSelectionContextMenu": "desktopShowSelectionContextMenu",
   "desktop:getSessionSnapshot": "desktopGetSessionSnapshot",

--- a/apps/app/test/electrobun-packaged/electrobun-windows-startup.e2e.spec.ts
+++ b/apps/app/test/electrobun-packaged/electrobun-windows-startup.e2e.spec.ts
@@ -241,12 +241,17 @@ test("packaged Windows app bootstraps the renderer against the external API over
         () =>
           appProcess && appProcess.exitCode === null ? "running" : "exited",
         {
-          timeout: 5_000,
+          timeout: 15_000,
           message:
             "Expected the packaged Windows app to stay alive after bootstrap",
         },
       )
       .toBe("running");
+
+    // Keep the process alive long enough to catch immediate post-bootstrap
+    // startup regressions that can happen after the first renderer requests.
+    await new Promise((resolve) => setTimeout(resolve, 8_000));
+    expect(appProcess.exitCode).toBeNull();
 
     expect(hasPackagedRendererBootstrapRequests(api.requests)).toBe(true);
     expect(api.requests.length).toBeGreaterThan(0);

--- a/docs/plans/2026-03-26-docs-onboarding-support-expansion.md
+++ b/docs/plans/2026-03-26-docs-onboarding-support-expansion.md
@@ -1,0 +1,44 @@
+# Stream S5 - Docs + Onboarding Support Expansion (Chinese-first)
+
+## Goal
+
+Reduce user confusion and support load by shipping practical tutorials, in-app guidance, and clearer cloud/provider behavior messaging, prioritizing Chinese users.
+
+## Branch / PR
+
+- Branch: `codex/docs-onboarding-support`
+- PR: `to open`
+
+## Scope
+
+- Chinese tutorial/documentation coverage.
+- In-app “how to use” guidance and support/reporting entry points.
+- Clarify cloud vs BYOK provider behavior and restart requirements.
+
+## Plan
+
+1. Docs Baseline
+- [ ] Inventory current EN guides and map missing zh equivalents.
+- [ ] Create prioritized doc set: install, onboarding, providers, cloud, wallet basics, troubleshooting.
+
+2. Onboarding Guidance
+- [ ] Add concise guided hints in onboarding for first-run decisions.
+- [ ] Add explicit messaging for restart-required settings paths.
+
+3. Support UX
+- [ ] Add prominent in-app bug-report entry in key failure surfaces.
+- [ ] Provide copy-ready support template (what to send, where to send).
+
+4. Cloud/Provider Clarity
+- [ ] Clarify inference routing when cloud is connected but local provider selected.
+- [ ] Clarify credit consumption expectations and service toggles.
+
+5. QA/Review
+- [ ] Native Chinese review pass for wording and intent.
+- [ ] Verify all links/actions in docs and UI help flow.
+
+## Acceptance
+
+- Chinese users can complete setup and first successful usage without Discord hand-holding.
+- Cloud/provider/credit behavior is understandable from in-app copy.
+- Support reports include actionable technical context.

--- a/docs/plans/2026-03-26-issue-1170-execution.md
+++ b/docs/plans/2026-03-26-issue-1170-execution.md
@@ -1,0 +1,32 @@
+# Stream S1 - Issue #1170 Execution
+
+## Goal
+
+Execute issue `#1170` strictly in listed order, one task at a time, one commit per task.
+
+## Branch / PR
+
+- Branch: `codex/issue-1170`
+- PR: `#1343` (active)
+
+## Rules
+
+- Baseline must be current `origin/develop`.
+- No batching across tasks.
+- Validate each task before moving to next.
+- If task already fixed on `develop`, mark as already resolved and continue.
+
+## Checklist
+
+- [ ] Rebase `codex/issue-1170` to latest `origin/develop`
+- [ ] Resolve conflicts cleanly
+- [ ] Continue ordered tasks from current stopping point
+- [ ] Keep commit format `fix(issue-1170): TNN ...`
+- [ ] Run task-local tests after each task
+- [ ] Update tracking checklist after each validated task
+
+## Acceptance
+
+- All issue `#1170` tasks completed or marked already resolved with evidence.
+- CI green on PR.
+- No unrelated fixes mixed into this branch.

--- a/docs/plans/2026-03-26-master-delivery-board.md
+++ b/docs/plans/2026-03-26-master-delivery-board.md
@@ -1,0 +1,35 @@
+# Delivery Board - 2026-03-26
+
+This is the top-level tracker for the parallel projects discussed.
+
+## Streams
+
+1. `S1` Issue `#1170` conflict-audit execution  
+   Plan: [2026-03-26-issue-1170-execution.md](/Users/epj33/Documents/Playground/milady-win-reporting/docs/plans/2026-03-26-issue-1170-execution.md)
+
+2. `S2` Windows crash telemetry + supportability hardening  
+   Plan: [2026-03-26-windows-crash-telemetry-supportability.md](/Users/epj33/Documents/Playground/milady-win-reporting/docs/plans/2026-03-26-windows-crash-telemetry-supportability.md)
+
+3. `S3` Wallet execution track (0x routing + fallback + UX parity)  
+   Plan: [2026-03-26-wallet-routing-and-ux-parity.md](/Users/epj33/Documents/Playground/milady-win-reporting/docs/plans/2026-03-26-wallet-routing-and-ux-parity.md)
+
+4. `S4` zh-CN companion input-lock regression  
+   Plan: [2026-03-26-zh-cn-companion-input-lock.md](/Users/epj33/Documents/Playground/milady-win-reporting/docs/plans/2026-03-26-zh-cn-companion-input-lock.md)
+
+5. `S5` Tutorials + onboarding guidance + support docs (Chinese-first)  
+   Plan: [2026-03-26-docs-onboarding-support-expansion.md](/Users/epj33/Documents/Playground/milady-win-reporting/docs/plans/2026-03-26-docs-onboarding-support-expansion.md)
+
+## Current Snapshot
+
+- `S1` in progress (`PR #1343`)
+- `S2` implemented locally in `codex/win-reporting` (commit/push pending)
+- `S3` not started (discovery complete, execution not started)
+- `S4` issue opened (`#1359`), fix not started
+- `S5` discovery complete, execution not started
+
+## Branch/PR Discipline
+
+- One stream = one branch = one PR.
+- No mixed commits across streams.
+- Use branch prefix `codex/`.
+- Keep checklist updates in each stream plan file.

--- a/docs/plans/2026-03-26-master-delivery-board.md
+++ b/docs/plans/2026-03-26-master-delivery-board.md
@@ -22,7 +22,7 @@ This is the top-level tracker for the parallel projects discussed.
 ## Current Snapshot
 
 - `S1` in progress (`PR #1343`)
-- `S2` implemented locally in `codex/win-reporting` (commit/push pending)
+- `S2` in progress on `PR #1358` (branch pushed, CI/review pending)
 - `S3` not started (discovery complete, execution not started)
 - `S4` issue opened (`#1359`), fix not started
 - `S5` discovery complete, execution not started

--- a/docs/plans/2026-03-26-wallet-routing-and-ux-parity.md
+++ b/docs/plans/2026-03-26-wallet-routing-and-ux-parity.md
@@ -1,0 +1,44 @@
+# Stream S3 - Wallet Routing and UX Parity
+
+## Goal
+
+Deliver production-ready wallet trade behavior with clear routing, predictable execution, and user-visible clarity on provider/path used.
+
+## Branch / PR
+
+- Branch: `codex/wallet-routing`
+- PR: `to open`
+
+## Current State
+
+- Wallet + BSC trade flow already exists.
+- Current swap implementation is Pancake V2 path (not 0x primary).
+
+## Planned Phases
+
+1. Routing Abstraction
+- [ ] Introduce router/provider abstraction for quote/build/execute path.
+
+2. 0x Integration
+- [ ] Add 0x quote/build integration for supported chains.
+- [ ] Define request/response mapping into existing wallet contracts.
+
+3. Fallback + Safety
+- [ ] Add deterministic fallback path when 0x unavailable.
+- [ ] Preserve existing quote freshness and permission safeguards.
+
+4. UX Clarity
+- [ ] Surface active route/provider in UI.
+- [ ] Improve failure messages for quote/execute and provider errors.
+
+5. Tests
+- [ ] Unit tests for routing selection and fallback logic.
+- [ ] API tests for quote/execute across route outcomes.
+- [ ] UI tests for route display + failure states.
+
+## Acceptance
+
+- 0x path works as primary where configured.
+- Fallback path is explicit and test-covered.
+- No regression to existing wallet security checks.
+- CI green.

--- a/docs/plans/2026-03-26-windows-crash-telemetry-supportability.md
+++ b/docs/plans/2026-03-26-windows-crash-telemetry-supportability.md
@@ -7,7 +7,7 @@ Turn low-signal “it crashes immediately” reports into actionable diagnostics
 ## Branch / PR
 
 - Branch: `codex/win-reporting`
-- PR: `to open` (changes implemented locally)
+- PR: `#1358` (https://github.com/milady-ai/milady/pull/1358)
 
 ## Scope
 
@@ -35,9 +35,9 @@ Turn low-signal “it crashes immediately” reports into actionable diagnostics
 
 ## Remaining
 
-- [ ] Commit local changes.
-- [ ] Push branch.
-- [ ] Open PR with focused scope statement.
+- [x] Commit local changes.
+- [x] Push branch.
+- [x] Open PR with focused scope statement.
 - [ ] Run full CI and address any non-target regressions.
 
 ## Acceptance

--- a/docs/plans/2026-03-26-windows-crash-telemetry-supportability.md
+++ b/docs/plans/2026-03-26-windows-crash-telemetry-supportability.md
@@ -1,0 +1,48 @@
+# Stream S2 - Windows Crash Telemetry + Supportability
+
+## Goal
+
+Turn low-signal “it crashes immediately” reports into actionable diagnostics for Windows installer + desktop launch path.
+
+## Branch / PR
+
+- Branch: `codex/win-reporting`
+- PR: `to open` (changes implemented locally)
+
+## Scope
+
+- Startup crash/recovery report standardization.
+- Bug report bundle enrichment.
+- Browser Surface sandbox crash fix.
+- Bug report default repo routing to `milady-ai/milady`.
+- Windows packaged startup survivability check hardening.
+
+## Out of Scope
+
+- Wallet router migration.
+- General docs/tutorial expansion.
+- Broad UX audit backlog.
+
+## Implemented Items
+
+- [x] Standardized startup crash report payload and copy guidance.
+- [x] Added report file write fallback path.
+- [x] Added startup diagnostics + log tail into bug report JSON bundle.
+- [x] Fixed Browser Surface `sandbox` getter-only crash path.
+- [x] Switched bug report default repo to `milady-ai/milady` + env override.
+- [x] Hardened packaged Windows startup e2e dwell check.
+- [x] Added/updated targeted tests.
+
+## Remaining
+
+- [ ] Commit local changes.
+- [ ] Push branch.
+- [ ] Open PR with focused scope statement.
+- [ ] Run full CI and address any non-target regressions.
+
+## Acceptance
+
+- No more Browser Surface crash on getter-only sandbox property runtime.
+- Startup failures produce copyable support report with diagnostics/log tail.
+- Bug-report fallback URL points to `milady-ai/milady`.
+- Targeted test suite passes.

--- a/docs/plans/2026-03-26-zh-cn-companion-input-lock.md
+++ b/docs/plans/2026-03-26-zh-cn-companion-input-lock.md
@@ -1,0 +1,39 @@
+# Stream S4 - zh-CN Companion Input Lock
+
+## Goal
+
+Fix reported bug where companion input remains disabled after agent responds in Chinese-localized usage.
+
+## Tracking
+
+- GitHub issue: `#1359`
+- Branch: `codex/zh-cn-input-lock`
+- PR: `to open`
+
+## Hypothesis
+
+- UI state machine for “agent thinking/responding” is not resetting under one localized/event path.
+
+## Plan
+
+1. Reproduce
+- [ ] Reproduce on zh-CN locale with companion mode.
+- [ ] Capture event/state transition logs around response completion.
+
+2. Root Cause
+- [ ] Identify stuck state source (`loading`, `streaming`, or pending action flag).
+- [ ] Confirm whether path differs between zh-CN and en.
+
+3. Fix
+- [ ] Ensure completion/error/cancel paths all unlock input.
+- [ ] Add guard to avoid permanent lock on dropped events.
+
+4. Tests
+- [ ] Add regression test for companion input re-enable after response.
+- [ ] Add locale-agnostic assertion so this cannot regress by translation.
+
+## Acceptance
+
+- Input is always re-enabled after response lifecycle ends.
+- Bug reproducible before fix and gone after fix.
+- Tests pass in CI.

--- a/packages/agent/src/api/bug-report-routes.ts
+++ b/packages/agent/src/api/bug-report-routes.ts
@@ -1,9 +1,36 @@
 import os from "node:os";
 import type { RouteRequestContext } from "./route-helpers";
 
-export const BUG_REPORT_REPO = "elizaos/eliza";
-const GITHUB_ISSUES_URL = `https://api.github.com/repos/${BUG_REPORT_REPO}/issues`;
-const GITHUB_NEW_ISSUE_URL = `https://github.com/${BUG_REPORT_REPO}/issues/new?template=bug_report.yml`;
+export const DEFAULT_BUG_REPORT_REPO = "milady-ai/milady";
+export const BUG_REPORT_REPO_ENV_KEY = "MILADY_BUG_REPORT_REPO";
+const BUG_REPORT_REPO_FALLBACK_ENV_KEY = "BUG_REPORT_REPO";
+
+function sanitizeRepoName(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  if (!/^[\w.-]+\/[\w.-]+$/.test(trimmed)) return null;
+  return trimmed;
+}
+
+export function resolveBugReportRepo(
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  return (
+    sanitizeRepoName(env[BUG_REPORT_REPO_ENV_KEY]) ??
+    sanitizeRepoName(env[BUG_REPORT_REPO_FALLBACK_ENV_KEY]) ??
+    DEFAULT_BUG_REPORT_REPO
+  );
+}
+
+export const BUG_REPORT_REPO = resolveBugReportRepo();
+
+function getGithubIssuesUrl(repo: string): string {
+  return `https://api.github.com/repos/${repo}/issues`;
+}
+
+function getGithubNewIssueUrl(repo: string): string {
+  return `https://github.com/${repo}/issues/new?template=bug_report.yml`;
+}
 
 const BUG_REPORT_WINDOW_MS = 10 * 60 * 1000;
 const BUG_REPORT_MAX_SUBMISSIONS = 5;
@@ -87,6 +114,9 @@ export async function handleBugReportRoutes(
   ctx: RouteRequestContext,
 ): Promise<boolean> {
   const { req, res, method, pathname, json, error, readJsonBody } = ctx;
+  const bugReportRepo = resolveBugReportRepo();
+  const githubIssuesUrl = getGithubIssuesUrl(bugReportRepo);
+  const githubNewIssueUrl = getGithubNewIssueUrl(bugReportRepo);
 
   if (method === "GET" && pathname === "/api/bug-report/info") {
     json(res, {
@@ -112,7 +142,7 @@ export async function handleBugReportRoutes(
 
     const githubToken = process.env.GITHUB_TOKEN;
     if (!githubToken) {
-      json(res, { fallback: GITHUB_NEW_ISSUE_URL });
+      json(res, { fallback: githubNewIssueUrl });
       return true;
     }
 
@@ -122,7 +152,7 @@ export async function handleBugReportRoutes(
         " ",
       );
       const issueBody = formatIssueBody(body);
-      const issueRes = await fetch(GITHUB_ISSUES_URL, {
+      const issueRes = await fetch(githubIssuesUrl, {
         method: "POST",
         headers: {
           Authorization: `Bearer ${githubToken}`,
@@ -145,7 +175,7 @@ export async function handleBugReportRoutes(
       const url = issueData.html_url;
       if (
         typeof url !== "string" ||
-        !url.startsWith(`https://github.com/${BUG_REPORT_REPO}/issues/`)
+        !url.startsWith(`https://github.com/${bugReportRepo}/issues/`)
       ) {
         error(res, "Unexpected response from GitHub API", 502);
         return true;

--- a/packages/app-core/src/api/__tests__/bug-report-routes.test.ts
+++ b/packages/app-core/src/api/__tests__/bug-report-routes.test.ts
@@ -183,7 +183,7 @@ describe("POST /api/bug-report", () => {
       const handled = await handleBugReportRoutes(ctx);
       expect(handled).toBe(true);
       expect(ctx.json).toHaveBeenCalledWith(ctx.res, {
-        fallback: expect.stringContaining("github.com/elizaos/eliza"),
+        fallback: expect.stringContaining("github.com/milady-ai/milady"),
       });
     });
   });
@@ -202,7 +202,7 @@ describe("POST /api/bug-report", () => {
         ok: true,
         json: () =>
           Promise.resolve({
-            html_url: "https://github.com/elizaos/eliza/issues/42",
+            html_url: "https://github.com/milady-ai/milady/issues/42",
           }),
       });
       vi.stubGlobal("fetch", mockFetch);
@@ -217,14 +217,14 @@ describe("POST /api/bug-report", () => {
 
       expect(mockFetch).toHaveBeenCalledOnce();
       const [url, opts] = mockFetch.mock.calls[0];
-      expect(url).toContain("api.github.com/repos/elizaos/eliza/issues");
+      expect(url).toContain("api.github.com/repos/milady-ai/milady/issues");
       expect(opts.method).toBe("POST");
       const body = JSON.parse(opts.body);
       expect(body.title).toContain("[Bug]");
       expect(body.labels).toEqual(["bug", "triage", "user-reported"]);
 
       expect(ctx.json).toHaveBeenCalledWith(ctx.res, {
-        url: "https://github.com/elizaos/eliza/issues/42",
+        url: "https://github.com/milady-ai/milady/issues/42",
       });
     });
 
@@ -257,7 +257,7 @@ describe("POST /api/bug-report", () => {
           ok: true,
           json: () =>
             Promise.resolve({
-              html_url: "https://github.com/elizaos/eliza/issues/99",
+              html_url: "https://github.com/milady-ai/milady/issues/99",
             }),
         }),
       );

--- a/packages/app-core/src/api/bug-report-routes.test.ts
+++ b/packages/app-core/src/api/bug-report-routes.test.ts
@@ -8,6 +8,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   BUG_REPORT_REPO,
+  resolveBugReportRepo,
   rateLimitBugReport,
   resetBugReportRateLimit,
   sanitize,
@@ -121,8 +122,24 @@ describe("bug-report-routes", () => {
 
   // ── BUG_REPORT_REPO constant ───────────────────────────────────────
   describe("BUG_REPORT_REPO", () => {
-    it("points to a GitHub repo for bug reports (milady or eliza)", () => {
-      expect(["milady-ai/milady", "elizaos/eliza"]).toContain(BUG_REPORT_REPO);
+    it("defaults to the Milady GitHub repo for bug reports", () => {
+      expect(BUG_REPORT_REPO).toBe("milady-ai/milady");
+    });
+
+    it("allows overriding the target repo via MILADY_BUG_REPORT_REPO", () => {
+      expect(
+        resolveBugReportRepo({
+          MILADY_BUG_REPORT_REPO: "custom-org/custom-repo",
+        } as NodeJS.ProcessEnv),
+      ).toBe("custom-org/custom-repo");
+    });
+
+    it("ignores invalid repo override values", () => {
+      expect(
+        resolveBugReportRepo({
+          MILADY_BUG_REPORT_REPO: "not-a-repo",
+        } as NodeJS.ProcessEnv),
+      ).toBe("milady-ai/milady");
     });
   });
 });

--- a/packages/app-core/src/components/BrowserSurfaceWindow.test.ts
+++ b/packages/app-core/src/components/BrowserSurfaceWindow.test.ts
@@ -145,7 +145,10 @@ describe("BrowserSurfaceWindow", () => {
     const originalCreateElement = document.createElement.bind(document);
     const createSpy = vi
       .spyOn(document, "createElement")
-      .mockImplementation(((tagName: string, options?: ElementCreationOptions) =>
+      .mockImplementation(((
+        tagName: string,
+        options?: ElementCreationOptions,
+      ) =>
         originalCreateElement(
           tagName === "electrobun-webview" ? elementName : tagName,
           options,

--- a/packages/app-core/src/components/BrowserSurfaceWindow.test.ts
+++ b/packages/app-core/src/components/BrowserSurfaceWindow.test.ts
@@ -29,6 +29,12 @@ class FakeElectrobunWebview extends HTMLElement {
   }
 }
 
+class GetterOnlySandboxWebview extends FakeElectrobunWebview {
+  get sandbox(): string {
+    return this.getAttribute("sandbox") ?? "";
+  }
+}
+
 describe("BrowserSurfaceWindow", () => {
   let host: HTMLDivElement;
   let root: Root;
@@ -117,6 +123,45 @@ describe("BrowserSurfaceWindow", () => {
       expect(FakeElectrobunWebview.latest?.loadURL).toHaveBeenCalledWith(
         "https://example.com/",
       );
+      expect(FakeElectrobunWebview.latest?.getAttribute("sandbox")).toBe(
+        "allow-scripts allow-same-origin allow-forms allow-popups",
+      );
+    } finally {
+      getSpy.mockRestore();
+      createSpy.mockRestore();
+    }
+  });
+
+  it("does not throw when sandbox is getter-only on the custom element", async () => {
+    customElements.define(elementName, GetterOnlySandboxWebview);
+    const originalGet = window.customElements.get.bind(window.customElements);
+    const getSpy = vi
+      .spyOn(window.customElements, "get")
+      .mockImplementation((name: string) =>
+        name === "electrobun-webview"
+          ? GetterOnlySandboxWebview
+          : originalGet(name),
+      );
+    const originalCreateElement = document.createElement.bind(document);
+    const createSpy = vi
+      .spyOn(document, "createElement")
+      .mockImplementation(((tagName: string, options?: ElementCreationOptions) =>
+        originalCreateElement(
+          tagName === "electrobun-webview" ? elementName : tagName,
+          options,
+        )) as typeof document.createElement);
+
+    try {
+      await act(async () => {
+        root.render(React.createElement(BrowserSurfaceWindow));
+      });
+
+      expect(host.textContent).not.toContain(
+        "Browser surface failed to initialize.",
+      );
+      expect(
+        GetterOnlySandboxWebview.latest?.getAttribute("sandbox"),
+      ).toContain("allow-scripts");
     } finally {
       getSpy.mockRestore();
       createSpy.mockRestore();

--- a/packages/app-core/src/components/BrowserSurfaceWindow.tsx
+++ b/packages/app-core/src/components/BrowserSurfaceWindow.tsx
@@ -71,6 +71,7 @@ export function BrowserSurfaceWindow() {
   const [canGoBack, setCanGoBack] = useState(false);
   const [canGoForward, setCanGoForward] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
+  const [webviewInitError, setWebviewInitError] = useState<string | null>(null);
 
   const syncNavigationState = useEffectEvent(async () => {
     const webview = webviewRef.current;
@@ -101,6 +102,24 @@ export function BrowserSurfaceWindow() {
     applyNavigationUrl(nextUrl);
     setIsLoading(true);
     webview?.loadURL(nextUrl);
+  });
+
+  const attachWebviewRef = useEffectEvent((node: HTMLElement | null) => {
+    webviewRef.current = node as WebviewTagElement | null;
+    if (!node) return;
+    try {
+      // Set sandbox as an attribute to avoid assigning into potential
+      // getter-only custom element properties in certain runtime builds.
+      node.setAttribute(
+        "sandbox",
+        "allow-scripts allow-same-origin allow-forms allow-popups",
+      );
+      setWebviewInitError(null);
+    } catch (err) {
+      setWebviewInitError(
+        err instanceof Error ? err.message : "Failed to initialize browser view",
+      );
+    }
   });
 
   useEffect(() => {
@@ -267,16 +286,17 @@ export function BrowserSurfaceWindow() {
         className="flex min-h-0 flex-1 overflow-hidden rounded-[1.1rem] bg-white"
         style={viewportStyle}
       >
-        {webviewTagAvailable ? (
+        {webviewTagAvailable && !webviewInitError ? (
           createElement("electrobun-webview", {
             className: "h-full min-h-0 w-full bg-white",
             partition: "milady-browser",
-            ref: (node: HTMLElement | null) => {
-              webviewRef.current = node as WebviewTagElement | null;
-            },
-            sandbox: "allow-scripts allow-same-origin allow-forms allow-popups",
+            ref: attachWebviewRef,
             src: initialUrl,
           })
+        ) : webviewTagAvailable && webviewInitError ? (
+          <div className="flex flex-1 items-center justify-center bg-black/5 px-6 text-center text-sm text-muted">
+            Browser surface failed to initialize. {webviewInitError}
+          </div>
         ) : (
           <div className="flex flex-1 items-center justify-center bg-black/5 px-6 text-center text-sm text-muted">
             Browser surface is only available in the Electrobun desktop runtime.

--- a/packages/app-core/src/components/BrowserSurfaceWindow.tsx
+++ b/packages/app-core/src/components/BrowserSurfaceWindow.tsx
@@ -117,7 +117,9 @@ export function BrowserSurfaceWindow() {
       setWebviewInitError(null);
     } catch (err) {
       setWebviewInitError(
-        err instanceof Error ? err.message : "Failed to initialize browser view",
+        err instanceof Error
+          ? err.message
+          : "Failed to initialize browser view",
       );
     }
   });

--- a/packages/app-core/src/components/BugReportModal.tsx
+++ b/packages/app-core/src/components/BugReportModal.tsx
@@ -11,10 +11,18 @@ import {
 import { ChevronRight } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { client } from "../api";
+import { isElectrobunRuntime } from "../bridge";
 import { useBranding } from "../config/branding";
 import { useBugReport, useTimeout } from "../hooks";
 import { useApp } from "../state";
 import { openExternalUrl } from "../utils";
+import {
+  createDesktopBugReportBundle,
+  type DesktopBugReportDiagnostics,
+  formatDesktopBugReportDiagnostics,
+  loadDesktopBugReportDiagnostics,
+  openDesktopLogsFolder,
+} from "../utils/desktop-bug-report";
 
 const ENV_OPTIONS = ["macOS", "Windows", "Linux", "Other"] as const;
 
@@ -44,6 +52,7 @@ export function BugReportModal() {
   const { setTimeout } = useTimeout();
 
   const { copyToClipboard, t } = useApp();
+  const desktopRuntime = isElectrobunRuntime();
   const branding = useBranding();
   const { isOpen, close } = useBugReport();
   const [form, setForm] = useState<BugReportForm>(EMPTY_FORM);
@@ -52,6 +61,13 @@ export function BugReportModal() {
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [showLogs, setShowLogs] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [copiedDiagnostics, setCopiedDiagnostics] = useState(false);
+  const [desktopDiagnostics, setDesktopDiagnostics] =
+    useState<DesktopBugReportDiagnostics | null>(null);
+  const [attachLogs, setAttachLogs] = useState(true);
+  const [attachSystemInfo, setAttachSystemInfo] = useState(true);
+  const [bundlePath, setBundlePath] = useState<string | null>(null);
+  const [savingBundle, setSavingBundle] = useState(false);
   const descRef = useRef<HTMLTextAreaElement>(null);
 
   // Fetch env info on open with cancellation guard
@@ -65,6 +81,12 @@ export function BugReportModal() {
     setErrorMsg(null);
     setShowLogs(false);
     setCopied(false);
+    setCopiedDiagnostics(false);
+    setDesktopDiagnostics(null);
+    setAttachLogs(true);
+    setAttachSystemInfo(true);
+    setBundlePath(null);
+    setSavingBundle(false);
 
     client
       .checkBugReportInfo()
@@ -88,12 +110,37 @@ export function BugReportModal() {
       .catch((err: unknown) => {
         console.warn("[BugReportModal] Failed to fetch bug report info:", err);
       });
+    if (desktopRuntime) {
+      loadDesktopBugReportDiagnostics()
+        .then((diagnostics) => {
+          if (cancelled || !diagnostics) return;
+          setDesktopDiagnostics(diagnostics);
+          if (diagnostics.platform === "win32") {
+            setForm((f) => ({
+              ...f,
+              environment: f.environment || "Windows",
+              logs: f.logs || diagnostics.logTail || "",
+            }));
+          } else {
+            setForm((f) => ({
+              ...f,
+              logs: f.logs || diagnostics.logTail || "",
+            }));
+          }
+        })
+        .catch((err: unknown) => {
+          console.warn(
+            "[BugReportModal] Failed to fetch desktop diagnostics:",
+            err,
+          );
+        });
+    }
     setTimeout(() => descRef.current?.focus(), 50);
 
     return () => {
       cancelled = true;
     };
-  }, [isOpen, setTimeout]);
+  }, [desktopRuntime, isOpen, setTimeout]);
 
   const updateField = useCallback(
     <K extends keyof BugReportForm>(key: K, value: BugReportForm[K]) => {
@@ -101,6 +148,25 @@ export function BugReportModal() {
     },
     [],
   );
+
+  const buildDiagnosticsBlock = useCallback((): string => {
+    if (!desktopDiagnostics) return "";
+    const sections: string[] = [];
+    if (attachSystemInfo) {
+      sections.push(formatDesktopBugReportDiagnostics(desktopDiagnostics));
+    }
+    if (attachLogs && desktopDiagnostics.logTail) {
+      sections.push(`Startup Log Tail\n${desktopDiagnostics.logTail}`);
+    }
+    return sections.join("\n\n");
+  }, [attachLogs, attachSystemInfo, desktopDiagnostics]);
+
+  const buildCombinedLogs = useCallback((): string => {
+    const sections = [form.logs.trim(), buildDiagnosticsBlock().trim()].filter(
+      Boolean,
+    );
+    return sections.join("\n\n");
+  }, [buildDiagnosticsBlock, form.logs]);
 
   const formatMarkdown = useCallback((): string => {
     const strip = (s: string, max = 10_000) =>
@@ -119,10 +185,33 @@ export function BugReportModal() {
       lines.push(`\n### Node Version\n${strip(form.nodeVersion, 200)}`);
     if (form.modelProvider)
       lines.push(`\n### Model Provider\n${strip(form.modelProvider, 200)}`);
-    if (form.logs)
-      lines.push(`\n### Logs\n\`\`\`\n${strip(form.logs, 50_000)}\n\`\`\``);
+    const combinedLogs = buildCombinedLogs();
+    if (combinedLogs) {
+      lines.push(`\n### Logs\n\`\`\`\n${strip(combinedLogs, 50_000)}\n\`\`\``);
+    }
     return lines.join("\n");
-  }, [form]);
+  }, [buildCombinedLogs, form]);
+
+  const buildReportPayload = useCallback(
+    () => ({
+      description: form.description,
+      stepsToReproduce: form.stepsToReproduce,
+      expectedBehavior: form.expectedBehavior,
+      actualBehavior: form.actualBehavior,
+      environment: form.environment,
+      nodeVersion: form.nodeVersion,
+      modelProvider: form.modelProvider,
+      attachLogs,
+      attachSystemInfo,
+      desktopDiagnostics: desktopDiagnostics
+        ? {
+            ...desktopDiagnostics,
+            logTail: attachLogs ? desktopDiagnostics.logTail : "",
+          }
+        : null,
+    }),
+    [attachLogs, attachSystemInfo, desktopDiagnostics, form],
+  );
 
   const handleSubmit = useCallback(async () => {
     if (!form.description.trim() || !form.stepsToReproduce.trim()) {
@@ -140,7 +229,7 @@ export function BugReportModal() {
         environment: form.environment,
         nodeVersion: form.nodeVersion,
         modelProvider: form.modelProvider,
-        logs: form.logs,
+        logs: buildCombinedLogs(),
       });
       if (result.url) {
         setResultUrl(result.url);
@@ -167,7 +256,7 @@ export function BugReportModal() {
     } finally {
       setSubmitting(false);
     }
-  }, [copyToClipboard, form, formatMarkdown, t]);
+  }, [buildCombinedLogs, copyToClipboard, form, formatMarkdown, t]);
 
   const handleCopyAndOpen = useCallback(async () => {
     let ok = false;
@@ -184,6 +273,38 @@ export function BugReportModal() {
     setCopied(ok);
     await openExternalUrl(branding.bugReportUrl);
   }, [copyToClipboard, formatMarkdown, branding.bugReportUrl]);
+
+  const handleCopyDiagnostics = useCallback(async () => {
+    const diagnosticsText = buildDiagnosticsBlock();
+    if (!diagnosticsText) return;
+    let ok = false;
+    try {
+      await copyToClipboard(diagnosticsText);
+      ok = true;
+    } catch (err) {
+      console.warn("[BugReportModal] Failed to copy diagnostics:", err);
+    }
+    setCopiedDiagnostics(ok);
+  }, [buildDiagnosticsBlock, copyToClipboard]);
+
+  const handleSaveBundle = useCallback(async () => {
+    setSavingBundle(true);
+    setErrorMsg(null);
+    try {
+      const bundle = await createDesktopBugReportBundle({
+        prefix: "milady-report",
+        reportMarkdown: formatMarkdown(),
+        reportJson: buildReportPayload(),
+      });
+      setBundlePath(bundle?.directory ?? null);
+    } catch (err) {
+      setErrorMsg(
+        err instanceof Error ? err.message : "Failed to create report bundle",
+      );
+    } finally {
+      setSavingBundle(false);
+    }
+  }, [buildReportPayload, formatMarkdown]);
 
   // Close on Escape
   useEffect(() => {
@@ -341,6 +462,17 @@ export function BugReportModal() {
               {errorMsg}
             </div>
           )}
+          {bundlePath && (
+            <div
+              className="text-xs px-3 py-2"
+              style={{
+                color: "var(--text)",
+                border: "1px solid var(--border)",
+              }}
+            >
+              {bundlePath}
+            </div>
+          )}
 
           {/* biome-ignore lint/a11y/noLabelWithoutControl: form control is associated programmatically */}
           <label className={labelClass} style={labelStyle}>
@@ -462,14 +594,46 @@ export function BugReportModal() {
               {t("bugreportmodal.Logs")}
             </Button>
             {showLogs && (
-              <Textarea
-                className={`${textareaClass} mt-1 font-mono text-xs`}
-                style={textareaStyle}
-                placeholder={t("bugreportmodal.PasteRelevantError")}
-                value={form.logs}
-                onChange={(e) => updateField("logs", e.target.value)}
-                rows={4}
-              />
+              <div className="mt-1 flex flex-col gap-2">
+                <div className="flex flex-wrap gap-3 text-[11px]">
+                  {desktopRuntime && (
+                    <>
+                      <label
+                        className="flex items-center gap-1"
+                        style={{ color: "var(--muted)" }}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={attachLogs}
+                          onChange={(e) => setAttachLogs(e.target.checked)}
+                        />
+                        {t("bugreportmodal.attachLogs")}
+                      </label>
+                      <label
+                        className="flex items-center gap-1"
+                        style={{ color: "var(--muted)" }}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={attachSystemInfo}
+                          onChange={(e) =>
+                            setAttachSystemInfo(e.target.checked)
+                          }
+                        />
+                        {t("bugreportmodal.attachSystemInfo")}
+                      </label>
+                    </>
+                  )}
+                </div>
+                <Textarea
+                  className={`${textareaClass} font-mono text-xs`}
+                  style={textareaStyle}
+                  placeholder={t("bugreportmodal.PasteRelevantError")}
+                  value={form.logs}
+                  onChange={(e) => updateField("logs", e.target.value)}
+                  rows={4}
+                />
+              </div>
             )}
           </div>
         </div>
@@ -483,6 +647,36 @@ export function BugReportModal() {
             {t("common.cancel")}
           </Button>
           <div className="flex items-center gap-2">
+            {desktopRuntime && (
+              <>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleCopyDiagnostics}
+                >
+                  {copiedDiagnostics
+                    ? t("bugreportmodal.copiedDiagnostics")
+                    : t("bugreportmodal.copyDiagnostics")}
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={openDesktopLogsFolder}
+                >
+                  {t("bugreportmodal.openLogsFolder")}
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleSaveBundle}
+                  disabled={savingBundle}
+                >
+                  {savingBundle
+                    ? t("bugreportmodal.savingBundle")
+                    : t("bugreportmodal.saveBundle")}
+                </Button>
+              </>
+            )}
             <Button
               variant="outline"
               size="sm"

--- a/packages/app-core/src/i18n/locales/en.json
+++ b/packages/app-core/src/i18n/locales/en.json
@@ -1301,5 +1301,12 @@
   "lifecycle.restartInProgress": "restarting",
   "lifecycle.resetInProgress": "resetting",
   "aria.close": "Close",
-  "aria.closeDialog": "Close dialog"
+  "aria.closeDialog": "Close dialog",
+  "bugreportmodal.attachLogs": "Attach startup logs",
+  "bugreportmodal.attachSystemInfo": "Attach system info",
+  "bugreportmodal.copyDiagnostics": "Copy Diagnostics",
+  "bugreportmodal.copiedDiagnostics": "Diagnostics Copied!",
+  "bugreportmodal.openLogsFolder": "Open Logs Folder",
+  "bugreportmodal.saveBundle": "Save Report Bundle",
+  "bugreportmodal.savingBundle": "Saving Bundle..."
 }

--- a/packages/app-core/src/i18n/locales/es.json
+++ b/packages/app-core/src/i18n/locales/es.json
@@ -1301,5 +1301,12 @@
   "whatsappqroverlay.Tap": "Toca",
   "whatsappqroverlay.TryAgain": "Intentar otra vez",
   "whatsappqroverlay.UsesAnUnofficialW": "Utiliza una API de WhatsApp no ​​oficial. Utilice un número de teléfono exclusivo.",
-  "whatsappqroverlay.andSelect": "y seleccione"
+  "whatsappqroverlay.andSelect": "y seleccione",
+  "bugreportmodal.attachLogs": "Attach startup logs",
+  "bugreportmodal.attachSystemInfo": "Attach system info",
+  "bugreportmodal.copyDiagnostics": "Copy Diagnostics",
+  "bugreportmodal.copiedDiagnostics": "Diagnostics Copied!",
+  "bugreportmodal.openLogsFolder": "Open Logs Folder",
+  "bugreportmodal.saveBundle": "Save Report Bundle",
+  "bugreportmodal.savingBundle": "Saving Bundle..."
 }

--- a/packages/app-core/src/i18n/locales/ko.json
+++ b/packages/app-core/src/i18n/locales/ko.json
@@ -1301,5 +1301,12 @@
   "whatsappqroverlay.Tap": "탭",
   "whatsappqroverlay.TryAgain": "다시 시도",
   "whatsappqroverlay.UsesAnUnofficialW": "비공식 WhatsApp API를 사용합니다. 전용 전화번호를 사용하세요.",
-  "whatsappqroverlay.andSelect": "그리고 선택"
+  "whatsappqroverlay.andSelect": "그리고 선택",
+  "bugreportmodal.attachLogs": "Attach startup logs",
+  "bugreportmodal.attachSystemInfo": "Attach system info",
+  "bugreportmodal.copyDiagnostics": "Copy Diagnostics",
+  "bugreportmodal.copiedDiagnostics": "Diagnostics Copied!",
+  "bugreportmodal.openLogsFolder": "Open Logs Folder",
+  "bugreportmodal.saveBundle": "Save Report Bundle",
+  "bugreportmodal.savingBundle": "Saving Bundle..."
 }

--- a/packages/app-core/src/i18n/locales/pt.json
+++ b/packages/app-core/src/i18n/locales/pt.json
@@ -1301,5 +1301,12 @@
   "whatsappqroverlay.Tap": "Tocar",
   "whatsappqroverlay.TryAgain": "Tente novamente",
   "whatsappqroverlay.UsesAnUnofficialW": "Usa uma API não oficial do WhatsApp. Use um número de telefone dedicado.",
-  "whatsappqroverlay.andSelect": "e selecione"
+  "whatsappqroverlay.andSelect": "e selecione",
+  "bugreportmodal.attachLogs": "Attach startup logs",
+  "bugreportmodal.attachSystemInfo": "Attach system info",
+  "bugreportmodal.copyDiagnostics": "Copy Diagnostics",
+  "bugreportmodal.copiedDiagnostics": "Diagnostics Copied!",
+  "bugreportmodal.openLogsFolder": "Open Logs Folder",
+  "bugreportmodal.saveBundle": "Save Report Bundle",
+  "bugreportmodal.savingBundle": "Saving Bundle..."
 }

--- a/packages/app-core/src/i18n/locales/tl.json
+++ b/packages/app-core/src/i18n/locales/tl.json
@@ -1301,5 +1301,12 @@
   "whatsappqroverlay.Tap": "I-tap ang",
   "whatsappqroverlay.TryAgain": "Subukan Muli",
   "whatsappqroverlay.UsesAnUnofficialW": "Gumagamit ng unofficial WhatsApp API. Gumamit ng dedicated phone number.",
-  "whatsappqroverlay.andSelect": "at piliin ang"
+  "whatsappqroverlay.andSelect": "at piliin ang",
+  "bugreportmodal.attachLogs": "Attach startup logs",
+  "bugreportmodal.attachSystemInfo": "Attach system info",
+  "bugreportmodal.copyDiagnostics": "Copy Diagnostics",
+  "bugreportmodal.copiedDiagnostics": "Diagnostics Copied!",
+  "bugreportmodal.openLogsFolder": "Open Logs Folder",
+  "bugreportmodal.saveBundle": "Save Report Bundle",
+  "bugreportmodal.savingBundle": "Saving Bundle..."
 }

--- a/packages/app-core/src/i18n/locales/vi.json
+++ b/packages/app-core/src/i18n/locales/vi.json
@@ -1301,5 +1301,12 @@
   "whatsappqroverlay.Tap": "Chạm",
   "whatsappqroverlay.TryAgain": "Thử lại",
   "whatsappqroverlay.UsesAnUnofficialW": "Dùng API WhatsApp không chính thức. Hãy dùng số riêng.",
-  "whatsappqroverlay.andSelect": "và chọn"
+  "whatsappqroverlay.andSelect": "và chọn",
+  "bugreportmodal.attachLogs": "Attach startup logs",
+  "bugreportmodal.attachSystemInfo": "Attach system info",
+  "bugreportmodal.copyDiagnostics": "Copy Diagnostics",
+  "bugreportmodal.copiedDiagnostics": "Diagnostics Copied!",
+  "bugreportmodal.openLogsFolder": "Open Logs Folder",
+  "bugreportmodal.saveBundle": "Save Report Bundle",
+  "bugreportmodal.savingBundle": "Saving Bundle..."
 }

--- a/packages/app-core/src/i18n/locales/zh-CN.json
+++ b/packages/app-core/src/i18n/locales/zh-CN.json
@@ -1301,5 +1301,12 @@
   "whatsappqroverlay.Tap": "轻敲",
   "whatsappqroverlay.TryAgain": "再试一次",
   "whatsappqroverlay.UsesAnUnofficialW": "使用非官方 WhatsApp API。使用专用电话号码。",
-  "whatsappqroverlay.andSelect": "并选择"
+  "whatsappqroverlay.andSelect": "并选择",
+  "bugreportmodal.attachLogs": "??????",
+  "bugreportmodal.attachSystemInfo": "??????",
+  "bugreportmodal.copyDiagnostics": "??????",
+  "bugreportmodal.copiedDiagnostics": "????????",
+  "bugreportmodal.openLogsFolder": "???????",
+  "bugreportmodal.saveBundle": "?????",
+  "bugreportmodal.savingBundle": "???????..."
 }

--- a/packages/app-core/src/utils/desktop-bug-report.ts
+++ b/packages/app-core/src/utils/desktop-bug-report.ts
@@ -1,0 +1,85 @@
+import { invokeDesktopBridgeRequest, isElectrobunRuntime } from "../bridge";
+
+export interface DesktopBugReportDiagnostics {
+  state: "not_started" | "starting" | "running" | "stopped" | "error";
+  phase: string;
+  updatedAt: string;
+  lastError: string | null;
+  agentName: string | null;
+  port: number | null;
+  startedAt: number | null;
+  platform: string;
+  arch: string;
+  configDir: string;
+  logPath: string;
+  statusPath: string;
+  logTail: string;
+  appVersion?: string;
+  appRuntime?: string;
+  packaged?: boolean;
+  locale?: string;
+}
+
+export interface DesktopBugReportBundleInfo {
+  directory: string;
+  reportMarkdownPath: string;
+  reportJsonPath: string;
+  startupLogPath: string | null;
+  startupStatusPath: string | null;
+}
+
+export async function loadDesktopBugReportDiagnostics(): Promise<DesktopBugReportDiagnostics | null> {
+  if (!isElectrobunRuntime()) {
+    return null;
+  }
+  return invokeDesktopBridgeRequest<DesktopBugReportDiagnostics>({
+    rpcMethod: "desktopGetStartupDiagnostics",
+    ipcChannel: "desktop:getStartupDiagnostics",
+  });
+}
+
+export async function openDesktopLogsFolder(): Promise<void> {
+  if (!isElectrobunRuntime()) {
+    return;
+  }
+  await invokeDesktopBridgeRequest<void>({
+    rpcMethod: "desktopOpenLogsFolder",
+    ipcChannel: "desktop:openLogsFolder",
+  });
+}
+
+export async function createDesktopBugReportBundle(options: {
+  reportMarkdown: string;
+  reportJson: Record<string, unknown>;
+  prefix?: string;
+}): Promise<DesktopBugReportBundleInfo | null> {
+  if (!isElectrobunRuntime()) {
+    return null;
+  }
+  return invokeDesktopBridgeRequest<DesktopBugReportBundleInfo>({
+    rpcMethod: "desktopCreateBugReportBundle",
+    ipcChannel: "desktop:createBugReportBundle",
+    params: options,
+  });
+}
+
+export function formatDesktopBugReportDiagnostics(
+  diagnostics: DesktopBugReportDiagnostics,
+): string {
+  const lines = [
+    `App Version: ${diagnostics.appVersion ?? "unknown"}`,
+    `Runtime: ${diagnostics.appRuntime ?? "unknown"}`,
+    `Packaged: ${diagnostics.packaged == null ? "unknown" : diagnostics.packaged ? "yes" : "no"}`,
+    `Platform: ${diagnostics.platform} ${diagnostics.arch}`,
+    `Locale: ${diagnostics.locale ?? "unknown"}`,
+    `Startup State: ${diagnostics.state}`,
+    `Startup Phase: ${diagnostics.phase}`,
+    `Last Error: ${diagnostics.lastError ?? "none"}`,
+    `Agent Name: ${diagnostics.agentName ?? "unknown"}`,
+    `Port: ${diagnostics.port ?? "unknown"}`,
+    `Updated At: ${diagnostics.updatedAt}`,
+    `Log Path: ${diagnostics.logPath}`,
+    `Status Path: ${diagnostics.statusPath}`,
+  ];
+  return lines.join("\n");
+}

--- a/packages/app-core/test/app/bug-report-modal.test.tsx
+++ b/packages/app-core/test/app/bug-report-modal.test.tsx
@@ -35,17 +35,52 @@ vi.mock("@miladyai/ui", () => {
 
 // --- hoisted mocks ----------------------------------------------------------
 
-const { mockUseBugReport, mockClient } = vi.hoisted(() => ({
+const {
+  mockUseBugReport,
+  mockClient,
+  mockCopyToClipboard,
+  isElectrobunRuntimeMock,
+  mockDesktopDiagnostics,
+  loadDesktopBugReportDiagnosticsMock,
+  openDesktopLogsFolderMock,
+  createDesktopBugReportBundleMock,
+} = vi.hoisted(() => ({
   mockUseBugReport: vi.fn(),
   mockClient: {
     getCodingAgentStatus: vi.fn(async () => null),
     checkBugReportInfo: vi.fn().mockResolvedValue({}),
     submitBugReport: vi.fn().mockResolvedValue({}),
   },
+  mockCopyToClipboard: vi.fn(),
+  isElectrobunRuntimeMock: vi.fn(() => false),
+  mockDesktopDiagnostics: {
+    state: "error",
+    phase: "startup_failed",
+    updatedAt: "2026-03-26T00:00:00.000Z",
+    lastError: "Boom",
+    agentName: null,
+    port: null,
+    startedAt: null,
+    platform: "win32",
+    arch: "x64",
+    configDir: "C:/Users/test/AppData/Roaming/Milady",
+    logPath: "C:/Users/test/AppData/Roaming/Milady/milady-startup.log",
+    statusPath: "C:/Users/test/AppData/Roaming/Milady/startup-status.json",
+    logTail: "startup line 1\\nstartup line 2",
+    appVersion: "2.0.0-alpha.125",
+    appRuntime: "electrobun/1.3.10",
+    packaged: true,
+    locale: "zh-CN",
+  },
+  loadDesktopBugReportDiagnosticsMock: vi.fn(),
+  openDesktopLogsFolderMock: vi.fn(),
+  createDesktopBugReportBundleMock: vi.fn(),
 }));
 
-const mockSetTimeout = (fn: () => void, ms: number) => globalThis.setTimeout(fn, ms);
-const mockClearTimeout = (id: ReturnType<typeof globalThis.setTimeout>) => globalThis.clearTimeout(id);
+const mockSetTimeout = (fn: () => void, ms: number) =>
+  globalThis.setTimeout(fn, ms);
+const mockClearTimeout = (id: ReturnType<typeof globalThis.setTimeout>) =>
+  globalThis.clearTimeout(id);
 
 vi.mock("@miladyai/app-core/hooks", () => ({
   useBugReport: () => mockUseBugReport(),
@@ -60,7 +95,10 @@ vi.mock("@miladyai/app-core/api", () => ({
 }));
 
 vi.mock("@miladyai/app-core/state", () => ({
-  useApp: () => ({ t: (key: string) => key, copyToClipboard: vi.fn() }),
+  useApp: () => ({
+    t: (key: string) => key,
+    copyToClipboard: mockCopyToClipboard,
+  }),
 }));
 
 vi.mock("@miladyai/app-core/config/branding", () => ({
@@ -69,6 +107,24 @@ vi.mock("@miladyai/app-core/config/branding", () => ({
 
 vi.mock("@miladyai/app-core/utils", () => ({
   openExternalUrl: vi.fn(),
+}));
+
+vi.mock("../../src/bridge", () => ({
+  isElectrobunRuntime: () => isElectrobunRuntimeMock(),
+}));
+
+vi.mock("../../src/utils/desktop-bug-report", () => ({
+  loadDesktopBugReportDiagnostics: (...args: unknown[]) =>
+    loadDesktopBugReportDiagnosticsMock(...args),
+  openDesktopLogsFolder: (...args: unknown[]) =>
+    openDesktopLogsFolderMock(...args),
+  createDesktopBugReportBundle: (...args: unknown[]) =>
+    createDesktopBugReportBundleMock(...args),
+  formatDesktopBugReportDiagnostics: (diagnostics: {
+    phase: string;
+    lastError: string | null;
+  }) =>
+    `Startup Phase: ${diagnostics.phase}\nLast Error: ${diagnostics.lastError ?? "none"}`,
 }));
 
 import { BugReportModal } from "../../src/components/BugReportModal";
@@ -119,10 +175,19 @@ describe("BugReportModal", () => {
     mockUseBugReport.mockReset();
     mockClient.checkBugReportInfo.mockReset().mockResolvedValue({});
     mockClient.submitBugReport.mockReset().mockResolvedValue({});
+    mockCopyToClipboard.mockReset().mockResolvedValue(undefined);
+    isElectrobunRuntimeMock.mockReset().mockReturnValue(false);
+    loadDesktopBugReportDiagnosticsMock
+      .mockReset()
+      .mockResolvedValue(mockDesktopDiagnostics);
+    openDesktopLogsFolderMock.mockReset().mockResolvedValue(undefined);
+    createDesktopBugReportBundleMock.mockReset().mockResolvedValue({
+      directory:
+        "C:/Users/test/AppData/Roaming/Milady/bug-reports/milady-report-1",
+    });
   });
 
-  afterEach(() => {
-  });
+  afterEach(() => {});
 
   // --- rendering ---
 
@@ -140,7 +205,7 @@ describe("BugReportModal", () => {
     let tree: TestRenderer.ReactTestRenderer;
     await act(async () => {
       tree = TestRenderer.create(React.createElement(BugReportModal));
-      await new Promise(r => globalThis.setTimeout(r, 60));
+      await new Promise((r) => globalThis.setTimeout(r, 60));
     });
     expect(getText(tree?.root)).toContain("bugreportmodal.ReportABug");
   });
@@ -150,7 +215,7 @@ describe("BugReportModal", () => {
     let tree: TestRenderer.ReactTestRenderer;
     await act(async () => {
       tree = TestRenderer.create(React.createElement(BugReportModal));
-      await new Promise(r => globalThis.setTimeout(r, 60));
+      await new Promise((r) => globalThis.setTimeout(r, 60));
     });
     const labels = tree?.root.findAllByType("label" as React.ElementType);
     const requiredLabels = labels?.filter((l) =>
@@ -167,7 +232,7 @@ describe("BugReportModal", () => {
     let tree: TestRenderer.ReactTestRenderer;
     await act(async () => {
       tree = TestRenderer.create(React.createElement(BugReportModal));
-      await new Promise(r => globalThis.setTimeout(r, 60));
+      await new Promise((r) => globalThis.setTimeout(r, 60));
     });
     // Description, Steps to Reproduce, Expected Behavior, Actual Behavior
     expect(getTextareas(tree?.root).length).toBeGreaterThanOrEqual(4);
@@ -186,7 +251,7 @@ describe("BugReportModal", () => {
     setupMock(true);
     await act(async () => {
       TestRenderer.create(React.createElement(BugReportModal));
-      await new Promise(r => globalThis.setTimeout(r, 60));
+      await new Promise((r) => globalThis.setTimeout(r, 60));
     });
     expect(mockClient.checkBugReportInfo).toHaveBeenCalledOnce();
   });
@@ -198,7 +263,7 @@ describe("BugReportModal", () => {
     let tree: TestRenderer.ReactTestRenderer;
     await act(async () => {
       tree = TestRenderer.create(React.createElement(BugReportModal));
-      await new Promise(r => globalThis.setTimeout(r, 60));
+      await new Promise((r) => globalThis.setTimeout(r, 60));
     });
     const submitBtn = findButton(tree?.root, "bugreportmodal.submit");
     expect(submitBtn?.props.disabled).toBe(true);
@@ -209,7 +274,7 @@ describe("BugReportModal", () => {
     let tree: TestRenderer.ReactTestRenderer;
     await act(async () => {
       tree = TestRenderer.create(React.createElement(BugReportModal));
-      await new Promise(r => globalThis.setTimeout(r, 60));
+      await new Promise((r) => globalThis.setTimeout(r, 60));
     });
 
     const submitBtn = findButton(tree?.root, "bugreportmodal.submit");
@@ -233,7 +298,7 @@ describe("BugReportModal", () => {
     let tree: TestRenderer.ReactTestRenderer;
     await act(async () => {
       tree = TestRenderer.create(React.createElement(BugReportModal));
-      await new Promise(r => globalThis.setTimeout(r, 60));
+      await new Promise((r) => globalThis.setTimeout(r, 60));
     });
 
     await fillRequired(tree?.root);
@@ -259,7 +324,7 @@ describe("BugReportModal", () => {
     let tree: TestRenderer.ReactTestRenderer;
     await act(async () => {
       tree = TestRenderer.create(React.createElement(BugReportModal));
-      await new Promise(r => globalThis.setTimeout(r, 60));
+      await new Promise((r) => globalThis.setTimeout(r, 60));
     });
 
     await fillRequired(tree?.root);
@@ -280,7 +345,7 @@ describe("BugReportModal", () => {
     let tree: TestRenderer.ReactTestRenderer;
     await act(async () => {
       tree = TestRenderer.create(React.createElement(BugReportModal));
-      await new Promise(r => globalThis.setTimeout(r, 60));
+      await new Promise((r) => globalThis.setTimeout(r, 60));
     });
 
     await fillRequired(tree?.root);
@@ -301,7 +366,7 @@ describe("BugReportModal", () => {
     let tree: TestRenderer.ReactTestRenderer;
     await act(async () => {
       tree = TestRenderer.create(React.createElement(BugReportModal));
-      await new Promise(r => globalThis.setTimeout(r, 60));
+      await new Promise((r) => globalThis.setTimeout(r, 60));
     });
 
     await fillRequired(tree?.root);
@@ -332,7 +397,7 @@ describe("BugReportModal", () => {
     let tree: TestRenderer.ReactTestRenderer;
     await act(async () => {
       tree = TestRenderer.create(React.createElement(BugReportModal));
-      await new Promise(r => globalThis.setTimeout(r, 60));
+      await new Promise((r) => globalThis.setTimeout(r, 60));
     });
 
     await fillRequired(tree?.root);
@@ -350,6 +415,78 @@ describe("BugReportModal", () => {
     expect(getTextareas(tree?.root).length).toBeGreaterThan(0);
   });
 
+  it("loads desktop diagnostics in the Electrobun runtime", async () => {
+    isElectrobunRuntimeMock.mockReturnValue(true);
+    setupMock(true);
+
+    await act(async () => {
+      TestRenderer.create(React.createElement(BugReportModal));
+      await new Promise((r) => globalThis.setTimeout(r, 60));
+    });
+
+    expect(loadDesktopBugReportDiagnosticsMock).toHaveBeenCalledOnce();
+  });
+
+  it("opens the desktop logs folder", async () => {
+    isElectrobunRuntimeMock.mockReturnValue(true);
+    setupMock(true);
+    let tree: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      tree = TestRenderer.create(React.createElement(BugReportModal));
+      await new Promise((r) => globalThis.setTimeout(r, 60));
+    });
+
+    const logsButton = findButton(tree?.root, "bugreportmodal.openLogsFolder");
+    await act(async () => {
+      await logsButton?.props.onClick();
+    });
+
+    expect(openDesktopLogsFolderMock).toHaveBeenCalledOnce();
+  });
+
+  it("copies desktop diagnostics", async () => {
+    isElectrobunRuntimeMock.mockReturnValue(true);
+    setupMock(true);
+    let tree: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      tree = TestRenderer.create(React.createElement(BugReportModal));
+      await new Promise((r) => globalThis.setTimeout(r, 60));
+    });
+
+    const copyButton = findButton(tree?.root, "bugreportmodal.copyDiagnostics");
+    await act(async () => {
+      await copyButton?.props.onClick();
+    });
+
+    expect(mockCopyToClipboard).toHaveBeenCalledWith(
+      expect.stringContaining("Startup Phase: startup_failed"),
+    );
+  });
+
+  it("creates a local report bundle", async () => {
+    isElectrobunRuntimeMock.mockReturnValue(true);
+    setupMock(true);
+    let tree: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      tree = TestRenderer.create(React.createElement(BugReportModal));
+      await new Promise((r) => globalThis.setTimeout(r, 60));
+    });
+
+    await fillRequired(tree?.root);
+
+    const saveButton = findButton(tree?.root, "bugreportmodal.saveBundle");
+    await act(async () => {
+      await saveButton?.props.onClick();
+    });
+
+    expect(createDesktopBugReportBundleMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prefix: "milady-report",
+        reportMarkdown: expect.any(String),
+      }),
+    );
+  });
+
   // --- close behavior ---
 
   it("calls close on Cancel button click", async () => {
@@ -357,7 +494,7 @@ describe("BugReportModal", () => {
     let tree: TestRenderer.ReactTestRenderer;
     await act(async () => {
       tree = TestRenderer.create(React.createElement(BugReportModal));
-      await new Promise(r => globalThis.setTimeout(r, 60));
+      await new Promise((r) => globalThis.setTimeout(r, 60));
     });
 
     const cancelBtn = findButton(tree?.root, "common.cancel");
@@ -375,7 +512,7 @@ describe("BugReportModal", () => {
     let tree: TestRenderer.ReactTestRenderer;
     await act(async () => {
       tree = TestRenderer.create(React.createElement(BugReportModal));
-      await new Promise(r => globalThis.setTimeout(r, 60));
+      await new Promise((r) => globalThis.setTimeout(r, 60));
     });
 
     const before = getTextareas(tree?.root).length;


### PR DESCRIPTION
## Summary
- add crash-safe desktop diagnostics persistence (`milady-startup.log` + `startup-status.json`)
- add desktop RPC endpoints for diagnostics and local report bundles
- extend Bug Report modal with desktop actions: Copy Diagnostics, Open Logs Folder, Save Report Bundle
- add startup crash recovery prompt on next launch with `Copy Report` and Discord escalation text (`@iono`)

## User-visible behavior
- when a startup crash occurs, next launch shows a native prompt with actionable recovery options
- `Copy Report` puts a ready-to-paste startup report on clipboard
- app writes `startup-crash-report-latest.md` automatically
- bug report flow can include startup log tail and system info voluntarily

## Files
- apps/app/electrobun/src/native/agent.ts
- apps/app/electrobun/src/native/desktop.ts
- apps/app/electrobun/src/rpc-schema.ts
- apps/app/electrobun/src/rpc-handlers.ts
- apps/app/electrobun/src/index.ts
- packages/app-core/src/components/BugReportModal.tsx
- packages/app-core/src/utils/desktop-bug-report.ts
- tests + locale updates

## Validation
- `bunx vitest run apps/app/electrobun/src/__tests__/startup-bootstrap.test.ts apps/app/electrobun/src/__tests__/agent.test.ts packages/app-core/test/app/bug-report-modal.test.tsx`
- targeted Biome checks on changed files

## Notes
- installer-side Inno failure UX improvements are not included in this PR
