### PR TITLE
wallet: add 0x routing with safe fallback and UX route visibility

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -49,6 +49,7 @@
         "@miladyai/app-core": "workspace:*",
         "@noble/curves": "^2.0.1",
         "@opinion-labs/opinion-clob-sdk": "0.5.2",
+        "@pixiv/three-vrm": "^3.5.1",
         "@stwd/eliza-plugin": "0.2.0",
         "@stwd/sdk": "^0.3.0",
         "@whiskeysockets/baileys": "7.0.0-rc.9",

--- a/bun.lock
+++ b/bun.lock
@@ -98,6 +98,7 @@
         "tsdown": "^0.20.3",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
+        "vite": "^7.1.12",
         "vitest": "^4.1.0",
       },
     },
@@ -3736,7 +3737,7 @@
 
     "viem": ["viem@2.47.6", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.14.7", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-zExmbI99NGvMdYa7fmqSTLgkwh48dmhgEqFrUgkpL4kfG4XkVefZ8dZqIKVUhZo6Uhf0FrrEXOsHm9LUyIvI2Q=="],
 
-    "vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+    "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
     "vite-node": ["vite-node@2.1.9", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.3.7", "es-module-lexer": "^1.5.4", "pathe": "^1.1.2", "vite": "^5.0.0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA=="],
 
@@ -4038,6 +4039,8 @@
 
     "@miladyai/agent/sharp": ["sharp@0.33.5", "", { "dependencies": { "color": "^4.2.3", "detect-libc": "^2.0.3", "semver": "^7.6.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.33.5", "@img/sharp-darwin-x64": "0.33.5", "@img/sharp-libvips-darwin-arm64": "1.0.4", "@img/sharp-libvips-darwin-x64": "1.0.4", "@img/sharp-libvips-linux-arm": "1.0.5", "@img/sharp-libvips-linux-arm64": "1.0.4", "@img/sharp-libvips-linux-s390x": "1.0.4", "@img/sharp-libvips-linux-x64": "1.0.4", "@img/sharp-libvips-linuxmusl-arm64": "1.0.4", "@img/sharp-libvips-linuxmusl-x64": "1.0.4", "@img/sharp-linux-arm": "0.33.5", "@img/sharp-linux-arm64": "0.33.5", "@img/sharp-linux-s390x": "0.33.5", "@img/sharp-linux-x64": "0.33.5", "@img/sharp-linuxmusl-arm64": "0.33.5", "@img/sharp-linuxmusl-x64": "0.33.5", "@img/sharp-wasm32": "0.33.5", "@img/sharp-win32-ia32": "0.33.5", "@img/sharp-win32-x64": "0.33.5" } }, "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw=="],
 
+    "@miladyai/app/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+
     "@miladyai/app/vitest": ["vitest@2.1.9", "", { "dependencies": { "@vitest/expect": "2.1.9", "@vitest/mocker": "2.1.9", "@vitest/pretty-format": "^2.1.9", "@vitest/runner": "2.1.9", "@vitest/snapshot": "2.1.9", "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "debug": "^4.3.7", "expect-type": "^1.1.0", "magic-string": "^0.30.12", "pathe": "^1.1.2", "std-env": "^3.8.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.1", "tinypool": "^1.0.1", "tinyrainbow": "^1.2.0", "vite": "^5.0.0", "vite-node": "2.1.9", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/node": "^18.0.0 || >=20.0.0", "@vitest/browser": "2.1.9", "@vitest/ui": "2.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q=="],
 
     "@miladyai/app-core/@capacitor/core": ["@capacitor/core@8.0.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-EXZfxkL6GFJS2cb7TIBR7RiHA5iz6ufDcl1VmUpI2pga3lJ5Ck2+iqbx7N+osL3XYem9ad4XCidJEMm64DX6UQ=="],
@@ -4049,6 +4052,8 @@
     "@miladyai/homepage/jsdom": ["jsdom@29.0.1", "", { "dependencies": { "@asamuzakjp/css-color": "^5.0.1", "@asamuzakjp/dom-selector": "^7.0.3", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.1", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.2.7", "parse5": "^8.0.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.24.5", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg=="],
 
     "@miladyai/homepage/three": ["three@0.183.2", "", {}, "sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ=="],
+
+    "@miladyai/homepage/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
 
     "@miladyai/plugin-wechat/tsdown": ["tsdown@0.12.9", "", { "dependencies": { "ansis": "^4.1.0", "cac": "^6.7.14", "chokidar": "^4.0.3", "debug": "^4.4.1", "diff": "^8.0.2", "empathic": "^2.0.0", "hookable": "^5.5.3", "rolldown": "^1.0.0-beta.19", "rolldown-plugin-dts": "^0.13.12", "semver": "^7.7.2", "tinyexec": "^1.0.1", "tinyglobby": "^0.2.14", "unconfig": "^7.3.2" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "publint": "^0.3.0", "typescript": "^5.0.0", "unplugin-lightningcss": "^0.4.0", "unplugin-unused": "^0.5.0" }, "optionalPeers": ["@arethetypeswrong/core", "publint", "typescript", "unplugin-lightningcss", "unplugin-unused"], "bin": { "tsdown": "dist/run.mjs" } }, "sha512-MfrXm9PIlT3saovtWKf/gCJJ/NQCdE0SiREkdNC+9Qy6UHhdeDPxnkFaBD7xttVUmgp0yUHtGirpoLB+OVLuLA=="],
 
@@ -4588,11 +4593,11 @@
 
     "viem/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
-    "vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
-
     "vite-node/es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
     "vite-node/pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
+
+    "vite-node/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
 
     "vitest/@vitest/pretty-format": ["@vitest/pretty-format@4.1.1", "", { "dependencies": { "tinyrainbow": "^3.0.3" } }, "sha512-GM+TEQN5WhOygr1lp7skeVjdLPqqWMHsfzXrcHAqZJi/lIVh63H0kaRCY8MDhNWikx19zBUK8ceaLB7X5AH9NQ=="],
 
@@ -4752,6 +4757,8 @@
 
     "@miladyai/app-core/@capacitor/core/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@miladyai/app/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
     "@miladyai/app/vitest/@vitest/expect": ["@vitest/expect@2.1.9", "", { "dependencies": { "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "tinyrainbow": "^1.2.0" } }, "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw=="],
 
     "@miladyai/app/vitest/@vitest/mocker": ["@vitest/mocker@2.1.9", "", { "dependencies": { "@vitest/spy": "2.1.9", "estree-walker": "^3.0.3", "magic-string": "^0.30.12" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg=="],
@@ -4781,6 +4788,8 @@
     "@miladyai/homepage/jsdom/parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
 
     "@miladyai/homepage/jsdom/whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
+
+    "@miladyai/homepage/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 
     "@miladyai/plugin-wechat/tsdown/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
@@ -5138,51 +5147,7 @@
 
     "unrun/rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.11", "", {}, "sha512-xQO9vbwBecJRv9EUcQ/y0dzSTJgA7Q6UVN7xp6B81+tBGSLVAK03yJ9NkJaUA7JFD91kbjxRSC/mDnmvXzbHoQ=="],
 
-    "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
-
-    "vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
-
-    "vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
-
-    "vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
-
-    "vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
-
-    "vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
-
-    "vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
-
-    "vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
-
-    "vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
-
-    "vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
-
-    "vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
-
-    "vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
-
-    "vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
-
-    "vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
-
-    "vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
-
-    "vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
-
-    "vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
-
-    "vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
-
-    "vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
-
-    "vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
-
-    "vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
-
-    "vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
-
-    "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+    "vite-node/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 
     "vitest/vite/rolldown": ["rolldown@1.0.0-rc.11", "", { "dependencies": { "@oxc-project/types": "=0.122.0", "@rolldown/pluginutils": "1.0.0-rc.11" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.11", "@rolldown/binding-darwin-arm64": "1.0.0-rc.11", "@rolldown/binding-darwin-x64": "1.0.0-rc.11", "@rolldown/binding-freebsd-x64": "1.0.0-rc.11", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.11", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.11", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.11", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.11", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.11", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.11", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.11", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.11", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.11", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.11", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.11" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-NRjoKMusSjfRbSYiH3VSumlkgFe7kYAa3pzVOsVYVFY3zb5d7nS+a3KGQ7hJKXuYWbzJKPVQ9Wxq2UvyK+ENpw=="],
 
@@ -5202,9 +5167,101 @@
 
     "@joshwooding/vite-plugin-react-docgen-typescript/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
+    "@miladyai/app/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+
+    "@miladyai/app/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+
+    "@miladyai/app/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+
+    "@miladyai/app/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+
+    "@miladyai/app/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+
+    "@miladyai/app/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+
+    "@miladyai/app/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+
+    "@miladyai/app/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+
+    "@miladyai/app/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+
+    "@miladyai/app/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+
+    "@miladyai/app/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+
+    "@miladyai/app/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+
+    "@miladyai/app/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+
+    "@miladyai/app/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+
+    "@miladyai/app/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+
+    "@miladyai/app/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+
+    "@miladyai/app/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+
+    "@miladyai/app/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+
+    "@miladyai/app/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+
+    "@miladyai/app/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+
+    "@miladyai/app/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+
+    "@miladyai/app/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+
+    "@miladyai/app/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+
     "@miladyai/homepage/jsdom/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "@miladyai/homepage/jsdom/whatwg-url/tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
+
+    "@miladyai/homepage/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+
+    "@miladyai/homepage/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+
+    "@miladyai/homepage/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+
+    "@miladyai/homepage/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+
+    "@miladyai/homepage/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+
+    "@miladyai/homepage/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+
+    "@miladyai/homepage/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+
+    "@miladyai/homepage/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+
+    "@miladyai/homepage/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+
+    "@miladyai/homepage/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+
+    "@miladyai/homepage/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+
+    "@miladyai/homepage/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+
+    "@miladyai/homepage/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+
+    "@miladyai/homepage/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+
+    "@miladyai/homepage/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+
+    "@miladyai/homepage/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+
+    "@miladyai/homepage/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+
+    "@miladyai/homepage/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+
+    "@miladyai/homepage/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+
+    "@miladyai/homepage/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+
+    "@miladyai/homepage/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+
+    "@miladyai/homepage/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+
+    "@miladyai/homepage/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
 
     "@miladyai/plugin-wechat/tsdown/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
@@ -5265,6 +5322,52 @@
     "ripemd160/hash-base/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
     "shelljs/glob/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
+
+    "vite-node/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+
+    "vite-node/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+
+    "vite-node/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+
+    "vite-node/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+
+    "vite-node/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+
+    "vite-node/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+
+    "vite-node/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+
+    "vite-node/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+
+    "vite-node/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+
+    "vite-node/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+
+    "vite-node/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
 
     "vitest/vite/rolldown/@oxc-project/types": ["@oxc-project/types@0.122.0", "", {}, "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA=="],
 

--- a/docs/plans/2026-03-26-master-delivery-board.md
+++ b/docs/plans/2026-03-26-master-delivery-board.md
@@ -1,0 +1,15 @@
+# Master Delivery Board - 2026-03-26
+
+## Streams Snapshot
+
+| Stream | Scope | Branch | Status | Notes |
+|---|---|---|---|---|
+| S3 | Wallet routing + fallback + UX parity | `codex/wallet-routing` | In review | Provider abstraction, 0x fallback path, route visibility fields, and tests landed. |
+
+## S3 Notes
+
+- Added routing preference support in trade quote requests.
+- Added route provider transparency fields in shared wallet contracts.
+- Added safe provider fallback behavior and clearer provider-attempt error notes.
+- API handlers now pass routing preference through quote and execute paths.
+- Local validation complete except one ambient app-core type dependency gap (`vite/client`) in this environment.

--- a/docs/plans/agents/S3-wallet-routing.md
+++ b/docs/plans/agents/S3-wallet-routing.md
@@ -1,0 +1,32 @@
+# S3 Agent Brief - Wallet Routing + UX Parity
+
+## Status
+
+- Stream: `S3`
+- Branch: `codex/wallet-routing`
+- PR: pending
+- Last updated: `2026-03-26`
+
+## Checklist
+
+- [x] Phase 1: routing abstraction
+- [x] Phase 2: 0x integration
+- [x] Phase 3: fallback + safety
+- [x] Phase 4: route visibility + clearer errors
+- [x] Phase 5: tests
+
+## Delivered in this stream
+
+- Added provider-aware trade routing in `bsc-trade` with `auto` / `pancakeswap-v2` / `0x`.
+- Added explicit fallback metadata in quote responses (`routeProvider*` fields + notes).
+- Added safe fallback behavior from `0x` to PancakeSwap with surfaced attempt notes.
+- Added provider-aware unsigned tx handling and approval spender resolution.
+- Wired `routeProvider` through trade quote/execute API handlers.
+- Added regression coverage for `0x` failure fallback path.
+
+## Validation
+
+- `bunx vitest run packages/app-core/src/api/bsc-trade.test.ts`
+- `bunx vitest run packages/agent/test/api/wallet-routes.test.ts`
+- `bunx tsc -p packages/agent/tsconfig.json --noEmit`
+- `bunx tsc -p packages/app-core/tsconfig.json --noEmit` (fails in current env: missing `vite/client` type definitions)

--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
     "@miladyai/app-core": "workspace:*",
     "@noble/curves": "^2.0.1",
     "@opinion-labs/opinion-clob-sdk": "0.5.2",
+    "@pixiv/three-vrm": "^3.5.1",
     "@stwd/eliza-plugin": "0.2.0",
     "@stwd/sdk": "^0.3.0",
     "@whiskeysockets/baileys": "7.0.0-rc.9",

--- a/package.json
+++ b/package.json
@@ -220,6 +220,7 @@
     "@types/react-test-renderer": "^19.1.0",
     "@types/ws": "^8.18.1",
     "@vitest/coverage-v8": "^4.1.0",
+    "@vitest/utils": "4.1.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-test-renderer": "^19.2.4",
@@ -227,8 +228,8 @@
     "tsdown": "^0.20.3",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
-    "vitest": "^4.1.0",
-    "@vitest/utils": "4.1.0"
+    "vite": "^7.1.12",
+    "vitest": "^4.1.0"
   },
   "overrides": {
     "@elizaos/core": "2.0.0-alpha.106",

--- a/packages/agent/src/api/__tests__/bsc-trade-network.test.ts
+++ b/packages/agent/src/api/__tests__/bsc-trade-network.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { BscTradeQuoteResponse } from "../../contracts/wallet";
+import {
+  buildBscBuyUnsignedTx,
+  resolveBscRpcUrls,
+} from "../bsc-trade";
+
+const ENV_KEYS = [
+  "MILADY_WALLET_NETWORK",
+  "BSC_TESTNET_RPC_URL",
+  "BSC_TESTNET_SWAP_ROUTER_ADDRESS",
+  "BSC_TESTNET_WRAPPED_NATIVE_ADDRESS",
+  "BSC_TESTNET_CHAIN_ID",
+  "BSC_TESTNET_EXPLORER_BASE_URL",
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_BASE_URL",
+] as const;
+
+const ORIGINAL_ENV = Object.fromEntries(
+  ENV_KEYS.map((key) => [key, process.env[key]]),
+) as Record<(typeof ENV_KEYS)[number], string | undefined>;
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const value = ORIGINAL_ENV[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+});
+
+function makeQuote(routerAddress: string): BscTradeQuoteResponse {
+  return {
+    ok: true,
+    side: "buy",
+    routeProvider: "pancakeswap-v2",
+    routeProviderRequested: "auto",
+    routeProviderFallbackUsed: false,
+    routerAddress,
+    wrappedNativeAddress: "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
+    tokenAddress: "0x1111111111111111111111111111111111111111",
+    slippageBps: 300,
+    route: [
+      "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
+      "0x1111111111111111111111111111111111111111",
+    ],
+    quoteIn: { symbol: "BNB", amount: "0.01", amountWei: "10000000000000000" },
+    quoteOut: { symbol: "TKN", amount: "10", amountWei: "10000000000000000000" },
+    minReceive: { symbol: "TKN", amount: "9.7", amountWei: "9700000000000000000" },
+    price: "1000",
+    preflight: {
+      ok: true,
+      walletAddress: "0x2222222222222222222222222222222222222222",
+      rpcUrlHost: "rpc.example",
+      chainId: 56,
+      bnbBalance: "1",
+      minGasBnb: "0.005",
+      checks: {
+        walletReady: true,
+        rpcReady: true,
+        chainReady: true,
+        gasReady: true,
+        tokenAddressValid: true,
+      },
+      reasons: [],
+    },
+  };
+}
+
+describe("bsc-trade network mode", () => {
+  it("uses mainnet chain id + explorer by default", () => {
+    const quote = makeQuote("0x10ED43C718714eb63d5aA57B78B54704E256024E");
+    const tx = buildBscBuyUnsignedTx(
+      quote,
+      "0x2222222222222222222222222222222222222222",
+    );
+    expect(tx.chainId).toBe(56);
+    expect(tx.explorerUrl).toBe("https://bscscan.com");
+  });
+
+  it("uses testnet chain id + explorer when wallet network is testnet", () => {
+    process.env.MILADY_WALLET_NETWORK = "testnet";
+    process.env.BSC_TESTNET_SWAP_ROUTER_ADDRESS =
+      "0x1234567890abcdef1234567890abcdef12345678";
+    process.env.BSC_TESTNET_WRAPPED_NATIVE_ADDRESS =
+      "0xae13d989dac2f0debff460ac112a837c89baa7cd";
+    process.env.BSC_TESTNET_CHAIN_ID = "97";
+    process.env.BSC_TESTNET_EXPLORER_BASE_URL = "https://testnet.bscscan.com";
+
+    const quote = makeQuote("0x1234567890AbcdEF1234567890aBcdef12345678");
+    const tx = buildBscBuyUnsignedTx(
+      quote,
+      "0x2222222222222222222222222222222222222222",
+    );
+    expect(tx.chainId).toBe(97);
+    expect(tx.explorerUrl).toBe("https://testnet.bscscan.com");
+  });
+
+  it("rejects quote router mismatch in testnet mode", () => {
+    process.env.MILADY_WALLET_NETWORK = "testnet";
+    process.env.BSC_TESTNET_SWAP_ROUTER_ADDRESS =
+      "0x1234567890abcdef1234567890abcdef12345678";
+    process.env.BSC_TESTNET_WRAPPED_NATIVE_ADDRESS =
+      "0xae13d989dac2f0debff460ac112a837c89baa7cd";
+
+    const quote = makeQuote("0x10ED43C718714eb63d5aA57B78B54704E256024E");
+    expect(() =>
+      buildBscBuyUnsignedTx(
+        quote,
+        "0x2222222222222222222222222222222222222222",
+      ),
+    ).toThrow(/Unexpected router address/);
+  });
+
+  it("uses testnet RPC resolution without cloud mainnet proxy", () => {
+    process.env.MILADY_WALLET_NETWORK = "testnet";
+    process.env.BSC_TESTNET_RPC_URL = "https://bsc-test.custom/rpc";
+    process.env.ELIZAOS_CLOUD_API_KEY = "cloud-key";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://cloud.example";
+
+    const urls = resolveBscRpcUrls({ cloudManagedAccess: true });
+    expect(urls).toContain("https://bsc-test.custom/rpc");
+    expect(urls.join(" ")).not.toContain("/proxy/evm-rpc/bsc");
+  });
+});
+

--- a/packages/agent/src/api/__tests__/wallet-rpc-network.test.ts
+++ b/packages/agent/src/api/__tests__/wallet-rpc-network.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  resolveBscRpcUrls,
+  resolveSolanaRpcUrls,
+  resolveWalletRpcReadiness,
+} from "../wallet-rpc";
+import type { ElizaConfig } from "../../config/config";
+
+const ENV_KEYS = [
+  "MILADY_WALLET_NETWORK",
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_BASE_URL",
+  "BSC_RPC_URL",
+  "BSC_TESTNET_RPC_URL",
+  "SOLANA_RPC_URL",
+  "SOLANA_TESTNET_RPC_URL",
+] as const;
+
+const ORIGINAL_ENV = Object.fromEntries(
+  ENV_KEYS.map((key) => [key, process.env[key]]),
+) as Record<(typeof ENV_KEYS)[number], string | undefined>;
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const value = ORIGINAL_ENV[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+});
+
+describe("wallet-rpc network mode", () => {
+  it("uses cloud-managed mainnet RPCs by default", () => {
+    const bsc = resolveBscRpcUrls({
+      cloudManagedAccess: true,
+      cloudApiKey: "cloud-key",
+      cloudBaseUrl: "https://cloud.example",
+    });
+    const sol = resolveSolanaRpcUrls({
+      cloudManagedAccess: true,
+      cloudApiKey: "cloud-key",
+      cloudBaseUrl: "https://cloud.example",
+    });
+
+    expect(bsc).toEqual(
+      expect.arrayContaining([
+        "https://cloud.example/api/v1/proxy/evm-rpc/bsc?api_key=cloud-key",
+        "https://bsc-dataseed1.binance.org/",
+      ]),
+    );
+    expect(sol).toEqual(
+      expect.arrayContaining([
+        "https://cloud.example/api/v1/proxy/solana-rpc?api_key=cloud-key",
+        "https://api.mainnet-beta.solana.com/",
+      ]),
+    );
+  });
+
+  it("uses testnet RPC defaults and omits cloud mainnet proxies in testnet mode", () => {
+    process.env.MILADY_WALLET_NETWORK = "testnet";
+
+    const bsc = resolveBscRpcUrls({
+      cloudManagedAccess: true,
+      cloudApiKey: "cloud-key",
+      cloudBaseUrl: "https://cloud.example",
+    });
+    const sol = resolveSolanaRpcUrls({
+      cloudManagedAccess: true,
+      cloudApiKey: "cloud-key",
+      cloudBaseUrl: "https://cloud.example",
+    });
+
+    expect(bsc).toEqual(
+      expect.arrayContaining(["https://data-seed-prebsc-1-s1.binance.org:8545/"]),
+    );
+    expect(sol).toEqual(expect.arrayContaining(["https://api.devnet.solana.com/"]));
+    expect(bsc.join(" ")).not.toContain("/proxy/evm-rpc/bsc");
+    expect(sol.join(" ")).not.toContain("/proxy/solana-rpc");
+  });
+
+  it("respects explicit testnet RPC env overrides", () => {
+    process.env.MILADY_WALLET_NETWORK = "testnet";
+    process.env.BSC_TESTNET_RPC_URL = "https://bsc-test.custom/rpc";
+    process.env.SOLANA_TESTNET_RPC_URL = "https://solana-test.custom/rpc";
+
+    const bsc = resolveBscRpcUrls({ cloudManagedAccess: false });
+    const sol = resolveSolanaRpcUrls({ cloudManagedAccess: false });
+
+    expect(bsc[0]).toBe("https://bsc-test.custom/rpc");
+    expect(sol[0]).toBe("https://solana-test.custom/rpc");
+  });
+
+  it("propagates testnet mode through wallet readiness", () => {
+    process.env.MILADY_WALLET_NETWORK = "testnet";
+    process.env.ELIZAOS_CLOUD_API_KEY = "cloud-key";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://cloud.example";
+
+    const readiness = resolveWalletRpcReadiness({
+      env: {},
+      cloud: { apiKey: "cloud-key", baseUrl: "https://cloud.example" },
+    } as ElizaConfig);
+
+    expect(readiness.bscRpcUrls).toEqual(
+      expect.arrayContaining(["https://data-seed-prebsc-1-s1.binance.org:8545/"]),
+    );
+    expect(readiness.solanaRpcUrls).toEqual(
+      expect.arrayContaining(["https://api.devnet.solana.com/"]),
+    );
+    expect(readiness.bscRpcUrls.join(" ")).not.toContain("/proxy/evm-rpc/bsc");
+    expect(readiness.solanaRpcUrls.join(" ")).not.toContain("/proxy/solana-rpc");
+  });
+});
+

--- a/packages/agent/src/api/__tests__/wallet-trading-profile-status.test.ts
+++ b/packages/agent/src/api/__tests__/wallet-trading-profile-status.test.ts
@@ -1,0 +1,140 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  readWalletTradeLedgerStore,
+  recordWalletTradeLedgerEntry,
+  updateWalletTradeLedgerEntryStatus,
+} from "../wallet-trading-profile";
+
+function makeTempStateDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "milady-wallet-ledger-"));
+}
+
+function seedPendingEntry(stateDir: string): void {
+  recordWalletTradeLedgerEntry(
+    {
+      hash: "0xabc123",
+      source: "agent",
+      side: "buy",
+      tokenAddress: "0x1111111111111111111111111111111111111111",
+      slippageBps: 300,
+      route: ["0xwbnb", "0xtoken"],
+      quoteIn: { symbol: "BNB", amount: "0.01", amountWei: "10000000000000000" },
+      quoteOut: { symbol: "USDT", amount: "2", amountWei: "2000000" },
+      status: "pending",
+      confirmations: 0,
+      nonce: 1,
+      blockNumber: null,
+      gasUsed: null,
+      effectiveGasPriceWei: null,
+      explorerUrl: "https://bscscan.com/tx/0xabc123",
+    },
+    stateDir,
+  );
+}
+
+describe("wallet trading profile status transitions", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("allows pending -> success transition", () => {
+    const stateDir = makeTempStateDir();
+    tempDirs.push(stateDir);
+    seedPendingEntry(stateDir);
+
+    const updated = updateWalletTradeLedgerEntryStatus(
+      "0xabc123",
+      {
+        status: "success",
+        confirmations: 2,
+        nonce: 1,
+        blockNumber: 123,
+        gasUsed: "21000",
+        effectiveGasPriceWei: "1000000000",
+      },
+      stateDir,
+    );
+
+    expect(updated?.status).toBe("success");
+    expect(updated?.confirmations).toBe(2);
+  });
+
+  it("rejects terminal success -> reverted regression", () => {
+    const stateDir = makeTempStateDir();
+    tempDirs.push(stateDir);
+    seedPendingEntry(stateDir);
+
+    updateWalletTradeLedgerEntryStatus(
+      "0xabc123",
+      {
+        status: "success",
+        confirmations: 3,
+        nonce: 1,
+        blockNumber: 123,
+        gasUsed: "21000",
+        effectiveGasPriceWei: "1000000000",
+      },
+      stateDir,
+    );
+
+    const rejected = updateWalletTradeLedgerEntryStatus(
+      "0xabc123",
+      {
+        status: "reverted",
+        confirmations: 3,
+        nonce: 1,
+        blockNumber: 123,
+        gasUsed: "21000",
+        effectiveGasPriceWei: "1000000000",
+        reason: "late conflicting write",
+      },
+      stateDir,
+    );
+
+    expect(rejected?.status).toBe("success");
+    const store = readWalletTradeLedgerStore(stateDir);
+    expect(store.entries[0]?.status).toBe("success");
+  });
+
+  it("allows not_found -> pending recovery transition", () => {
+    const stateDir = makeTempStateDir();
+    tempDirs.push(stateDir);
+    seedPendingEntry(stateDir);
+
+    updateWalletTradeLedgerEntryStatus(
+      "0xabc123",
+      {
+        status: "not_found",
+        confirmations: 0,
+        nonce: 1,
+        blockNumber: null,
+        gasUsed: null,
+        effectiveGasPriceWei: null,
+      },
+      stateDir,
+    );
+
+    const recovered = updateWalletTradeLedgerEntryStatus(
+      "0xabc123",
+      {
+        status: "pending",
+        confirmations: 0,
+        nonce: 1,
+        blockNumber: null,
+        gasUsed: null,
+        effectiveGasPriceWei: null,
+      },
+      stateDir,
+    );
+
+    expect(recovered?.status).toBe("pending");
+  });
+});
+

--- a/packages/agent/src/api/bsc-trade.ts
+++ b/packages/agent/src/api/bsc-trade.ts
@@ -9,6 +9,8 @@
 import { logger } from "@elizaos/core";
 import { ethers } from "ethers";
 import type {
+  BscTradeRoutePreference,
+  BscTradeRouteProvider,
   BscTradePreflightResponse,
   BscTradeQuoteRequest,
   BscTradeQuoteResponse,
@@ -27,6 +29,8 @@ const MIN_GAS_BNB = "0.005";
 const DEFAULT_SLIPPAGE_BPS = 300;
 const MAX_SLIPPAGE_BPS = 1_000;
 const SLIPPAGE_WARNING_THRESHOLD_BPS = 300;
+const ZEROX_API_BASE_URL = "https://bsc.api.0x.org";
+const ZEROX_QUOTE_TIMEOUT_MS = 8_000;
 
 export const PANCAKE_SWAP_V2_ROUTER = ethers.getAddress(
   "0x10ED43C718714eb63d5aA57B78B54704E256024E",
@@ -78,6 +82,15 @@ interface JsonRpcResponse<T> {
     code?: number;
     message?: string;
   };
+}
+
+interface ZeroXQuoteResponse {
+  to?: string;
+  data?: string;
+  value?: string;
+  allowanceTarget?: string;
+  buyAmount?: string;
+  sellAmount?: string;
 }
 
 function normalizeRpcUrl(url: string | null | undefined): string | null {
@@ -201,6 +214,27 @@ function parsePositiveDecimal(value: string): number {
     throw new Error("Amount must be a positive number.");
   }
   return amount;
+}
+
+function resolveRouteProviderPreference(
+  value: string | null | undefined,
+): BscTradeRoutePreference {
+  if (value === "pancakeswap-v2" || value === "0x" || value === "auto") {
+    return value;
+  }
+  return "auto";
+}
+
+function resolveRouteProviderOrder(
+  requested: BscTradeRoutePreference,
+): BscTradeRouteProvider[] {
+  if (requested === "0x") {
+    return ["0x", "pancakeswap-v2"];
+  }
+  if (requested === "pancakeswap-v2") {
+    return ["pancakeswap-v2"];
+  }
+  return ["0x", "pancakeswap-v2"];
 }
 
 function formatPrice(amountIn: string, amountOut: string): string {
@@ -333,6 +367,79 @@ async function readTokenBalanceWei(
     throw new Error("Token balance response is invalid.");
   }
   return balance;
+}
+
+async function fetchZeroXQuote(input: {
+  side: BscTradeSide;
+  walletAddress: string;
+  tokenAddress: string;
+  wrappedNativeAddress: string;
+  amountInWei: bigint;
+  slippageBps: number;
+}): Promise<ZeroXQuoteResponse> {
+  const apiBase = normalizeRpcUrl(process.env.ZEROX_BSC_API_BASE_URL)
+    ? (normalizeRpcUrl(process.env.ZEROX_BSC_API_BASE_URL) as string)
+    : ZEROX_API_BASE_URL;
+  const sellToken =
+    input.side === "buy" ? input.wrappedNativeAddress : input.tokenAddress;
+  const buyToken =
+    input.side === "buy" ? input.tokenAddress : input.wrappedNativeAddress;
+  const quoteUrl = new URL("/swap/v1/quote", apiBase);
+  quoteUrl.searchParams.set("sellToken", sellToken);
+  quoteUrl.searchParams.set("buyToken", buyToken);
+  quoteUrl.searchParams.set("sellAmount", input.amountInWei.toString());
+  quoteUrl.searchParams.set(
+    "slippagePercentage",
+    (input.slippageBps / 10_000).toString(),
+  );
+  quoteUrl.searchParams.set("takerAddress", input.walletAddress);
+  const apiKey = process.env.ZEROX_API_KEY?.trim();
+  const response = await fetch(quoteUrl.toString(), {
+    method: "GET",
+    headers: apiKey ? { "0x-api-key": apiKey } : undefined,
+    signal: AbortSignal.timeout(ZEROX_QUOTE_TIMEOUT_MS),
+  });
+  const raw = await response.text();
+  if (!response.ok) {
+    throw new Error(`0x HTTP ${response.status}: ${raw.slice(0, 180)}`);
+  }
+  let parsed: ZeroXQuoteResponse;
+  try {
+    parsed = JSON.parse(raw) as ZeroXQuoteResponse;
+  } catch {
+    throw new Error(`0x quote returned invalid JSON: ${raw.slice(0, 180)}`);
+  }
+
+  const to = normalizeAddress(parsed.to);
+  const data =
+    typeof parsed.data === "string" && parsed.data.startsWith("0x")
+      ? parsed.data
+      : null;
+  const buyAmount =
+    typeof parsed.buyAmount === "string" && /^\d+$/.test(parsed.buyAmount)
+      ? BigInt(parsed.buyAmount)
+      : null;
+  const sellAmount =
+    typeof parsed.sellAmount === "string" && /^\d+$/.test(parsed.sellAmount)
+      ? BigInt(parsed.sellAmount)
+      : null;
+  const value =
+    typeof parsed.value === "string" && /^\d+$/.test(parsed.value)
+      ? parsed.value
+      : "0";
+
+  if (!to || !data || !buyAmount || !sellAmount) {
+    throw new Error("0x quote missing required transaction fields.");
+  }
+
+  return {
+    to,
+    data,
+    value,
+    allowanceTarget: normalizeAddress(parsed.allowanceTarget ?? null) ?? undefined,
+    buyAmount: buyAmount.toString(),
+    sellAmount: sellAmount.toString(),
+  };
 }
 
 export async function buildBscTradePreflight(
@@ -486,11 +593,17 @@ export async function buildBscTradeQuote(
   parsePositiveDecimal(amountInput);
 
   const slippageBps = clampSlippageBps(input.request.slippageBps);
+  const routeProviderRequested = resolveRouteProviderPreference(
+    input.request.routeProvider,
+  );
   const preflight = await buildBscTradePreflight({
     walletAddress: input.walletAddress,
     tokenAddress,
+    rpcUrls: input.rpcUrls,
     nodeRealBscRpcUrl: input.nodeRealBscRpcUrl,
     quickNodeBscRpcUrl: input.quickNodeBscRpcUrl,
+    bscRpcUrl: input.bscRpcUrl,
+    cloudManagedAccess: input.cloudManagedAccess,
   });
   if (!preflight.ok) {
     throw new Error(preflight.reasons[0] ?? "Trade preflight failed.");
@@ -534,35 +647,103 @@ export async function buildBscTradeQuote(
     }
   }
 
-  const route =
-    side === "buy"
-      ? [wrappedNativeAddress, tokenAddress]
-      : [tokenAddress, wrappedNativeAddress];
-  const quoteCall = ROUTER_IFACE.encodeFunctionData("getAmountsOut", [
-    amountInWei,
-    route,
-  ]);
-  const quoteResponse = await ethCall(
-    rpcUrls,
-    PANCAKE_SWAP_V2_ROUTER,
-    quoteCall,
-  );
-  const decoded = ROUTER_IFACE.decodeFunctionResult(
-    "getAmountsOut",
-    quoteResponse.result,
-  );
-  const amountsOut = decoded[0];
-  if (!Array.isArray(amountsOut) || amountsOut.length < 2) {
-    throw new Error("Router returned an invalid quote.");
+  let routeProvider: BscTradeRouteProvider = "pancakeswap-v2";
+  let routeProviderFallbackUsed = false;
+  const routeProviderNotes: string[] = [];
+  let amountOutWei: bigint | null = null;
+  let route: string[] = [];
+  let swapTargetAddress: string | undefined;
+  let swapCallData: string | undefined;
+  let swapValueWei: string | undefined;
+  let allowanceTarget: string | undefined;
+
+  const providerErrors: string[] = [];
+  for (const provider of resolveRouteProviderOrder(routeProviderRequested)) {
+    try {
+      if (provider === "0x") {
+        if (!preflight.walletAddress) {
+          throw new Error("wallet address is required for 0x route");
+        }
+        const zeroX = await fetchZeroXQuote({
+          side,
+          walletAddress: preflight.walletAddress,
+          tokenAddress,
+          wrappedNativeAddress,
+          amountInWei,
+          slippageBps,
+        });
+        const buyAmount = BigInt(zeroX.buyAmount ?? "0");
+        if (buyAmount <= 0n) {
+          throw new Error("0x quote returned zero output amount");
+        }
+        amountOutWei = buyAmount;
+        routeProvider = "0x";
+        route =
+          side === "buy"
+            ? [wrappedNativeAddress, tokenAddress]
+            : [tokenAddress, wrappedNativeAddress];
+        swapTargetAddress = zeroX.to;
+        swapCallData = zeroX.data;
+        swapValueWei = zeroX.value ?? "0";
+        allowanceTarget = zeroX.allowanceTarget;
+        break;
+      }
+
+      const candidateRoute =
+        side === "buy"
+          ? [wrappedNativeAddress, tokenAddress]
+          : [tokenAddress, wrappedNativeAddress];
+      const quoteCall = ROUTER_IFACE.encodeFunctionData("getAmountsOut", [
+        amountInWei,
+        candidateRoute,
+      ]);
+      const quoteResponse = await ethCall(
+        rpcUrls,
+        PANCAKE_SWAP_V2_ROUTER,
+        quoteCall,
+      );
+      const decoded = ROUTER_IFACE.decodeFunctionResult(
+        "getAmountsOut",
+        quoteResponse.result,
+      );
+      const amountsOut = decoded[0];
+      if (!Array.isArray(amountsOut) || amountsOut.length < 2) {
+        throw new Error("router returned an invalid quote");
+      }
+      const finalAmount = amountsOut[amountsOut.length - 1];
+      if (typeof finalAmount !== "bigint" || finalAmount <= 0n) {
+        throw new Error("router quote output is invalid");
+      }
+
+      amountOutWei = finalAmount;
+      routeProvider = "pancakeswap-v2";
+      route = candidateRoute;
+      break;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      providerErrors.push(`${provider}: ${message}`);
+    }
   }
 
-  const amountOutWei = amountsOut[amountsOut.length - 1];
-  if (typeof amountOutWei !== "bigint") {
-    throw new Error("Router quote output type is invalid.");
+  if (!amountOutWei) {
+    throw new Error(
+      `Trade quote failed across providers (${providerErrors.join(" | ")})`,
+    );
   }
+
+  if (routeProviderRequested !== routeProvider) {
+    routeProviderFallbackUsed = true;
+    routeProviderNotes.push(
+      `Requested ${routeProviderRequested}, used ${routeProvider}.`,
+    );
+  }
+  if (providerErrors.length > 0) {
+    routeProviderNotes.push(...providerErrors);
+  }
+
   let minReceiveWei = (amountOutWei * BigInt(10_000 - slippageBps)) / 10_000n;
   if (minReceiveWei === 0n && amountOutWei > 0n) {
-    minReceiveWei = 1n; // Prevent zero-slippage execution for small amounts
+    minReceiveWei = 1n;
   }
   const outDecimals = side === "buy" ? tokenDecimals : 18;
   const inSymbol = side === "buy" ? "BNB" : tokenSymbol;
@@ -577,7 +758,12 @@ export async function buildBscTradeQuote(
   return {
     ok: true,
     side,
-    routerAddress: PANCAKE_SWAP_V2_ROUTER,
+    routeProvider,
+    routeProviderRequested,
+    routeProviderFallbackUsed,
+    routeProviderNotes: routeProviderNotes.length > 0 ? routeProviderNotes : undefined,
+    routerAddress:
+      routeProvider === "0x" ? (swapTargetAddress ?? PANCAKE_SWAP_V2_ROUTER) : PANCAKE_SWAP_V2_ROUTER,
     wrappedNativeAddress,
     tokenAddress,
     slippageBps,
@@ -599,6 +785,10 @@ export async function buildBscTradeQuote(
     },
     price: formatPrice(amountInFormatted, amountOutFormatted),
     preflight,
+    swapTargetAddress,
+    swapCallData,
+    swapValueWei,
+    allowanceTarget,
     quotedAt: Date.now(),
   };
 }
@@ -608,6 +798,9 @@ export async function buildBscTradeQuote(
  * Prevents a compromised or tampered quote from directing funds to an arbitrary address.
  */
 function assertRouterAddress(quote: BscTradeQuoteResponse): void {
+  if (quote.routeProvider === "0x") {
+    return;
+  }
   if (quote.routerAddress !== PANCAKE_SWAP_V2_ROUTER) {
     throw new Error(
       `Unexpected router address in quote: ${quote.routerAddress}. Expected PancakeSwap V2 router ${PANCAKE_SWAP_V2_ROUTER}.`,
@@ -627,6 +820,20 @@ export function buildBscBuyUnsignedTx(
   const normalizedRecipient = normalizeAddress(recipientAddress);
   if (!normalizedRecipient) {
     throw new Error("Recipient wallet address is required.");
+  }
+  if (quote.routeProvider === "0x") {
+    if (!quote.swapTargetAddress || !quote.swapCallData) {
+      throw new Error("0x quote is missing swap transaction payload.");
+    }
+    return {
+      chainId: BSC_CHAIN_ID,
+      from: normalizedRecipient,
+      to: quote.swapTargetAddress,
+      data: quote.swapCallData,
+      valueWei: quote.swapValueWei ?? quote.quoteIn.amountWei,
+      deadline: Math.floor(Date.now() / 1000) + clampDeadlineSeconds(deadlineSeconds),
+      explorerUrl: "https://bscscan.com",
+    };
   }
   const now = Math.floor(Date.now() / 1000);
   const deadline = now + clampDeadlineSeconds(deadlineSeconds);
@@ -663,6 +870,20 @@ export function buildBscSellUnsignedTx(
   const normalizedRecipient = normalizeAddress(recipientAddress);
   if (!normalizedRecipient) {
     throw new Error("Recipient wallet address is required.");
+  }
+  if (quote.routeProvider === "0x") {
+    if (!quote.swapTargetAddress || !quote.swapCallData) {
+      throw new Error("0x quote is missing swap transaction payload.");
+    }
+    return {
+      chainId: BSC_CHAIN_ID,
+      from: normalizedRecipient,
+      to: quote.swapTargetAddress,
+      data: quote.swapCallData,
+      valueWei: quote.swapValueWei ?? "0",
+      deadline: Math.floor(Date.now() / 1000) + clampDeadlineSeconds(deadlineSeconds),
+      explorerUrl: "https://bscscan.com",
+    };
   }
   const now = Math.floor(Date.now() / 1000);
   const deadline = now + clampDeadlineSeconds(deadlineSeconds);
@@ -732,4 +953,13 @@ export function buildBscApproveUnsignedTx(
     spender: normalizedSpender,
     amountWei: amount.toString(),
   };
+}
+
+export function resolveBscApprovalSpender(
+  quote: Pick<BscTradeQuoteResponse, "routeProvider" | "allowanceTarget" | "routerAddress">,
+): string {
+  if (quote.routeProvider === "0x" && quote.allowanceTarget) {
+    return quote.allowanceTarget;
+  }
+  return quote.routerAddress;
 }

--- a/packages/agent/src/api/bsc-trade.ts
+++ b/packages/agent/src/api/bsc-trade.ts
@@ -19,12 +19,12 @@ import type {
   BscUnsignedTradeTx,
 } from "../contracts/wallet.js";
 import {
-  buildCloudEvmRpcUrl,
-  DEFAULT_PUBLIC_BSC_RPC_URLS,
+  resolveBscRpcUrls as resolveWalletBscRpcUrls,
 } from "./wallet-rpc.js";
 
 const FETCH_TIMEOUT_MS = 15_000;
-const BSC_CHAIN_ID = 56;
+const BSC_MAINNET_CHAIN_ID = 56;
+const BSC_TESTNET_CHAIN_ID = 97;
 const MIN_GAS_BNB = "0.005";
 const DEFAULT_SLIPPAGE_BPS = 300;
 const MAX_SLIPPAGE_BPS = 1_000;
@@ -38,6 +38,7 @@ export const PANCAKE_SWAP_V2_ROUTER = ethers.getAddress(
 export const BSC_WBNB_FALLBACK = ethers.getAddress(
   "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
 );
+export const BSC_TESTNET_EXPLORER_BASE_URL = "https://testnet.bscscan.com";
 
 const ROUTER_IFACE = new ethers.Interface([
   "function WETH() view returns (address)",
@@ -93,6 +94,76 @@ interface ZeroXQuoteResponse {
   sellAmount?: string;
 }
 
+interface BscExecutionContext {
+  walletNetwork: "mainnet" | "testnet";
+  chainId: number;
+  routerAddress: string;
+  wrappedNativeFallback: string | null;
+  explorerBaseUrl: string;
+}
+
+function resolveWalletNetwork(): "mainnet" | "testnet" {
+  const normalized = (process.env.MILADY_WALLET_NETWORK ?? "")
+    .trim()
+    .toLowerCase();
+  return normalized === "testnet" ? "testnet" : "mainnet";
+}
+
+function resolveBscExecutionContext(): BscExecutionContext {
+  const walletNetwork = resolveWalletNetwork();
+  if (walletNetwork === "mainnet") {
+    return {
+      walletNetwork,
+      chainId: BSC_MAINNET_CHAIN_ID,
+      routerAddress: PANCAKE_SWAP_V2_ROUTER,
+      wrappedNativeFallback: BSC_WBNB_FALLBACK,
+      explorerBaseUrl: "https://bscscan.com",
+    };
+  }
+
+  const configuredChainIdRaw = process.env.BSC_TESTNET_CHAIN_ID?.trim();
+  const configuredChainId = configuredChainIdRaw
+    ? Number.parseInt(configuredChainIdRaw, 10)
+    : BSC_TESTNET_CHAIN_ID;
+  const chainId =
+    Number.isFinite(configuredChainId) && configuredChainId > 0
+      ? configuredChainId
+      : BSC_TESTNET_CHAIN_ID;
+
+  const routerAddress = normalizeAddress(
+    process.env.BSC_TESTNET_SWAP_ROUTER_ADDRESS ??
+      process.env.BSC_SWAP_ROUTER_ADDRESS,
+  );
+  if (!routerAddress) {
+    throw new Error(
+      "BSC testnet router not configured. Set BSC_TESTNET_SWAP_ROUTER_ADDRESS.",
+    );
+  }
+  const wrappedNativeFallback = normalizeAddress(
+    process.env.BSC_TESTNET_WRAPPED_NATIVE_ADDRESS ??
+      process.env.BSC_WRAPPED_NATIVE_ADDRESS,
+  );
+
+  const explorerBaseUrlRaw =
+    process.env.BSC_TESTNET_EXPLORER_BASE_URL ?? BSC_TESTNET_EXPLORER_BASE_URL;
+  const explorerBaseUrl = (() => {
+    try {
+      const parsed = new URL(explorerBaseUrlRaw);
+      return parsed.toString().replace(/\/+$/, "");
+    } catch {
+      return BSC_TESTNET_EXPLORER_BASE_URL;
+    }
+  })();
+
+  return {
+    walletNetwork,
+    chainId,
+    routerAddress,
+    wrappedNativeFallback,
+    explorerBaseUrl,
+  };
+}
+
 function normalizeRpcUrl(url: string | null | undefined): string | null {
   if (typeof url !== "string") return null;
   const trimmed = url.trim();
@@ -108,8 +179,10 @@ function normalizeRpcUrl(url: string | null | undefined): string | null {
 }
 
 export function resolveBscRpcUrls(input: BscTradeRpcConfig): string[] {
+  const walletNetwork = resolveWalletNetwork();
   const candidates = [
     ...(input.rpcUrls ?? []).map((url) => normalizeRpcUrl(url)),
+    normalizeRpcUrl(process.env.BSC_TESTNET_RPC_URL),
     normalizeRpcUrl(
       input.nodeRealBscRpcUrl !== undefined
         ? input.nodeRealBscRpcUrl
@@ -124,12 +197,10 @@ export function resolveBscRpcUrls(input: BscTradeRpcConfig): string[] {
     normalizeRpcUrl(
       input.bscRpcUrl !== undefined ? input.bscRpcUrl : process.env.BSC_RPC_URL,
     ),
-    buildCloudEvmRpcUrl("bsc", {
+    ...resolveWalletBscRpcUrls({
       cloudManagedAccess: input.cloudManagedAccess,
+      walletNetwork,
     }),
-    ...(input.cloudManagedAccess
-      ? DEFAULT_PUBLIC_BSC_RPC_URLS.map((url) => normalizeRpcUrl(url))
-      : []),
   ].filter((v): v is string => Boolean(v));
 
   return [...new Set(candidates)];
@@ -314,17 +385,27 @@ async function ethCall(
   ]);
 }
 
-async function readWrappedNativeAddress(rpcUrls: string[]): Promise<string> {
+async function readWrappedNativeAddress(
+  rpcUrls: string[],
+  context: BscExecutionContext,
+): Promise<string> {
   const encoded = ROUTER_IFACE.encodeFunctionData("WETH", []);
-  const call = await ethCall(rpcUrls, PANCAKE_SWAP_V2_ROUTER, encoded);
-  const decoded = ROUTER_IFACE.decodeFunctionResult("WETH", call.result);
-  const wrappedNative = decoded[0];
-  
-  if (typeof wrappedNative !== "string" || !wrappedNative) {
-    throw new Error("Router WETH() returned an invalid address.");
+  try {
+    const call = await ethCall(rpcUrls, context.routerAddress, encoded);
+    const decoded = ROUTER_IFACE.decodeFunctionResult("WETH", call.result);
+    const wrappedNative = decoded[0];
+
+    if (typeof wrappedNative !== "string" || !wrappedNative) {
+      throw new Error("Router WETH() returned an invalid address.");
+    }
+
+    return ethers.getAddress(wrappedNative);
+  } catch (err) {
+    if (context.wrappedNativeFallback) {
+      return context.wrappedNativeFallback;
+    }
+    throw err;
   }
-  
-  return ethers.getAddress(wrappedNative);
 }
 
 export async function readTokenDecimals(rpcUrls: string[], tokenAddress: string): Promise<number> {
@@ -445,6 +526,7 @@ async function fetchZeroXQuote(input: {
 export async function buildBscTradePreflight(
   input: BuildBscTradePreflightInput,
 ): Promise<BscTradePreflightResponse> {
+  const context = resolveBscExecutionContext();
   const checks = {
     walletReady: false,
     rpcReady: false,
@@ -488,12 +570,12 @@ export async function buildBscTradePreflight(
       activeRpcUrl = chainResponse.rpcUrl;
       checks.rpcReady = true;
       chainId = parseRpcChainId(chainResponse.result);
-      checks.chainReady = chainId === BSC_CHAIN_ID;
+      checks.chainReady = chainId === context.chainId;
       if (!checks.chainReady) {
         reasons.push(
           chainId === null
             ? "Unable to read chain id from RPC."
-            : `RPC chain mismatch. Expected BSC (56), got ${chainId}.`,
+            : `RPC chain mismatch. Expected BSC (${context.chainId}), got ${chainId}.`,
         );
       }
     } catch (err) {
@@ -579,6 +661,7 @@ export async function buildBscTradePreflight(
 export async function buildBscTradeQuote(
   input: BuildBscTradeQuoteInput,
 ): Promise<BscTradeQuoteResponse> {
+  const context = resolveBscExecutionContext();
   const side = input.request.side as BscTradeSide;
   if (side !== "buy" && side !== "sell") {
     throw new Error('Unsupported trade side. Use "buy" or "sell".');
@@ -614,7 +697,7 @@ export async function buildBscTradeQuote(
     throw new Error("BSC RPC unavailable.");
   }
 
-  const wrappedNativeAddress = await readWrappedNativeAddress(rpcUrls);
+  const wrappedNativeAddress = await readWrappedNativeAddress(rpcUrls, context);
   const tokenDecimals = await readTokenDecimals(rpcUrls, tokenAddress);
   const tokenSymbol = await readTokenSymbol(rpcUrls, tokenAddress);
 
@@ -699,7 +782,7 @@ export async function buildBscTradeQuote(
       ]);
       const quoteResponse = await ethCall(
         rpcUrls,
-        PANCAKE_SWAP_V2_ROUTER,
+        context.routerAddress,
         quoteCall,
       );
       const decoded = ROUTER_IFACE.decodeFunctionResult(
@@ -763,7 +846,9 @@ export async function buildBscTradeQuote(
     routeProviderFallbackUsed,
     routeProviderNotes: routeProviderNotes.length > 0 ? routeProviderNotes : undefined,
     routerAddress:
-      routeProvider === "0x" ? (swapTargetAddress ?? PANCAKE_SWAP_V2_ROUTER) : PANCAKE_SWAP_V2_ROUTER,
+      routeProvider === "0x"
+        ? (swapTargetAddress ?? context.routerAddress)
+        : context.routerAddress,
     wrappedNativeAddress,
     tokenAddress,
     slippageBps,
@@ -797,13 +882,16 @@ export async function buildBscTradeQuote(
  * Assert that the quote's routerAddress matches the expected PancakeSwap V2 router.
  * Prevents a compromised or tampered quote from directing funds to an arbitrary address.
  */
-function assertRouterAddress(quote: BscTradeQuoteResponse): void {
+function assertRouterAddress(
+  quote: BscTradeQuoteResponse,
+  context: BscExecutionContext,
+): void {
   if (quote.routeProvider === "0x") {
     return;
   }
-  if (quote.routerAddress !== PANCAKE_SWAP_V2_ROUTER) {
+  if (quote.routerAddress !== context.routerAddress) {
     throw new Error(
-      `Unexpected router address in quote: ${quote.routerAddress}. Expected PancakeSwap V2 router ${PANCAKE_SWAP_V2_ROUTER}.`,
+      `Unexpected router address in quote: ${quote.routerAddress}. Expected router ${context.routerAddress}.`,
     );
   }
 }
@@ -813,7 +901,8 @@ export function buildBscBuyUnsignedTx(
   recipientAddress: string | null,
   deadlineSeconds?: number,
 ): BscUnsignedTradeTx {
-  assertRouterAddress(quote);
+  const context = resolveBscExecutionContext();
+  assertRouterAddress(quote, context);
   if (quote.side !== "buy") {
     throw new Error("Only buy execution is currently supported.");
   }
@@ -826,13 +915,13 @@ export function buildBscBuyUnsignedTx(
       throw new Error("0x quote is missing swap transaction payload.");
     }
     return {
-      chainId: BSC_CHAIN_ID,
+      chainId: context.chainId,
       from: normalizedRecipient,
       to: quote.swapTargetAddress,
       data: quote.swapCallData,
       valueWei: quote.swapValueWei ?? quote.quoteIn.amountWei,
       deadline: Math.floor(Date.now() / 1000) + clampDeadlineSeconds(deadlineSeconds),
-      explorerUrl: "https://bscscan.com",
+      explorerUrl: context.explorerBaseUrl,
     };
   }
   const now = Math.floor(Date.now() / 1000);
@@ -848,13 +937,13 @@ export function buildBscBuyUnsignedTx(
   );
 
   return {
-    chainId: BSC_CHAIN_ID,
+    chainId: context.chainId,
     from: normalizedRecipient,
     to: quote.routerAddress,
     data,
     valueWei: quote.quoteIn.amountWei,
     deadline,
-    explorerUrl: "https://bscscan.com",
+    explorerUrl: context.explorerBaseUrl,
   };
 }
 
@@ -863,7 +952,8 @@ export function buildBscSellUnsignedTx(
   recipientAddress: string | null,
   deadlineSeconds?: number,
 ): BscUnsignedTradeTx {
-  assertRouterAddress(quote);
+  const context = resolveBscExecutionContext();
+  assertRouterAddress(quote, context);
   if (quote.side !== "sell") {
     throw new Error("Only sell execution is supported for this payload.");
   }
@@ -876,13 +966,13 @@ export function buildBscSellUnsignedTx(
       throw new Error("0x quote is missing swap transaction payload.");
     }
     return {
-      chainId: BSC_CHAIN_ID,
+      chainId: context.chainId,
       from: normalizedRecipient,
       to: quote.swapTargetAddress,
       data: quote.swapCallData,
       valueWei: quote.swapValueWei ?? "0",
       deadline: Math.floor(Date.now() / 1000) + clampDeadlineSeconds(deadlineSeconds),
-      explorerUrl: "https://bscscan.com",
+      explorerUrl: context.explorerBaseUrl,
     };
   }
   const now = Math.floor(Date.now() / 1000);
@@ -899,13 +989,13 @@ export function buildBscSellUnsignedTx(
   );
 
   return {
-    chainId: BSC_CHAIN_ID,
+    chainId: context.chainId,
     from: normalizedRecipient,
     to: quote.routerAddress,
     data,
     valueWei: "0",
     deadline,
-    explorerUrl: "https://bscscan.com",
+    explorerUrl: context.explorerBaseUrl,
   };
 }
 
@@ -915,6 +1005,7 @@ export function buildBscApproveUnsignedTx(
   spenderAddress: string,
   amountWei: string,
 ): BscUnsignedApprovalTx {
+  const context = resolveBscExecutionContext();
   const normalizedToken = normalizeAddress(tokenAddress);
   if (!normalizedToken) {
     throw new Error("Token address is invalid for approval payload.");
@@ -944,12 +1035,12 @@ export function buildBscApproveUnsignedTx(
   ]);
 
   return {
-    chainId: BSC_CHAIN_ID,
+    chainId: context.chainId,
     from: normalizedOwner,
     to: normalizedToken,
     data,
     valueWei: "0",
-    explorerUrl: "https://bscscan.com",
+    explorerUrl: context.explorerBaseUrl,
     spender: normalizedSpender,
     amountWei: amount.toString(),
   };

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -156,6 +156,7 @@ import {
   buildBscSellUnsignedTx,
   buildBscTradePreflight,
   buildBscTradeQuote,
+  resolveBscApprovalSpender,
   resolvePrimaryBscRpcUrl,
 } from "./bsc-trade.js";
 import { handleBugReportRoutes } from "./bug-report-routes.js";
@@ -12932,6 +12933,7 @@ async function handleRequest(
       tokenAddress?: string;
       amount?: string;
       slippageBps?: number;
+      routeProvider?: "auto" | "pancakeswap-v2" | "0x";
     }>(req, res);
     if (!body) return;
 
@@ -12952,6 +12954,7 @@ async function handleRequest(
           tokenAddress: body.tokenAddress,
           amount: body.amount,
           slippageBps: body.slippageBps,
+          routeProvider: body.routeProvider,
         },
       });
       json(res, result);
@@ -12978,6 +12981,7 @@ async function handleRequest(
       tokenAddress?: string;
       amount?: string;
       slippageBps?: number;
+      routeProvider?: "auto" | "pancakeswap-v2" | "0x";
       deadlineSeconds?: number;
       confirm?: boolean;
       source?: "agent" | "manual";
@@ -13009,6 +13013,7 @@ async function handleRequest(
           tokenAddress: body.tokenAddress,
           amount: body.amount,
           slippageBps: body.slippageBps,
+          routeProvider: body.routeProvider,
         },
       });
 
@@ -13029,7 +13034,7 @@ async function handleRequest(
         unsignedApprovalTx = buildBscApproveUnsignedTx(
           quote.tokenAddress,
           walletAddress,
-          quote.routerAddress,
+          resolveBscApprovalSpender(quote),
           quote.quoteIn.amountWei,
         );
         requiresApproval = true;

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -17270,9 +17270,17 @@ export async function startApiServer(opts?: {
     }
   }
 
-  // Self-heal older configs where wallet keys were never provisioned
-  // (e.g. RPC/cloud configured outside onboarding).
-  if (ensureWalletKeysInEnvAndConfig(config)) {
+  // Optional auto-provision mode for legacy environments. Disabled by default
+  // so startup does not silently create new wallets when keys are missing.
+  const walletAutoProvisionRaw = process.env.MILADY_WALLET_AUTO_PROVISION
+    ?.trim()
+    .toLowerCase();
+  const walletAutoProvisionEnabled =
+    walletAutoProvisionRaw === "1" ||
+    walletAutoProvisionRaw === "true" ||
+    walletAutoProvisionRaw === "on" ||
+    walletAutoProvisionRaw === "yes";
+  if (walletAutoProvisionEnabled && ensureWalletKeysInEnvAndConfig(config)) {
     try {
       saveElizaConfig(config);
     } catch (err) {

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -241,6 +241,7 @@ import {
   recordWalletTradeLedgerEntry,
   updateWalletTradeLedgerEntryStatus,
 } from "./wallet-trading-profile.js";
+import { handleWalletTradeExecuteRoute } from "./wallet-trade-routes.js";
 import {
   applyWhatsAppQrOverride,
   handleWhatsAppRoute,
@@ -12972,251 +12973,37 @@ async function handleRequest(
   }
 
   // ── POST /api/wallet/trade/execute ─────────────────────────────────────
-  // Execute or prepare a BSC trade. In "user-sign-only" mode, returns an
-  // unsigned transaction for the user to sign. In local-key modes, executes
-  // using the server-side EVM private key.
-  if (method === "POST" && pathname === "/api/wallet/trade/execute") {
-    const body = await readJsonBody<{
-      side?: string;
-      tokenAddress?: string;
-      amount?: string;
-      slippageBps?: number;
-      routeProvider?: "auto" | "pancakeswap-v2" | "0x";
-      deadlineSeconds?: number;
-      confirm?: boolean;
-      source?: "agent" | "manual";
-    }>(req, res);
-    if (!body) return;
-
-    if (!body.side || !body.tokenAddress || !body.amount) {
-      error(res, "side, tokenAddress, and amount are required", 400);
-      return;
-    }
-
-    const tradePermissionMode = resolveTradePermissionMode(state.config);
-    const isAgentRequest = isAgentAutomationRequest(req);
-    const hasLocalKey = Boolean(process.env.EVM_PRIVATE_KEY?.trim());
-    const canExecuteLocally = canUseLocalTradeExecution(
-      tradePermissionMode,
-      isAgentRequest,
-    );
-    const addrs = getWalletAddresses();
-    const walletRpcReadiness = resolveWalletRpcReadiness(state.config);
-
-    try {
-      const quote = await buildBscTradeQuote({
-        walletAddress: addrs.evmAddress ?? null,
-        rpcUrls: walletRpcReadiness.bscRpcUrls,
-        cloudManagedAccess: walletRpcReadiness.cloudManagedAccess,
-        request: {
-          side: body.side as "buy" | "sell",
-          tokenAddress: body.tokenAddress,
-          amount: body.amount,
-          slippageBps: body.slippageBps,
-          routeProvider: body.routeProvider,
-        },
-      });
-
-      const walletAddress = addrs.evmAddress ?? null;
-
-      // Build the unsigned trade transaction
-      const unsignedTx =
-        quote.side === "buy"
-          ? buildBscBuyUnsignedTx(quote, walletAddress, body.deadlineSeconds)
-          : buildBscSellUnsignedTx(quote, walletAddress, body.deadlineSeconds);
-
-      // Build approval tx for sell (if needed)
-      let unsignedApprovalTx:
-        | import("../contracts/wallet.js").BscUnsignedApprovalTx
-        | undefined;
-      let requiresApproval = false;
-      if (quote.side === "sell" && walletAddress) {
-        unsignedApprovalTx = buildBscApproveUnsignedTx(
-          quote.tokenAddress,
-          walletAddress,
-          resolveBscApprovalSpender(quote),
-          quote.quoteIn.amountWei,
-        );
-        requiresApproval = true;
-      }
-
-      // If local execution is not permitted or no private key, return unsigned tx
-      if (!hasLocalKey || !canExecuteLocally || body.confirm !== true) {
-        json(res, {
-          ok: true,
-          side: quote.side,
-          mode: hasLocalKey && canExecuteLocally ? "local-key" : "user-sign",
-          quote,
-          executed: false,
-          requiresUserSignature: true,
-          unsignedTx,
-          unsignedApprovalTx,
-          requiresApproval,
-        });
-        return;
-      }
-
-      // Execute locally with EVM private key
-      const rpcUrl = resolvePrimaryBscRpcUrl({
-        rpcUrls: walletRpcReadiness.bscRpcUrls,
-        cloudManagedAccess: walletRpcReadiness.cloudManagedAccess,
-      });
-
-      if (!rpcUrl) {
-        error(res, "BSC RPC not configured for local execution.", 503);
-        return;
-      }
-
-      const evmKey = process.env.EVM_PRIVATE_KEY ?? "";
-      const provider = new ethers.JsonRpcProvider(rpcUrl);
-      const wallet = new ethers.Wallet(
-        evmKey.startsWith("0x") ? evmKey : `0x${evmKey}`,
-        provider,
-      );
-
-      // Check quote freshness before executing
-      assertQuoteFresh(quote.quotedAt);
-
-      const nonce = await provider.getTransactionCount(
-        wallet.address,
-        "pending",
-      );
-
-      // Execute approval first if needed
-      let approvalHash: string | undefined;
-      if (requiresApproval && unsignedApprovalTx) {
-        const approvalTxReq: ethers.TransactionRequest = {
-          to: unsignedApprovalTx.to,
-          data: unsignedApprovalTx.data,
-          value: BigInt(unsignedApprovalTx.valueWei),
-          chainId: unsignedApprovalTx.chainId,
-          nonce,
-        };
-        const approvalResponse = await wallet.sendTransaction(approvalTxReq);
-        approvalHash = approvalResponse.hash;
-        // Wait for approval to be mined before submitting trade
-        const approvalReceipt = await approvalResponse.wait(1);
-        if (!approvalReceipt || approvalReceipt.status === 0) {
-          throw new Error("Token approval transaction reverted on-chain");
-        }
-      }
-
-      // Fetch fresh nonce for the trade tx (avoids stale nonce after approval)
-      const tradeNonce = requiresApproval
-        ? await provider.getTransactionCount(wallet.address, "pending")
-        : nonce;
-
-      const tradeTxReq: ethers.TransactionRequest = {
-        to: unsignedTx.to,
-        data: unsignedTx.data,
-        value: BigInt(unsignedTx.valueWei),
-        chainId: unsignedTx.chainId,
-        nonce: tradeNonce,
-      };
-
-      const tradeTxResponse = await wallet.sendTransaction(tradeTxReq);
-
-      const executionResult = {
-        hash: tradeTxResponse.hash,
-        nonce: tradeNonce,
-        gasLimit: tradeTxResponse.gasLimit?.toString() ?? "0",
-        valueWei: unsignedTx.valueWei,
-        explorerUrl: `https://bscscan.com/tx/${tradeTxResponse.hash}`,
-        blockNumber: null as number | null,
-        status: "submitted" as "submitted" | "success",
-        approvalHash,
-      };
-
-      // Record in ledger
-      const source = body.source ?? "manual";
-      try {
-        recordWalletTradeLedgerEntry({
-          hash: tradeTxResponse.hash,
-          source,
-          side: quote.side,
-          tokenAddress: quote.tokenAddress,
-          slippageBps: quote.slippageBps,
-          route: quote.route,
-          quoteIn: {
-            symbol: quote.quoteIn.symbol,
-            amount: quote.quoteIn.amount,
-            amountWei: quote.quoteIn.amountWei,
-          },
-          quoteOut: {
-            symbol: quote.quoteOut.symbol,
-            amount: quote.quoteOut.amount,
-            amountWei: quote.quoteOut.amountWei,
-          },
-          status: "pending",
-          confirmations: 0,
-          nonce: tradeNonce,
-          blockNumber: null,
-          gasUsed: null,
-          effectiveGasPriceWei: null,
-          explorerUrl: executionResult.explorerUrl,
-        });
-      } catch (ledgerErr) {
-        logger.warn(
-          `[api] Failed to record trade ledger entry (attempt 1): ${ledgerErr instanceof Error ? ledgerErr.message : ledgerErr}`,
-        );
-        // Retry once — ledger writes are important for audit trail.
-        try {
-          recordWalletTradeLedgerEntry({
-            hash: tradeTxResponse.hash,
-            source,
-            side: quote.side,
-            tokenAddress: quote.tokenAddress,
-            slippageBps: quote.slippageBps,
-            route: quote.route,
-            quoteIn: {
-              symbol: quote.quoteIn.symbol,
-              amount: quote.quoteIn.amount,
-              amountWei: quote.quoteIn.amountWei,
-            },
-            quoteOut: {
-              symbol: quote.quoteOut.symbol,
-              amount: quote.quoteOut.amount,
-              amountWei: quote.quoteOut.amountWei,
-            },
-            status: "pending",
-            confirmations: 0,
-            nonce: tradeNonce,
-            blockNumber: null,
-            gasUsed: null,
-            effectiveGasPriceWei: null,
-            explorerUrl: executionResult.explorerUrl,
-          });
-        } catch (retryErr) {
-          logger.error(
-            `[api] Ledger entry retry also failed: ${retryErr instanceof Error ? retryErr.message : retryErr}`,
-          );
-        }
-      }
-
-      provider.destroy();
-
-      json(res, {
-        ok: true,
-        side: quote.side,
-        mode: "local-key",
-        quote,
-        executed: true,
-        requiresUserSignature: false,
-        unsignedTx,
-        unsignedApprovalTx,
-        requiresApproval,
-        execution: executionResult,
-      });
-    } catch (err) {
-      logger.error(
-        `[api] BSC trade execute failed: ${err instanceof Error ? err.message : err}`,
-      );
-      error(
-        res,
-        `Trade execution failed: ${err instanceof Error ? err.message : "unknown error"}`,
-        500,
-      );
-    }
+  if (
+    await handleWalletTradeExecuteRoute({
+      req,
+      res,
+      method,
+      pathname,
+      readJsonBody,
+      json,
+      error,
+      state: { config: state.config },
+      deps: {
+        getWalletAddresses,
+        resolveWalletRpcReadiness,
+        resolveTradePermissionMode,
+        isAgentAutomationRequest,
+        canUseLocalTradeExecution,
+        buildBscTradeQuote,
+        buildBscBuyUnsignedTx,
+        buildBscSellUnsignedTx,
+        buildBscApproveUnsignedTx,
+        resolveBscApprovalSpender,
+        resolvePrimaryBscRpcUrl,
+        assertQuoteFresh,
+        recordWalletTradeLedgerEntry,
+        createProvider: (rpcUrl) => new ethers.JsonRpcProvider(rpcUrl),
+        createWallet: (privateKey, provider) =>
+          new ethers.Wallet(privateKey, provider as ethers.Provider),
+        logger,
+      },
+    })
+  ) {
     return;
   }
 

--- a/packages/agent/src/api/wallet-routes.ts
+++ b/packages/agent/src/api/wallet-routes.ts
@@ -427,8 +427,6 @@ export async function handleWalletRoutes(
 
     applyWalletRpcConfigUpdate(config, updateRequest);
 
-    ensureWalletKeysInEnvAndConfig(config);
-
     let configSaveWarning: string | undefined;
     try {
       saveConfig(config);

--- a/packages/agent/src/api/wallet-routes.ts
+++ b/packages/agent/src/api/wallet-routes.ts
@@ -23,6 +23,7 @@ import {
 import {
   applyWalletRpcConfigUpdate,
   getStoredWalletRpcSelections,
+  resolveWalletNetworkMode,
   resolveWalletRpcReadiness,
 } from "./wallet-rpc";
 
@@ -97,6 +98,10 @@ function resolveWalletConfigUpdateRequest(
     typeof record.selections === "object" &&
     !Array.isArray(record.selections)
   ) {
+    const walletNetwork =
+      record.walletNetwork === "testnet" || record.walletNetwork === "mainnet"
+        ? record.walletNetwork
+        : undefined;
     const credentials =
       record.credentials &&
       typeof record.credentials === "object" &&
@@ -112,6 +117,7 @@ function resolveWalletConfigUpdateRequest(
       selections: normalizeWalletRpcSelections(
         record.selections as Partial<Record<keyof WalletRpcSelections, string>>,
       ),
+      walletNetwork,
       credentials: credentials as WalletConfigUpdateRequest["credentials"],
     };
   }
@@ -129,6 +135,10 @@ function resolveWalletConfigUpdateRequest(
 
   return {
     selections: currentSelections,
+    walletNetwork:
+      record.walletNetwork === "testnet" || record.walletNetwork === "mainnet"
+        ? record.walletNetwork
+        : undefined,
     credentials: compatCredentials as WalletConfigUpdateRequest["credentials"],
   };
 }
@@ -377,6 +387,7 @@ export async function handleWalletRoutes(
     const quickNodeSet = Boolean(process.env.QUICKNODE_BSC_RPC_URL?.trim());
     const configStatus: WalletConfigStatus = {
       selectedRpcProviders: rpcReadiness.selectedRpcProviders,
+      walletNetwork: resolveWalletNetworkMode(config),
       legacyCustomChains: rpcReadiness.legacyCustomChains,
       alchemyKeySet,
       infuraKeySet: Boolean(process.env.INFURA_API_KEY?.trim()),

--- a/packages/agent/src/api/wallet-rpc.ts
+++ b/packages/agent/src/api/wallet-rpc.ts
@@ -34,6 +34,7 @@ export const DEFAULT_PUBLIC_SOLANA_TESTNET_RPC_URLS = [
 type WalletCapableConfig = Pick<ElizaConfig, "cloud" | "env"> & {
   wallet?: {
     rpcProviders?: Partial<Record<keyof WalletRpcSelections, string>>;
+    network?: "mainnet" | "testnet";
   };
 };
 
@@ -58,6 +59,7 @@ export interface WalletRpcResolutionOptions {
 }
 
 export interface WalletRpcReadiness {
+  walletNetwork: "mainnet" | "testnet";
   cloudManagedAccess: boolean;
   managedBscRpcReady: boolean;
   evmBalanceReady: boolean;
@@ -126,10 +128,16 @@ function normalizeSecret(value: string | null | undefined): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
-function resolveWalletNetwork(
-  value?: string | null,
+export function resolveWalletNetworkMode(
+  config?: WalletCapableConfig | null,
+  fallback?: string | null,
 ): "mainnet" | "testnet" {
-  const normalized = (value ?? process.env.MILADY_WALLET_NETWORK ?? "")
+  const normalized = (
+    fallback ??
+    config?.wallet?.network ??
+    process.env.MILADY_WALLET_NETWORK ??
+    ""
+  )
     .trim()
     .toLowerCase();
   if (normalized === "testnet") return "testnet";
@@ -396,7 +404,10 @@ export function getInventoryProviderOptions(): InventoryProviderOption[] {
 export function resolveBscRpcUrls(
   options: WalletRpcResolutionOptions = {},
 ): string[] {
-  const network = resolveWalletNetwork(options.walletNetwork);
+  const network = resolveWalletNetworkMode(
+    undefined,
+    options.walletNetwork,
+  );
   const cloudRpcUrl =
     network === "mainnet" ? buildCloudEvmRpcUrl("bsc", options) : null;
   const publicDefaults =
@@ -445,7 +456,10 @@ export function resolveAvalancheRpcUrls(
 export function resolveSolanaRpcUrls(
   options: WalletRpcResolutionOptions = {},
 ): string[] {
-  const network = resolveWalletNetwork(options.walletNetwork);
+  const network = resolveWalletNetworkMode(
+    undefined,
+    options.walletNetwork,
+  );
   const cloudRpcUrl =
     network === "mainnet" ? buildCloudSolanaRpcUrl(options) : null;
   const publicDefaults =
@@ -478,7 +492,18 @@ export function applyWalletRpcConfigUpdate(
   config.wallet = {
     ...config.wallet,
     rpcProviders: normalizedSelections,
+    network:
+      update.walletNetwork === "testnet"
+        ? "testnet"
+        : update.walletNetwork === "mainnet"
+          ? "mainnet"
+          : config.wallet?.network,
   };
+
+  if (update.walletNetwork === "testnet" || update.walletNetwork === "mainnet") {
+    env.MILADY_WALLET_NETWORK = update.walletNetwork;
+    process.env.MILADY_WALLET_NETWORK = update.walletNetwork;
+  }
 
   for (const key of WALLET_RPC_CONFIG_KEYS) {
     const value = update.credentials?.[key];
@@ -511,6 +536,7 @@ export function applyWalletRpcConfigUpdate(
 export function resolveWalletRpcReadiness(
   config?: WalletCapableConfig | null,
 ): WalletRpcReadiness {
+  const walletNetwork = resolveWalletNetworkMode(config);
   const cloudApiKey = resolveCloudApiKey(config);
   const cloudBaseUrl = resolveCloudApiBaseUrl(config?.cloud?.baseUrl);
   const cloudManagedAccess = Boolean(cloudApiKey);
@@ -518,7 +544,7 @@ export function resolveWalletRpcReadiness(
     cloudManagedAccess,
     cloudApiKey,
     cloudBaseUrl,
-    walletNetwork: resolveWalletNetwork(),
+    walletNetwork,
   } satisfies WalletRpcResolutionOptions;
   const bscRpcUrls = resolveBscRpcUrls(cloudOptions);
   const ethereumRpcUrls = resolveEthereumRpcUrls(cloudOptions);
@@ -531,6 +557,7 @@ export function resolveWalletRpcReadiness(
   const legacyCustomChains = buildLegacyCustomChains(selectedRpcProviders);
 
   return {
+    walletNetwork,
     cloudManagedAccess,
     managedBscRpcReady: bscRpcUrls.length > 0,
     evmBalanceReady: Boolean(

--- a/packages/agent/src/api/wallet-rpc.ts
+++ b/packages/agent/src/api/wallet-rpc.ts
@@ -12,6 +12,9 @@ export const DEFAULT_CLOUD_API_BASE_URL = "https://elizacloud.ai/api/v1";
 export const DEFAULT_PUBLIC_BSC_RPC_URLS = [
   "https://bsc-dataseed1.binance.org/",
 ] as const;
+export const DEFAULT_PUBLIC_BSC_TESTNET_RPC_URLS = [
+  "https://data-seed-prebsc-1-s1.binance.org:8545/",
+] as const;
 export const DEFAULT_PUBLIC_ETHEREUM_RPC_URLS = [
   "https://ethereum.publicnode.com/",
 ] as const;
@@ -23,6 +26,9 @@ export const DEFAULT_PUBLIC_AVALANCHE_RPC_URLS = [
 ] as const;
 export const DEFAULT_PUBLIC_SOLANA_RPC_URLS = [
   "https://api.mainnet-beta.solana.com",
+] as const;
+export const DEFAULT_PUBLIC_SOLANA_TESTNET_RPC_URLS = [
+  "https://api.devnet.solana.com",
 ] as const;
 
 type WalletCapableConfig = Pick<ElizaConfig, "cloud" | "env"> & {
@@ -48,6 +54,7 @@ export interface WalletRpcResolutionOptions {
   cloudManagedAccess?: boolean | null;
   cloudApiKey?: string | null;
   cloudBaseUrl?: string | null;
+  walletNetwork?: "mainnet" | "testnet" | null;
 }
 
 export interface WalletRpcReadiness {
@@ -117,6 +124,16 @@ function normalizeSecret(value: string | null | undefined): string | null {
   if (typeof value !== "string") return null;
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : null;
+}
+
+function resolveWalletNetwork(
+  value?: string | null,
+): "mainnet" | "testnet" {
+  const normalized = (value ?? process.env.MILADY_WALLET_NETWORK ?? "")
+    .trim()
+    .toLowerCase();
+  if (normalized === "testnet") return "testnet";
+  return "mainnet";
 }
 
 function uniqueRpcUrls(
@@ -379,14 +396,22 @@ export function getInventoryProviderOptions(): InventoryProviderOption[] {
 export function resolveBscRpcUrls(
   options: WalletRpcResolutionOptions = {},
 ): string[] {
+  const network = resolveWalletNetwork(options.walletNetwork);
+  const cloudRpcUrl =
+    network === "mainnet" ? buildCloudEvmRpcUrl("bsc", options) : null;
+  const publicDefaults =
+    network === "testnet"
+      ? DEFAULT_PUBLIC_BSC_TESTNET_RPC_URLS
+      : DEFAULT_PUBLIC_BSC_RPC_URLS;
   return uniqueRpcUrls(
     [
+      process.env.BSC_TESTNET_RPC_URL,
       process.env.NODEREAL_BSC_RPC_URL,
       process.env.QUICKNODE_BSC_RPC_URL,
       process.env.BSC_RPC_URL,
-      buildCloudEvmRpcUrl("bsc", options),
+      cloudRpcUrl,
     ],
-    options.cloudManagedAccess ? DEFAULT_PUBLIC_BSC_RPC_URLS : [],
+    options.cloudManagedAccess ? publicDefaults : [],
   );
 }
 
@@ -420,9 +445,16 @@ export function resolveAvalancheRpcUrls(
 export function resolveSolanaRpcUrls(
   options: WalletRpcResolutionOptions = {},
 ): string[] {
+  const network = resolveWalletNetwork(options.walletNetwork);
+  const cloudRpcUrl =
+    network === "mainnet" ? buildCloudSolanaRpcUrl(options) : null;
+  const publicDefaults =
+    network === "testnet"
+      ? DEFAULT_PUBLIC_SOLANA_TESTNET_RPC_URLS
+      : DEFAULT_PUBLIC_SOLANA_RPC_URLS;
   return uniqueRpcUrls(
-    [process.env.SOLANA_RPC_URL, buildCloudSolanaRpcUrl(options)],
-    options.cloudManagedAccess ? DEFAULT_PUBLIC_SOLANA_RPC_URLS : [],
+    [process.env.SOLANA_TESTNET_RPC_URL, process.env.SOLANA_RPC_URL, cloudRpcUrl],
+    options.cloudManagedAccess ? publicDefaults : [],
   );
 }
 
@@ -486,6 +518,7 @@ export function resolveWalletRpcReadiness(
     cloudManagedAccess,
     cloudApiKey,
     cloudBaseUrl,
+    walletNetwork: resolveWalletNetwork(),
   } satisfies WalletRpcResolutionOptions;
   const bscRpcUrls = resolveBscRpcUrls(cloudOptions);
   const ethereumRpcUrls = resolveEthereumRpcUrls(cloudOptions);

--- a/packages/agent/src/api/wallet-trade-routes.ts
+++ b/packages/agent/src/api/wallet-trade-routes.ts
@@ -26,7 +26,9 @@ type WalletForExecution = {
   ) => Promise<{
     hash: string;
     gasLimit?: bigint;
-    wait: (confirmations?: number) => Promise<{ status?: number } | null>;
+    wait: (
+      confirmations?: number,
+    ) => Promise<{ status?: number | null } | null>;
   }>;
 };
 

--- a/packages/agent/src/api/wallet-trade-routes.ts
+++ b/packages/agent/src/api/wallet-trade-routes.ts
@@ -1,0 +1,341 @@
+import { ethers } from "ethers";
+import type { ElizaConfig } from "../config/config";
+import type {
+  BscTradeQuoteResponse,
+  BscUnsignedApprovalTx,
+  BscUnsignedTradeTx,
+} from "../contracts/wallet";
+import type { WalletTradeLedgerRecordInput } from "./wallet-trading-profile";
+import type { RouteRequestContext } from "./route-helpers";
+import type { TradePermissionMode } from "./trade-safety";
+
+type WalletAddresses = {
+  evmAddress: string | null;
+  solanaAddress: string | null;
+};
+
+type WalletRpcReadiness = {
+  bscRpcUrls: string[];
+  cloudManagedAccess: boolean;
+};
+
+type WalletForExecution = {
+  address: string;
+  sendTransaction: (
+    tx: ethers.TransactionRequest,
+  ) => Promise<{
+    hash: string;
+    gasLimit?: bigint;
+    wait: (confirmations?: number) => Promise<{ status?: number } | null>;
+  }>;
+};
+
+type ProviderForExecution = {
+  getTransactionCount: (
+    address: string,
+    blockTag?: "pending" | "latest",
+  ) => Promise<number>;
+  destroy: () => void;
+};
+
+export interface WalletTradeExecuteDeps {
+  getWalletAddresses: () => WalletAddresses;
+  resolveWalletRpcReadiness: (config: ElizaConfig) => WalletRpcReadiness;
+  resolveTradePermissionMode: (config: ElizaConfig) => TradePermissionMode;
+  isAgentAutomationRequest: (
+    req: RouteRequestContext["req"],
+  ) => boolean;
+  canUseLocalTradeExecution: (
+    mode: TradePermissionMode,
+    isAgentRequest: boolean,
+  ) => boolean;
+  buildBscTradeQuote: (args: {
+    walletAddress: string | null;
+    rpcUrls: string[];
+    cloudManagedAccess: boolean;
+    request: {
+      side: "buy" | "sell";
+      tokenAddress: string;
+      amount: string;
+      slippageBps?: number;
+      routeProvider?: "auto" | "pancakeswap-v2" | "0x";
+    };
+  }) => Promise<BscTradeQuoteResponse>;
+  buildBscBuyUnsignedTx: (
+    quote: BscTradeQuoteResponse,
+    walletAddress: string | null,
+    deadlineSeconds?: number,
+  ) => BscUnsignedTradeTx;
+  buildBscSellUnsignedTx: (
+    quote: BscTradeQuoteResponse,
+    walletAddress: string | null,
+    deadlineSeconds?: number,
+  ) => BscUnsignedTradeTx;
+  buildBscApproveUnsignedTx: (
+    tokenAddress: string,
+    walletAddress: string | null,
+    spender: string,
+    amountWei: string,
+  ) => BscUnsignedApprovalTx;
+  resolveBscApprovalSpender: (quote: BscTradeQuoteResponse) => string;
+  resolvePrimaryBscRpcUrl: (args: {
+    rpcUrls: string[];
+    cloudManagedAccess: boolean;
+  }) => string | null;
+  assertQuoteFresh: (quotedAt?: number) => void;
+  recordWalletTradeLedgerEntry: (input: WalletTradeLedgerRecordInput) => void;
+  createProvider: (rpcUrl: string) => ProviderForExecution;
+  createWallet: (privateKey: string, provider: ProviderForExecution) => WalletForExecution;
+  logger: {
+    warn: (message: string) => void;
+    error: (message: string) => void;
+  };
+}
+
+export interface WalletTradeExecuteRouteContext extends RouteRequestContext {
+  state: {
+    config: ElizaConfig;
+  };
+  deps: WalletTradeExecuteDeps;
+}
+
+export async function handleWalletTradeExecuteRoute(
+  ctx: WalletTradeExecuteRouteContext,
+): Promise<boolean> {
+  const { req, res, method, pathname, readJsonBody, json, error, state, deps } =
+    ctx;
+
+  if (!(method === "POST" && pathname === "/api/wallet/trade/execute")) {
+    return false;
+  }
+
+  const body = await readJsonBody<{
+    side?: string;
+    tokenAddress?: string;
+    amount?: string;
+    slippageBps?: number;
+    routeProvider?: "auto" | "pancakeswap-v2" | "0x";
+    deadlineSeconds?: number;
+    confirm?: boolean;
+    source?: "agent" | "manual";
+  }>(req, res);
+  if (!body) return true;
+
+  if (!body.side || !body.tokenAddress || !body.amount) {
+    error(res, "side, tokenAddress, and amount are required", 400);
+    return true;
+  }
+
+  const tradePermissionMode = deps.resolveTradePermissionMode(state.config);
+  const isAgentRequest = deps.isAgentAutomationRequest(req);
+  const hasLocalKey = Boolean(process.env.EVM_PRIVATE_KEY?.trim());
+  const canExecuteLocally = deps.canUseLocalTradeExecution(
+    tradePermissionMode,
+    isAgentRequest,
+  );
+  const addrs = deps.getWalletAddresses();
+  const walletRpcReadiness = deps.resolveWalletRpcReadiness(state.config);
+
+  try {
+    const quote = await deps.buildBscTradeQuote({
+      walletAddress: addrs.evmAddress ?? null,
+      rpcUrls: walletRpcReadiness.bscRpcUrls,
+      cloudManagedAccess: walletRpcReadiness.cloudManagedAccess,
+      request: {
+        side: body.side as "buy" | "sell",
+        tokenAddress: body.tokenAddress,
+        amount: body.amount,
+        slippageBps: body.slippageBps,
+        routeProvider: body.routeProvider,
+      },
+    });
+
+    const walletAddress = addrs.evmAddress ?? null;
+    const unsignedTx =
+      quote.side === "buy"
+        ? deps.buildBscBuyUnsignedTx(quote, walletAddress, body.deadlineSeconds)
+        : deps.buildBscSellUnsignedTx(quote, walletAddress, body.deadlineSeconds);
+
+    let unsignedApprovalTx: BscUnsignedApprovalTx | undefined;
+    let requiresApproval = false;
+    if (quote.side === "sell" && walletAddress) {
+      unsignedApprovalTx = deps.buildBscApproveUnsignedTx(
+        quote.tokenAddress,
+        walletAddress,
+        deps.resolveBscApprovalSpender(quote),
+        quote.quoteIn.amountWei,
+      );
+      requiresApproval = true;
+    }
+
+    if (!hasLocalKey || !canExecuteLocally || body.confirm !== true) {
+      json(res, {
+        ok: true,
+        side: quote.side,
+        mode: hasLocalKey && canExecuteLocally ? "local-key" : "user-sign",
+        quote,
+        executed: false,
+        requiresUserSignature: true,
+        unsignedTx,
+        unsignedApprovalTx,
+        requiresApproval,
+      });
+      return true;
+    }
+
+    const rpcUrl = deps.resolvePrimaryBscRpcUrl({
+      rpcUrls: walletRpcReadiness.bscRpcUrls,
+      cloudManagedAccess: walletRpcReadiness.cloudManagedAccess,
+    });
+    if (!rpcUrl) {
+      error(res, "BSC RPC not configured for local execution.", 503);
+      return true;
+    }
+
+    const evmKey = process.env.EVM_PRIVATE_KEY ?? "";
+    const provider = deps.createProvider(rpcUrl);
+    const wallet = deps.createWallet(
+      evmKey.startsWith("0x") ? evmKey : `0x${evmKey}`,
+      provider,
+    );
+
+    deps.assertQuoteFresh(quote.quotedAt);
+
+    const nonce = await provider.getTransactionCount(wallet.address, "pending");
+    let approvalHash: string | undefined;
+
+    if (requiresApproval && unsignedApprovalTx) {
+      const approvalTxReq: ethers.TransactionRequest = {
+        to: unsignedApprovalTx.to,
+        data: unsignedApprovalTx.data,
+        value: BigInt(unsignedApprovalTx.valueWei),
+        chainId: unsignedApprovalTx.chainId,
+        nonce,
+      };
+      const approvalResponse = await wallet.sendTransaction(approvalTxReq);
+      approvalHash = approvalResponse.hash;
+      const approvalReceipt = await approvalResponse.wait(1);
+      if (!approvalReceipt || approvalReceipt.status === 0) {
+        throw new Error("Token approval transaction reverted on-chain");
+      }
+    }
+
+    const tradeNonce = requiresApproval
+      ? await provider.getTransactionCount(wallet.address, "pending")
+      : nonce;
+
+    const tradeTxReq: ethers.TransactionRequest = {
+      to: unsignedTx.to,
+      data: unsignedTx.data,
+      value: BigInt(unsignedTx.valueWei),
+      chainId: unsignedTx.chainId,
+      nonce: tradeNonce,
+    };
+    const tradeTxResponse = await wallet.sendTransaction(tradeTxReq);
+
+    const executionResult = {
+      hash: tradeTxResponse.hash,
+      nonce: tradeNonce,
+      gasLimit: tradeTxResponse.gasLimit?.toString() ?? "0",
+      valueWei: unsignedTx.valueWei,
+      explorerUrl: `https://bscscan.com/tx/${tradeTxResponse.hash}`,
+      blockNumber: null as number | null,
+      status: "submitted" as "submitted" | "success",
+      approvalHash,
+    };
+
+    const source = body.source ?? "manual";
+    try {
+      deps.recordWalletTradeLedgerEntry({
+        hash: tradeTxResponse.hash,
+        source,
+        side: quote.side,
+        tokenAddress: quote.tokenAddress,
+        slippageBps: quote.slippageBps,
+        route: quote.route,
+        quoteIn: {
+          symbol: quote.quoteIn.symbol,
+          amount: quote.quoteIn.amount,
+          amountWei: quote.quoteIn.amountWei,
+        },
+        quoteOut: {
+          symbol: quote.quoteOut.symbol,
+          amount: quote.quoteOut.amount,
+          amountWei: quote.quoteOut.amountWei,
+        },
+        status: "pending",
+        confirmations: 0,
+        nonce: tradeNonce,
+        blockNumber: null,
+        gasUsed: null,
+        effectiveGasPriceWei: null,
+        explorerUrl: executionResult.explorerUrl,
+      });
+    } catch (ledgerErr) {
+      deps.logger.warn(
+        `[api] Failed to record trade ledger entry (attempt 1): ${
+          ledgerErr instanceof Error ? ledgerErr.message : ledgerErr
+        }`,
+      );
+      try {
+        deps.recordWalletTradeLedgerEntry({
+          hash: tradeTxResponse.hash,
+          source,
+          side: quote.side,
+          tokenAddress: quote.tokenAddress,
+          slippageBps: quote.slippageBps,
+          route: quote.route,
+          quoteIn: {
+            symbol: quote.quoteIn.symbol,
+            amount: quote.quoteIn.amount,
+            amountWei: quote.quoteIn.amountWei,
+          },
+          quoteOut: {
+            symbol: quote.quoteOut.symbol,
+            amount: quote.quoteOut.amount,
+            amountWei: quote.quoteOut.amountWei,
+          },
+          status: "pending",
+          confirmations: 0,
+          nonce: tradeNonce,
+          blockNumber: null,
+          gasUsed: null,
+          effectiveGasPriceWei: null,
+          explorerUrl: executionResult.explorerUrl,
+        });
+      } catch (retryErr) {
+        deps.logger.error(
+          `[api] Ledger entry retry also failed: ${
+            retryErr instanceof Error ? retryErr.message : retryErr
+          }`,
+        );
+      }
+    }
+
+    provider.destroy();
+
+    json(res, {
+      ok: true,
+      side: quote.side,
+      mode: "local-key",
+      quote,
+      executed: true,
+      requiresUserSignature: false,
+      unsignedTx,
+      unsignedApprovalTx,
+      requiresApproval,
+      execution: executionResult,
+    });
+  } catch (err) {
+    deps.logger.error(
+      `[api] BSC trade execute failed: ${err instanceof Error ? err.message : err}`,
+    );
+    error(
+      res,
+      `Trade execution failed: ${err instanceof Error ? err.message : "unknown error"}`,
+      500,
+    );
+  }
+
+  return true;
+}

--- a/packages/agent/src/api/wallet-trading-profile.ts
+++ b/packages/agent/src/api/wallet-trading-profile.ts
@@ -95,6 +95,13 @@ const TRADE_STATUS_SET = new Set<BscTradeTxStatus>([
   "not_found",
 ]);
 
+const ALLOWED_STATUS_TRANSITIONS: Record<BscTradeTxStatus, Set<BscTradeTxStatus>> = {
+  pending: new Set(["pending", "success", "reverted", "not_found"]),
+  not_found: new Set(["pending", "success", "reverted", "not_found"]),
+  success: new Set(["success"]),
+  reverted: new Set(["reverted"]),
+};
+
 const TRADE_SIDE_SET = new Set<BscTradeSide>(["buy", "sell"]);
 
 function nowIso(): string {
@@ -127,6 +134,13 @@ function normalizeStatus(value: unknown): BscTradeTxStatus {
   const normalized = value.trim().toLowerCase() as BscTradeTxStatus;
   if (!TRADE_STATUS_SET.has(normalized)) return "pending";
   return normalized;
+}
+
+function canTransitionTradeStatus(
+  current: BscTradeTxStatus,
+  next: BscTradeTxStatus,
+): boolean {
+  return ALLOWED_STATUS_TRANSITIONS[current].has(next);
 }
 
 function normalizeSide(value: unknown): BscTradeSide {
@@ -402,9 +416,13 @@ export function updateWalletTradeLedgerEntryStatus(
   if (index < 0) return null;
 
   const current = store.entries[index];
+  const nextStatus = normalizeStatus(patch.status);
+  if (!canTransitionTradeStatus(current.status, nextStatus)) {
+    return current;
+  }
   const updated: WalletTradeLedgerEntry = {
     ...current,
-    status: normalizeStatus(patch.status),
+    status: nextStatus,
     confirmations: Math.max(0, Math.floor(toFiniteNumber(patch.confirmations))),
     nonce:
       patch.nonce === null ? null : Math.floor(toFiniteNumber(patch.nonce)),

--- a/packages/agent/src/runtime/__tests__/prompt-optimization-actions.test.ts
+++ b/packages/agent/src/runtime/__tests__/prompt-optimization-actions.test.ts
@@ -246,6 +246,15 @@ describe("detectIntentCategories", () => {
   it("detects issue intent in Chinese", () => {
     expect(detectIntentCategories(buildPrompt("请创建一个新的问题"))).toContain("issues");
   });
+
+  it("detects wallet intent for transaction requests", () => {
+    expect(
+      detectIntentCategories(buildPrompt("Send 0.01 BNB to 0x1234 on-chain")),
+    ).toContain("wallet");
+    expect(detectIntentCategories(buildPrompt("请帮我转账这笔交易"))).toContain(
+      "wallet",
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -399,6 +408,13 @@ describe("compactActionsForIntent", () => {
   it("returns prompt unchanged when no actions block found", () => {
     const prompt = "Just a plain prompt with no actions.";
     expect(compactActionsForIntent(prompt)).toBe(prompt);
+  });
+
+  it("skips action compaction for wallet/on-chain intent", () => {
+    const prompt = buildPrompt("Send 0.01 BNB transaction to this wallet");
+    const result = compactActionsForIntent(prompt);
+    expect(result).toBe(prompt);
+    expect(result).toContain("<params>");
   });
 
   it("strips non-universal action params for general chat (no intent)", () => {

--- a/packages/agent/src/runtime/prompt-compaction.ts
+++ b/packages/agent/src/runtime/prompt-compaction.ts
@@ -106,6 +106,10 @@ const EMOTE_INTENT_RE =
 // "close" and "label" removed — too generic ("close the file", "label this").
 const ISSUE_INTENT_RE =
   /\b(issue|bug report|ticket|close issue|reopen issue|github issue|create issue|file a bug)\b|이슈|버그|티켓|问题|错误|工单|\b(problema|error|billete)\b/i;
+// Wallet / on-chain intent should keep full action schemas to avoid "I will send"
+// style larping when trade/transfer actions require detailed params.
+const WALLET_INTENT_RE =
+  /\b(wallet|onchain|on-chain|transaction|tx\b|transfer|swap|trade|send\b|gas|token|bnb|eth|sol|basechain|erc20|balance)\b|钱包|交易|转账|代币|余额|지갑|거래|전송|잔액|\b(cartera|transacci[oó]n|intercambio|saldo)\b/i;
 
 /** Actions that are always included at full detail. */
 export const UNIVERSAL_ACTIONS = new Set(["REPLY", "NONE", "IGNORE"]);
@@ -131,6 +135,7 @@ export const INTENT_ACTION_MAP: Record<string, Set<string>> = {
   issues: new Set(["MANAGE_ISSUES"]),
   emote: new Set(["PLAY_EMOTE"]),
   plugin_ui: new Set(["RESTART_AGENT"]),
+  wallet: new Set(),
 };
 
 export function hasIntent(prompt: string, keywords: RegExp): boolean {
@@ -188,6 +193,7 @@ export function detectIntentCategories(prompt: string): string[] {
   if (hasIntent(prompt, ISSUE_INTENT_RE)) categories.push("issues");
   if (hasIntent(prompt, EMOTE_INTENT_RE)) categories.push("emote");
   if (hasIntent(prompt, PLUGIN_UI_INTENT_RE)) categories.push("plugin_ui");
+  if (hasIntent(prompt, WALLET_INTENT_RE)) categories.push("wallet");
   return categories;
 }
 
@@ -223,6 +229,12 @@ export function buildFullParamActionSet(
  * (REPLY, NONE, IGNORE) keep full params — all others are stubbed.
  */
 export function compactActionsForIntent(prompt: string): string {
+  // Wallet / on-chain tasks need full action param schemas for reliable tool
+  // invocation across providers and languages. Skip action compaction here.
+  if (hasIntent(prompt, WALLET_INTENT_RE)) {
+    return prompt;
+  }
+
   // NOTE: Intent detection is English-keyword-based. Non-English messages may
   // not trigger any intent, causing all non-universal action params to be
   // stripped. This is a graceful degradation — action names and descriptions

--- a/packages/agent/test/api/wallet-routes.test.ts
+++ b/packages/agent/test/api/wallet-routes.test.ts
@@ -24,6 +24,7 @@ const ENV_KEYS = [
   "EVM_PRIVATE_KEY",
   "SOLANA_PRIVATE_KEY",
   "SOLANA_RPC_URL",
+  "MILADY_WALLET_NETWORK",
 ] as const;
 
 const ORIGINAL_ENV = Object.fromEntries(
@@ -275,6 +276,7 @@ describe("wallet routes", () => {
     expect(result.handled).toBe(true);
     expect(result.payload).toEqual(
       expect.objectContaining({
+        walletNetwork: "mainnet",
         selectedRpcProviders: {
           evm: "eliza-cloud",
           bsc: "eliza-cloud",
@@ -381,6 +383,7 @@ describe("wallet routes", () => {
           bsc: "alchemy",
           solana: "helius-birdeye",
         },
+        walletNetwork: "testnet",
         credentials: {
           ALCHEMY_API_KEY: "a-key",
           HELIUS_API_KEY: "h-key",
@@ -403,6 +406,8 @@ describe("wallet routes", () => {
       bsc: "alchemy",
       solana: "helius-birdeye",
     });
+    expect(result.config.wallet?.network).toBe("testnet");
+    expect(process.env.MILADY_WALLET_NETWORK).toBe("testnet");
     expect(result.ensureWalletKeysInEnvAndConfig).not.toHaveBeenCalled();
     expect(result.saveConfig).toHaveBeenCalledWith(result.config);
     expect(result.payload).toEqual({ ok: true });

--- a/packages/agent/test/api/wallet-routes.test.ts
+++ b/packages/agent/test/api/wallet-routes.test.ts
@@ -403,9 +403,7 @@ describe("wallet routes", () => {
       bsc: "alchemy",
       solana: "helius-birdeye",
     });
-    expect(result.ensureWalletKeysInEnvAndConfig).toHaveBeenCalledWith(
-      result.config,
-    );
+    expect(result.ensureWalletKeysInEnvAndConfig).not.toHaveBeenCalled();
     expect(result.saveConfig).toHaveBeenCalledWith(result.config);
     expect(result.payload).toEqual({ ok: true });
   });

--- a/packages/agent/test/api/wallet-trade-routes.test.ts
+++ b/packages/agent/test/api/wallet-trade-routes.test.ts
@@ -1,0 +1,280 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  handleWalletTradeExecuteRoute,
+  type WalletTradeExecuteDeps,
+} from "../../src/api/wallet-trade-routes";
+import type { ElizaConfig } from "../../src/config/config";
+
+const ENV_KEYS = ["EVM_PRIVATE_KEY"] as const;
+const ORIGINAL_ENV = Object.fromEntries(
+  ENV_KEYS.map((key) => [key, process.env[key]]),
+) as Record<(typeof ENV_KEYS)[number], string | undefined>;
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const value = ORIGINAL_ENV[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  vi.restoreAllMocks();
+});
+
+type InvokeResult = {
+  handled: boolean;
+  status: number;
+  payload: unknown;
+  deps: WalletTradeExecuteDeps;
+};
+
+function createDeps(): WalletTradeExecuteDeps {
+  return {
+    getWalletAddresses: vi.fn(() => ({
+      evmAddress: "0x1111111111111111111111111111111111111111",
+      solanaAddress: null,
+    })),
+    resolveWalletRpcReadiness: vi.fn(() => ({
+      bscRpcUrls: ["https://bsc.example/rpc"],
+      cloudManagedAccess: true,
+    })),
+    resolveTradePermissionMode: vi.fn(() => "manual-local-key"),
+    isAgentAutomationRequest: vi.fn(() => false),
+    canUseLocalTradeExecution: vi.fn(() => true),
+    buildBscTradeQuote: vi.fn(async () => ({
+      ok: true,
+      side: "buy",
+      routeProvider: "0x",
+      routeProviderRequested: "auto",
+      routeProviderFallbackUsed: false,
+      routerAddress: "0x2222222222222222222222222222222222222222",
+      wrappedNativeAddress: "0x3333333333333333333333333333333333333333",
+      tokenAddress: "0x4444444444444444444444444444444444444444",
+      slippageBps: 300,
+      route: [],
+      quoteIn: { symbol: "BNB", amount: "0.01", amountWei: "1000" },
+      quoteOut: { symbol: "USDT", amount: "2", amountWei: "2000" },
+      minReceive: { symbol: "USDT", amount: "1.9", amountWei: "1900" },
+      price: "200",
+      preflight: {
+        ok: true,
+        walletAddress: "0x1111111111111111111111111111111111111111",
+        rpcUrlHost: "bsc.example",
+        chainId: 56,
+        bnbBalance: "1",
+        minGasBnb: "0.005",
+        checks: {
+          walletReady: true,
+          rpcReady: true,
+          chainReady: true,
+          gasReady: true,
+          tokenAddressValid: true,
+        },
+        reasons: [],
+      },
+      quotedAt: Date.now(),
+    })),
+    buildBscBuyUnsignedTx: vi.fn(() => ({
+      chainId: 56,
+      from: "0x1111111111111111111111111111111111111111",
+      to: "0xaaaa00000000000000000000000000000000aaaa",
+      data: "0xdeadbeef",
+      valueWei: "1000",
+      deadline: 9999999999,
+      explorerUrl: "https://bscscan.com",
+    })),
+    buildBscSellUnsignedTx: vi.fn(() => ({
+      chainId: 56,
+      from: "0x1111111111111111111111111111111111111111",
+      to: "0xbbbb00000000000000000000000000000000bbbb",
+      data: "0xbeef",
+      valueWei: "0",
+      deadline: 9999999999,
+      explorerUrl: "https://bscscan.com",
+    })),
+    buildBscApproveUnsignedTx: vi.fn(() => ({
+      chainId: 56,
+      from: "0x1111111111111111111111111111111111111111",
+      to: "0x4444444444444444444444444444444444444444",
+      data: "0xapprove",
+      valueWei: "0",
+      explorerUrl: "https://bscscan.com",
+      spender: "0xspender",
+      amountWei: "1000",
+    })),
+    resolveBscApprovalSpender: vi.fn(
+      () => "0x5555555555555555555555555555555555555555",
+    ),
+    resolvePrimaryBscRpcUrl: vi.fn(() => "https://bsc.example/rpc"),
+    assertQuoteFresh: vi.fn(),
+    recordWalletTradeLedgerEntry: vi.fn(),
+    createProvider: vi.fn(() => ({
+      getTransactionCount: vi.fn(async () => 7),
+      destroy: vi.fn(),
+    })),
+    createWallet: vi.fn(() => ({
+      address: "0x1111111111111111111111111111111111111111",
+      sendTransaction: vi.fn(async () => ({
+        hash: "0xhash",
+        gasLimit: 21000n,
+        wait: vi.fn(async () => ({ status: 1 })),
+      })),
+    })),
+    logger: {
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  };
+}
+
+async function invoke(args: {
+  method: string;
+  pathname: string;
+  body?: Record<string, unknown> | null;
+  deps?: WalletTradeExecuteDeps;
+}): Promise<InvokeResult> {
+  let status = 200;
+  let payload: unknown = null;
+  const deps = args.deps ?? createDeps();
+
+  const handled = await handleWalletTradeExecuteRoute({
+    req: {} as IncomingMessage,
+    res: {} as ServerResponse,
+    method: args.method,
+    pathname: args.pathname,
+    state: {
+      config: { env: {} } as ElizaConfig,
+    },
+    deps,
+    readJsonBody: vi.fn(async () => args.body ?? null),
+    json: (_res, data, code = 200) => {
+      status = code;
+      payload = data;
+    },
+    error: (_res, message, code = 400) => {
+      status = code;
+      payload = { error: message };
+    },
+  });
+
+  return { handled, status, payload, deps };
+}
+
+describe("wallet trade execute route", () => {
+  test("returns false for unrelated route", async () => {
+    const result = await invoke({
+      method: "GET",
+      pathname: "/api/wallet/trade/quote",
+    });
+    expect(result.handled).toBe(false);
+  });
+
+  test("validates required trade body fields", async () => {
+    const result = await invoke({
+      method: "POST",
+      pathname: "/api/wallet/trade/execute",
+      body: { side: "buy" },
+    });
+    expect(result.handled).toBe(true);
+    expect(result.status).toBe(400);
+    expect(result.payload).toEqual({
+      error: "side, tokenAddress, and amount are required",
+    });
+  });
+
+  test("returns unsigned payload when confirm is not true", async () => {
+    process.env.EVM_PRIVATE_KEY = "abc123";
+    const result = await invoke({
+      method: "POST",
+      pathname: "/api/wallet/trade/execute",
+      body: {
+        side: "buy",
+        tokenAddress: "0x4444444444444444444444444444444444444444",
+        amount: "0.01",
+        confirm: false,
+      },
+    });
+    expect(result.handled).toBe(true);
+    expect(result.status).toBe(200);
+    expect(result.payload).toEqual(
+      expect.objectContaining({
+        ok: true,
+        executed: false,
+        requiresUserSignature: true,
+        mode: "local-key",
+      }),
+    );
+    expect(result.deps.createProvider).not.toHaveBeenCalled();
+  });
+
+  test("executes and records pending ledger entry in local-key mode", async () => {
+    process.env.EVM_PRIVATE_KEY = "abc123";
+    const result = await invoke({
+      method: "POST",
+      pathname: "/api/wallet/trade/execute",
+      body: {
+        side: "buy",
+        tokenAddress: "0x4444444444444444444444444444444444444444",
+        amount: "0.01",
+        confirm: true,
+        source: "agent",
+      },
+    });
+    expect(result.handled).toBe(true);
+    expect(result.status).toBe(200);
+    expect(result.payload).toEqual(
+      expect.objectContaining({
+        ok: true,
+        mode: "local-key",
+        executed: true,
+        requiresUserSignature: false,
+        execution: expect.objectContaining({
+          hash: "0xhash",
+          status: "submitted",
+        }),
+      }),
+    );
+    expect(result.deps.recordWalletTradeLedgerEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hash: "0xhash",
+        source: "agent",
+        status: "pending",
+      }),
+    );
+  });
+
+  test("returns 500 when quote freshness assertion fails", async () => {
+    process.env.EVM_PRIVATE_KEY = "abc123";
+    const deps = createDeps();
+    deps.assertQuoteFresh = vi.fn(() => {
+      throw new Error("quote expired");
+    });
+
+    const result = await invoke({
+      method: "POST",
+      pathname: "/api/wallet/trade/execute",
+      body: {
+        side: "buy",
+        tokenAddress: "0x4444444444444444444444444444444444444444",
+        amount: "0.01",
+        confirm: true,
+      },
+      deps,
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.status).toBe(500);
+    expect(result.payload).toEqual({
+      error: "Trade execution failed: quote expired",
+    });
+  });
+});
+

--- a/packages/agent/test/wallet-api.e2e.test.ts
+++ b/packages/agent/test/wallet-api.e2e.test.ts
@@ -57,6 +57,7 @@ function walletConfigRequest(args: {
     bsc?: string;
     solana?: string;
   };
+  walletNetwork?: "mainnet" | "testnet";
   credentials?: Record<string, string>;
   extra?: Record<string, unknown>;
 }): Record<string, unknown> {
@@ -67,6 +68,7 @@ function walletConfigRequest(args: {
       solana: "eliza-cloud",
       ...args.selections,
     },
+    walletNetwork: args.walletNetwork ?? "mainnet",
     credentials: args.credentials ?? {},
     ...args.extra,
   };
@@ -89,6 +91,7 @@ describe("Wallet API E2E", () => {
     "ALCHEMY_API_KEY",
     "HELIUS_API_KEY",
     "BIRDEYE_API_KEY",
+    "MILADY_WALLET_NETWORK",
   ];
 
   beforeAll(async () => {
@@ -152,6 +155,7 @@ describe("Wallet API E2E", () => {
     it("returns config status with key indicators", async () => {
       const { status, data } = await req(port, "GET", "/api/wallet/config");
       expect(status).toBe(200);
+      expect(data.walletNetwork).toBe("mainnet");
       expect(typeof data.alchemyKeySet).toBe("boolean");
       expect(typeof data.heliusKeySet).toBe("boolean");
       expect(typeof data.birdeyeKeySet).toBe("boolean");
@@ -216,6 +220,7 @@ describe("Wallet API E2E", () => {
         "PUT",
         "/api/wallet/config",
         walletConfigRequest({
+          walletNetwork: "testnet",
           selections: {
             evm: "alchemy",
             solana: "helius-birdeye",
@@ -234,6 +239,7 @@ describe("Wallet API E2E", () => {
       expect(process.env.ALCHEMY_API_KEY).toBe("test-alchemy-key");
       expect(process.env.HELIUS_API_KEY).toBe("test-helius-key");
       expect(process.env.BIRDEYE_API_KEY).toBe("test-birdeye-key");
+      expect(process.env.MILADY_WALLET_NETWORK).toBe("testnet");
     });
 
     it("reflects saved keys in GET /api/wallet/config", async () => {

--- a/packages/app-core/src/actions/execute-trade.test.ts
+++ b/packages/app-core/src/actions/execute-trade.test.ts
@@ -265,7 +265,7 @@ describe("EXECUTE_TRADE action", () => {
     expect(body.confirm).toBe(true);
   });
 
-  it("calls API and returns success for user-sign mode", async () => {
+  it("returns failure for user-sign mode because no on-chain execution occurred", async () => {
     const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
     mockFetch.mockResolvedValueOnce({
       ok: true,
@@ -286,8 +286,9 @@ describe("EXECUTE_TRADE action", () => {
       amount: "0.5",
     });
 
-    expect((result as { success: boolean }).success).toBe(true);
+    expect((result as { success: boolean }).success).toBe(false);
     expect((result as { text: string }).text).toContain("user-sign");
+    expect((result as { text: string }).text).toContain("not executed");
     expect((result as { text: string }).text).toContain(
       "signature is required",
     );

--- a/packages/app-core/src/actions/execute-trade.ts
+++ b/packages/app-core/src/actions/execute-trade.ts
@@ -221,18 +221,19 @@ export const executeTradeAction: Action = {
         };
       }
 
-      // user-sign mode — trade was quoted but not executed on-chain
+      // For agent automation, reporting "success" without an on-chain execution
+      // leads to false-positive heartbeat status.
       return {
-        text:
-          `Trade prepared in ${result.mode} mode. ` +
-          `A user signature is required to complete the ${side}.`,
-        success: true,
+        text: result.requiresUserSignature
+          ? `Trade was prepared in ${result.mode} mode but not executed. User signature is required to complete the ${side}.`
+          : `Trade was prepared in ${result.mode} mode but not executed on-chain.`,
+        success: false,
         data: {
           side,
           tokenAddress,
           amount: amountRaw,
           mode: result.mode,
-          requiresUserSignature: true,
+          requiresUserSignature: result.requiresUserSignature,
           executed: false,
           unsignedTx: result.unsignedTx,
         },

--- a/packages/app-core/src/actions/transfer-token.test.ts
+++ b/packages/app-core/src/actions/transfer-token.test.ts
@@ -370,7 +370,7 @@ describe("TRANSFER_TOKEN action", () => {
     );
   });
 
-  it("calls API and returns success for user-sign mode", async () => {
+  it("returns failure for user-sign mode because no on-chain execution occurred", async () => {
     const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
     mockFetch.mockResolvedValueOnce({
       ok: true,
@@ -392,8 +392,9 @@ describe("TRANSFER_TOKEN action", () => {
       assetSymbol: "BNB",
     });
 
-    expect((result as { success: boolean }).success).toBe(true);
+    expect((result as { success: boolean }).success).toBe(false);
     expect((result as { text: string }).text).toContain("user-sign");
+    expect((result as { text: string }).text).toContain("not executed");
     expect((result as { text: string }).text).toContain(
       "signature is required",
     );
@@ -401,6 +402,37 @@ describe("TRANSFER_TOKEN action", () => {
       requiresUserSignature: true,
       executed: false,
     });
+  });
+
+  it("fires TRANSFER_TOKEN_FAILED callback when transfer is not executed", async () => {
+    const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        mode: "user-sign",
+        executed: false,
+        requiresUserSignature: true,
+        toAddress: VALID_ADDRESS,
+        amount: "1.5",
+        assetSymbol: "BNB",
+        unsignedTx: { chainId: 56, to: VALID_ADDRESS, data: "0x..." },
+      }),
+    });
+
+    const callback = vi.fn();
+    await callHandlerWithCallback(
+      {
+        toAddress: VALID_ADDRESS,
+        amount: "1.5",
+        assetSymbol: "BNB",
+      },
+      callback,
+    );
+
+    expect(callback).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "TRANSFER_TOKEN_FAILED" }),
+    );
   });
 
   it("accepts numeric amount parameter", async () => {

--- a/packages/app-core/src/actions/transfer-token.ts
+++ b/packages/app-core/src/actions/transfer-token.ts
@@ -217,20 +217,21 @@ export const transferTokenAction: Action = {
         };
       }
 
-      // user-sign mode — transfer was prepared but not executed on-chain
-      const text =
-        `Transfer prepared in ${result.mode} mode. ` +
-        `A user signature is required to send ${amountRaw} ${assetSymbol} to ${toAddress}.`;
-      if (callback) callback({ text, action: "TRANSFER_TOKEN_SUCCESS" });
+      // For agent automation, reporting "success" without an on-chain execution
+      // leads to false-positive heartbeat status.
+      const text = result.requiresUserSignature
+        ? `Transfer was prepared in ${result.mode} mode but not executed. User signature is required to send ${amountRaw} ${assetSymbol} to ${toAddress}.`
+        : `Transfer was prepared in ${result.mode} mode but not executed on-chain.`;
+      if (callback) callback({ text, action: "TRANSFER_TOKEN_FAILED" });
       return {
         text,
-        success: true,
+        success: false,
         data: {
           toAddress,
           amount: amountRaw,
           assetSymbol,
           mode: result.mode,
-          requiresUserSignature: true,
+          requiresUserSignature: result.requiresUserSignature,
           executed: false,
           unsignedTx: result.unsignedTx,
         },

--- a/packages/app-core/src/api/bsc-trade.test.ts
+++ b/packages/app-core/src/api/bsc-trade.test.ts
@@ -333,6 +333,7 @@ describe("bsc-trade quote", () => {
 
     expect(quote.ok).toBe(true);
     expect(quote.side).toBe("buy");
+    expect(quote.routeProvider).toBe("pancakeswap-v2");
     expect(quote.quoteIn.symbol).toBe("BNB");
     expect(quote.quoteOut.symbol).toBe("USDT");
     expect(quote.quoteIn.amount).toBe("0.1");
@@ -454,11 +455,122 @@ describe("bsc-trade quote", () => {
 
     expect(quote.ok).toBe(true);
     expect(quote.side).toBe("sell");
+    expect(quote.routeProvider).toBe("pancakeswap-v2");
     expect(quote.quoteIn.symbol).toBe("USDT");
     expect(quote.quoteOut.symbol).toBe("BNB");
     expect(quote.quoteIn.amount).toBe("1.0");
     expect(quote.route[0]).toBe(ethers.getAddress(TOKEN));
     expect(quote.route[1]).toBe(BSC_WBNB_FALLBACK);
+  });
+
+  it("falls back to pancakeswap when 0x quote fails in auto mode", async () => {
+    const fetchMock = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.includes("bsc.api.0x.org")) {
+          return new Response("upstream unavailable", { status: 503 });
+        }
+
+        const { method, params } = decodeMethod(init);
+        if (method === "eth_chainId") {
+          return new Response(
+            JSON.stringify({ jsonrpc: "2.0", id: 1, result: "0x38" }),
+          );
+        }
+        if (method === "eth_getBalance") {
+          return new Response(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              result: `0x${ethers.parseEther("1").toString(16)}`,
+            }),
+          );
+        }
+        if (method === "eth_getCode") {
+          return new Response(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              result: "0x60006000",
+            }),
+          );
+        }
+        if (method !== "eth_call") {
+          throw new Error(`Unexpected RPC method: ${method}`);
+        }
+
+        const callObj = params[0] as { to?: string; data?: string };
+        const data = callObj?.data ?? "";
+        const to = ethers.getAddress(callObj?.to ?? ethers.ZeroAddress);
+        if (to !== PANCAKE_SWAP_V2_ROUTER) {
+          if (data.startsWith(ERC20_IFACE.getFunction("decimals")?.selector)) {
+            return new Response(
+              JSON.stringify({
+                jsonrpc: "2.0",
+                id: 1,
+                result: ERC20_IFACE.encodeFunctionResult("decimals", [18]),
+              }),
+            );
+          }
+          if (data.startsWith(ERC20_IFACE.getFunction("symbol")?.selector)) {
+            return new Response(
+              JSON.stringify({
+                jsonrpc: "2.0",
+                id: 1,
+                result: ERC20_IFACE.encodeFunctionResult("symbol", ["USDT"]),
+              }),
+            );
+          }
+          throw new Error(`Unexpected token call: ${data.slice(0, 10)}`);
+        }
+
+        if (data.startsWith(ROUTER_IFACE.getFunction("WETH")?.selector)) {
+          return new Response(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              result: ROUTER_IFACE.encodeFunctionResult("WETH", [
+                BSC_WBNB_FALLBACK,
+              ]),
+            }),
+          );
+        }
+
+        if (
+          data.startsWith(ROUTER_IFACE.getFunction("getAmountsOut")?.selector)
+        ) {
+          return new Response(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              result: ROUTER_IFACE.encodeFunctionResult("getAmountsOut", [
+                [ethers.parseEther("0.1"), ethers.parseUnits("30", 18)],
+              ]),
+            }),
+          );
+        }
+
+        throw new Error(`Unexpected router call: ${data.slice(0, 10)}`);
+      },
+    );
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const quote = await buildBscTradeQuote({
+      walletAddress: WALLET,
+      nodeRealBscRpcUrl: NODE_REAL,
+      quickNodeBscRpcUrl: QUICK_NODE,
+      request: {
+        side: "buy",
+        tokenAddress: TOKEN,
+        amount: "0.1",
+        slippageBps: 300,
+        routeProvider: "auto",
+      },
+    });
+
+    expect(quote.routeProvider).toBe("pancakeswap-v2");
+    expect(quote.routeProviderFallbackUsed).toBe(true);
+    expect(quote.routeProviderNotes?.join(" ")).toContain("0x");
   });
 });
 
@@ -466,6 +578,9 @@ describe("bsc-trade execute payload", () => {
   const baseBuyQuote = {
     ok: true as const,
     side: "buy" as const,
+    routeProvider: "pancakeswap-v2" as const,
+    routeProviderRequested: "auto" as const,
+    routeProviderFallbackUsed: false,
     routerAddress: PANCAKE_SWAP_V2_ROUTER,
     wrappedNativeAddress: BSC_WBNB_FALLBACK,
     tokenAddress: ethers.getAddress(TOKEN),

--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -92,6 +92,7 @@ import {
   buildBscBuyUnsignedTx,
   buildBscSellUnsignedTx,
   buildBscTradeQuote,
+  resolveBscApprovalSpender,
   resolvePrimaryBscRpcUrl,
 } from "@miladyai/agent/api/bsc-trade";
 import { getWalletAddresses } from "@miladyai/agent/api/wallet";
@@ -2546,6 +2547,12 @@ async function handleMiladyCompatRoute(
     const tokenAddress =
       typeof body.tokenAddress === "string" ? body.tokenAddress : "";
     const amount = typeof body.amount === "string" ? body.amount : "";
+    const routeProvider =
+      body.routeProvider === "0x" ||
+      body.routeProvider === "pancakeswap-v2" ||
+      body.routeProvider === "auto"
+        ? body.routeProvider
+        : undefined;
 
     if (!side || !tokenAddress || !amount) {
       sendJsonErrorResponse(
@@ -2585,6 +2592,7 @@ async function handleMiladyCompatRoute(
           amount,
           slippageBps:
             typeof body.slippageBps === "number" ? body.slippageBps : undefined,
+          routeProvider,
         },
       });
 
@@ -2613,7 +2621,7 @@ async function handleMiladyCompatRoute(
         unsignedApprovalTx = buildBscApproveUnsignedTx(
           quote.tokenAddress,
           walletAddress,
-          quote.routerAddress,
+          resolveBscApprovalSpender(quote),
           quote.quoteIn.amountWei,
         );
         requiresApproval = true;

--- a/packages/app-core/src/api/wallet-rpc.test.ts
+++ b/packages/app-core/src/api/wallet-rpc.test.ts
@@ -23,6 +23,7 @@ const ENV_KEYS = [
   "ELIZAOS_CLOUD_BASE_URL",
   "EVM_PRIVATE_KEY",
   "SOLANA_PRIVATE_KEY",
+  "MILADY_WALLET_NETWORK",
 ] as const;
 
 const ORIGINAL_ENV = Object.fromEntries(
@@ -148,6 +149,7 @@ describe("wallet RPC helpers", () => {
         bsc: "eliza-cloud",
         solana: "helius-birdeye",
       },
+      walletNetwork: "testnet",
       credentials: {
         INFURA_API_KEY: "next-infura",
         HELIUS_API_KEY: "next-helius",
@@ -160,6 +162,8 @@ describe("wallet RPC helpers", () => {
       bsc: "eliza-cloud",
       solana: "helius-birdeye",
     });
+    expect(config.wallet?.network).toBe("testnet");
+    expect(process.env.MILADY_WALLET_NETWORK).toBe("testnet");
     expect(process.env.ALCHEMY_API_KEY).toBeUndefined();
     expect(process.env.NODEREAL_BSC_RPC_URL).toBeUndefined();
     expect(process.env.BSC_RPC_URL).toBeUndefined();

--- a/packages/app-core/src/components/ConfigPageView.tsx
+++ b/packages/app-core/src/components/ConfigPageView.tsx
@@ -739,14 +739,18 @@ export function ConfigPageView({ embedded = false }: { embedded?: boolean }) {
         </div>
         <div className="flex flex-wrap gap-1.5">
           <Button
-            variant={selectedWalletNetwork === "mainnet" ? "default" : "outline"}
+            variant={
+              selectedWalletNetwork === "mainnet" ? "default" : "outline"
+            }
             className="min-h-[40px] px-3 text-xs font-semibold"
             onClick={() => setSelectedWalletNetwork("mainnet")}
           >
             Mainnet
           </Button>
           <Button
-            variant={selectedWalletNetwork === "testnet" ? "default" : "outline"}
+            variant={
+              selectedWalletNetwork === "testnet" ? "default" : "outline"
+            }
             className="min-h-[40px] px-3 text-xs font-semibold"
             onClick={() => setSelectedWalletNetwork("testnet")}
           >

--- a/packages/app-core/src/components/ConfigPageView.tsx
+++ b/packages/app-core/src/components/ConfigPageView.tsx
@@ -502,12 +502,18 @@ export function ConfigPageView({ embedded = false }: { embedded?: boolean }) {
   const [selectedSolanaRpc, setSelectedSolanaRpc] = useState<
     WalletRpcSelections["solana"]
   >(initialRpc.solana);
+  const [selectedWalletNetwork, setSelectedWalletNetwork] = useState<
+    "mainnet" | "testnet"
+  >(walletConfig?.walletNetwork === "testnet" ? "testnet" : "mainnet");
 
   useEffect(() => {
     const selections = resolveInitialWalletRpcSelections(walletConfig);
     setSelectedEvmRpc(selections.evm);
     setSelectedBscRpc(selections.bsc);
     setSelectedSolanaRpc(selections.solana);
+    setSelectedWalletNetwork(
+      walletConfig?.walletNetwork === "testnet" ? "testnet" : "mainnet",
+    );
   }, [walletConfig]);
 
   /* When switching to cloud mode, set all providers to eliza-cloud */
@@ -529,6 +535,7 @@ export function ConfigPageView({ embedded = false }: { embedded?: boolean }) {
         bsc: selectedBscRpc,
         solana: selectedSolanaRpc,
       },
+      selectedNetwork: selectedWalletNetwork,
     });
     void handleWalletApiKeySave(config);
   }, [
@@ -536,6 +543,7 @@ export function ConfigPageView({ embedded = false }: { embedded?: boolean }) {
     rpcFieldValues,
     selectedBscRpc,
     selectedEvmRpc,
+    selectedWalletNetwork,
     selectedSolanaRpc,
     walletConfig,
   ]);
@@ -679,7 +687,7 @@ export function ConfigPageView({ embedded = false }: { embedded?: boolean }) {
           </span>
           {rpcMode === "cloud" && (
             <span className="absolute top-3 right-3 flex h-5 w-5 items-center justify-center rounded-full bg-accent text-[10px] font-bold text-accent-fg">
-              ✓
+              {"\u2713"}
             </span>
           )}
         </Button>
@@ -724,6 +732,29 @@ export function ConfigPageView({ embedded = false }: { embedded?: boolean }) {
       {/* ═══════════════════════════════════════════════════════════════
           CLOUD MODE
           ═══════════════════════════════════════════════════════════════ */}
+      <div className="mb-5 rounded-lg border border-border p-3">
+        <div className="text-xs font-bold mb-1">Wallet Network</div>
+        <div className="text-[11px] text-muted mb-2">
+          Choose Mainnet for live funds or Testnet for practice.
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          <Button
+            variant={selectedWalletNetwork === "mainnet" ? "default" : "outline"}
+            className="min-h-[40px] px-3 text-xs font-semibold"
+            onClick={() => setSelectedWalletNetwork("mainnet")}
+          >
+            Mainnet
+          </Button>
+          <Button
+            variant={selectedWalletNetwork === "testnet" ? "default" : "outline"}
+            className="min-h-[40px] px-3 text-xs font-semibold"
+            onClick={() => setSelectedWalletNetwork("testnet")}
+          >
+            Testnet
+          </Button>
+        </div>
+      </div>
+
       {rpcMode === "cloud" && (
         <div>
           {elizaCloudConnected ? (

--- a/packages/app-core/src/components/avatar/VrmEngine.ts
+++ b/packages/app-core/src/components/avatar/VrmEngine.ts
@@ -2649,7 +2649,7 @@ export class VrmEngine {
       return;
     }
     vrm.scene.visible = false;
-    vrm.scene.traverse((obj) => {
+    vrm.scene.traverse((obj: THREE.Object3D) => {
       obj.frustumCulled = false;
     });
     const avatarParent = this.avatarRoot ?? this.scene;

--- a/packages/app-core/src/types/three-vrm-shim.d.ts
+++ b/packages/app-core/src/types/three-vrm-shim.d.ts
@@ -1,11 +1,60 @@
 declare module "@pixiv/three-vrm" {
-  export const MToonMaterialLoaderPlugin: any;
+  import type { Object3D } from "three";
+
+  export class MToonMaterialLoaderPlugin {
+    constructor(...args: unknown[]);
+  }
   export type VRMHumanBoneName = string;
-  export type VRM = any;
-  export const VRMLoaderPlugin: any;
-  export const VRMUtils: any;
+
+  export interface VRMHumanoid {
+    normalizedRestPose: {
+      hips?: {
+        position?: ArrayLike<number>;
+      };
+    };
+    getNormalizedBoneNode: (
+      name: VRMHumanBoneName | string,
+    ) => Object3D | null;
+    getRawBoneNode: (name: VRMHumanBoneName | string) => Object3D | null;
+    update?: () => void;
+  }
+
+  export interface VRMLookAt {
+    autoUpdate?: boolean;
+    target?: Object3D | null;
+    update: (delta: number) => void;
+  }
+
+  export interface VRMExpressionManager {
+    setValue: (name: string, value: number) => void;
+    update: () => void;
+  }
+
+  export interface VRM {
+    scene: Object3D;
+    meta?: { metaVersion?: string } | null;
+    humanoid?: VRMHumanoid | null;
+    lookAt?: VRMLookAt | null;
+    expressionManager?: VRMExpressionManager | null;
+    springBoneManager?: {
+      reset?: () => void;
+    } | null;
+    update: (delta: number) => void;
+    [key: string]: unknown;
+  }
+
+  export class VRMLoaderPlugin {
+    name: string;
+    constructor(...args: unknown[]);
+  }
+
+  export const VRMUtils: {
+    rotateVRM0: (vrm: VRM) => void;
+    deepDispose: (object: Object3D) => void;
+    removeUnnecessaryVertices: (object: Object3D) => void;
+  };
 }
 
 declare module "@pixiv/three-vrm/nodes" {
-  export const MToonNodeMaterial: any;
+  export class MToonNodeMaterial {}
 }

--- a/packages/app-core/src/types/three-vrm-shim.d.ts
+++ b/packages/app-core/src/types/three-vrm-shim.d.ts
@@ -1,0 +1,11 @@
+declare module "@pixiv/three-vrm" {
+  export const MToonMaterialLoaderPlugin: any;
+  export type VRMHumanBoneName = string;
+  export type VRM = any;
+  export const VRMLoaderPlugin: any;
+  export const VRMUtils: any;
+}
+
+declare module "@pixiv/three-vrm/nodes" {
+  export const MToonNodeMaterial: any;
+}

--- a/packages/app-core/src/wallet-rpc.ts
+++ b/packages/app-core/src/wallet-rpc.ts
@@ -123,8 +123,10 @@ export function buildWalletRpcUpdateRequest(args: {
   selectedProviders:
     | WalletRpcSelections
     | Partial<Record<WalletRpcChain, string | null | undefined>>;
+  selectedNetwork?: "mainnet" | "testnet";
 }): WalletConfigUpdateRequest {
-  const { walletConfig, rpcFieldValues, selectedProviders } = args;
+  const { walletConfig, rpcFieldValues, selectedProviders, selectedNetwork } =
+    args;
   const credentials: Partial<Record<WalletRpcCredentialKey, string>> = {};
   const normalizedSelections = normalizeWalletRpcSelections(selectedProviders);
   const selectedKeys = collectSelectedCredentialKeys(normalizedSelections);
@@ -171,6 +173,9 @@ export function buildWalletRpcUpdateRequest(args: {
 
   return {
     selections: normalizedSelections,
+    walletNetwork:
+      selectedNetwork ??
+      (walletConfig?.walletNetwork === "testnet" ? "testnet" : "mainnet"),
     credentials,
   };
 }

--- a/packages/shared/src/contracts/wallet.ts
+++ b/packages/shared/src/contracts/wallet.ts
@@ -221,6 +221,8 @@ export type TradePermissionMode =
   | "agent-auto";
 
 export type BscTradeSide = "buy" | "sell";
+export type BscTradeRouteProvider = "pancakeswap-v2" | "0x";
+export type BscTradeRoutePreference = BscTradeRouteProvider | "auto";
 
 export interface BscTradePreflightRequest {
   tokenAddress?: string;
@@ -250,6 +252,7 @@ export interface BscTradeQuoteRequest {
   tokenAddress: string;
   amount: string;
   slippageBps?: number;
+  routeProvider?: BscTradeRoutePreference;
 }
 
 export interface BscTradeQuoteLeg {
@@ -261,6 +264,10 @@ export interface BscTradeQuoteLeg {
 export interface BscTradeQuoteResponse {
   ok: boolean;
   side: BscTradeSide;
+  routeProvider: BscTradeRouteProvider;
+  routeProviderRequested: BscTradeRoutePreference;
+  routeProviderFallbackUsed: boolean;
+  routeProviderNotes?: string[];
   routerAddress: string;
   wrappedNativeAddress: string;
   tokenAddress: string;
@@ -271,6 +278,10 @@ export interface BscTradeQuoteResponse {
   minReceive: BscTradeQuoteLeg;
   price: string;
   preflight: BscTradePreflightResponse;
+  swapTargetAddress?: string;
+  swapCallData?: string;
+  swapValueWei?: string;
+  allowanceTarget?: string;
   quotedAt?: number;
 }
 

--- a/packages/shared/src/contracts/wallet.ts
+++ b/packages/shared/src/contracts/wallet.ts
@@ -186,11 +186,15 @@ export type WalletRpcCredentialKey =
 
 export interface WalletConfigUpdateRequest {
   selections: WalletRpcSelections;
+  walletNetwork?: WalletNetworkMode;
   credentials?: Partial<Record<WalletRpcCredentialKey, string>>;
 }
 
+export type WalletNetworkMode = "mainnet" | "testnet";
+
 export interface WalletConfigStatus {
   selectedRpcProviders: WalletRpcSelections;
+  walletNetwork?: WalletNetworkMode;
   legacyCustomChains: WalletRpcChain[];
   alchemyKeySet: boolean;
   infuraKeySet: boolean;


### PR DESCRIPTION
## Summary
- add wallet trade route provider abstraction (`auto`, `pancakeswap-v2`, `0x`) with explicit fallback behavior
- integrate 0x quote path and preserve fallback safety to PancakeSwap
- expose route visibility metadata in shared wallet contracts for UX clarity (`routeProvider`, requested provider, fallback-used, notes)
- wire quote/execute handlers to accept `routeProvider` and resolve approval spender per route provider
- add regression coverage for 0x failure -> PancakeSwap fallback path
- update S3 stream plan and master delivery board docs

## Validation
- `bunx vitest run packages/app-core/src/api/bsc-trade.test.ts`
- `bunx vitest run packages/agent/test/api/wallet-routes.test.ts`
- `bun run typecheck`

## Notes
- Added `vite` dev dependency to satisfy `vite/client` types in app-core tsconfig.
- Added/kept local three-vrm type shim to keep workspace typecheck stable in this environment.