### PR TITLE
fix: case-insensitive boilerplate check for workspace init files

### DIFF
--- a/packages/agent/src/providers/workspace.test.ts
+++ b/packages/agent/src/providers/workspace.test.ts
@@ -91,4 +91,26 @@ configuration is required.
 `;
     expect(isDefaultBoilerplate("TOOLS.md", content)).toBe(true);
   });
+
+  it("matches despite casing drift (elizaOS vs ElizaOS)", () => {
+    const content = `# Agents
+
+You are an autonomous AI agent powered by elizaOS.
+
+## Capabilities
+
+- Respond to user messages conversationally
+- Execute actions and use available tools
+- Access and manage knowledge from your workspace
+- Maintain context across conversations
+
+## Guidelines
+
+- Be helpful, concise, and accurate
+- Ask for clarification when instructions are ambiguous
+- Use tools when they would help accomplish the user's goal
+- Respect the user's preferences and communication style
+`;
+    expect(isDefaultBoilerplate("AGENTS.md", content)).toBe(true);
+  });
 });

--- a/packages/agent/src/providers/workspace.ts
+++ b/packages/agent/src/providers/workspace.ts
@@ -214,7 +214,9 @@ export type WorkspaceInitFile = {
 export function isDefaultBoilerplate(name: string, content: string): boolean {
   const template = WORKSPACE_TEMPLATES[name];
   if (!template) return false;
-  return content.trim() === template.trim();
+  // Case-insensitive comparison — template casing may drift from on-disk files
+  // (e.g. "ElizaOS" vs "elizaOS") written by an older version.
+  return content.trim().toLowerCase() === template.trim().toLowerCase();
 }
 
 type ElizaCoreWorkspaceHelpers = {


### PR DESCRIPTION
isDefaultBoilerplate used strict equality but on-disk files from older versions have 'elizaOS' while the template has 'ElizaOS'. This one-char mismatch caused AGENTS.md boilerplate to leak into every prompt (~500 chars of generic placeholder). Fix: compare with toLowerCase(). Files stay on disk — only default template content is excluded. User-customized files are always included.