### PR TITLE
fix: trajectory step ID mismatch causing synthetic LLM call data

### DIFF
--- a/packages/agent/src/api/__tests__/chat-trajectory-wiring.test.ts
+++ b/packages/agent/src/api/__tests__/chat-trajectory-wiring.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Verifies that the /api/chat handler delegates trajectory creation to
+ * @elizaos/plugin-trajectory-logger's MESSAGE_RECEIVED event handler,
+ * which sets trajectoryStepId on the message metadata before handleMessage.
+ *
+ * The server.ts code must NOT create its own trajectory (which would
+ * conflict with the plugin's step ID).
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const serverSource = readFileSync(
+	path.resolve(import.meta.dirname, "..", "server.ts"),
+	"utf-8",
+);
+
+describe("chat trajectory wiring", () => {
+	it("emits MESSAGE_RECEIVED before handleMessage", () => {
+		const emitIdx = serverSource.indexOf(
+			'emitEvent("MESSAGE_RECEIVED"',
+		);
+		const handleIdx = serverSource.indexOf(
+			"runtime.messageService?.handleMessage",
+		);
+		expect(emitIdx).toBeGreaterThan(-1);
+		expect(handleIdx).toBeGreaterThan(-1);
+		expect(emitIdx).toBeLessThan(handleIdx);
+	});
+
+	it("does NOT manually start a trajectory (delegates to plugin)", () => {
+		// The server should NOT call startTrajectory directly — that creates
+		// a duplicate trajectory that conflicts with the plugin's step ID.
+		expect(serverSource).not.toContain("trajLogger.startTrajectory");
+	});
+
+	it("documents that trajectory creation is handled by the plugin", () => {
+		expect(serverSource).toContain(
+			"Trajectory creation is handled by @elizaos/plugin-trajectory-logger",
+		);
+	});
+});

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -3256,8 +3256,10 @@ async function generateChatResponse(
     );
   }
 
-  // Fallback when MESSAGE_RECEIVED hooks are unavailable: start a trajectory
-  // directly so /api/chat still produces rows for the Trajectories view.
+  // Trajectory creation is handled by @elizaos/plugin-trajectory-logger's
+  // MESSAGE_RECEIVED event handler (fired above). It creates a step ID and
+  // sets message.metadata.trajectoryStepId, which core's handleMessage picks
+  // up via runWithTrajectoryContext to capture live LLM calls.
 
   let result:
     | Awaited<

--- a/packages/agent/src/runtime/trajectory-persistence.ts
+++ b/packages/agent/src/runtime/trajectory-persistence.ts
@@ -2466,10 +2466,11 @@ export class DatabaseTrajectoryLogger extends Service {
   /**
    * Start a new step within an existing trajectory.
    */
-  startStep(_trajectoryId: string): string {
-    const stepId = `step-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-    // For database logger, steps are independent - we just return the new stepId
-    return stepId;
+  startStep(trajectoryId: string): string {
+    // Return the trajectory ID so LLM calls logged with this step ID attach
+    // to the same trajectory row that startTrajectory created. Generating a
+    // separate step-xxx ID would create a disconnected trajectory row.
+    return trajectoryId;
   }
 
   /**


### PR DESCRIPTION
startStep() generated disconnected step-xxx IDs, so LLM calls logged to one trajectory while the UI queried another — making all calls appear as synthetic backfills. Fix: return the trajectory ID from startStep(). Also delegate trajectory creation to the plugin's MESSAGE_RECEIVED handler instead of duplicating it in server.ts.