### PR TITLE
release: prep alpha.126 wallet conversation fixes

### DIFF
--- a/.github/workflows/release-electrobun.yml
+++ b/.github/workflows/release-electrobun.yml
@@ -69,7 +69,7 @@ env:
 jobs:
   prepare:
     name: Prepare Release
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ github.repository_owner == 'milady-ai' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-latest' }}
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
@@ -105,7 +105,7 @@ jobs:
   validate-release:
     name: Validate Release Inputs
     needs: prepare
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ github.repository_owner == 'milady-ai' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-latest' }}
     defaults:
       run:
         shell: bash -euo pipefail {0}
@@ -183,7 +183,7 @@ jobs:
             artifact-name: macos-x64
           - name: Windows
             os: windows
-            runner: blacksmith-4vcpu-windows-2025
+            runner: ${{ github.repository_owner == 'milady-ai' && 'blacksmith-4vcpu-windows-2025' || 'windows-latest' }}
             artifact-name: windows-x64
           - name: Linux
             os: linux
@@ -1168,7 +1168,7 @@ jobs:
     name: Create Release
     if: ${{ github.event_name != 'workflow_call' || inputs.publish_release }}
     needs: [prepare, build]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ github.repository_owner == 'milady-ai' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-latest' }}
     timeout-minutes: 10
     permissions:
       contents: write

--- a/apps/app/electrobun/src/__tests__/background-notice.test.ts
+++ b/apps/app/electrobun/src/__tests__/background-notice.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   BACKGROUND_NOTICE_MARKER_FILE,
@@ -8,22 +9,30 @@ import {
 } from "../background-notice";
 
 describe("background notice", () => {
+  const join = (...parts: string[]) => path.join(...parts);
+
   it("resolves the marker path under the userData directory", () => {
-    expect(resolveBackgroundNoticeMarkerPath("/tmp/milady")).toBe(
-      `/tmp/milady/${BACKGROUND_NOTICE_MARKER_FILE}`,
+    expect(resolveBackgroundNoticeMarkerPath(join("/tmp", "milady"))).toBe(
+      join("/tmp", "milady", BACKGROUND_NOTICE_MARKER_FILE),
     );
   });
 
   it("reports whether the background notice marker already exists", () => {
-    const seenPaths = new Set([`/tmp/milady/${BACKGROUND_NOTICE_MARKER_FILE}`]);
+    const seenPaths = new Set([
+      join("/tmp", "milady", BACKGROUND_NOTICE_MARKER_FILE),
+    ]);
     const fileSystem = {
       existsSync: (filePath: string) => seenPaths.has(filePath),
       mkdirSync: () => {},
       writeFileSync: () => {},
     };
 
-    expect(hasSeenBackgroundNotice(fileSystem, "/tmp/milady")).toBe(true);
-    expect(hasSeenBackgroundNotice(fileSystem, "/tmp/other")).toBe(false);
+    expect(hasSeenBackgroundNotice(fileSystem, join("/tmp", "milady"))).toBe(
+      true,
+    );
+    expect(hasSeenBackgroundNotice(fileSystem, join("/tmp", "other"))).toBe(
+      false,
+    );
   });
 
   it("writes the marker file when the background notice is shown", () => {
@@ -52,18 +61,23 @@ describe("background notice", () => {
       },
     };
 
-    const markerPath = markBackgroundNoticeSeen(fileSystem, "/tmp/milady");
+    const markerPath = markBackgroundNoticeSeen(
+      fileSystem,
+      join("/tmp", "milady"),
+    );
 
-    expect(markerPath).toBe(`/tmp/milady/${BACKGROUND_NOTICE_MARKER_FILE}`);
+    expect(markerPath).toBe(
+      join("/tmp", "milady", BACKGROUND_NOTICE_MARKER_FILE),
+    );
     expect(mkdirCalls).toEqual([
       {
-        dirPath: "/tmp/milady",
+        dirPath: join("/tmp", "milady"),
         recursive: true,
       },
     ]);
     expect(writeCalls).toEqual([
       {
-        filePath: `/tmp/milady/${BACKGROUND_NOTICE_MARKER_FILE}`,
+        filePath: join("/tmp", "milady", BACKGROUND_NOTICE_MARKER_FILE),
         data: '{"seen":true}\n',
         encoding: "utf8",
       },
@@ -84,7 +98,7 @@ describe("background notice", () => {
     expect(
       showBackgroundNoticeOnce({
         fileSystem,
-        userDataDir: "/tmp/milady",
+        userDataDir: join("/tmp", "milady"),
         showNotification: (options) => {
           notifications.push(options);
         },
@@ -93,7 +107,7 @@ describe("background notice", () => {
     expect(
       showBackgroundNoticeOnce({
         fileSystem,
-        userDataDir: "/tmp/milady",
+        userDataDir: join("/tmp", "milady"),
         showNotification: (options) => {
           notifications.push(options);
         },

--- a/apps/app/electrobun/src/__tests__/renderer-static.test.ts
+++ b/apps/app/electrobun/src/__tests__/renderer-static.test.ts
@@ -1,9 +1,10 @@
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { resolveRendererAsset } from "../renderer-static";
 
 describe("resolveRendererAsset", () => {
-  const rendererDir = "/tmp/renderer";
+  const rendererDir = path.join("/tmp", "renderer");
 
   function resolve(paths: Record<string, "file" | "dir">, urlPath: string) {
     return resolveRendererAsset({
@@ -19,14 +20,14 @@ describe("resolveRendererAsset", () => {
   it("serves precompressed assets when the plain file is missing", () => {
     const result = resolve(
       {
-        "/tmp/renderer/index.html": "file",
-        "/tmp/renderer/animations/idle.glb.gz": "file",
+        [path.join("/tmp", "renderer", "index.html")]: "file",
+        [path.join("/tmp", "renderer", "animations", "idle.glb.gz")]: "file",
       },
       "/animations/idle.glb",
     );
 
     expect(result).toEqual({
-      filePath: "/tmp/renderer/animations/idle.glb.gz",
+      filePath: path.join("/tmp", "renderer", "animations", "idle.glb.gz"),
       isGzipped: true,
       mimeExt: ".glb",
     });
@@ -35,14 +36,14 @@ describe("resolveRendererAsset", () => {
   it("falls back to plain assets when packaged wrappers drop the .gz suffix", () => {
     const result = resolve(
       {
-        "/tmp/renderer/index.html": "file",
-        "/tmp/renderer/vrms/milady-1.vrm": "file",
+        [path.join("/tmp", "renderer", "index.html")]: "file",
+        [path.join("/tmp", "renderer", "vrms", "milady-1.vrm")]: "file",
       },
       "/vrms/milady-1.vrm.gz",
     );
 
     expect(result).toEqual({
-      filePath: "/tmp/renderer/vrms/milady-1.vrm",
+      filePath: path.join("/tmp", "renderer", "vrms", "milady-1.vrm"),
       isGzipped: false,
       mimeExt: ".vrm",
     });
@@ -51,13 +52,13 @@ describe("resolveRendererAsset", () => {
   it("falls back to index.html for traversal attempts", () => {
     const result = resolve(
       {
-        "/tmp/renderer/index.html": "file",
+        [path.join("/tmp", "renderer", "index.html")]: "file",
       },
       "/../../etc/passwd",
     );
 
     expect(result).toEqual({
-      filePath: "/tmp/renderer/index.html",
+      filePath: path.join("/tmp", "renderer", "index.html"),
       isGzipped: false,
       mimeExt: ".html",
     });

--- a/apps/app/electrobun/src/native/__tests__/credentials.test.ts
+++ b/apps/app/electrobun/src/native/__tests__/credentials.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import os from "node:os";
+import path from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -14,7 +15,7 @@ vi.mock("node:fs", () => {
 });
 
 vi.mock("node:os", () => {
-  const homedir = vi.fn(() => "/Users/test");
+  const homedir = vi.fn(() => TEST_HOME);
   return {
     default: { homedir },
     homedir,
@@ -38,6 +39,11 @@ const mockReadFileSync = vi.mocked(fs.readFileSync);
 const mockHomedir = vi.mocked(os.homedir);
 
 const ORIGINAL_PLATFORM = process.platform;
+const TEST_HOME = path.join(path.sep, "Users", "test");
+
+function homePath(...parts: string[]): string {
+  return path.join(TEST_HOME, ...parts);
+}
 
 function makeSpawnResult(exitCode: number, stdout = ""): SpawnResult {
   return {
@@ -70,7 +76,7 @@ describe("scanProviderCredentials", () => {
     mockReadFileSync.mockImplementation(
       (filePath) => files[String(filePath)] ?? "",
     );
-    mockHomedir.mockReturnValue("/Users/test");
+    mockHomedir.mockReturnValue(TEST_HOME);
 
     mockSpawn = vi.fn((cmd: string[]) => {
       if (cmd[0] === "which") {
@@ -100,7 +106,7 @@ describe("scanProviderCredentials", () => {
 
   it("returns openai from codex auth and preserves auth mode", async () => {
     setPlatform("linux");
-    files["/Users/test/.codex/auth.json"] = JSON.stringify({
+    files[homePath(".codex", "auth.json")] = JSON.stringify({
       OPENAI_API_KEY: "sk-openai",
       auth_mode: "chatgpt",
     });
@@ -127,7 +133,7 @@ describe("scanProviderCredentials", () => {
 
   it("returns anthropic from claude credentials file with oauth mode", async () => {
     setPlatform("linux");
-    files["/Users/test/.claude/.credentials.json"] = JSON.stringify({
+    files[homePath(".claude", ".credentials.json")] = JSON.stringify({
       claudeAiOauth: { accessToken: "claude-oauth-token" },
     });
     installedClis.add("claude");
@@ -153,10 +159,10 @@ describe("scanProviderCredentials", () => {
 
   it("prefers file credentials over keychain and env values", async () => {
     setPlatform("darwin");
-    files["/Users/test/.codex/auth.json"] = JSON.stringify({
+    files[homePath(".codex", "auth.json")] = JSON.stringify({
       OPENAI_API_KEY: "file-openai",
     });
-    files["/Users/test/.claude/.credentials.json"] = JSON.stringify({
+    files[homePath(".claude", ".credentials.json")] = JSON.stringify({
       claudeAiOauth: { accessToken: "file-anthropic" },
     });
     installedClis.add("codex");
@@ -345,8 +351,8 @@ describe("scanProviderCredentials", () => {
 
   it("swallows malformed json and returns an empty result when no fallbacks exist", async () => {
     setPlatform("linux");
-    files["/Users/test/.codex/auth.json"] = "{bad-json";
-    files["/Users/test/.claude/.credentials.json"] = "{bad-json";
+    files[homePath(".codex", "auth.json")] = "{bad-json";
+    files[homePath(".claude", ".credentials.json")] = "{bad-json";
 
     await expect(scanProviderCredentials()).resolves.toEqual([]);
     expect(mockSpawn).not.toHaveBeenCalled();
@@ -373,7 +379,7 @@ describe("scanAndValidateProviderCredentials", () => {
     mockReadFileSync.mockImplementation(
       (filePath) => files[String(filePath)] ?? "",
     );
-    mockHomedir.mockReturnValue("/Users/test");
+    mockHomedir.mockReturnValue(TEST_HOME);
     mockSpawn = vi.fn((cmd: string[]) => {
       if (cmd[0] === "which")
         return makeSpawnResult(installedClis.has(cmd[1] ?? "") ? 0 : 1);
@@ -393,7 +399,7 @@ describe("scanAndValidateProviderCredentials", () => {
   });
 
   it("valid key returns status 'valid'", async () => {
-    files["/Users/test/.codex/auth.json"] = JSON.stringify({
+    files[homePath(".codex", "auth.json")] = JSON.stringify({
       OPENAI_API_KEY: "sk-test",
     });
     mockFetch.mockResolvedValue({ ok: true, status: 200 });
@@ -403,7 +409,7 @@ describe("scanAndValidateProviderCredentials", () => {
   });
 
   it("401 response returns status 'invalid' with statusDetail", async () => {
-    files["/Users/test/.codex/auth.json"] = JSON.stringify({
+    files[homePath(".codex", "auth.json")] = JSON.stringify({
       OPENAI_API_KEY: "sk-bad",
     });
     mockFetch.mockResolvedValue({ ok: false, status: 401 });
@@ -420,7 +426,7 @@ describe("scanAndValidateProviderCredentials", () => {
   });
 
   it("network error returns status 'error' with message", async () => {
-    files["/Users/test/.codex/auth.json"] = JSON.stringify({
+    files[homePath(".codex", "auth.json")] = JSON.stringify({
       OPENAI_API_KEY: "sk-test",
     });
     mockFetch.mockRejectedValue(new Error("fetch failed"));
@@ -430,7 +436,7 @@ describe("scanAndValidateProviderCredentials", () => {
   });
 
   it("OAuth token skips validation and returns 'unchecked'", async () => {
-    files["/Users/test/.claude/.credentials.json"] = JSON.stringify({
+    files[homePath(".claude", ".credentials.json")] = JSON.stringify({
       claudeAiOauth: { accessToken: "oauth-token" },
     });
     const providers = await scanAndValidateProviderCredentials();
@@ -440,7 +446,7 @@ describe("scanAndValidateProviderCredentials", () => {
 
   it("unknown provider returns 'unchecked'", async () => {
     vi.stubEnv("OPENAI_API_KEY", "");
-    files["/Users/test/.codex/auth.json"] = JSON.stringify({
+    files[homePath(".codex", "auth.json")] = JSON.stringify({
       OPENAI_API_KEY: "sk-test",
     });
     mockFetch.mockResolvedValue({ ok: true, status: 200 });
@@ -451,7 +457,7 @@ describe("scanAndValidateProviderCredentials", () => {
   });
 
   it("HTTP 500 returns status 'error' with detail", async () => {
-    files["/Users/test/.codex/auth.json"] = JSON.stringify({
+    files[homePath(".codex", "auth.json")] = JSON.stringify({
       OPENAI_API_KEY: "sk-test",
     });
     mockFetch.mockResolvedValue({ ok: false, status: 500 });
@@ -461,7 +467,7 @@ describe("scanAndValidateProviderCredentials", () => {
   });
 
   it("provider without apiKey returns 'unchecked'", async () => {
-    files["/Users/test/.codex/auth.json"] = JSON.stringify({
+    files[homePath(".codex", "auth.json")] = JSON.stringify({
       OPENAI_API_KEY: "sk-key",
     });
     mockFetch.mockResolvedValue({ ok: true, status: 200 });
@@ -491,7 +497,7 @@ describe("scanProviderCredentials — env var detection", () => {
     mockReadFileSync.mockImplementation(
       (filePath) => files[String(filePath)] ?? "",
     );
-    mockHomedir.mockReturnValue("/Users/test");
+    mockHomedir.mockReturnValue(TEST_HOME);
     mockSpawn = vi.fn((cmd: string[]) => {
       if (cmd[0] === "which") return makeSpawnResult(1);
       throw new Error(`unexpected spawn: ${cmd.join(" ")}`);
@@ -605,7 +611,7 @@ describe("scanAndValidateProviderCredentials — endpoint validation", () => {
     mockReadFileSync.mockImplementation(
       (filePath) => files[String(filePath)] ?? "",
     );
-    mockHomedir.mockReturnValue("/Users/test");
+    mockHomedir.mockReturnValue(TEST_HOME);
     mockSpawn = vi.fn((cmd: string[]) => {
       if (cmd[0] === "which") return makeSpawnResult(1);
       throw new Error(`unexpected spawn: ${cmd.join(" ")}`);
@@ -704,7 +710,7 @@ describe("scanAndValidateProviderCredentials — integration", () => {
     mockReadFileSync.mockImplementation(
       (filePath) => files[String(filePath)] ?? "",
     );
-    mockHomedir.mockReturnValue("/Users/test");
+    mockHomedir.mockReturnValue(TEST_HOME);
     mockSpawn = vi.fn((cmd: string[]) => {
       if (cmd[0] === "which") return makeSpawnResult(1);
       throw new Error(`unexpected spawn: ${cmd.join(" ")}`);

--- a/apps/app/electrobun/src/native/desktop.ts
+++ b/apps/app/electrobun/src/native/desktop.ts
@@ -1753,15 +1753,16 @@ X-GNOME-Autostart-enabled=true
       };
     }
 
+    const pathApi = process.platform === "darwin" ? path.posix : path;
     const supportedRoots = [
       "/Applications",
-      path.join(Utils.paths.home, "Applications"),
-    ].map((root) => path.resolve(root));
-    const normalizedBundlePath = path.resolve(appBundlePath);
+      pathApi.join(Utils.paths.home, "Applications"),
+    ].map((root) => pathApi.resolve(root));
+    const normalizedBundlePath = pathApi.resolve(appBundlePath);
     const inApplications = supportedRoots.some((root) => {
-      const normalizedRoot = root.endsWith(path.sep)
+      const normalizedRoot = root.endsWith(pathApi.sep)
         ? root
-        : `${root}${path.sep}`;
+        : `${root}${pathApi.sep}`;
       return (
         normalizedBundlePath === root ||
         normalizedBundlePath.startsWith(normalizedRoot)
@@ -1779,19 +1780,20 @@ X-GNOME-Autostart-enabled=true
     return {
       appBundlePath: normalizedBundlePath,
       canAutoUpdate: false,
-      autoUpdateDisabledReason: `Move ${path.basename(
+      autoUpdateDisabledReason: `Move ${pathApi.basename(
         normalizedBundlePath,
       )} to /Applications to enable in-place desktop updates.`,
     };
   }
 
   private resolveMacAppBundlePath(execPath: string): string | null {
-    let current = path.resolve(execPath);
+    const pathApi = path.posix;
+    let current = pathApi.resolve(execPath);
     while (true) {
       if (current.endsWith(".app")) {
         return current;
       }
-      const parent = path.dirname(current);
+      const parent = pathApi.dirname(current);
       if (parent === current) {
         return null;
       }

--- a/docs/plans/2026-03-26-alpha-126-release-draft.md
+++ b/docs/plans/2026-03-26-alpha-126-release-draft.md
@@ -1,0 +1,77 @@
+# `v2.0.0-alpha.126` Draft Release Notes
+
+## Release status
+- Release prep branch merged into local `develop`
+- Fork branch pushed: `dutchiono:codex/release-alpha-126-develop`
+- PR opened against upstream `develop`: [#1368](https://github.com/milady-ai/milady/pull/1368)
+- Canonical release workflow dispatch is still blocked on upstream repo permissions
+
+## Official summary since `v2.0.0-alpha.125`
+
+### Desktop / runtime fixes
+- Eliminated a broad set of silent failures across cloud, wallet, knowledge, and runtime paths.
+- Re-enabled the autonomy loop so heartbeat and trigger instructions execute again.
+- Stabilized desktop UI regression coverage and cleaned up related typecheck drift.
+- Fixed workspace boilerplate detection to be case-insensitive during setup.
+
+### Onboarding / cloud / provider fixes
+- Improved onboarding and settings flows across the desktop shell refresh.
+- Fixed onboarding preview routing and TTS helper gaps.
+- Improved cloud detection and graceful handling when cloud agents are unavailable.
+- Kept provider abstraction work moving forward, but it is not finalized in this release.
+
+### Wallet / onchain fixes
+- Hardened wallet conversation execution paths in chat.
+- Added deterministic wallet fallback routing for balance, send, and trade intents.
+- Fixed the live BSC wallet send path so conversational send can complete with a tx hash.
+- Restored the wallet trade execute route on `develop` so the release branch matches the wallet server path expected by the tests.
+- `/api/wallet/config` now reports wallet capability readiness fields needed by the desktop and tests.
+- Live BSC testnet conversational **send** is working.
+- Live **swap** is still in progress and should not be claimed as complete in this release.
+
+### Windows / packaging / supportability
+- Regenerated the Windows ICO with all standard sizes for installer/runtime icon correctness.
+- Continued cleanup around supportability, CI parity, and startup warnings.
+
+### Docs / support
+- Added a release-facing wallet conversation status summary.
+- Continued docs and review-follow-up cleanup around security and reliability notes.
+
+## Yesterday's patches and fixes
+
+### High-signal fixes
+- `fix: eliminate 19 silent failures across cloud, wallet, knowledge, runtime (#1356)`
+- `fix: enable autonomy loop so heartbeat/trigger instructions execute (#1354)`
+- `fix: regenerate Windows ICO with all standard sizes (#1353)`
+- `fix: remove dangling test file reference`
+
+### Prompt / compaction / security follow-up
+- `fix: double compaction, WeakSet guard, compactModelPrompt tests`
+- `fix: word boundaries on multilingual keywords, installPromptOptimizations tests`
+- `fix: remove security/social eval bypass — belongs upstream in eliza`
+- `fix: review feedback — security docs, multilingual intent, test split`
+- `fix: gitignore .tmp/, fix security docs, narrow issue regex, verify schema`
+- `fix: remove prompt injection vector, tighten intent keywords, add tests`
+- `fix: restore MILADY_CAPTURE_PROMPTS for dev prompt analysis`
+- `fix: startup warnings, action map validation, review feedback`
+- `fix: make security eval dynamic per message source`
+- `fix: flip security eval default to disabled, document env vars in CLAUDE.md`
+- `fix: restore security eval bypass + social throttling with MILADY_* naming`
+
+### Wallet conversation milestone included for `alpha.126`
+- BSC testnet conversational send now works live with tx-hash reply/log proof.
+- Swap remains unfinished and should stay out of release claims.
+- Steward has not replaced the other wallet backends in this release.
+
+## Focused verification run on release prep
+- `bunx vitest run --config vitest.e2e.config.ts packages/agent/test/api-server.e2e.test.ts -t "wallet mode guidance fallback"`
+- `bunx vitest run packages/app-core/src/actions/check-balance.test.ts packages/app-core/src/actions/transfer-token.test.ts packages/app-core/src/actions/execute-trade.test.ts packages/agent/test/api/wallet-trade-routes.test.ts`
+
+## Merge and release runbook
+1. Merge [PR #1368](https://github.com/milady-ai/milady/pull/1368) into `develop`.
+2. Open [release-electrobun workflow](https://github.com/milady-ai/milady/actions/workflows/release-electrobun.yml).
+3. Click `Run workflow`.
+4. Select branch `develop`.
+5. Set tag to `v2.0.0-alpha.126`.
+6. Keep `draft = true`.
+7. Verify the workflow creates the draft release and attaches the platform artifacts.

--- a/docs/plans/2026-03-26-conversation-wallet-execution-status.md
+++ b/docs/plans/2026-03-26-conversation-wallet-execution-status.md
@@ -1,0 +1,156 @@
+﻿# Conversation Wallet Execution Status (BSC Testnet)
+
+## Goal
+Get conversation-driven wallet execution working end-to-end on BSC testnet with one clean path:
+- local wallet signer first
+- tx hash in assistant reply
+- same tx hash visible in conversation/trajectory logs
+- swap after send
+
+## What Was Missing
+- No single wallet abstraction across plugin-evm, local wallet, Privy, and Steward.
+- Chat routing, action handlers, and execution backends were split across different paths.
+- Some wallet turns produced prose without any action execution.
+- Model-generated action parameters were often malformed.
+- Live runtime behavior and tested server behavior were diverging.
+- Wallet actions could target the wrong loopback API port.
+- Some compat execution routes still preferred Steward-style signing even when local-key execution should have been used.
+- Stale watcher/runtime processes repeatedly masked whether code changes were actually loaded.
+
+## What Has Been Fixed
+### Wallet capability and visibility
+- Wallet capability/readiness fields are surfaced in backend/UI.
+- Wallet address/status replies are deterministic instead of persona-driven.
+- plugin-evm visibility and readiness diagnostics were improved.
+
+### Runtime/action execution hardening
+- Wallet actions are registered in the live runtime.
+- Balance execution from chat is working.
+- Transfer/trade action responses were normalized to canonical text blocks with:
+  - action
+  - chain
+  - execution mode
+  - executed true/false
+  - tx hash when executed
+- Wallet chat tests now cover deterministic fallback behavior for:
+  - CHECK_BALANCE
+  - TRANSFER_TOKEN
+  - EXECUTE_TRADE
+- Wallet action fallback execution now captures returned text even when a handler forgets to emit a callback.
+- Wallet execution failures now return explicit blocked/failure text instead of filler like "let me check that for you".
+
+### Test coverage
+- `packages/agent/test/api-server.e2e.test.ts`
+  - prose-only balance fallback
+  - prose-only send fallback
+  - prose-only swap fallback
+  - explicit missing-token swap failure
+- `packages/app-core/src/actions/transfer-token.test.ts`
+- `packages/app-core/src/actions/execute-trade.test.ts`
+
+## What We Learned From Live Debugging
+### Live send failure sequence
+1. Chat/action routing was initially failing.
+2. Then malformed action params caused invalid-address failures.
+3. Then execution reached the compat wallet API but attempted Steward signing when local-key execution should have been allowed.
+4. Then we found some runs were targeting a dead loopback API port (`2138`) instead of the active API server.
+5. Stale dev-server/watcher processes repeatedly made it look like patches were not working.
+
+### Current grounded live status
+- Wallet exists.
+- plugin-evm is loaded.
+- BSC RPC is ready.
+- automation mode is `full`.
+- trade permission mode is `agent-auto`.
+- Balance from conversation works.
+- Send and swap are not yet proven end-to-end in the live desktop runtime.
+
+## Current Code Changes On This Branch
+### Agent/server path
+- `packages/agent/src/api/server.ts`
+  - deterministic wallet-execution fallback logic
+  - wallet-intent failure hardening
+  - canonical wallet response trimming
+  - fallback action result capture
+
+### App-core action path
+- `packages/app-core/src/actions/transfer-token.ts`
+  - canonical transfer success/failure responses
+  - callback metadata includes tx hash/execution info
+  - partial parameter recovery from the original message
+- `packages/app-core/src/actions/execute-trade.ts`
+  - canonical trade success/failure responses
+  - callback metadata includes tx hash/route provider/execution info
+  - `routeProvider` support exposed in action params
+
+### App-core compat API path
+- `packages/app-core/src/api/server.ts`
+  - work started to prefer local-key execution where allowed instead of always relying on Steward signing paths
+
+### Drill tooling
+- `scripts/wallet-chat-testnet-drill.mjs`
+  - can set trade mode to `agent-auto`
+  - can print conversation log after prompts
+
+## What Is Still Blocked
+### 1. One live runtime path
+The live desktop runtime is still more brittle than the tested API path.
+We need one consistently loaded runtime with no stale watchers competing for the same port.
+
+### 2. One wallet execution target
+Wallet actions must always target the active API server.
+No hidden fallback to dead sidecar ports.
+
+### 3. One signer abstraction
+We need a single provider contract for:
+- local signer
+- Steward signer
+- managed signer (if retained)
+
+Callers should ask for wallet execution capability, not for Privy/Steward/local-specific behavior.
+
+### 4. End-to-end live send
+Required acceptance:
+- prompt: `send 0.001 tBNB on BSC testnet to 0x8DFBdEEC8c5d4970BB5F481C6ec7f73fa1C65be5`
+- assistant reply includes tx hash
+- conversation log contains same tx hash
+- trajectory contains same tx hash
+
+### 5. End-to-end live swap
+Required acceptance:
+- prompt: `swap 0.001 tBNB to <configured token> on BSC testnet using pancakeswap-v2`
+- executed true
+- tx hash present
+- route provider visible in assistant/logs
+
+## Recommended Architecture Direction
+Build one abstraction and get one provider working first.
+
+### Target shape
+- `WalletProvider`
+  - `getStatus()`
+  - `getAddresses()`
+  - `getBalances()`
+  - `sendTransfer(input)`
+  - `executeTrade(input)`
+- `WalletCapabilityService`
+  - chooses active provider
+  - exposes readiness
+  - exposes one execution interface to UI/chat/actions
+
+### Practical order
+1. BSC testnet
+2. local signer first
+3. conversation send
+4. conversation swap
+5. Steward as a pluggable signer backend
+6. remove Privy dependence later if desired
+
+## Bottom Line
+We are on the right path now.
+The main improvement is that the failures are no longer vague:
+- we know which layer is failing
+- we have tests around the routing/fallback layer
+- we know the next narrowing step is live local-key send from conversation
+
+The system is not done, but the architecture problem is now much clearer than when this work started.

--- a/docs/plans/2026-03-26-conversation-wallet-execution-status.md
+++ b/docs/plans/2026-03-26-conversation-wallet-execution-status.md
@@ -62,8 +62,7 @@ Get conversation-driven wallet execution working end-to-end on BSC testnet with 
 - BSC RPC is ready.
 - automation mode is `full`.
 - trade permission mode is `agent-auto`.
-- Balance from conversation works.
-- Send and swap are not yet proven end-to-end in the live desktop runtime.
+- Balance from conversation works.`r`n- Conversational send on BSC testnet is now working live with a real tx hash and saved conversation log proof.`r`n- Swap is not yet proven live because the test token address is not configured and the live swap path still needs the same end-to-end proof.
 
 ## Current Code Changes On This Branch
 ### Agent/server path
@@ -109,12 +108,7 @@ We need a single provider contract for:
 
 Callers should ask for wallet execution capability, not for Privy/Steward/local-specific behavior.
 
-### 4. End-to-end live send
-Required acceptance:
-- prompt: `send 0.001 tBNB on BSC testnet to 0x8DFBdEEC8c5d4970BB5F481C6ec7f73fa1C65be5`
-- assistant reply includes tx hash
-- conversation log contains same tx hash
-- trajectory contains same tx hash
+### 4. End-to-end live send`r`nStatus: completed.`r`n`r`nProof:`r`n- prompt: `send 0.001 tBNB on BSC testnet to 0x8DFBdEEC8c5d4970BB5F481C6ec7f73fa1C65be5``r`n- assistant reply included tx hash `0x2eebb8104814ac017515d8c002b749f010ce8e16b42e01a2fe3830befbd74cb5``r`n- saved conversation log contained the same tx hash
 
 ### 5. End-to-end live swap
 Required acceptance:
@@ -154,3 +148,4 @@ The main improvement is that the failures are no longer vague:
 - we know the next narrowing step is live local-key send from conversation
 
 The system is not done, but the architecture problem is now much clearer than when this work started.
+

--- a/packages/agent/src/api/bsc-trade.ts
+++ b/packages/agent/src/api/bsc-trade.ts
@@ -141,6 +141,12 @@ export function resolvePrimaryBscRpcUrl(
   return primary;
 }
 
+export function resolveBscApprovalSpender(
+  quote: Pick<BscTradeQuoteResponse, "routerAddress">,
+): string {
+  return ethers.getAddress(quote.routerAddress);
+}
+
 function hostLabel(url: string): string {
   try {
     return new URL(url).host;

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -156,6 +156,7 @@ import {
   buildBscSellUnsignedTx,
   buildBscTradePreflight,
   buildBscTradeQuote,
+  resolveBscApprovalSpender,
   resolvePrimaryBscRpcUrl,
 } from "./bsc-trade.js";
 import { handleBugReportRoutes } from "./bug-report-routes.js";
@@ -232,7 +233,16 @@ import {
   verifyTweet,
 } from "./twitter-verify.js";
 import { TxService } from "./tx-service.js";
-import { generateWalletKeys, getWalletAddresses } from "./wallet.js";
+import {
+  fetchEvmBalances,
+  fetchSolanaBalances,
+  fetchSolanaNativeBalanceViaRpc,
+  generateWalletForChain,
+  generateWalletKeys,
+  getWalletAddresses,
+  importWallet,
+  validatePrivateKey,
+} from "./wallet.js";
 import { handleWalletRoutes } from "./wallet-routes.js";
 import { resolveWalletRpcReadiness } from "./wallet-rpc.js";
 import {
@@ -240,6 +250,7 @@ import {
   recordWalletTradeLedgerEntry,
   updateWalletTradeLedgerEntryStatus,
 } from "./wallet-trading-profile.js";
+import { handleWalletTradeExecuteRoute } from "./wallet-trade-routes.js";
 import {
   applyWhatsAppQrOverride,
   handleWhatsAppRoute,
@@ -604,6 +615,16 @@ interface PluginEntry {
   homepage?: string;
   repository?: string;
   setupGuideUrl?: string;
+  autoEnabled?: boolean;
+  managementMode?: "standard" | "core-optional";
+  capabilityStatus?:
+    | "loaded"
+    | "auto-enabled"
+    | "blocked"
+    | "missing-prerequisites"
+    | "disabled";
+  capabilityReason?: string | null;
+  prerequisites?: Array<{ label: string; met: boolean }>;
 }
 
 interface SkillEntry {
@@ -637,6 +658,155 @@ interface StreamEventEnvelope {
   agentId?: string;
   roomId?: UUID;
   payload: object;
+}
+
+// ---------------------------------------------------------------------------
+// Response block extraction — parse agent text for structured UI blocks
+// ---------------------------------------------------------------------------
+
+/** Content block types returned in the /api/chat and /api/conversations/:id/messages responses. */
+type ResponseBlock =
+  | { type: "text"; text: string }
+  | { type: "ui-spec"; spec: Record<string, unknown>; raw: string }
+  | {
+      type: "config-form";
+      pluginId: string;
+      pluginName?: string;
+      schema: Record<string, unknown>;
+      hints?: Record<string, unknown>;
+      values?: Record<string, unknown>;
+    };
+
+/** Regex matching fenced JSON code blocks: ```json ... ``` or ``` ... ``` */
+const FENCED_JSON_RE_SERVER = /```(?:json)?\s*\n([\s\S]*?)```/g;
+
+/** CONFIG marker pattern: [CONFIG:pluginId] */
+const CONFIG_MARKER_RE = /\[CONFIG:([^\]]+)\]/g;
+
+function tryParseJsonServer(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function isUiSpecObject(
+  obj: unknown,
+): obj is { root: string; elements: Record<string, unknown> } {
+  if (obj === null || typeof obj !== "object" || Array.isArray(obj))
+    return false;
+  const c = obj as Record<string, unknown>;
+  return (
+    typeof c.root === "string" &&
+    c.elements !== null &&
+    typeof c.elements === "object" &&
+    !Array.isArray(c.elements)
+  );
+}
+
+/**
+ * Scan agent response text for:
+ * 1. Fenced UiSpec JSON blocks → extract as { type: "ui-spec", spec, raw }
+ * 2. [CONFIG:pluginId] markers → generate { type: "config-form", ... } from plugin list
+ * 3. Remaining text → { type: "text", text }
+ *
+ * Returns { cleanText, blocks } where cleanText has UI blocks/markers removed.
+ */
+function _extractResponseBlocks(
+  responseText: string,
+  plugins: PluginEntry[],
+): { cleanText: string; blocks: ResponseBlock[] } {
+  const blocks: ResponseBlock[] = [];
+  let text = responseText;
+
+  // Pass 1: extract fenced UiSpec JSON blocks
+  FENCED_JSON_RE_SERVER.lastIndex = 0;
+  const uiSpecRanges: Array<{
+    start: number;
+    end: number;
+    block: ResponseBlock;
+  }> = [];
+  let match: RegExpExecArray | null = FENCED_JSON_RE_SERVER.exec(text);
+
+  while (match !== null) {
+    const jsonContent = match[1].trim();
+    const parsed = tryParseJsonServer(jsonContent);
+    if (parsed !== null && isUiSpecObject(parsed)) {
+      uiSpecRanges.push({
+        start: match.index,
+        end: match.index + match[0].length,
+        block: {
+          type: "ui-spec",
+          spec: parsed as Record<string, unknown>,
+          raw: jsonContent,
+        },
+      });
+    }
+    match = FENCED_JSON_RE_SERVER.exec(text);
+  }
+
+  // Remove UiSpec blocks from text (reverse order to preserve indices)
+  if (uiSpecRanges.length > 0) {
+    for (let i = uiSpecRanges.length - 1; i >= 0; i--) {
+      const r = uiSpecRanges[i];
+      blocks.unshift(r.block);
+      text = text.slice(0, r.start) + text.slice(r.end);
+    }
+  }
+
+  // Pass 2: extract [CONFIG:pluginId] markers
+  CONFIG_MARKER_RE.lastIndex = 0;
+  const configMarkers: Array<{ start: number; end: number; pluginId: string }> =
+    [];
+  match = CONFIG_MARKER_RE.exec(text);
+  while (match !== null) {
+    configMarkers.push({
+      start: match.index,
+      end: match.index + match[0].length,
+      pluginId: match[1].trim(),
+    });
+    match = CONFIG_MARKER_RE.exec(text);
+  }
+
+  if (configMarkers.length > 0) {
+    for (let i = configMarkers.length - 1; i >= 0; i--) {
+      const m = configMarkers[i];
+      const plugin = plugins.find((p) => p.id === m.pluginId);
+      if (plugin) {
+        const schema: Record<string, unknown> = {};
+        const values: Record<string, unknown> = {};
+        for (const param of plugin.parameters) {
+          schema[param.key] = {
+            type: param.type,
+            description: param.description,
+            required: param.required,
+          };
+          if (param.currentValue !== null)
+            values[param.key] = param.currentValue;
+        }
+        blocks.push({
+          type: "config-form",
+          pluginId: m.pluginId,
+          pluginName: plugin.name,
+          schema,
+          hints: plugin.configUiHints ?? {},
+          values,
+        });
+      }
+      text = text.slice(0, m.start) + text.slice(m.end);
+    }
+  }
+
+  // Build clean text (trim whitespace from block removal)
+  const cleanText = text.replace(/\n{3,}/g, "\n\n").trim();
+
+  // If there's remaining text content, prepend it as a text block
+  if (cleanText) {
+    blocks.unshift({ type: "text", text: cleanText });
+  }
+
+  return { cleanText, blocks };
 }
 
 // ---------------------------------------------------------------------------
@@ -761,6 +931,91 @@ function buildParamDefs(
   });
 }
 
+/**
+ * Infer parameter definitions from bare config key names when explicit
+ * pluginParameters metadata is not provided.  Uses naming conventions to
+ * determine type, sensitivity, requirement level, and a human-readable
+ * description.
+ */
+function _inferParamDefs(configKeys: string[]): PluginParamDef[] {
+  return configKeys.map((key) => {
+    const upper = key.toUpperCase();
+
+    // Detect sensitive keys
+    const sensitive =
+      upper.includes("_API_KEY") ||
+      upper.includes("_SECRET") ||
+      upper.includes("_TOKEN") ||
+      upper.includes("_PASSWORD") ||
+      upper.includes("_PRIVATE_KEY") ||
+      upper.includes("_SIGNING_") ||
+      upper.includes("ENCRYPTION_");
+
+    // Detect booleans
+    const isBoolean =
+      upper.includes("ENABLED") ||
+      upper.includes("_ENABLE_") ||
+      upper.startsWith("ENABLE_") ||
+      upper.includes("DRY_RUN") ||
+      upper.includes("_DEBUG") ||
+      upper.includes("_VERBOSE") ||
+      upper.includes("AUTO_") ||
+      upper.includes("FORCE_") ||
+      upper.includes("DISABLE_") ||
+      upper.includes("SHOULD_") ||
+      upper.endsWith("_SSL");
+
+    // Detect numbers
+    const isNumber =
+      upper.endsWith("_PORT") ||
+      upper.endsWith("_INTERVAL") ||
+      upper.endsWith("_TIMEOUT") ||
+      upper.endsWith("_MS") ||
+      upper.endsWith("_MINUTES") ||
+      upper.endsWith("_SECONDS") ||
+      upper.endsWith("_LIMIT") ||
+      upper.endsWith("_MAX") ||
+      upper.endsWith("_MIN") ||
+      upper.includes("_MAX_") ||
+      upper.includes("_MIN_") ||
+      upper.endsWith("_COUNT") ||
+      upper.endsWith("_SIZE") ||
+      upper.endsWith("_STEPS");
+
+    const type = isBoolean ? "boolean" : isNumber ? "number" : "string";
+
+    // Primary keys are required (API keys, tokens, bot tokens, account IDs)
+    const required =
+      sensitive &&
+      (upper.endsWith("_API_KEY") ||
+        upper.endsWith("_BOT_TOKEN") ||
+        upper.endsWith("_TOKEN") ||
+        upper.endsWith("_PRIVATE_KEY"));
+
+    // Generate a human-readable description from the key name
+    const description = inferDescription(key);
+
+    const envValue = process.env[key];
+    const isSet = Boolean(envValue?.trim());
+
+    return {
+      key,
+      type,
+      description,
+      required,
+      sensitive,
+      default: undefined,
+      options: undefined,
+      currentValue: isSet
+        ? sensitive
+          ? maskValue(envValue ?? "")
+          : (envValue ?? "")
+        : null,
+      isSet,
+    };
+  });
+}
+
 /** Derive a human-readable description from an environment variable key. */
 function inferDescription(key: string): string {
   const upper = key.toUpperCase();
@@ -859,6 +1114,7 @@ const BLOCKED_ENV_KEYS = new Set([
   "ELIZA_API_TOKEN",
   "ELIZA_API_TOKEN",
   "ELIZA_WALLET_EXPORT_TOKEN",
+  "MILADY_WALLET_EXPORT_TOKEN",
   "ELIZA_TERMINAL_RUN_TOKEN",
   "HYPERSCAPE_AUTH_TOKEN",
   // Wallet private keys — writable via API would enable key theft / replacement
@@ -2931,6 +3187,13 @@ function shouldForceCheckBalanceFallback(
   return balanceIntent;
 }
 
+function isBalanceIntent(input: string): boolean {
+  const normalized = input.toLowerCase();
+  return /\b(balance|wallet|holdings|portfolio|funds|how much)\b/.test(
+    normalized,
+  );
+}
+
 function parseFallbackActionBlocks(value: unknown): FallbackParsedAction[] {
   const rawValues: string[] = [];
   if (typeof value === "string") {
@@ -3016,7 +3279,8 @@ async function executeFallbackParsedActions(
       if (!valid) continue;
     }
 
-    await Promise.resolve(
+    let callbackSeen = false;
+    const actionResult = await Promise.resolve(
       action.handler(
         runtime,
         message,
@@ -3035,6 +3299,7 @@ async function executeFallbackParsedActions(
             contentRecord && typeof contentRecord === "object"
               ? extractCompatTextContent(contentRecord as Content)
               : "";
+          callbackSeen = true;
           onActionCallback(actionTag, Boolean(chunk));
           if (chunk) appendIncomingText(chunk);
           return [];
@@ -3042,6 +3307,16 @@ async function executeFallbackParsedActions(
         [],
       ),
     );
+    if (!callbackSeen) {
+      const fallbackText =
+        actionResult && typeof actionResult === "object"
+          ? extractCompatTextContent(actionResult as Content)
+          : "";
+      if (fallbackText) {
+        onActionCallback(parsed.name, true);
+        appendIncomingText(fallbackText);
+      }
+    }
   }
 }
 
@@ -3125,6 +3400,67 @@ function buildChatKnowledgePrompt(
   ].join("\n");
 }
 
+const WALLET_CONTEXT_INTENT_RE =
+  /\b(wallet|address|balance|swap|trade|transfer|send|token|bnb|eth|sol|onchain|on-chain)\b/i;
+
+function buildWalletContextPrompt(
+  runtime: AgentRuntime,
+  userPrompt: string,
+): string {
+  const addrs = getWalletAddresses();
+  const walletNetwork =
+    process.env.MILADY_WALLET_NETWORK?.trim().toLowerCase() === "testnet"
+      ? "testnet"
+      : "mainnet";
+  const localSignerAvailable = Boolean(process.env.EVM_PRIVATE_KEY?.trim());
+  const pluginEvmLoaded = isPluginLoadedByName(runtime, EVM_PLUGIN_PACKAGE);
+  const rpcReady = Boolean(
+    process.env.BSC_RPC_URL?.trim() ||
+      process.env.BSC_TESTNET_RPC_URL?.trim() ||
+      process.env.NODEREAL_BSC_RPC_URL?.trim() ||
+      process.env.QUICKNODE_BSC_RPC_URL?.trim(),
+  );
+  const executionReady =
+    Boolean(addrs.evmAddress) && rpcReady && pluginEvmLoaded;
+  const executionBlockedReason = !addrs.evmAddress
+    ? "No EVM wallet is active yet."
+    : !rpcReady
+      ? "BSC RPC is not configured."
+      : !pluginEvmLoaded
+        ? "plugin-evm is not loaded."
+        : "none";
+  return [
+    "Server-verified wallet context:",
+    `- walletNetwork: ${walletNetwork}`,
+    `- evmAddress: ${addrs.evmAddress ?? "not generated"}`,
+    `- solanaAddress: ${addrs.solanaAddress ?? "not generated"}`,
+    `- localSignerAvailable: ${localSignerAvailable ? "true" : "false"}`,
+    `- rpcReady: ${rpcReady ? "true" : "false"}`,
+    `- pluginEvmLoaded: ${pluginEvmLoaded ? "true" : "false"}`,
+    `- executionReady: ${executionReady ? "true" : "false"}`,
+    `- executionBlockedReason: ${executionBlockedReason}`,
+    "Use this context as source of truth for wallet questions and on-chain actions.",
+    "",
+    `User message: ${userPrompt}`,
+  ].join("\n");
+}
+
+function maybeAugmentChatMessageWithWalletContext(
+  runtime: AgentRuntime,
+  message: ReturnType<typeof createMessageMemory>,
+): ReturnType<typeof createMessageMemory> {
+  const userPrompt = extractCompatTextContent(message.content)?.trim();
+  if (!userPrompt) return message;
+  if (!WALLET_CONTEXT_INTENT_RE.test(userPrompt)) return message;
+  return {
+    ...message,
+    content: {
+      ...message.content,
+      text: buildWalletContextPrompt(runtime, userPrompt),
+    },
+  };
+}
+
 async function maybeAugmentChatMessageWithKnowledge(
   runtime: AgentRuntime,
   message: ReturnType<typeof createMessageMemory>,
@@ -3198,8 +3534,10 @@ async function generateChatResponse(
   agentName: string,
   opts?: ChatGenerateOptions,
 ): Promise<ChatGenerationResult> {
+  const originalUserText = String(extractCompatTextContent(message.content) ?? "");
   type StreamSource = "unset" | "callback" | "onStreamChunk";
   let responseText = "";
+  let forcedWalletExecutionText = false;
   let activeStreamSource: StreamSource = "unset";
   const messageSource =
     typeof message.content.source === "string" &&
@@ -3265,52 +3603,92 @@ async function generateChatResponse(
       >
     | undefined;
   let actionCallbacksSeen = 0;
+  let _handlerError: unknown = null;
+  const directWalletExecutionFallback =
+    WALLET_EXECUTION_INTENT_RE.test(originalUserText)
+      ? inferWalletExecutionFallback(originalUserText)
+      : null;
   try {
-    const generationMessage = await maybeAugmentChatMessageWithKnowledge(
-      runtime,
-      message,
-    );
-    result = await runtime.messageService?.handleMessage(
-      runtime,
-      generationMessage,
-      async (content: Content) => {
-        if (opts?.isAborted?.()) {
-          throw new Error("client_disconnected");
-        }
-
-        // Trace action callback invocations so we can verify handlers execute.
-        const actionTag = (content as Record<string, unknown>)?.action;
-        if (actionTag) {
+    if (directWalletExecutionFallback?.errorText) {
+      forcedWalletExecutionText = true;
+      responseText = directWalletExecutionFallback.errorText;
+      result = { responseContent: { text: directWalletExecutionFallback.errorText } };
+    } else if (directWalletExecutionFallback?.action) {
+      runtime.logger?.info(
+        {
+          src: "eliza-api",
+          action: directWalletExecutionFallback.action.name,
+          parameters: directWalletExecutionFallback.action.parameters,
+        },
+        "[eliza-api] Direct wallet execution dispatch from prompt intent",
+      );
+      await executeFallbackParsedActions(
+        runtime,
+        message,
+        [directWalletExecutionFallback.action],
+        appendIncomingText,
+        (actionTag, hasText) => {
           actionCallbacksSeen += 1;
           runtime.logger?.info(
             {
               src: "eliza-api",
               action: actionTag,
-              hasText: Boolean(extractCompatTextContent(content)),
+              hasText,
             },
             `[eliza-api] Action callback fired: ${actionTag}`,
           );
-        }
+        },
+      );
+      result = { responseContent: { text: responseText } };
+    } else {
+      const walletAugmentedMessage =
+        maybeAugmentChatMessageWithWalletContext(runtime, message);
+      const generationMessage = await maybeAugmentChatMessageWithKnowledge(
+        runtime,
+        walletAugmentedMessage,
+      );
+      result = await runtime.messageService?.handleMessage(
+        runtime,
+        generationMessage,
+        async (content: Content) => {
+          if (opts?.isAborted?.()) {
+            throw new Error("client_disconnected");
+          }
 
-        const chunk = extractCompatTextContent(content);
-        if (!chunk) return [];
-        if (!claimStreamSource("callback")) return [];
-        appendIncomingText(chunk);
-        return [];
-      },
-      {
-        onStreamChunk: opts?.onChunk
-          ? async (chunk: string) => {
-              if (opts?.isAborted?.()) {
-                throw new Error("client_disconnected");
+          // Trace action callback invocations so we can verify handlers execute.
+          const actionTag = (content as Record<string, unknown>)?.action;
+          if (actionTag) {
+            actionCallbacksSeen += 1;
+            runtime.logger?.info(
+              {
+                src: "eliza-api",
+                action: actionTag,
+                hasText: Boolean(extractCompatTextContent(content)),
+              },
+              `[eliza-api] Action callback fired: ${actionTag}`,
+            );
+          }
+
+          const chunk = extractCompatTextContent(content);
+          if (!chunk) return [];
+          if (!claimStreamSource("callback")) return [];
+          appendIncomingText(chunk);
+          return [];
+        },
+        {
+          onStreamChunk: opts?.onChunk
+            ? async (chunk: string) => {
+                if (opts?.isAborted?.()) {
+                  throw new Error("client_disconnected");
+                }
+                if (!chunk) return;
+                if (!claimStreamSource("onStreamChunk")) return;
+                appendIncomingText(chunk);
               }
-              if (!chunk) return;
-              if (!claimStreamSource("onStreamChunk")) return;
-              appendIncomingText(chunk);
-            }
-          : undefined,
-      },
-    );
+            : undefined,
+        },
+      );
+    }
 
     // Ensure MESSAGE_SENT hooks run for API chat flows. Some runtimes emit this
     // internally, but API wrappers can bypass those hooks.
@@ -3348,6 +3726,7 @@ async function generateChatResponse(
       );
     }
   } catch (err) {
+    _handlerError = err;
     throw err;
   }
 
@@ -3371,6 +3750,7 @@ async function generateChatResponse(
     const userText = String(extractCompatTextContent(message.content) ?? "");
     const modelText = String(extractCompatTextContent(result.responseContent) ?? "");
     const fallbackActionsToRun = [...parsedFallbackActions];
+    const inferredBalanceChain = inferBalanceChainFromText(userText);
 
     if (
       shouldForceCheckBalanceFallback(fallbackActionsToRun, userText, modelText) &&
@@ -3378,15 +3758,69 @@ async function generateChatResponse(
     ) {
       fallbackActionsToRun.push({
         name: "CHECK_BALANCE",
-        parameters: { chain: inferBalanceChainFromText(userText) },
+        parameters: { chain: inferredBalanceChain },
       });
       runtime.logger?.warn(
         {
           src: "eliza-api",
-          inferredChain: inferBalanceChainFromText(userText),
+          inferredChain: inferredBalanceChain,
         },
         "[eliza-api] Injecting CHECK_BALANCE fallback for REPLY-only malformed action payload",
       );
+    }
+
+    if (
+      actionCallbacksSeen === 0 &&
+      fallbackActionsToRun.length === 0 &&
+      isBalanceIntent(userText)
+    ) {
+      fallbackActionsToRun.push({
+        name: "CHECK_BALANCE",
+        parameters: { chain: inferredBalanceChain },
+      });
+      runtime.logger?.warn(
+        {
+          src: "eliza-api",
+          inferredChain: inferredBalanceChain,
+        },
+        "[eliza-api] Injecting CHECK_BALANCE fallback for balance intent without any action payload",
+      );
+    }
+
+    if (
+      actionCallbacksSeen === 0 &&
+      WALLET_EXECUTION_INTENT_RE.test(userText)
+    ) {
+      const inferredWalletFallback = inferWalletExecutionFallback(userText);
+      if (inferredWalletFallback?.action) {
+        const existingIndex = fallbackActionsToRun.findIndex(
+          (action) => action.name === inferredWalletFallback.action.name,
+        );
+        if (
+          existingIndex === -1 ||
+          !hasUsableWalletFallbackParams(fallbackActionsToRun[existingIndex]!)
+        ) {
+          if (existingIndex >= 0) {
+            fallbackActionsToRun.splice(existingIndex, 1);
+          }
+          fallbackActionsToRun.push(inferredWalletFallback.action);
+          runtime.logger?.warn(
+            {
+              src: "eliza-api",
+              action: inferredWalletFallback.action.name,
+              parameters: inferredWalletFallback.action.parameters,
+            },
+            "[eliza-api] Injecting wallet execution fallback from prompt intent",
+          );
+        }
+      } else if (inferredWalletFallback?.errorText) {
+        forcedWalletExecutionText = true;
+        if (opts?.onSnapshot) {
+          emitSnapshot(inferredWalletFallback.errorText);
+        } else {
+          responseText = inferredWalletFallback.errorText;
+        }
+      }
     }
 
     if (actionCallbacksSeen === 0 && fallbackActionsToRun.length > 0) {
@@ -3435,7 +3869,12 @@ async function generateChatResponse(
   ) {
     // Keep streaming monotonic when final text extends emitted chunks.
     emitChunk(resultText.slice(responseText.length));
-  } else if (actionCallbacksSeen === 0 && resultText && resultText !== responseText) {
+  } else if (
+    actionCallbacksSeen === 0 &&
+    resultText &&
+    resultText !== responseText &&
+    !forcedWalletExecutionText
+  ) {
     // Canonical final response may differ from streamed chunks (normalization).
     if (opts?.onSnapshot) {
       emitSnapshot(resultText);
@@ -3444,10 +3883,31 @@ async function generateChatResponse(
     }
   }
 
+  if (actionCallbacksSeen === 0 && isWalletActionRequiredIntent(originalUserText)) {
+    const normalizedVisibleText = stripAssistantStageDirections(
+      (responseText || resultText || "").trim(),
+    );
+    if (
+      normalizedVisibleText.length === 0 ||
+      WALLET_PROGRESS_ONLY_RE.test(normalizedVisibleText)
+    ) {
+      const failureText = buildWalletActionNotExecutedReply(
+        runtime,
+        originalUserText.trim(),
+      );
+      if (opts?.onSnapshot) {
+        emitSnapshot(failureText);
+      } else {
+        responseText = failureText;
+      }
+    }
+  }
+
   const noResponseFallback = opts?.resolveNoResponseText?.();
-  const finalText = isClientVisibleNoResponse(responseText)
+  const normalizedResponseText = trimWalletProgressPrefix(responseText);
+  const finalText = isClientVisibleNoResponse(normalizedResponseText)
     ? (noResponseFallback ?? (responseText || "(no response)"))
-    : responseText;
+    : normalizedResponseText;
 
   // Estimate token usage from text lengths (~4 chars per token)
   const promptText = extractCompatTextContent(message.content) ?? "";
@@ -5426,6 +5886,7 @@ import {
   type TradePermissionMode,
   assertQuoteFresh,
   canUseLocalTradeExecution,
+  recordAgentAutoTrade,
 } from "./trade-safety.js";
 
 export {
@@ -5450,6 +5911,7 @@ const AGENT_AUTOMATION_MODES = new Set<AgentAutomationMode>([
   "connectors-only",
   "full",
 ]);
+const EVM_PLUGIN_PACKAGE = "@elizaos/plugin-evm";
 
 function parseAgentAutomationMode(value: unknown): AgentAutomationMode | null {
   if (typeof value !== "string") return null;
@@ -5506,6 +5968,465 @@ function persistAgentAutomationMode(
     enabled: true,
     mode,
   };
+}
+
+function isPluginLoadedByName(
+  runtime: AgentRuntime | null,
+  pluginName: string,
+): boolean {
+  if (!runtime || !Array.isArray(runtime.plugins)) return false;
+  const shortId = pluginName.replace("@elizaos/plugin-", "");
+  const packageSuffix = `plugin-${shortId}`;
+  return runtime.plugins.some((plugin) => {
+    const name = typeof plugin?.name === "string" ? plugin.name : "";
+    return (
+      name === pluginName ||
+      name === shortId ||
+      name === packageSuffix ||
+      name.endsWith(`/${packageSuffix}`) ||
+      name.includes(shortId)
+    );
+  });
+}
+
+function resolveWalletCapabilityStatus(
+  state: Pick<ServerState, "config" | "runtime">,
+) {
+  const addrs = getWalletAddresses();
+  const rpcReadiness = resolveWalletRpcReadiness(state.config);
+  const automationMode = resolveAgentAutomationModeFromConfig(state.config);
+  const localSignerAvailable = Boolean(process.env.EVM_PRIVATE_KEY?.trim());
+  const hasWallet = Boolean(addrs.evmAddress || addrs.solanaAddress);
+  const hasEvm = Boolean(addrs.evmAddress);
+  const pluginEvmLoaded = isPluginLoadedByName(
+    state.runtime,
+    EVM_PLUGIN_PACKAGE,
+  );
+  const pluginEvmRequired = hasEvm || localSignerAvailable;
+  const rpcReady = Boolean(rpcReadiness.managedBscRpcReady);
+  const walletSource = localSignerAvailable
+    ? "local"
+    : hasWallet
+      ? "managed"
+      : "none";
+
+  let executionBlockedReason: string | null = null;
+  if (!hasEvm) {
+    executionBlockedReason = "No EVM wallet is active yet.";
+  } else if (!rpcReady) {
+    executionBlockedReason = "BSC RPC is not configured.";
+  } else if (!pluginEvmLoaded) {
+    executionBlockedReason =
+      "plugin-evm is not loaded, so EVM wallet execution is unavailable.";
+  } else if (automationMode !== "full") {
+    executionBlockedReason =
+      "Agent automation is in connectors-only mode, so wallet execution is blocked in chat.";
+  }
+
+  return {
+    walletSource,
+    walletNetwork: rpcReadiness.walletNetwork,
+    evmAddress: addrs.evmAddress ?? null,
+    solanaAddress: addrs.solanaAddress ?? null,
+    hasWallet,
+    hasEvm,
+    localSignerAvailable,
+    rpcReady,
+    automationMode,
+    pluginEvmLoaded,
+    pluginEvmRequired,
+    executionReady:
+      hasEvm && rpcReady && pluginEvmLoaded && automationMode === "full",
+    executionBlockedReason,
+  };
+}
+
+function buildPluginEvmDiagnosticEntry(
+  state: Pick<ServerState, "config" | "runtime">,
+): PluginEntry {
+  const capability = resolveWalletCapabilityStatus(state);
+  const enabled =
+    capability.pluginEvmLoaded ||
+    capability.pluginEvmRequired ||
+    (state.config.plugins?.allow ?? []).some((entry) => {
+      return entry === EVM_PLUGIN_PACKAGE || entry === "evm";
+    });
+
+  const capabilityStatus = capability.pluginEvmLoaded
+    ? capability.pluginEvmRequired
+      ? "loaded"
+      : "auto-enabled"
+    : enabled
+      ? capability.evmAddress || capability.localSignerAvailable
+        ? "blocked"
+        : "missing-prerequisites"
+      : "disabled";
+
+  return {
+    id: "evm",
+    name: "Plugin EVM",
+    description:
+      "EVM wallet runtime for balance, transfer, and trade actions. Required for wallet execution in chat.",
+    tags: ["wallet", "evm", "bsc", "onchain"],
+    enabled,
+    configured: capability.pluginEvmRequired,
+    envKey: "EVM_PRIVATE_KEY",
+    category: "feature",
+    source: "bundled",
+    configKeys: [
+      "EVM_PRIVATE_KEY",
+      "BSC_RPC_URL",
+      "BSC_TESTNET_RPC_URL",
+      "MILADY_WALLET_NETWORK",
+    ],
+    parameters: [],
+    validationErrors: [],
+    validationWarnings: [],
+    npmName: EVM_PLUGIN_PACKAGE,
+    isActive: capability.pluginEvmLoaded,
+    autoEnabled: capability.pluginEvmRequired && !capability.pluginEvmLoaded,
+    managementMode: "core-optional",
+    capabilityStatus,
+    capabilityReason: capability.executionReady
+      ? "Wallet execution is ready."
+      : capability.executionBlockedReason,
+    prerequisites: [
+      { label: "wallet present", met: Boolean(capability.evmAddress) },
+      { label: "rpc ready", met: capability.rpcReady },
+      { label: "plugin loaded", met: capability.pluginEvmLoaded },
+    ],
+  };
+}
+
+const WALLET_CHAT_INTENT_RE =
+  /\b(wallet|privy|onchain|on-chain|address|balance|swap|trade|transfer|send|token|bnb|eth|sol)\b/i;
+
+const WALLET_EXECUTION_INTENT_RE =
+  /\b(swap|trade|transfer|send|buy|sell|execute|approve)\b/i;
+
+const WALLET_IDENTITY_INTENT_RE =
+  /\b(wallet\s*address|address)\b/i;
+
+const WALLET_ACTION_REQUIRED_INTENT_RE =
+  /\b(balance|portfolio|holdings|funds|swap|trade|transfer|send|buy|sell|execute|approve)\b/i;
+
+const WALLET_PROGRESS_ONLY_RE =
+  /\b(let me|i(?:'| wi)ll|checking|fetching|looking up|pulling|one moment|just a second|hold on)\b[\s\S]{0,80}\b(check|look|fetch|pull|get|verify|see|review)\b/i;
+
+const WALLET_PROGRESS_PREFIX_RE =
+  /^\s*(?:let me|i(?:'ll| will)|checking|fetching|looking up|pulling|one moment|just a second|hold on)[\s\S]{0,120}?(?:now|\.{3}|…)?\s*/i;
+
+function isWalletActionRequiredIntent(prompt: string): boolean {
+  return (
+    WALLET_CHAT_INTENT_RE.test(prompt) &&
+    !WALLET_IDENTITY_INTENT_RE.test(prompt) &&
+    WALLET_ACTION_REQUIRED_INTENT_RE.test(prompt)
+  );
+}
+
+const EVM_ADDRESS_CAPTURE_RE = /\b0x[a-fA-F0-9]{40}\b/g;
+const DECIMAL_AMOUNT_CAPTURE_RE = /\b(\d+(?:\.\d+)?)\b/;
+const SEND_NATIVE_ASSET_RE =
+  /\b(?:t?bnb|bnb|eth|usdt|usdc|busd|dai|weth|wbtc)\b/i;
+const SWAP_ROUTE_PROVIDER_RE = /\b(pancakeswap-v2|0x|auto)\b/i;
+
+type WalletIntentFallback =
+  | { action: FallbackParsedAction; errorText?: undefined }
+  | { action?: undefined; errorText: string };
+
+function normalizeWalletAssetSymbol(asset: string): string {
+  const normalized = asset.trim().toUpperCase();
+  if (normalized === "TBNB") return "BNB";
+  return normalized;
+}
+
+function resolveWalletDrillTokenAddress(): string | null {
+  const raw = process.env.WALLET_DRILL_TOKEN_ADDRESS?.trim();
+  return raw && /^0x[a-fA-F0-9]{40}$/.test(raw) ? raw : null;
+}
+
+function buildWalletParameterFailureReply(
+  actionName: "TRANSFER_TOKEN" | "EXECUTE_TRADE",
+  reason: string,
+): string {
+  const walletNetwork =
+    process.env.MILADY_WALLET_NETWORK?.trim().toLowerCase() === "testnet"
+      ? "BSC testnet"
+      : "BSC";
+  return [
+    `Action: ${actionName}`,
+    `Chain: ${walletNetwork}`,
+    "Executed: false",
+    `Reason: ${reason}`,
+  ].join("\n");
+}
+
+function inferTransferFallbackAction(prompt: string): WalletIntentFallback | null {
+  if (!/\b(send|transfer|pay)\b/i.test(prompt)) return null;
+
+  const recipient = prompt.match(EVM_ADDRESS_CAPTURE_RE)?.[0];
+  if (!recipient) {
+    return {
+      errorText: buildWalletParameterFailureReply(
+        "TRANSFER_TOKEN",
+        "I need a recipient EVM address to send funds.",
+      ),
+    };
+  }
+
+  const amount = prompt.match(DECIMAL_AMOUNT_CAPTURE_RE)?.[1];
+  if (!amount) {
+    return {
+      errorText: buildWalletParameterFailureReply(
+        "TRANSFER_TOKEN",
+        "I need a positive transfer amount.",
+      ),
+    };
+  }
+
+  const assetMatch = prompt.match(SEND_NATIVE_ASSET_RE)?.[0];
+  if (!assetMatch) {
+    return {
+      errorText: buildWalletParameterFailureReply(
+        "TRANSFER_TOKEN",
+        "I need an asset symbol such as BNB, USDT, or USDC.",
+      ),
+    };
+  }
+
+  return {
+    action: {
+      name: "TRANSFER_TOKEN",
+      parameters: {
+        toAddress: recipient,
+        amount,
+        assetSymbol: normalizeWalletAssetSymbol(assetMatch),
+      },
+    },
+  };
+}
+
+function inferTradeSide(prompt: string): "buy" | "sell" | null {
+  if (/\bsell\b/i.test(prompt)) return "sell";
+  if (/\b(buy|swap|trade)\b/i.test(prompt)) return "buy";
+  return null;
+}
+
+function inferTradeFallbackAction(prompt: string): WalletIntentFallback | null {
+  if (!/\b(swap|trade|buy|sell)\b/i.test(prompt)) return null;
+
+  const side = inferTradeSide(prompt);
+  if (!side) {
+    return {
+      errorText: buildWalletParameterFailureReply(
+        "EXECUTE_TRADE",
+        'I need a trade side ("buy" or "sell").',
+      ),
+    };
+  }
+
+  const amount = prompt.match(DECIMAL_AMOUNT_CAPTURE_RE)?.[1];
+  if (!amount) {
+    return {
+      errorText: buildWalletParameterFailureReply(
+        "EXECUTE_TRADE",
+        "I need a positive trade amount.",
+      ),
+    };
+  }
+
+  const addresses = prompt.match(EVM_ADDRESS_CAPTURE_RE) ?? [];
+  const tokenAddress = addresses[0] ?? resolveWalletDrillTokenAddress();
+  if (!tokenAddress) {
+    return {
+      errorText: buildWalletParameterFailureReply(
+        "EXECUTE_TRADE",
+        "I need a target token address. Set WALLET_DRILL_TOKEN_ADDRESS or include the token contract address in the prompt.",
+      ),
+    };
+  }
+
+  const routeProvider =
+    prompt.match(SWAP_ROUTE_PROVIDER_RE)?.[1]?.toLowerCase() ??
+    "pancakeswap-v2";
+
+  return {
+    action: {
+      name: "EXECUTE_TRADE",
+      parameters: {
+        side,
+        amount,
+        tokenAddress,
+        routeProvider,
+      },
+    },
+  };
+}
+
+function inferWalletExecutionFallback(prompt: string): WalletIntentFallback | null {
+  return inferTransferFallbackAction(prompt) ?? inferTradeFallbackAction(prompt);
+}
+
+function hasUsableWalletFallbackParams(action: FallbackParsedAction): boolean {
+  if (action.name === "TRANSFER_TOKEN") {
+    return (
+      typeof action.parameters.toAddress === "string" &&
+      /^0x[a-fA-F0-9]{40}$/.test(action.parameters.toAddress) &&
+      typeof action.parameters.amount === "string" &&
+      action.parameters.amount.trim().length > 0 &&
+      typeof action.parameters.assetSymbol === "string" &&
+      action.parameters.assetSymbol.trim().length > 0
+    );
+  }
+
+  if (action.name === "EXECUTE_TRADE") {
+    return (
+      (action.parameters.side === "buy" || action.parameters.side === "sell") &&
+      typeof action.parameters.amount === "string" &&
+      action.parameters.amount.trim().length > 0 &&
+      typeof action.parameters.tokenAddress === "string" &&
+      /^0x[a-fA-F0-9]{40}$/.test(action.parameters.tokenAddress)
+    );
+  }
+
+  return true;
+}
+
+function buildWalletActionNotExecutedReply(
+  runtime: AgentRuntime,
+  userPrompt: string,
+): string {
+  const addrs = getWalletAddresses();
+  const walletNetwork =
+    process.env.MILADY_WALLET_NETWORK?.trim().toLowerCase() === "testnet"
+      ? "testnet"
+      : "mainnet";
+  const pluginEvmLoaded = isPluginLoadedByName(runtime, EVM_PLUGIN_PACKAGE);
+  const rpcReady = Boolean(
+    process.env.BSC_RPC_URL?.trim() ||
+      process.env.BSC_TESTNET_RPC_URL?.trim() ||
+      process.env.NODEREAL_BSC_RPC_URL?.trim() ||
+      process.env.QUICKNODE_BSC_RPC_URL?.trim(),
+  );
+  const executionBlockedReason = !addrs.evmAddress
+    ? "No EVM wallet is active yet."
+    : !rpcReady
+      ? "BSC RPC is not configured."
+      : !pluginEvmLoaded
+        ? "plugin-evm is not loaded, so EVM wallet execution is unavailable."
+        : "A wallet action was not executed for this turn.";
+
+  return [
+    `I could not complete "${userPrompt}" because no wallet action actually ran.`,
+    `Wallet network: ${walletNetwork}.`,
+    `Detected wallets:`,
+    `- EVM: ${addrs.evmAddress ?? "not generated"}`,
+    `- Solana: ${addrs.solanaAddress ?? "not generated"}`,
+    `plugin-evm: ${pluginEvmLoaded ? "loaded" : "not loaded"}.`,
+    `RPC ready: ${rpcReady ? "yes" : "no"}.`,
+    `Blocked reason: ${executionBlockedReason}`,
+  ].join("\n");
+}
+
+function trimWalletProgressPrefix(text: string): string {
+  const balanceIdx = text.indexOf("Wallet Balances:");
+  if (balanceIdx > 0) {
+    return text.slice(balanceIdx).trimStart();
+  }
+
+  const markers = [
+    "Action: TRANSFER_TOKEN",
+    "Action: EXECUTE_TRADE",
+    "Transfer",
+    "Swap",
+    "Trade",
+    "Tx hash:",
+    "Transaction hash:",
+  ];
+  for (const marker of markers) {
+    const idx = text.indexOf(marker);
+    if (idx <= 0) continue;
+    const prefix = text.slice(0, idx);
+    if (WALLET_PROGRESS_PREFIX_RE.test(prefix)) {
+      return text.slice(idx).trimStart();
+    }
+  }
+  return text;
+}
+
+function resolveWalletModeGuidanceReply(
+  state: ServerState,
+  prompt: string,
+): string | null {
+  if (!WALLET_CHAT_INTENT_RE.test(prompt)) {
+    return null;
+  }
+
+  const capability = resolveWalletCapabilityStatus(state);
+  const {
+    automationMode,
+    evmAddress,
+    solanaAddress,
+    walletNetwork,
+    pluginEvmLoaded,
+    executionReady,
+    executionBlockedReason,
+  } = capability;
+  const walletSummary = `Detected wallets:
+- EVM: ${evmAddress ?? "not generated"}
+- Solana: ${solanaAddress ?? "not generated"}`;
+
+  if (automationMode === "connectors-only") {
+    if (!WALLET_EXECUTION_INTENT_RE.test(prompt)) {
+      return null;
+    }
+    return [
+      "I am in connectors-only mode, so wallet actions are disabled in chat right now.",
+      "Turn on full mode with one of these:",
+      '1) Settings -> Permissions -> Agent Automation Mode -> "Full".',
+      '2) API: PUT /api/permissions/automation-mode with {"mode":"full"}.',
+      "Then retry your wallet request.",
+      `Wallet network: ${walletNetwork}.`,
+      walletSummary,
+    ].join("\n");
+  }
+
+  if (
+    !evmAddress &&
+    !solanaAddress &&
+    WALLET_EXECUTION_INTENT_RE.test(prompt)
+  ) {
+    const privyConfigured = isPrivyWalletProvisioningEnabled();
+    return [
+      "No wallet is active yet.",
+      "Open Wallet page and choose one setup path:",
+      `- Managed (Privy): ${privyConfigured ? "available" : "blocked until PRIVY_APP_ID and PRIVY_APP_SECRET are set on the backend"}.`,
+      "- Local: Generate or Import wallet in the Wallet wizard.",
+      walletSummary,
+    ].join("\n");
+  }
+
+  if (WALLET_IDENTITY_INTENT_RE.test(prompt)) {
+    return [
+      `Wallet network: ${walletNetwork}.`,
+      walletSummary,
+      `plugin-evm: ${pluginEvmLoaded ? "loaded" : "not loaded"}.`,
+      `Execution readiness: ${executionReady ? "ready for wallet actions" : (executionBlockedReason ?? "blocked")}.`,
+      `Automation mode: ${automationMode}.`,
+    ].join("\n");
+  }
+
+  if (WALLET_EXECUTION_INTENT_RE.test(prompt) && !executionReady) {
+    return [
+      `Wallet execution is currently blocked: ${executionBlockedReason ?? "unknown reason"}`,
+      `Wallet network: ${walletNetwork}.`,
+      walletSummary,
+      `plugin-evm: ${pluginEvmLoaded ? "loaded" : "not loaded"}.`,
+      `Automation mode: ${automationMode}.`,
+    ].join("\n");
+  }
+
+  return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -5619,7 +6540,7 @@ export function isAllowedHost(req: http.IncomingMessage): boolean {
 
   const bindHost = (
     process.env.ELIZA_API_BIND ??
-    process.env.ELIZA_API_BIND ??
+    process.env.MILADY_API_BIND ??
     ""
   )
     .trim()
@@ -5660,7 +6581,7 @@ export function resolveCorsOrigin(origin?: string): string | null {
   // require an explicit token, so this only relaxes the browser origin check.
   const bindHost = (
     process.env.ELIZA_API_BIND ??
-    process.env.ELIZA_API_BIND ??
+    process.env.MILADY_API_BIND ??
     ""
   )
     .trim()
@@ -5995,12 +6916,14 @@ export function resolveWalletExportRejection(
     };
   }
 
-  const expected = process.env.ELIZA_WALLET_EXPORT_TOKEN?.trim();
+  const expected =
+    process.env.ELIZA_WALLET_EXPORT_TOKEN?.trim() ||
+    process.env.MILADY_WALLET_EXPORT_TOKEN?.trim();
   if (!expected) {
     return {
       status: 403,
       reason:
-        "Wallet export is disabled. Set ELIZA_WALLET_EXPORT_TOKEN to enable secure exports.",
+        "Wallet export is disabled. Set ELIZA_WALLET_EXPORT_TOKEN (or MILADY_WALLET_EXPORT_TOKEN) to enable secure exports.",
     };
   }
 
@@ -6094,6 +7017,23 @@ function extractWsQueryToken(url: URL): string | null {
   return token?.trim() || null;
 }
 
+function hasWsQueryToken(url: URL): boolean {
+  return (
+    url.searchParams.has("token") ||
+    url.searchParams.has("apiKey") ||
+    url.searchParams.has("api_key")
+  );
+}
+
+function extractWebSocketHandshakeToken(
+  request: http.IncomingMessage,
+  url: URL,
+): string | null {
+  const headerToken = extractAuthToken(request);
+  if (headerToken) return headerToken;
+  return extractWsQueryToken(url);
+}
+
 function isWebSocketAuthorized(
   request: http.IncomingMessage,
   url: URL,
@@ -6101,12 +7041,9 @@ function isWebSocketAuthorized(
   const expected = getConfiguredApiToken();
   if (!expected) return true;
 
-  const headerToken = extractAuthToken(request);
-  if (headerToken) return tokenMatches(expected, headerToken);
-
-  const queryToken = extractWsQueryToken(url);
-  if (!queryToken) return false;
-  return tokenMatches(expected, queryToken);
+  const handshakeToken = extractWebSocketHandshakeToken(request, url);
+  if (!handshakeToken) return false;
+  return tokenMatches(expected, handshakeToken);
 }
 
 export interface WebSocketUpgradeRejection {
@@ -6129,7 +7066,20 @@ export function resolveWebSocketUpgradeRejection(
     return { status: 403, reason: "Origin not allowed" };
   }
 
-  if (!isWebSocketAuthorized(req, wsUrl)) {
+  const expected = getConfiguredApiToken();
+  if (!expected) {
+    return null;
+  }
+
+  if (
+    process.env.ELIZA_ALLOW_WS_QUERY_TOKEN !== "1" &&
+    hasWsQueryToken(wsUrl)
+  ) {
+    return { status: 401, reason: "Unauthorized" };
+  }
+
+  const handshakeToken = extractWebSocketHandshakeToken(req, wsUrl);
+  if (handshakeToken && !tokenMatches(expected, handshakeToken)) {
     return { status: 401, reason: "Unauthorized" };
   }
 
@@ -9155,6 +10105,27 @@ async function handleRequest(
     const bundledIds = new Set(state.plugins.map((p) => p.id));
     const installedEntries = discoverInstalledPlugins(freshConfig, bundledIds);
     const allPlugins: PluginEntry[] = [...state.plugins, ...installedEntries];
+    const evmDiagnostic = buildPluginEvmDiagnosticEntry({
+      config: state.config,
+      runtime: state.runtime,
+    });
+    const existingEvmPlugin = allPlugins.find(
+      (plugin) => plugin.id === "evm" || plugin.npmName === EVM_PLUGIN_PACKAGE,
+    );
+    if (existingEvmPlugin) {
+      existingEvmPlugin.autoEnabled = evmDiagnostic.autoEnabled;
+      existingEvmPlugin.managementMode = "core-optional";
+      existingEvmPlugin.capabilityStatus = evmDiagnostic.capabilityStatus;
+      existingEvmPlugin.capabilityReason = evmDiagnostic.capabilityReason;
+      existingEvmPlugin.prerequisites = evmDiagnostic.prerequisites;
+      existingEvmPlugin.setupGuideUrl =
+        existingEvmPlugin.setupGuideUrl ?? evmDiagnostic.setupGuideUrl;
+      existingEvmPlugin.tags = Array.from(
+        new Set([...(existingEvmPlugin.tags ?? []), ...evmDiagnostic.tags]),
+      );
+    } else {
+      allPlugins.push(evmDiagnostic);
+    }
 
     // Resolve enabled state from config and loaded state from runtime.
     // "enabled" = user wants it active (config). "isActive" = actually loaded.
@@ -9201,6 +10172,15 @@ async function handleRequest(
           plugin.loadError =
             "Plugin installed but failed to load — the package may be missing compiled files.";
         }
+      }
+      if (plugin.id === "evm" || plugin.npmName === EVM_PLUGIN_PACKAGE) {
+        plugin.enabled = evmDiagnostic.enabled;
+        plugin.isActive = evmDiagnostic.isActive;
+        plugin.autoEnabled = evmDiagnostic.autoEnabled;
+        plugin.managementMode = "core-optional";
+        plugin.capabilityStatus = evmDiagnostic.capabilityStatus;
+        plugin.capabilityReason = evmDiagnostic.capabilityReason;
+        plugin.prerequisites = evmDiagnostic.prerequisites;
       }
     }
 
@@ -11200,6 +12180,18 @@ async function handleRequest(
       ensureWalletKeysInEnvAndConfig,
       resolveWalletExportRejection,
       scheduleRuntimeRestart,
+      deps: {
+        getWalletAddresses,
+        fetchEvmBalances,
+        fetchSolanaBalances,
+        fetchSolanaNativeBalanceViaRpc,
+        validatePrivateKey,
+        importWallet,
+        generateWalletForChain,
+        getAutomationMode: resolveAgentAutomationModeFromConfig,
+        getPluginEvmLoaded: () =>
+          isPluginLoadedByName(state.runtime, EVM_PLUGIN_PACKAGE),
+      },
       readJsonBody,
       json,
       error,
@@ -12176,6 +13168,7 @@ async function handleRequest(
       delete envPatch.ELIZA_API_TOKEN;
       delete envPatch.ELIZA_API_TOKEN;
       delete envPatch.ELIZA_WALLET_EXPORT_TOKEN;
+      delete envPatch.MILADY_WALLET_EXPORT_TOKEN;
       delete envPatch.ELIZA_TERMINAL_RUN_TOKEN;
       delete envPatch.HYPERSCAPE_AUTH_TOKEN;
       delete envPatch.EVM_PRIVATE_KEY;
@@ -12190,6 +13183,7 @@ async function handleRequest(
         delete vars.ELIZA_API_TOKEN;
         delete vars.ELIZA_API_TOKEN;
         delete vars.ELIZA_WALLET_EXPORT_TOKEN;
+        delete vars.MILADY_WALLET_EXPORT_TOKEN;
         delete vars.ELIZA_TERMINAL_RUN_TOKEN;
         delete vars.HYPERSCAPE_AUTH_TOKEN;
         delete vars.EVM_PRIVATE_KEY;
@@ -12461,9 +13455,9 @@ async function handleRequest(
   // used by action handlers (can-i, etc.) to evaluate permissions.
   if (method === "GET" && pathname === "/api/agent/self-status") {
     const addrs = getWalletAddresses();
-    const evmAddress = addrs.evmAddress ?? null;
+    const capability = resolveWalletCapabilityStatus(state);
+    const evmAddress = capability.evmAddress;
     const tradePermissionMode = resolveTradePermissionMode(state.config);
-    const localSigner = Boolean(process.env.EVM_PRIVATE_KEY?.trim());
     const walletRpcReadiness = resolveWalletRpcReadiness(state.config);
     const bscRpcReady = walletRpcReadiness.managedBscRpcReady;
     const canLocalTrade = canUseLocalTradeExecution(tradePermissionMode, false);
@@ -12476,11 +13470,7 @@ async function handleRequest(
       },
     );
     const canTrade = Boolean(evmAddress) && bscRpcReady;
-    const automationMode: "connectors-only" | "full" =
-      (state.config.features as Record<string, unknown> | undefined)
-        ?.automationMode === "full"
-        ? "full"
-        : "connectors-only";
+    const automationMode = capability.automationMode;
 
     // Include registry snapshot summary if available
     let registrySummary: string | null = null;
@@ -12557,8 +13547,9 @@ async function handleRequest(
       tradePermissionMode,
       shellEnabled: state.shellEnabled !== false,
       wallet: {
-        hasWallet: Boolean(evmAddress || addrs.solanaAddress),
-        hasEvm: Boolean(evmAddress),
+        walletSource: capability.walletSource,
+        hasWallet: capability.hasWallet,
+        hasEvm: capability.hasEvm,
         hasSolana: Boolean(addrs.solanaAddress),
         evmAddress,
         evmAddressShort:
@@ -12570,8 +13561,13 @@ async function handleRequest(
           addrs.solanaAddress && addrs.solanaAddress.length >= 12
             ? `${addrs.solanaAddress.slice(0, 4)}...${addrs.solanaAddress.slice(-4)}`
             : (addrs.solanaAddress ?? null),
-        localSignerAvailable: localSigner,
+        localSignerAvailable: capability.localSignerAvailable,
         managedBscRpcReady: bscRpcReady,
+        rpcReady: capability.rpcReady,
+        pluginEvmLoaded: capability.pluginEvmLoaded,
+        pluginEvmRequired: capability.pluginEvmRequired,
+        executionReady: capability.executionReady,
+        executionBlockedReason: capability.executionBlockedReason,
       },
       plugins: {
         totalActive: pluginNames.length,
@@ -12581,8 +13577,10 @@ async function handleRequest(
       },
       capabilities: {
         canTrade,
-        canLocalTrade: canTrade && localSigner && canLocalTrade,
-        canAutoTrade: canTrade && localSigner && canAgentAutoTrade,
+        canLocalTrade:
+          canTrade && capability.localSignerAvailable && canLocalTrade,
+        canAutoTrade:
+          canTrade && capability.localSignerAvailable && canAgentAutoTrade,
         canUseBrowser: hasBrowserPlugin,
         canUseComputer: hasComputerPlugin,
         canRunTerminal: state.shellEnabled !== false,
@@ -12695,6 +13693,7 @@ async function handleRequest(
       tokenAddress?: string;
       amount?: string;
       slippageBps?: number;
+      routeProvider?: "auto" | "pancakeswap-v2" | "0x";
     }>(req, res);
     if (!body) return;
 
@@ -12715,6 +13714,7 @@ async function handleRequest(
           tokenAddress: body.tokenAddress,
           amount: body.amount,
           slippageBps: body.slippageBps,
+          routeProvider: body.routeProvider,
         },
       });
       json(res, result);
@@ -12732,249 +13732,37 @@ async function handleRequest(
   }
 
   // ── POST /api/wallet/trade/execute ─────────────────────────────────────
-  // Execute or prepare a BSC trade. In "user-sign-only" mode, returns an
-  // unsigned transaction for the user to sign. In local-key modes, executes
-  // using the server-side EVM private key.
-  if (method === "POST" && pathname === "/api/wallet/trade/execute") {
-    const body = await readJsonBody<{
-      side?: string;
-      tokenAddress?: string;
-      amount?: string;
-      slippageBps?: number;
-      deadlineSeconds?: number;
-      confirm?: boolean;
-      source?: "agent" | "manual";
-    }>(req, res);
-    if (!body) return;
-
-    if (!body.side || !body.tokenAddress || !body.amount) {
-      error(res, "side, tokenAddress, and amount are required", 400);
-      return;
-    }
-
-    const tradePermissionMode = resolveTradePermissionMode(state.config);
-    const isAgentRequest = isAgentAutomationRequest(req);
-    const hasLocalKey = Boolean(process.env.EVM_PRIVATE_KEY?.trim());
-    const canExecuteLocally = canUseLocalTradeExecution(
-      tradePermissionMode,
-      isAgentRequest,
-    );
-    const addrs = getWalletAddresses();
-    const walletRpcReadiness = resolveWalletRpcReadiness(state.config);
-
-    try {
-      const quote = await buildBscTradeQuote({
-        walletAddress: addrs.evmAddress ?? null,
-        rpcUrls: walletRpcReadiness.bscRpcUrls,
-        cloudManagedAccess: walletRpcReadiness.cloudManagedAccess,
-        request: {
-          side: body.side as "buy" | "sell",
-          tokenAddress: body.tokenAddress,
-          amount: body.amount,
-          slippageBps: body.slippageBps,
-        },
-      });
-
-      const walletAddress = addrs.evmAddress ?? null;
-
-      // Build the unsigned trade transaction
-      const unsignedTx =
-        quote.side === "buy"
-          ? buildBscBuyUnsignedTx(quote, walletAddress, body.deadlineSeconds)
-          : buildBscSellUnsignedTx(quote, walletAddress, body.deadlineSeconds);
-
-      // Build approval tx for sell (if needed)
-      let unsignedApprovalTx:
-        | import("../contracts/wallet.js").BscUnsignedApprovalTx
-        | undefined;
-      let requiresApproval = false;
-      if (quote.side === "sell" && walletAddress) {
-        unsignedApprovalTx = buildBscApproveUnsignedTx(
-          quote.tokenAddress,
-          walletAddress,
-          quote.routerAddress,
-          quote.quoteIn.amountWei,
-        );
-        requiresApproval = true;
-      }
-
-      // If local execution is not permitted or no private key, return unsigned tx
-      if (!hasLocalKey || !canExecuteLocally || body.confirm !== true) {
-        json(res, {
-          ok: true,
-          side: quote.side,
-          mode: hasLocalKey && canExecuteLocally ? "local-key" : "user-sign",
-          quote,
-          executed: false,
-          requiresUserSignature: true,
-          unsignedTx,
-          unsignedApprovalTx,
-          requiresApproval,
-        });
-        return;
-      }
-
-      // Execute locally with EVM private key
-      const rpcUrl = resolvePrimaryBscRpcUrl({
-        rpcUrls: walletRpcReadiness.bscRpcUrls,
-        cloudManagedAccess: walletRpcReadiness.cloudManagedAccess,
-      });
-
-      if (!rpcUrl) {
-        error(res, "BSC RPC not configured for local execution.", 503);
-        return;
-      }
-
-      const evmKey = process.env.EVM_PRIVATE_KEY ?? "";
-      const provider = new ethers.JsonRpcProvider(rpcUrl);
-      const wallet = new ethers.Wallet(
-        evmKey.startsWith("0x") ? evmKey : `0x${evmKey}`,
-        provider,
-      );
-
-      // Check quote freshness before executing
-      assertQuoteFresh(quote.quotedAt);
-
-      const nonce = await provider.getTransactionCount(
-        wallet.address,
-        "pending",
-      );
-
-      // Execute approval first if needed
-      let approvalHash: string | undefined;
-      if (requiresApproval && unsignedApprovalTx) {
-        const approvalTxReq: ethers.TransactionRequest = {
-          to: unsignedApprovalTx.to,
-          data: unsignedApprovalTx.data,
-          value: BigInt(unsignedApprovalTx.valueWei),
-          chainId: unsignedApprovalTx.chainId,
-          nonce,
-        };
-        const approvalResponse = await wallet.sendTransaction(approvalTxReq);
-        approvalHash = approvalResponse.hash;
-        // Wait for approval to be mined before submitting trade
-        const approvalReceipt = await approvalResponse.wait(1);
-        if (!approvalReceipt || approvalReceipt.status === 0) {
-          throw new Error("Token approval transaction reverted on-chain");
-        }
-      }
-
-      // Fetch fresh nonce for the trade tx (avoids stale nonce after approval)
-      const tradeNonce = requiresApproval
-        ? await provider.getTransactionCount(wallet.address, "pending")
-        : nonce;
-
-      const tradeTxReq: ethers.TransactionRequest = {
-        to: unsignedTx.to,
-        data: unsignedTx.data,
-        value: BigInt(unsignedTx.valueWei),
-        chainId: unsignedTx.chainId,
-        nonce: tradeNonce,
-      };
-
-      const tradeTxResponse = await wallet.sendTransaction(tradeTxReq);
-
-      const executionResult = {
-        hash: tradeTxResponse.hash,
-        nonce: tradeNonce,
-        gasLimit: tradeTxResponse.gasLimit?.toString() ?? "0",
-        valueWei: unsignedTx.valueWei,
-        explorerUrl: `https://bscscan.com/tx/${tradeTxResponse.hash}`,
-        blockNumber: null as number | null,
-        status: "submitted" as "submitted" | "success",
-        approvalHash,
-      };
-
-      // Record in ledger
-      const source = body.source ?? "manual";
-      try {
-        recordWalletTradeLedgerEntry({
-          hash: tradeTxResponse.hash,
-          source,
-          side: quote.side,
-          tokenAddress: quote.tokenAddress,
-          slippageBps: quote.slippageBps,
-          route: quote.route,
-          quoteIn: {
-            symbol: quote.quoteIn.symbol,
-            amount: quote.quoteIn.amount,
-            amountWei: quote.quoteIn.amountWei,
-          },
-          quoteOut: {
-            symbol: quote.quoteOut.symbol,
-            amount: quote.quoteOut.amount,
-            amountWei: quote.quoteOut.amountWei,
-          },
-          status: "pending",
-          confirmations: 0,
-          nonce: tradeNonce,
-          blockNumber: null,
-          gasUsed: null,
-          effectiveGasPriceWei: null,
-          explorerUrl: executionResult.explorerUrl,
-        });
-      } catch (ledgerErr) {
-        logger.warn(
-          `[api] Failed to record trade ledger entry (attempt 1): ${ledgerErr instanceof Error ? ledgerErr.message : ledgerErr}`,
-        );
-        // Retry once — ledger writes are important for audit trail.
-        try {
-          recordWalletTradeLedgerEntry({
-            hash: tradeTxResponse.hash,
-            source,
-            side: quote.side,
-            tokenAddress: quote.tokenAddress,
-            slippageBps: quote.slippageBps,
-            route: quote.route,
-            quoteIn: {
-              symbol: quote.quoteIn.symbol,
-              amount: quote.quoteIn.amount,
-              amountWei: quote.quoteIn.amountWei,
-            },
-            quoteOut: {
-              symbol: quote.quoteOut.symbol,
-              amount: quote.quoteOut.amount,
-              amountWei: quote.quoteOut.amountWei,
-            },
-            status: "pending",
-            confirmations: 0,
-            nonce: tradeNonce,
-            blockNumber: null,
-            gasUsed: null,
-            effectiveGasPriceWei: null,
-            explorerUrl: executionResult.explorerUrl,
-          });
-        } catch (retryErr) {
-          logger.error(
-            `[api] Ledger entry retry also failed: ${retryErr instanceof Error ? retryErr.message : retryErr}`,
-          );
-        }
-      }
-
-      provider.destroy();
-
-      json(res, {
-        ok: true,
-        side: quote.side,
-        mode: "local-key",
-        quote,
-        executed: true,
-        requiresUserSignature: false,
-        unsignedTx,
-        unsignedApprovalTx,
-        requiresApproval,
-        execution: executionResult,
-      });
-    } catch (err) {
-      logger.error(
-        `[api] BSC trade execute failed: ${err instanceof Error ? err.message : err}`,
-      );
-      error(
-        res,
-        `Trade execution failed: ${err instanceof Error ? err.message : "unknown error"}`,
-        500,
-      );
-    }
+  if (
+    await handleWalletTradeExecuteRoute({
+      req,
+      res,
+      method,
+      pathname,
+      readJsonBody,
+      json,
+      error,
+      state: { config: state.config },
+      deps: {
+        getWalletAddresses,
+        resolveWalletRpcReadiness,
+        resolveTradePermissionMode,
+        isAgentAutomationRequest,
+        canUseLocalTradeExecution,
+        buildBscTradeQuote,
+        buildBscBuyUnsignedTx,
+        buildBscSellUnsignedTx,
+        buildBscApproveUnsignedTx,
+        resolveBscApprovalSpender,
+        resolvePrimaryBscRpcUrl,
+        assertQuoteFresh,
+        recordWalletTradeLedgerEntry,
+        createProvider: (rpcUrl) => new ethers.JsonRpcProvider(rpcUrl),
+        createWallet: (privateKey, provider) =>
+          new ethers.Wallet(privateKey, provider as ethers.Provider),
+        logger,
+      },
+    })
+  ) {
     return;
   }
 
@@ -14628,6 +15416,42 @@ async function handleRequest(
       return;
     }
 
+    const walletModeGuidance = resolveWalletModeGuidanceReply(state, prompt);
+    if (walletModeGuidance) {
+      initSse(res);
+      let aborted = false;
+      req.on("close", () => {
+        aborted = true;
+      });
+      if (!aborted) {
+        writeChatTokenSse(res, walletModeGuidance, walletModeGuidance);
+        try {
+          await persistAssistantConversationMemory(
+            runtime,
+            conv.roomId,
+            walletModeGuidance,
+            channelType,
+            turnStartedAt,
+          );
+          conv.updatedAt = new Date().toISOString();
+        } catch (persistErr) {
+          writeSse(res, {
+            type: "error",
+            message: getErrorMessage(persistErr),
+          });
+          res.end();
+          return;
+        }
+        writeSseJson(res, {
+          type: "done",
+          fullText: walletModeGuidance,
+          agentName: state.agentName,
+        });
+      }
+      res.end();
+      return;
+    }
+
     // ── Local runtime path (existing code below) ───────────────────────
 
     initSse(res);
@@ -14769,6 +15593,27 @@ async function handleRequest(
       await persistConversationMemory(runtime, messageToStore);
     } catch (err) {
       error(res, `Failed to store user message: ${getErrorMessage(err)}`, 500);
+      return;
+    }
+
+    const walletModeGuidance = resolveWalletModeGuidanceReply(state, prompt);
+    if (walletModeGuidance) {
+      try {
+        await persistAssistantConversationMemory(
+          runtime,
+          conv.roomId,
+          walletModeGuidance,
+          channelType,
+          turnStartedAt,
+        );
+        conv.updatedAt = new Date().toISOString();
+        json(res, {
+          text: walletModeGuidance,
+          agentName: state.agentName,
+        });
+      } catch (persistErr) {
+        error(res, getErrorMessage(persistErr), 500);
+      }
       return;
     }
 
@@ -15011,6 +15856,19 @@ async function handleRequest(
     let streamedText = "";
 
     try {
+      const walletModeGuidance = resolveWalletModeGuidanceReply(state, prompt);
+      if (walletModeGuidance) {
+        if (!aborted) {
+          writeChatTokenSse(res, walletModeGuidance, walletModeGuidance);
+          writeSseJson(res, {
+            type: "done",
+            fullText: walletModeGuidance,
+            agentName: state.agentName,
+          });
+        }
+        return;
+      }
+
       const runtime = state.runtime;
       const agentName = runtime.character.name ?? "Eliza";
       await ensureLegacyChatConnection(runtime, agentName);
@@ -15115,6 +15973,15 @@ async function handleRequest(
     }
 
     try {
+      const walletModeGuidance = resolveWalletModeGuidanceReply(state, prompt);
+      if (walletModeGuidance) {
+        json(res, {
+          text: walletModeGuidance,
+          agentName: state.agentName,
+        });
+        return;
+      }
+
       const runtime = state.runtime;
       const agentName = runtime.character.name ?? "Eliza";
       await ensureLegacyChatConnection(runtime, agentName);
@@ -16991,7 +17858,7 @@ export async function startApiServer(opts?: {
   const host =
     (
       process.env.ELIZA_API_BIND ??
-      process.env.ELIZA_API_BIND ??
+      process.env.MILADY_API_BIND ??
       "127.0.0.1"
     ).trim() || "127.0.0.1";
   ensureApiTokenForBindHost(host);
@@ -17028,9 +17895,17 @@ export async function startApiServer(opts?: {
     }
   }
 
-  // Self-heal older configs where wallet keys were never provisioned
-  // (e.g. RPC/cloud configured outside onboarding).
-  if (ensureWalletKeysInEnvAndConfig(config)) {
+  // Optional auto-provision mode for legacy environments. Disabled by default
+  // so startup does not silently create new wallets when keys are missing.
+  const walletAutoProvisionRaw = process.env.MILADY_WALLET_AUTO_PROVISION
+    ?.trim()
+    .toLowerCase();
+  const walletAutoProvisionEnabled =
+    walletAutoProvisionRaw === "1" ||
+    walletAutoProvisionRaw === "true" ||
+    walletAutoProvisionRaw === "on" ||
+    walletAutoProvisionRaw === "yes";
+  if (walletAutoProvisionEnabled && ensureWalletKeysInEnvAndConfig(config)) {
     try {
       saveElizaConfig(config);
     } catch (err) {
@@ -17825,8 +18700,9 @@ export async function startApiServer(opts?: {
 
   // Handle WebSocket connections
   wss.on("connection", (ws: WebSocket, request: http.IncomingMessage) => {
+    let wsUrl: URL;
     try {
-      const wsUrl = new URL(
+      wsUrl = new URL(
         request.url ?? "/",
         `http://${request.headers.host ?? "localhost"}`,
       );
@@ -17834,41 +18710,66 @@ export async function startApiServer(opts?: {
       if (clientId) wsClientIds.set(ws, clientId);
     } catch {
       // Ignore malformed WS URL metadata; auth/path were already validated.
+      wsUrl = new URL("ws://localhost/ws");
     }
 
-    wsClients.add(ws);
-    addLog("info", "WebSocket client connected", "websocket", [
-      "server",
-      "websocket",
-    ]);
+    let isAuthenticated = isWebSocketAuthorized(request, wsUrl);
 
-    // Send initial status and latest stream events.
-    try {
-      ws.send(
-        JSON.stringify({
-          type: "status",
-          state: state.agentState,
-          agentName: state.agentName,
-          model: state.model,
-          startedAt: state.startedAt,
-          startup: state.startup,
-          pendingRestart: state.pendingRestartReasons.length > 0,
-          pendingRestartReasons: state.pendingRestartReasons,
-        }),
-      );
-      const replay = state.eventBuffer.slice(-120);
-      for (const event of replay) {
-        ws.send(JSON.stringify(event));
+    const activateAuthenticatedConnection = () => {
+      wsClients.add(ws);
+      addLog("info", "WebSocket client connected", "websocket", [
+        "server",
+        "websocket",
+      ]);
+
+      try {
+        ws.send(
+          JSON.stringify({
+            type: "status",
+            state: state.agentState,
+            agentName: state.agentName,
+            model: state.model,
+            startedAt: state.startedAt,
+            startup: state.startup,
+            pendingRestart: state.pendingRestartReasons.length > 0,
+            pendingRestartReasons: state.pendingRestartReasons,
+          }),
+        );
+        const replay = state.eventBuffer.slice(-120);
+        for (const event of replay) {
+          ws.send(JSON.stringify(event));
+        }
+      } catch (err) {
+        logger.error(
+          `[eliza-api] WebSocket send error: ${err instanceof Error ? err.message : err}`,
+        );
       }
-    } catch (err) {
-      logger.error(
-        `[eliza-api] WebSocket send error: ${err instanceof Error ? err.message : err}`,
-      );
+    };
+
+    if (isAuthenticated) {
+      activateAuthenticatedConnection();
     }
 
     ws.on("message", (data) => {
       try {
         const msg = JSON.parse(data.toString());
+        if (!isAuthenticated) {
+          const expected = getConfiguredApiToken();
+          if (
+            expected &&
+            msg.type === "auth" &&
+            typeof msg.token === "string" &&
+            tokenMatches(expected, msg.token.trim())
+          ) {
+            isAuthenticated = true;
+            ws.send(JSON.stringify({ type: "auth-ok" }));
+            activateAuthenticatedConnection();
+          } else {
+            logger.warn("[eliza-api] WebSocket message rejected before auth");
+            ws.close(1008, "Unauthorized");
+          }
+          return;
+        }
         if (msg.type === "ping") {
           ws.send(JSON.stringify({ type: "pong" }));
         } else if (msg.type === "active-conversation") {

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -3612,7 +3612,11 @@ async function generateChatResponse(
     if (directWalletExecutionFallback?.errorText) {
       forcedWalletExecutionText = true;
       responseText = directWalletExecutionFallback.errorText;
-      result = { responseContent: { text: directWalletExecutionFallback.errorText } };
+      result = {
+        responseContent: { text: directWalletExecutionFallback.errorText },
+        didRespond: true,
+        responseMessages: [],
+      };
     } else if (directWalletExecutionFallback?.action) {
       runtime.logger?.info(
         {
@@ -3639,7 +3643,11 @@ async function generateChatResponse(
           );
         },
       );
-      result = { responseContent: { text: responseText } };
+      result = {
+        responseContent: { text: responseText },
+        didRespond: true,
+        responseMessages: [],
+      };
     } else {
       const walletAugmentedMessage =
         maybeAugmentChatMessageWithWalletContext(runtime, message);
@@ -7079,6 +7087,9 @@ export function resolveWebSocketUpgradeRejection(
   }
 
   const handshakeToken = extractWebSocketHandshakeToken(req, wsUrl);
+  if (!handshakeToken) {
+    return { status: 401, reason: "Unauthorized" };
+  }
   if (handshakeToken && !tokenMatches(expected, handshakeToken)) {
     return { status: 401, reason: "Unauthorized" };
   }

--- a/packages/agent/src/api/stream-routes-mjpeg.test.ts
+++ b/packages/agent/src/api/stream-routes-mjpeg.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { fileURLToPath } from "node:url";
 
 /**
  * Validates that MJPEG subscriber cleanup doesn't modify the Set
@@ -8,7 +9,7 @@ describe("MJPEG subscriber cleanup pattern", () => {
   it("collects failed subscribers before deleting from Set", async () => {
     const fs = await import("node:fs");
     const path = await import("node:path");
-    const testDir = path.dirname(new URL(import.meta.url).pathname);
+    const testDir = path.dirname(fileURLToPath(import.meta.url));
     const source = fs.readFileSync(
       path.resolve(testDir, "stream-routes.ts"),
       "utf-8",

--- a/packages/agent/src/api/wallet-routes.ts
+++ b/packages/agent/src/api/wallet-routes.ts
@@ -133,6 +133,24 @@ function resolveWalletConfigUpdateRequest(
   };
 }
 
+function resolveWalletAutomationMode(
+  config: ElizaConfig,
+): "full" | "connectors-only" {
+  const features =
+    config.features && typeof config.features === "object"
+      ? (config.features as Record<string, unknown>)
+      : null;
+  const agentAutomation =
+    features?.agentAutomation &&
+    typeof features.agentAutomation === "object" &&
+    !Array.isArray(features.agentAutomation)
+      ? (features.agentAutomation as Record<string, unknown>)
+      : null;
+  return agentAutomation?.mode === "connectors-only"
+    ? "connectors-only"
+    : "full";
+}
+
 export interface WalletRouteDependencies {
   getWalletAddresses: typeof getWalletAddresses;
   fetchEvmBalances: typeof fetchEvmBalances;
@@ -371,6 +389,27 @@ export async function handleWalletRoutes(
   if (method === "GET" && pathname === "/api/wallet/config") {
     const addresses = deps.getWalletAddresses();
     const rpcReadiness = resolveWalletRpcReadiness(config);
+    const automationMode = resolveWalletAutomationMode(config);
+    const localSignerAvailable = Boolean(process.env.EVM_PRIVATE_KEY?.trim());
+    const pluginEvmLoaded = localSignerAvailable || Boolean(addresses.evmAddress);
+    const pluginEvmRequired = localSignerAvailable || Boolean(addresses.evmAddress);
+    const walletSource = localSignerAvailable
+      ? "local"
+      : addresses.evmAddress || addresses.solanaAddress
+        ? "managed"
+        : "none";
+    let executionBlockedReason: string | null = null;
+    if (!addresses.evmAddress) {
+      executionBlockedReason = "No EVM wallet is active yet.";
+    } else if (!rpcReadiness.managedBscRpcReady) {
+      executionBlockedReason = "BSC RPC is not configured.";
+    } else if (!pluginEvmLoaded) {
+      executionBlockedReason =
+        "plugin-evm is not loaded, so EVM wallet execution is unavailable.";
+    } else if (automationMode !== "full") {
+      executionBlockedReason =
+        "Agent automation is in connectors-only mode, so wallet execution is blocked in chat.";
+    }
     const alchemyKeySet = Boolean(process.env.ALCHEMY_API_KEY?.trim());
     const ankrKeySet = Boolean(process.env.ANKR_API_KEY?.trim());
     const nodeRealSet = Boolean(process.env.NODEREAL_BSC_RPC_URL?.trim());
@@ -406,6 +445,17 @@ export async function handleWalletRoutes(
       ],
       evmAddress: addresses.evmAddress,
       solanaAddress: addresses.solanaAddress,
+      walletSource,
+      walletNetwork: rpcReadiness.walletNetwork,
+      automationMode,
+      pluginEvmLoaded,
+      pluginEvmRequired,
+      executionReady:
+        Boolean(addresses.evmAddress) &&
+        rpcReadiness.managedBscRpcReady &&
+        pluginEvmLoaded &&
+        automationMode === "full",
+      executionBlockedReason,
     };
     json(res, configStatus);
     return true;

--- a/packages/agent/src/api/wallet-routes.ts
+++ b/packages/agent/src/api/wallet-routes.ts
@@ -159,6 +159,8 @@ export interface WalletRouteDependencies {
   validatePrivateKey: typeof validatePrivateKey;
   importWallet: typeof importWallet;
   generateWalletForChain: typeof generateWalletForChain;
+  getAutomationMode?: (config: ElizaConfig) => "full" | "connectors-only";
+  getPluginEvmLoaded?: () => boolean;
 }
 
 export const DEFAULT_WALLET_ROUTE_DEPENDENCIES: WalletRouteDependencies = {

--- a/packages/agent/src/api/wallet-rpc.ts
+++ b/packages/agent/src/api/wallet-rpc.ts
@@ -55,6 +55,7 @@ export interface WalletRpcReadiness {
   managedBscRpcReady: boolean;
   evmBalanceReady: boolean;
   solanaBalanceReady: boolean;
+  walletNetwork: "mainnet" | "testnet";
   selectedRpcProviders: WalletRpcSelections;
   legacyCustomChains: WalletRpcChain[];
   bscRpcUrls: string[];
@@ -112,6 +113,13 @@ const WALLET_RPC_CONFIG_KEYS = [
   "BSC_RPC_URL",
   "SOLANA_RPC_URL",
 ] as const satisfies readonly WalletRpcCredentialKey[];
+
+function resolveWalletNetwork(): "mainnet" | "testnet" {
+  const explicit = process.env.MILADY_WALLET_NETWORK?.trim().toLowerCase();
+  if (explicit === "testnet") return "testnet";
+  if (explicit === "mainnet") return "mainnet";
+  return process.env.BSC_TESTNET_RPC_URL?.trim() ? "testnet" : "mainnet";
+}
 
 function normalizeSecret(value: string | null | undefined): string | null {
   if (typeof value !== "string") return null;
@@ -379,10 +387,12 @@ export function getInventoryProviderOptions(): InventoryProviderOption[] {
 export function resolveBscRpcUrls(
   options: WalletRpcResolutionOptions = {},
 ): string[] {
+  const walletNetwork = resolveWalletNetwork();
   return uniqueRpcUrls(
     [
       process.env.NODEREAL_BSC_RPC_URL,
       process.env.QUICKNODE_BSC_RPC_URL,
+      walletNetwork === "testnet" ? process.env.BSC_TESTNET_RPC_URL : null,
       process.env.BSC_RPC_URL,
       buildCloudEvmRpcUrl("bsc", options),
     ],
@@ -479,6 +489,7 @@ export function applyWalletRpcConfigUpdate(
 export function resolveWalletRpcReadiness(
   config?: WalletCapableConfig | null,
 ): WalletRpcReadiness {
+  const walletNetwork = resolveWalletNetwork();
   const cloudApiKey = resolveCloudApiKey(config);
   const cloudBaseUrl = resolveCloudApiBaseUrl(config?.cloud?.baseUrl);
   const cloudManagedAccess = Boolean(cloudApiKey);
@@ -512,6 +523,7 @@ export function resolveWalletRpcReadiness(
     solanaBalanceReady: Boolean(
       process.env.HELIUS_API_KEY?.trim() || solanaRpcUrls.length > 0,
     ),
+    walletNetwork,
     selectedRpcProviders,
     legacyCustomChains,
     bscRpcUrls,

--- a/packages/agent/src/api/wallet-trade-routes.ts
+++ b/packages/agent/src/api/wallet-trade-routes.ts
@@ -1,0 +1,343 @@
+﻿import { ethers } from "ethers";
+import type { ElizaConfig } from "../config/config";
+import type {
+  BscTradeQuoteResponse,
+  BscUnsignedApprovalTx,
+  BscUnsignedTradeTx,
+} from "../contracts/wallet";
+import type { WalletTradeLedgerRecordInput } from "./wallet-trading-profile";
+import type { RouteRequestContext } from "./route-helpers";
+import type { TradePermissionMode } from "./trade-safety";
+
+type WalletAddresses = {
+  evmAddress: string | null;
+  solanaAddress: string | null;
+};
+
+type WalletRpcReadiness = {
+  bscRpcUrls: string[];
+  cloudManagedAccess: boolean;
+};
+
+type WalletForExecution = {
+  address: string;
+  sendTransaction: (
+    tx: ethers.TransactionRequest,
+  ) => Promise<{
+    hash: string;
+    gasLimit?: bigint;
+    wait: (
+      confirmations?: number,
+    ) => Promise<{ status?: number | null } | null>;
+  }>;
+};
+
+type ProviderForExecution = {
+  getTransactionCount: (
+    address: string,
+    blockTag?: "pending" | "latest",
+  ) => Promise<number>;
+  destroy: () => void;
+};
+
+export interface WalletTradeExecuteDeps {
+  getWalletAddresses: () => WalletAddresses;
+  resolveWalletRpcReadiness: (config: ElizaConfig) => WalletRpcReadiness;
+  resolveTradePermissionMode: (config: ElizaConfig) => TradePermissionMode;
+  isAgentAutomationRequest: (
+    req: RouteRequestContext["req"],
+  ) => boolean;
+  canUseLocalTradeExecution: (
+    mode: TradePermissionMode,
+    isAgentRequest: boolean,
+  ) => boolean;
+  buildBscTradeQuote: (args: {
+    walletAddress: string | null;
+    rpcUrls: string[];
+    cloudManagedAccess: boolean;
+    request: {
+      side: "buy" | "sell";
+      tokenAddress: string;
+      amount: string;
+      slippageBps?: number;
+      routeProvider?: "auto" | "pancakeswap-v2" | "0x";
+    };
+  }) => Promise<BscTradeQuoteResponse>;
+  buildBscBuyUnsignedTx: (
+    quote: BscTradeQuoteResponse,
+    walletAddress: string | null,
+    deadlineSeconds?: number,
+  ) => BscUnsignedTradeTx;
+  buildBscSellUnsignedTx: (
+    quote: BscTradeQuoteResponse,
+    walletAddress: string | null,
+    deadlineSeconds?: number,
+  ) => BscUnsignedTradeTx;
+  buildBscApproveUnsignedTx: (
+    tokenAddress: string,
+    walletAddress: string | null,
+    spender: string,
+    amountWei: string,
+  ) => BscUnsignedApprovalTx;
+  resolveBscApprovalSpender: (quote: BscTradeQuoteResponse) => string;
+  resolvePrimaryBscRpcUrl: (args: {
+    rpcUrls: string[];
+    cloudManagedAccess: boolean;
+  }) => string | null;
+  assertQuoteFresh: (quotedAt?: number) => void;
+  recordWalletTradeLedgerEntry: (input: WalletTradeLedgerRecordInput) => void;
+  createProvider: (rpcUrl: string) => ProviderForExecution;
+  createWallet: (privateKey: string, provider: ProviderForExecution) => WalletForExecution;
+  logger: {
+    warn: (message: string) => void;
+    error: (message: string) => void;
+  };
+}
+
+export interface WalletTradeExecuteRouteContext extends RouteRequestContext {
+  state: {
+    config: ElizaConfig;
+  };
+  deps: WalletTradeExecuteDeps;
+}
+
+export async function handleWalletTradeExecuteRoute(
+  ctx: WalletTradeExecuteRouteContext,
+): Promise<boolean> {
+  const { req, res, method, pathname, readJsonBody, json, error, state, deps } =
+    ctx;
+
+  if (!(method === "POST" && pathname === "/api/wallet/trade/execute")) {
+    return false;
+  }
+
+  const body = await readJsonBody<{
+    side?: string;
+    tokenAddress?: string;
+    amount?: string;
+    slippageBps?: number;
+    routeProvider?: "auto" | "pancakeswap-v2" | "0x";
+    deadlineSeconds?: number;
+    confirm?: boolean;
+    source?: "agent" | "manual";
+  }>(req, res);
+  if (!body) return true;
+
+  if (!body.side || !body.tokenAddress || !body.amount) {
+    error(res, "side, tokenAddress, and amount are required", 400);
+    return true;
+  }
+
+  const tradePermissionMode = deps.resolveTradePermissionMode(state.config);
+  const isAgentRequest = deps.isAgentAutomationRequest(req);
+  const hasLocalKey = Boolean(process.env.EVM_PRIVATE_KEY?.trim());
+  const canExecuteLocally = deps.canUseLocalTradeExecution(
+    tradePermissionMode,
+    isAgentRequest,
+  );
+  const addrs = deps.getWalletAddresses();
+  const walletRpcReadiness = deps.resolveWalletRpcReadiness(state.config);
+
+  try {
+    const quote = await deps.buildBscTradeQuote({
+      walletAddress: addrs.evmAddress ?? null,
+      rpcUrls: walletRpcReadiness.bscRpcUrls,
+      cloudManagedAccess: walletRpcReadiness.cloudManagedAccess,
+      request: {
+        side: body.side as "buy" | "sell",
+        tokenAddress: body.tokenAddress,
+        amount: body.amount,
+        slippageBps: body.slippageBps,
+        routeProvider: body.routeProvider,
+      },
+    });
+
+    const walletAddress = addrs.evmAddress ?? null;
+    const unsignedTx =
+      quote.side === "buy"
+        ? deps.buildBscBuyUnsignedTx(quote, walletAddress, body.deadlineSeconds)
+        : deps.buildBscSellUnsignedTx(quote, walletAddress, body.deadlineSeconds);
+
+    let unsignedApprovalTx: BscUnsignedApprovalTx | undefined;
+    let requiresApproval = false;
+    if (quote.side === "sell" && walletAddress) {
+      unsignedApprovalTx = deps.buildBscApproveUnsignedTx(
+        quote.tokenAddress,
+        walletAddress,
+        deps.resolveBscApprovalSpender(quote),
+        quote.quoteIn.amountWei,
+      );
+      requiresApproval = true;
+    }
+
+    if (!hasLocalKey || !canExecuteLocally || body.confirm !== true) {
+      json(res, {
+        ok: true,
+        side: quote.side,
+        mode: hasLocalKey && canExecuteLocally ? "local-key" : "user-sign",
+        quote,
+        executed: false,
+        requiresUserSignature: true,
+        unsignedTx,
+        unsignedApprovalTx,
+        requiresApproval,
+      });
+      return true;
+    }
+
+    const rpcUrl = deps.resolvePrimaryBscRpcUrl({
+      rpcUrls: walletRpcReadiness.bscRpcUrls,
+      cloudManagedAccess: walletRpcReadiness.cloudManagedAccess,
+    });
+    if (!rpcUrl) {
+      error(res, "BSC RPC not configured for local execution.", 503);
+      return true;
+    }
+
+    const evmKey = process.env.EVM_PRIVATE_KEY ?? "";
+    const provider = deps.createProvider(rpcUrl);
+    const wallet = deps.createWallet(
+      evmKey.startsWith("0x") ? evmKey : `0x${evmKey}`,
+      provider,
+    );
+
+    deps.assertQuoteFresh(quote.quotedAt);
+
+    const nonce = await provider.getTransactionCount(wallet.address, "pending");
+    let approvalHash: string | undefined;
+
+    if (requiresApproval && unsignedApprovalTx) {
+      const approvalTxReq: ethers.TransactionRequest = {
+        to: unsignedApprovalTx.to,
+        data: unsignedApprovalTx.data,
+        value: BigInt(unsignedApprovalTx.valueWei),
+        chainId: unsignedApprovalTx.chainId,
+        nonce,
+      };
+      const approvalResponse = await wallet.sendTransaction(approvalTxReq);
+      approvalHash = approvalResponse.hash;
+      const approvalReceipt = await approvalResponse.wait(1);
+      if (!approvalReceipt || approvalReceipt.status === 0) {
+        throw new Error("Token approval transaction reverted on-chain");
+      }
+    }
+
+    const tradeNonce = requiresApproval
+      ? await provider.getTransactionCount(wallet.address, "pending")
+      : nonce;
+
+    const tradeTxReq: ethers.TransactionRequest = {
+      to: unsignedTx.to,
+      data: unsignedTx.data,
+      value: BigInt(unsignedTx.valueWei),
+      chainId: unsignedTx.chainId,
+      nonce: tradeNonce,
+    };
+    const tradeTxResponse = await wallet.sendTransaction(tradeTxReq);
+
+    const executionResult = {
+      hash: tradeTxResponse.hash,
+      nonce: tradeNonce,
+      gasLimit: tradeTxResponse.gasLimit?.toString() ?? "0",
+      valueWei: unsignedTx.valueWei,
+      explorerUrl: `https://bscscan.com/tx/${tradeTxResponse.hash}`,
+      blockNumber: null as number | null,
+      status: "submitted" as "submitted" | "success",
+      approvalHash,
+    };
+
+    const source = body.source ?? "manual";
+    try {
+      deps.recordWalletTradeLedgerEntry({
+        hash: tradeTxResponse.hash,
+        source,
+        side: quote.side,
+        tokenAddress: quote.tokenAddress,
+        slippageBps: quote.slippageBps,
+        route: quote.route,
+        quoteIn: {
+          symbol: quote.quoteIn.symbol,
+          amount: quote.quoteIn.amount,
+          amountWei: quote.quoteIn.amountWei,
+        },
+        quoteOut: {
+          symbol: quote.quoteOut.symbol,
+          amount: quote.quoteOut.amount,
+          amountWei: quote.quoteOut.amountWei,
+        },
+        status: "pending",
+        confirmations: 0,
+        nonce: tradeNonce,
+        blockNumber: null,
+        gasUsed: null,
+        effectiveGasPriceWei: null,
+        explorerUrl: executionResult.explorerUrl,
+      });
+    } catch (ledgerErr) {
+      deps.logger.warn(
+        `[api] Failed to record trade ledger entry (attempt 1): ${
+          ledgerErr instanceof Error ? ledgerErr.message : ledgerErr
+        }`,
+      );
+      try {
+        deps.recordWalletTradeLedgerEntry({
+          hash: tradeTxResponse.hash,
+          source,
+          side: quote.side,
+          tokenAddress: quote.tokenAddress,
+          slippageBps: quote.slippageBps,
+          route: quote.route,
+          quoteIn: {
+            symbol: quote.quoteIn.symbol,
+            amount: quote.quoteIn.amount,
+            amountWei: quote.quoteIn.amountWei,
+          },
+          quoteOut: {
+            symbol: quote.quoteOut.symbol,
+            amount: quote.quoteOut.amount,
+            amountWei: quote.quoteOut.amountWei,
+          },
+          status: "pending",
+          confirmations: 0,
+          nonce: tradeNonce,
+          blockNumber: null,
+          gasUsed: null,
+          effectiveGasPriceWei: null,
+          explorerUrl: executionResult.explorerUrl,
+        });
+      } catch (retryErr) {
+        deps.logger.error(
+          `[api] Ledger entry retry also failed: ${
+            retryErr instanceof Error ? retryErr.message : retryErr
+          }`,
+        );
+      }
+    }
+
+    provider.destroy();
+
+    json(res, {
+      ok: true,
+      side: quote.side,
+      mode: "local-key",
+      quote,
+      executed: true,
+      requiresUserSignature: false,
+      unsignedTx,
+      unsignedApprovalTx,
+      requiresApproval,
+      execution: executionResult,
+    });
+  } catch (err) {
+    deps.logger.error(
+      `[api] BSC trade execute failed: ${err instanceof Error ? err.message : err}`,
+    );
+    error(
+      res,
+      `Trade execution failed: ${err instanceof Error ? err.message : "unknown error"}`,
+      500,
+    );
+  }
+
+  return true;
+}

--- a/packages/agent/src/services/stream-manager-restart.test.ts
+++ b/packages/agent/src/services/stream-manager-restart.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { fileURLToPath } from "node:url";
 
 /**
  * Validates that FFmpeg auto-restart properly resets _running state
@@ -9,14 +10,17 @@ describe("stream-manager autoRestart error recovery", () => {
   it("resets _running in the catch block of autoRestart", async () => {
     const fs = await import("node:fs");
     const path = await import("node:path");
-    const testDir = path.dirname(new URL(import.meta.url).pathname);
+    const testDir = path.dirname(fileURLToPath(import.meta.url));
     const source = fs.readFileSync(
       path.resolve(testDir, "stream-manager.ts"),
       "utf-8",
     );
 
     // Find the autoRestart catch block
-    const catchIdx = source.indexOf("} catch (err) {", source.indexOf("autoRestart"));
+    const catchIdx = source.indexOf(
+      "} catch (err) {",
+      source.indexOf("autoRestart"),
+    );
     expect(catchIdx).toBeGreaterThan(-1);
 
     // Verify _running = false appears within 100 chars after the catch

--- a/packages/agent/test/api-server.e2e.test.ts
+++ b/packages/agent/test/api-server.e2e.test.ts
@@ -23,6 +23,7 @@ import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import type { AgentRuntime, Content, Task, UUID } from "@elizaos/core";
+import { Wallet } from "ethers";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { WebSocket } from "ws";
 import { startApiServer } from "../src/api/server";
@@ -2885,6 +2886,568 @@ describe("API Server E2E (no runtime)", () => {
 
   });
 
+  describe("wallet mode guidance fallback", () => {
+    it("GET /api/wallet/config exposes wallet capability readiness fields", async () => {
+      const prevKey = process.env.EVM_PRIVATE_KEY;
+      process.env.EVM_PRIVATE_KEY =
+        "0x59c6995e998f97a5a0044976f4b8c0fcbf2d34f95f0f70f7f6f6e3d54d3f5f31";
+      const runtime = createRuntimeForChatSseTests();
+      const server = await startApiServer({ port: 0, runtime });
+      try {
+        const { status, data } = await req(server.port, "GET", "/api/wallet/config");
+        expect(status).toBe(200);
+        expect(data.walletSource).toBe("local");
+        expect(data.automationMode).toBe("full");
+        expect(typeof data.pluginEvmLoaded).toBe("boolean");
+        expect(typeof data.executionReady).toBe("boolean");
+        expect(data.executionBlockedReason === null || typeof data.executionBlockedReason === "string").toBe(true);
+      } finally {
+        await server.close();
+        if (prevKey === undefined) delete process.env.EVM_PRIVATE_KEY;
+        else process.env.EVM_PRIVATE_KEY = prevKey;
+      }
+    });
+
+    it("POST /api/chat includes the active EVM address when wallet key is configured", async () => {
+      const prevKey = process.env.EVM_PRIVATE_KEY;
+      const testKey =
+        "0x59c6995e998f97a5a0044976f4b8c0fcbf2d34f95f0f70f7f6f6e3d54d3f5f31";
+      process.env.EVM_PRIVATE_KEY = testKey;
+      const expectedAddress = new Wallet(testKey).address;
+
+      const handleMessage = vi.fn<
+        Parameters<
+          NonNullable<AgentRuntime["messageService"]>["handleMessage"]
+        >,
+        ReturnType<NonNullable<AgentRuntime["messageService"]>["handleMessage"]>
+      >(async () => ({
+        responseContent: { text: "i don't have a wallet - wrong fallback" },
+      }));
+      const runtime = createRuntimeForChatSseTests({ handleMessage });
+      const server = await startApiServer({ port: 0, runtime });
+      try {
+        const { status, data } = await req(server.port, "POST", "/api/chat", {
+          text: "what is your wallet address?",
+          mode: "power",
+        });
+        expect(status).toBe(200);
+        expect(String(data.text)).toContain(`EVM: ${expectedAddress}`);
+        expect(String(data.text)).toContain("Automation mode:");
+        expect(handleMessage).not.toHaveBeenCalled();
+      } finally {
+        await server.close();
+        if (prevKey === undefined) {
+          delete process.env.EVM_PRIVATE_KEY;
+        } else {
+          process.env.EVM_PRIVATE_KEY = prevKey;
+        }
+      }
+    });
+
+    it("POST /api/chat returns deterministic wallet status for wallet address prompts", async () => {
+      const handleMessage = vi.fn<
+        Parameters<
+          NonNullable<AgentRuntime["messageService"]>["handleMessage"]
+        >,
+        ReturnType<NonNullable<AgentRuntime["messageService"]>["handleMessage"]>
+      >(async () => ({
+        responseContent: { text: "i don't have a wallet - wrong fallback" },
+      }));
+      const runtime = createRuntimeForChatSseTests({ handleMessage });
+      const server = await startApiServer({ port: 0, runtime });
+      try {
+        const { status, data } = await req(server.port, "POST", "/api/chat", {
+          text: "what is your wallet address?",
+          mode: "power",
+        });
+        expect(status).toBe(200);
+        expect(String(data.text)).toContain("Detected wallets:");
+        expect(String(data.text)).toContain("Automation mode:");
+        expect(handleMessage).not.toHaveBeenCalled();
+      } finally {
+        await server.close();
+      }
+    });
+
+    it("POST /api/chat does not intercept wallet balance prompts in full mode", async () => {
+      const handleMessage = vi.fn<
+        Parameters<
+          NonNullable<AgentRuntime["messageService"]>["handleMessage"]
+        >,
+        ReturnType<NonNullable<AgentRuntime["messageService"]>["handleMessage"]>
+      >(async (_runtime, _message, onResponse) => {
+        await onResponse({
+          text: "Balance from plugin path",
+          action: "CHECK_BALANCE",
+        } as Content);
+        return {
+          responseContent: { text: "Balance from plugin path" },
+        };
+      });
+      const runtime = createRuntimeForChatSseTests({ handleMessage });
+      const server = await startApiServer({ port: 0, runtime });
+      try {
+        const { status, data } = await req(server.port, "POST", "/api/chat", {
+          text: "what is your wallet balance?",
+          mode: "power",
+        });
+        expect(status).toBe(200);
+        expect(String(data.text)).toContain("Balance from plugin path");
+        expect(handleMessage).toHaveBeenCalledTimes(1);
+        const handledMessage = handleMessage.mock.calls[0]?.[1] as
+          | { content?: { text?: string } }
+          | undefined;
+        expect(String(handledMessage?.content?.text ?? "")).toContain(
+          "Server-verified wallet context:",
+        );
+        expect(String(handledMessage?.content?.text ?? "")).toContain(
+          "User message: what is your wallet balance?",
+        );
+      } finally {
+        await server.close();
+      }
+    });
+
+    it("POST /api/chat trims wallet progress filler when CHECK_BALANCE returns a real result", async () => {
+      const handleMessage = vi.fn<
+        Parameters<
+          NonNullable<AgentRuntime["messageService"]>["handleMessage"]
+        >,
+        ReturnType<NonNullable<AgentRuntime["messageService"]>["handleMessage"]>
+      >(async (_runtime, _message, onResponse) => {
+        await onResponse({ text: "checking your evm balance now..." } as Content);
+        await onResponse({
+          text: "Wallet Balances:\n\nBSC (0x51a5...a4Ee):\n  BNB: 0.1 ($63.03)",
+          action: "CHECK_BALANCE_RESPONSE",
+        } as Content);
+        return {
+          responseContent: {
+            text: "checking your evm balance now...Wallet Balances:\n\nBSC (0x51a5...a4Ee):\n  BNB: 0.1 ($63.03)",
+          },
+        };
+      });
+      const runtime = createRuntimeForChatSseTests({ handleMessage });
+      const server = await startApiServer({ port: 0, runtime });
+      try {
+        const { status, data } = await req(server.port, "POST", "/api/chat", {
+          text: "what is your wallet balance?",
+          mode: "power",
+        });
+        expect(status).toBe(200);
+        expect(String(data.text)).toContain("Wallet Balances:");
+        expect(String(data.text)).not.toContain("checking your evm balance now");
+      } finally {
+        await server.close();
+      }
+    });
+
+    it("POST /api/chat turns wallet progress filler into an explicit execution failure when no action runs", async () => {
+      const handleMessage = vi.fn<
+        Parameters<
+          NonNullable<AgentRuntime["messageService"]>["handleMessage"]
+        >,
+        ReturnType<NonNullable<AgentRuntime["messageService"]>["handleMessage"]>
+      >(async () => ({
+        responseContent: { text: "let me check that for you" },
+      }));
+      const runtime = createRuntimeForChatSseTests({ handleMessage });
+      const server = await startApiServer({ port: 0, runtime });
+      try {
+        const { status, data } = await req(server.port, "POST", "/api/chat", {
+          text: "what is your wallet balance?",
+          mode: "power",
+        });
+        expect(status).toBe(200);
+        expect(String(data.text)).toContain(
+          "no wallet action actually ran",
+        );
+        expect(String(data.text)).toContain("plugin-evm:");
+        expect(String(data.text)).not.toContain("let me check that for you");
+      } finally {
+        await server.close();
+      }
+    });
+
+    it("POST /api/chat executes CHECK_BALANCE fallback when the model emits prose with no action payload", async () => {
+      const handleMessage = vi.fn<
+        Parameters<
+          NonNullable<AgentRuntime["messageService"]>["handleMessage"]
+        >,
+        ReturnType<NonNullable<AgentRuntime["messageService"]>["handleMessage"]>
+      >(async () => ({
+        responseContent: { text: "let me check that for you" },
+      }));
+      const runtime = createRuntimeForChatSseTests({ handleMessage });
+      (runtime as unknown as { actions: unknown[] }).actions = [
+        {
+          name: "CHECK_BALANCE",
+          validate: async () => true,
+          handler: async (
+            _runtime: unknown,
+            _message: unknown,
+            _state: unknown,
+            _options: unknown,
+            callback?: (content: Content) => void,
+          ) => {
+            callback?.({
+              text: "Wallet Balances:\n\nBSC (0x51a5...a4Ee):\n  BNB: 0.1000 ($0.00)",
+              action: "CHECK_BALANCE_RESPONSE",
+            } as Content);
+            return {
+              text: "Wallet Balances:\n\nBSC (0x51a5...a4Ee):\n  BNB: 0.1000 ($0.00)",
+              success: true,
+            };
+          },
+        },
+      ];
+      const server = await startApiServer({ port: 0, runtime });
+      try {
+        const { status, data } = await req(server.port, "POST", "/api/chat", {
+          text: "what is your wallet balance?",
+          mode: "power",
+        });
+        expect(status).toBe(200);
+        expect(String(data.text)).toContain("Wallet Balances:");
+        expect(String(data.text)).toContain("BNB: 0.1000");
+        expect(String(data.text)).not.toContain(
+          "no wallet action actually ran",
+        );
+      } finally {
+        await server.close();
+      }
+    });
+
+    it("POST /api/chat executes TRANSFER_TOKEN fallback from a prose-only send prompt and returns the tx hash", async () => {
+      const previousKey = process.env.EVM_PRIVATE_KEY;
+      const previousRpc = process.env.BSC_TESTNET_RPC_URL;
+      process.env.EVM_PRIVATE_KEY =
+        "0x59c6995e998f97a5a0044976f4b8c0fcbf2d34f95f0f70f7f6f6e3d54d3f5f31";
+      process.env.BSC_TESTNET_RPC_URL = "https://example-rpc.invalid";
+      const handleMessage = vi.fn<
+        Parameters<
+          NonNullable<AgentRuntime["messageService"]>["handleMessage"]
+        >,
+        ReturnType<NonNullable<AgentRuntime["messageService"]>["handleMessage"]>
+      >(async () => ({
+        responseContent: { text: "I can handle that send for you." },
+      }));
+      const runtime = createRuntimeForChatSseTests({ handleMessage });
+      (runtime as unknown as { plugins: Array<{ name: string }> }).plugins = [
+        { name: "@elizaos/plugin-evm" },
+      ];
+      (runtime as unknown as { actions: unknown[] }).actions = [
+        {
+          name: "TRANSFER_TOKEN",
+          validate: async () => true,
+          handler: async (
+            _runtime: unknown,
+            _message: unknown,
+            _state: unknown,
+            options: { parameters?: Record<string, string> },
+            callback?: (content: Content) => void,
+          ) => {
+            expect(options.parameters?.toAddress).toBe(
+              "0x8DFBdEEC8c5d4970BB5F481C6ec7f73fa1C65be5",
+            );
+            expect(options.parameters?.amount).toBe("0.001");
+            expect(options.parameters?.assetSymbol).toBe("BNB");
+            callback?.({
+              text:
+                "Action: TRANSFER_TOKEN\nChain: BSC testnet\nAmount: 0.001 BNB\nRecipient: 0x8DFBdEEC8c5d4970BB5F481C6ec7f73fa1C65be5\nExecution mode: agent-auto\nExecuted: true\nTx hash: 0xsendhash\nExplorer: https://testnet.bscscan.com/tx/0xsendhash\nStatus: success",
+              action: "TRANSFER_TOKEN_SUCCESS",
+            } as Content);
+            return {
+              text:
+                "Action: TRANSFER_TOKEN\nChain: BSC testnet\nAmount: 0.001 BNB\nRecipient: 0x8DFBdEEC8c5d4970BB5F481C6ec7f73fa1C65be5\nExecution mode: agent-auto\nExecuted: true\nTx hash: 0xsendhash\nExplorer: https://testnet.bscscan.com/tx/0xsendhash\nStatus: success",
+              success: true,
+            };
+          },
+        },
+      ];
+      const server = await startApiServer({ port: 0, runtime });
+      try {
+        const { status, data } = await req(server.port, "POST", "/api/chat", {
+          text: "send 0.001 tBNB on BSC testnet to 0x8DFBdEEC8c5d4970BB5F481C6ec7f73fa1C65be5",
+          mode: "power",
+        });
+        expect(status).toBe(200);
+        expect(String(data.text)).toContain("Action: TRANSFER_TOKEN");
+        expect(String(data.text)).toContain("Tx hash: 0xsendhash");
+        expect(String(data.text)).not.toContain("no wallet action actually ran");
+      } finally {
+        await server.close();
+        if (previousKey === undefined) delete process.env.EVM_PRIVATE_KEY;
+        else process.env.EVM_PRIVATE_KEY = previousKey;
+        if (previousRpc === undefined) delete process.env.BSC_TESTNET_RPC_URL;
+        else process.env.BSC_TESTNET_RPC_URL = previousRpc;
+      }
+    });
+
+    it("POST /api/chat executes EXECUTE_TRADE fallback from a prose-only swap prompt and returns the tx hash", async () => {
+      const previousKey = process.env.EVM_PRIVATE_KEY;
+      const previousRpc = process.env.BSC_TESTNET_RPC_URL;
+      const previousToken = process.env.WALLET_DRILL_TOKEN_ADDRESS;
+      process.env.EVM_PRIVATE_KEY =
+        "0x59c6995e998f97a5a0044976f4b8c0fcbf2d34f95f0f70f7f6f6e3d54d3f5f31";
+      process.env.BSC_TESTNET_RPC_URL = "https://example-rpc.invalid";
+      process.env.WALLET_DRILL_TOKEN_ADDRESS =
+        "0x1111111111111111111111111111111111111111";
+      const handleMessage = vi.fn<
+        Parameters<
+          NonNullable<AgentRuntime["messageService"]>["handleMessage"]
+        >,
+        ReturnType<NonNullable<AgentRuntime["messageService"]>["handleMessage"]>
+      >(async () => ({
+        responseContent: { text: "I can make that swap." },
+      }));
+      const runtime = createRuntimeForChatSseTests({ handleMessage });
+      (runtime as unknown as { plugins: Array<{ name: string }> }).plugins = [
+        { name: "@elizaos/plugin-evm" },
+      ];
+      (runtime as unknown as { actions: unknown[] }).actions = [
+        {
+          name: "EXECUTE_TRADE",
+          validate: async () => true,
+          handler: async (
+            _runtime: unknown,
+            _message: unknown,
+            _state: unknown,
+            options: { parameters?: Record<string, string> },
+            callback?: (content: Content) => void,
+          ) => {
+            expect(options.parameters?.side).toBe("buy");
+            expect(options.parameters?.amount).toBe("0.001");
+            expect(options.parameters?.tokenAddress).toBe(
+              "0x1111111111111111111111111111111111111111",
+            );
+            expect(options.parameters?.routeProvider).toBe("pancakeswap-v2");
+            callback?.({
+              text:
+                "Action: EXECUTE_TRADE\nChain: BSC testnet\nSide: buy\nAmount: 0.001 BNB\nToken: 0x1111111111111111111111111111111111111111\nRoute provider: pancakeswap-v2\nExecution mode: agent-auto\nExecuted: true\nTx hash: 0xswaphash\nExplorer: https://testnet.bscscan.com/tx/0xswaphash\nStatus: success",
+              action: "EXECUTE_TRADE_SUCCESS",
+            } as Content);
+            return {
+              text:
+                "Action: EXECUTE_TRADE\nChain: BSC testnet\nSide: buy\nAmount: 0.001 BNB\nToken: 0x1111111111111111111111111111111111111111\nRoute provider: pancakeswap-v2\nExecution mode: agent-auto\nExecuted: true\nTx hash: 0xswaphash\nExplorer: https://testnet.bscscan.com/tx/0xswaphash\nStatus: success",
+              success: true,
+            };
+          },
+        },
+      ];
+      const server = await startApiServer({ port: 0, runtime });
+      try {
+        const { status, data } = await req(server.port, "POST", "/api/chat", {
+          text: "swap 0.001 tBNB to the configured token on BSC testnet using pancakeswap-v2",
+          mode: "power",
+        });
+        expect(status).toBe(200);
+        expect(String(data.text)).toContain("Action: EXECUTE_TRADE");
+        expect(String(data.text)).toContain("Route provider: pancakeswap-v2");
+        expect(String(data.text)).toContain("Tx hash: 0xswaphash");
+      } finally {
+        await server.close();
+        if (previousKey === undefined) {
+          delete process.env.EVM_PRIVATE_KEY;
+        } else {
+          process.env.EVM_PRIVATE_KEY = previousKey;
+        }
+        if (previousRpc === undefined) {
+          delete process.env.BSC_TESTNET_RPC_URL;
+        } else {
+          process.env.BSC_TESTNET_RPC_URL = previousRpc;
+        }
+        if (previousToken === undefined) {
+          delete process.env.WALLET_DRILL_TOKEN_ADDRESS;
+        } else {
+          process.env.WALLET_DRILL_TOKEN_ADDRESS = previousToken;
+        }
+      }
+    });
+
+    it("POST /api/chat returns an explicit swap parameter failure when no token address is available", async () => {
+      const previousKey = process.env.EVM_PRIVATE_KEY;
+      const previousRpc = process.env.BSC_TESTNET_RPC_URL;
+      const previousToken = process.env.WALLET_DRILL_TOKEN_ADDRESS;
+      process.env.EVM_PRIVATE_KEY =
+        "0x59c6995e998f97a5a0044976f4b8c0fcbf2d34f95f0f70f7f6f6e3d54d3f5f31";
+      process.env.BSC_TESTNET_RPC_URL = "https://example-rpc.invalid";
+      delete process.env.WALLET_DRILL_TOKEN_ADDRESS;
+      const handleMessage = vi.fn<
+        Parameters<
+          NonNullable<AgentRuntime["messageService"]>["handleMessage"]
+        >,
+        ReturnType<NonNullable<AgentRuntime["messageService"]>["handleMessage"]>
+      >(async () => ({
+        responseContent: { text: "I can make that swap." },
+      }));
+      const runtime = createRuntimeForChatSseTests({ handleMessage });
+      (runtime as unknown as { plugins: Array<{ name: string }> }).plugins = [
+        { name: "@elizaos/plugin-evm" },
+      ];
+      const server = await startApiServer({ port: 0, runtime });
+      try {
+        const { status, data } = await req(server.port, "POST", "/api/chat", {
+          text: "swap 0.001 tBNB on BSC testnet using pancakeswap-v2",
+          mode: "power",
+        });
+        expect(status).toBe(200);
+        expect(String(data.text)).toContain("Action: EXECUTE_TRADE");
+        expect(String(data.text)).toContain("Executed: false");
+        expect(String(data.text)).toContain("I need a target token address");
+      } finally {
+        await server.close();
+        if (previousKey === undefined) {
+          delete process.env.EVM_PRIVATE_KEY;
+        } else {
+          process.env.EVM_PRIVATE_KEY = previousKey;
+        }
+        if (previousRpc === undefined) {
+          delete process.env.BSC_TESTNET_RPC_URL;
+        } else {
+          process.env.BSC_TESTNET_RPC_URL = previousRpc;
+        }
+        if (previousToken === undefined) {
+          delete process.env.WALLET_DRILL_TOKEN_ADDRESS;
+        } else {
+          process.env.WALLET_DRILL_TOKEN_ADDRESS = previousToken;
+        }
+      }
+    });
+
+    it("POST /api/conversations/:id/messages/stream emits deterministic wallet status for address prompts", async () => {
+      const prevKey = process.env.EVM_PRIVATE_KEY;
+      const testKey =
+        "0x8b3a350cf5c34c9194ca3b0f2f4f1a4f7f6c8c8d8b6f4a7c5d2e9f4a1b2c3d4e";
+      process.env.EVM_PRIVATE_KEY = testKey;
+      const expectedAddress = new Wallet(testKey).address;
+
+      const handleMessage = vi.fn<
+        Parameters<
+          NonNullable<AgentRuntime["messageService"]>["handleMessage"]
+        >,
+        ReturnType<NonNullable<AgentRuntime["messageService"]>["handleMessage"]>
+      >(async () => ({
+        responseContent: { text: "wrong streamed fallback" },
+      }));
+      const runtime = createRuntimeForChatSseTests({ handleMessage });
+      const server = await startApiServer({ port: 0, runtime });
+      try {
+        const created = await req(server.port, "POST", "/api/conversations", {
+          title: "Wallet stream status",
+        });
+        expect(created.status).toBe(200);
+        const conversationId = String(
+          (created.data as { conversation?: { id?: string } }).conversation
+            ?.id ?? "",
+        );
+        expect(conversationId.length).toBeGreaterThan(0);
+
+        const { status, events } = await reqSse(
+          server.port,
+          `/api/conversations/${conversationId}/messages/stream`,
+          {
+            text: "what is your wallet address?",
+            mode: "power",
+          },
+        );
+        expect(status).toBe(200);
+        const doneEvent = events.find((event) => event.type === "done");
+        expect(String(doneEvent?.fullText ?? "")).toContain(
+          `EVM: ${expectedAddress}`,
+        );
+        expect(handleMessage).not.toHaveBeenCalled();
+      } finally {
+        await server.close();
+        if (prevKey === undefined) {
+          delete process.env.EVM_PRIVATE_KEY;
+        } else {
+          process.env.EVM_PRIVATE_KEY = prevKey;
+        }
+      }
+    });
+
+    it("POST /api/chat returns connectors-only guidance for wallet intent without invoking runtime", async () => {
+      const handleMessage = vi.fn<
+        Parameters<
+          NonNullable<AgentRuntime["messageService"]>["handleMessage"]
+        >,
+        ReturnType<NonNullable<AgentRuntime["messageService"]>["handleMessage"]>
+      >(async () => ({
+        responseContent: { text: "unexpected-runtime-response" },
+      }));
+      const runtime = createRuntimeForChatSseTests({ handleMessage });
+      const server = await startApiServer({ port: 0, runtime });
+      try {
+        const mode = await req(
+          server.port,
+          "PUT",
+          "/api/permissions/automation-mode",
+          { mode: "connectors-only" },
+        );
+        expect(mode.status).toBe(200);
+
+        const { status, data } = await req(server.port, "POST", "/api/chat", {
+          text: "swap 0.001 bnb on bsc testnet",
+          mode: "power",
+        });
+        expect(status).toBe(200);
+        expect(String(data.text)).toContain("connectors-only mode");
+        expect(String(data.text)).toContain("/api/permissions/automation-mode");
+        expect(handleMessage).not.toHaveBeenCalled();
+      } finally {
+        await server.close();
+      }
+    });
+
+    it("POST /api/conversations/:id/messages returns connectors-only guidance for wallet intent", async () => {
+      const handleMessage = vi.fn<
+        Parameters<
+          NonNullable<AgentRuntime["messageService"]>["handleMessage"]
+        >,
+        ReturnType<NonNullable<AgentRuntime["messageService"]>["handleMessage"]>
+      >(async () => ({
+        responseContent: { text: "unexpected-runtime-response" },
+      }));
+      const runtime = createRuntimeForChatSseTests({ handleMessage });
+      const server = await startApiServer({ port: 0, runtime });
+      try {
+        const mode = await req(
+          server.port,
+          "PUT",
+          "/api/permissions/automation-mode",
+          { mode: "connectors-only" },
+        );
+        expect(mode.status).toBe(200);
+
+        const created = await req(server.port, "POST", "/api/conversations", {
+          title: "Wallet mode guidance",
+        });
+        expect(created.status).toBe(200);
+        const conversationId = String(
+          (created.data as { conversation?: { id?: string } }).conversation
+            ?.id ?? "",
+        );
+        expect(conversationId.length).toBeGreaterThan(0);
+
+        const { status, data } = await req(
+          server.port,
+          "POST",
+          `/api/conversations/${conversationId}/messages`,
+          {
+            text: "can you swap on bsc for me?",
+            mode: "power",
+          },
+        );
+        expect(status).toBe(200);
+        expect(String(data.text)).toContain("connectors-only mode");
+        expect(String(data.text)).toContain("/api/permissions/automation-mode");
+        expect(handleMessage).not.toHaveBeenCalled();
+      } finally {
+        await server.close();
+      }
+    });
+  });
+
   describe("provider issue fallback", () => {
     it("POST /api/chat replaces '(no response)' with the provider issue message", async () => {
       const runtime = createRuntimeForCreditNoResponseTests();
@@ -3270,6 +3833,20 @@ describe("API Server E2E (no runtime)", () => {
       const { status, data } = await req(port, "GET", "/api/plugins");
       expect(status).toBe(200);
       expect(Array.isArray(data.plugins)).toBe(true);
+    });
+
+    it("includes plugin-evm as a visible diagnostic plugin entry", async () => {
+      const { data } = await req(port, "GET", "/api/plugins");
+      const plugins = data.plugins as Array<Record<string, unknown>>;
+      const evm = plugins.find(
+        (plugin) =>
+          plugin.id === "evm" ||
+          plugin.npmName === "@elizaos/plugin-evm",
+      );
+      expect(evm).toBeDefined();
+      expect(evm?.managementMode).toBe("core-optional");
+      expect(Array.isArray(evm?.prerequisites)).toBe(true);
+      expect(typeof evm?.capabilityStatus).toBe("string");
     });
 
     it("plugins have correct shape", async () => {

--- a/packages/agent/test/api/wallet-trade-routes.test.ts
+++ b/packages/agent/test/api/wallet-trade-routes.test.ts
@@ -1,0 +1,280 @@
+﻿import type { IncomingMessage, ServerResponse } from "node:http";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  handleWalletTradeExecuteRoute,
+  type WalletTradeExecuteDeps,
+} from "../../src/api/wallet-trade-routes";
+import type { ElizaConfig } from "../../src/config/config";
+
+const ENV_KEYS = ["EVM_PRIVATE_KEY"] as const;
+const ORIGINAL_ENV = Object.fromEntries(
+  ENV_KEYS.map((key) => [key, process.env[key]]),
+) as Record<(typeof ENV_KEYS)[number], string | undefined>;
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const value = ORIGINAL_ENV[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  vi.restoreAllMocks();
+});
+
+type InvokeResult = {
+  handled: boolean;
+  status: number;
+  payload: unknown;
+  deps: WalletTradeExecuteDeps;
+};
+
+function createDeps(): WalletTradeExecuteDeps {
+  return {
+    getWalletAddresses: vi.fn(() => ({
+      evmAddress: "0x1111111111111111111111111111111111111111",
+      solanaAddress: null,
+    })),
+    resolveWalletRpcReadiness: vi.fn(() => ({
+      bscRpcUrls: ["https://bsc.example/rpc"],
+      cloudManagedAccess: true,
+    })),
+    resolveTradePermissionMode: vi.fn(() => "manual-local-key"),
+    isAgentAutomationRequest: vi.fn(() => false),
+    canUseLocalTradeExecution: vi.fn(() => true),
+    buildBscTradeQuote: vi.fn(async () => ({
+      ok: true,
+      side: "buy",
+      routeProvider: "0x",
+      routeProviderRequested: "auto",
+      routeProviderFallbackUsed: false,
+      routerAddress: "0x2222222222222222222222222222222222222222",
+      wrappedNativeAddress: "0x3333333333333333333333333333333333333333",
+      tokenAddress: "0x4444444444444444444444444444444444444444",
+      slippageBps: 300,
+      route: [],
+      quoteIn: { symbol: "BNB", amount: "0.01", amountWei: "1000" },
+      quoteOut: { symbol: "USDT", amount: "2", amountWei: "2000" },
+      minReceive: { symbol: "USDT", amount: "1.9", amountWei: "1900" },
+      price: "200",
+      preflight: {
+        ok: true,
+        walletAddress: "0x1111111111111111111111111111111111111111",
+        rpcUrlHost: "bsc.example",
+        chainId: 56,
+        bnbBalance: "1",
+        minGasBnb: "0.005",
+        checks: {
+          walletReady: true,
+          rpcReady: true,
+          chainReady: true,
+          gasReady: true,
+          tokenAddressValid: true,
+        },
+        reasons: [],
+      },
+      quotedAt: Date.now(),
+    })),
+    buildBscBuyUnsignedTx: vi.fn(() => ({
+      chainId: 56,
+      from: "0x1111111111111111111111111111111111111111",
+      to: "0xaaaa00000000000000000000000000000000aaaa",
+      data: "0xdeadbeef",
+      valueWei: "1000",
+      deadline: 9999999999,
+      explorerUrl: "https://bscscan.com",
+    })),
+    buildBscSellUnsignedTx: vi.fn(() => ({
+      chainId: 56,
+      from: "0x1111111111111111111111111111111111111111",
+      to: "0xbbbb00000000000000000000000000000000bbbb",
+      data: "0xbeef",
+      valueWei: "0",
+      deadline: 9999999999,
+      explorerUrl: "https://bscscan.com",
+    })),
+    buildBscApproveUnsignedTx: vi.fn(() => ({
+      chainId: 56,
+      from: "0x1111111111111111111111111111111111111111",
+      to: "0x4444444444444444444444444444444444444444",
+      data: "0xapprove",
+      valueWei: "0",
+      explorerUrl: "https://bscscan.com",
+      spender: "0xspender",
+      amountWei: "1000",
+    })),
+    resolveBscApprovalSpender: vi.fn(
+      () => "0x5555555555555555555555555555555555555555",
+    ),
+    resolvePrimaryBscRpcUrl: vi.fn(() => "https://bsc.example/rpc"),
+    assertQuoteFresh: vi.fn(),
+    recordWalletTradeLedgerEntry: vi.fn(),
+    createProvider: vi.fn(() => ({
+      getTransactionCount: vi.fn(async () => 7),
+      destroy: vi.fn(),
+    })),
+    createWallet: vi.fn(() => ({
+      address: "0x1111111111111111111111111111111111111111",
+      sendTransaction: vi.fn(async () => ({
+        hash: "0xhash",
+        gasLimit: 21000n,
+        wait: vi.fn(async () => ({ status: 1 })),
+      })),
+    })),
+    logger: {
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  };
+}
+
+async function invoke(args: {
+  method: string;
+  pathname: string;
+  body?: Record<string, unknown> | null;
+  deps?: WalletTradeExecuteDeps;
+}): Promise<InvokeResult> {
+  let status = 200;
+  let payload: unknown = null;
+  const deps = args.deps ?? createDeps();
+
+  const handled = await handleWalletTradeExecuteRoute({
+    req: {} as IncomingMessage,
+    res: {} as ServerResponse,
+    method: args.method,
+    pathname: args.pathname,
+    state: {
+      config: { env: {} } as ElizaConfig,
+    },
+    deps,
+    readJsonBody: vi.fn(async () => args.body ?? null),
+    json: (_res, data, code = 200) => {
+      status = code;
+      payload = data;
+    },
+    error: (_res, message, code = 400) => {
+      status = code;
+      payload = { error: message };
+    },
+  });
+
+  return { handled, status, payload, deps };
+}
+
+describe("wallet trade execute route", () => {
+  test("returns false for unrelated route", async () => {
+    const result = await invoke({
+      method: "GET",
+      pathname: "/api/wallet/trade/quote",
+    });
+    expect(result.handled).toBe(false);
+  });
+
+  test("validates required trade body fields", async () => {
+    const result = await invoke({
+      method: "POST",
+      pathname: "/api/wallet/trade/execute",
+      body: { side: "buy" },
+    });
+    expect(result.handled).toBe(true);
+    expect(result.status).toBe(400);
+    expect(result.payload).toEqual({
+      error: "side, tokenAddress, and amount are required",
+    });
+  });
+
+  test("returns unsigned payload when confirm is not true", async () => {
+    process.env.EVM_PRIVATE_KEY = "abc123";
+    const result = await invoke({
+      method: "POST",
+      pathname: "/api/wallet/trade/execute",
+      body: {
+        side: "buy",
+        tokenAddress: "0x4444444444444444444444444444444444444444",
+        amount: "0.01",
+        confirm: false,
+      },
+    });
+    expect(result.handled).toBe(true);
+    expect(result.status).toBe(200);
+    expect(result.payload).toEqual(
+      expect.objectContaining({
+        ok: true,
+        executed: false,
+        requiresUserSignature: true,
+        mode: "local-key",
+      }),
+    );
+    expect(result.deps.createProvider).not.toHaveBeenCalled();
+  });
+
+  test("executes and records pending ledger entry in local-key mode", async () => {
+    process.env.EVM_PRIVATE_KEY = "abc123";
+    const result = await invoke({
+      method: "POST",
+      pathname: "/api/wallet/trade/execute",
+      body: {
+        side: "buy",
+        tokenAddress: "0x4444444444444444444444444444444444444444",
+        amount: "0.01",
+        confirm: true,
+        source: "agent",
+      },
+    });
+    expect(result.handled).toBe(true);
+    expect(result.status).toBe(200);
+    expect(result.payload).toEqual(
+      expect.objectContaining({
+        ok: true,
+        mode: "local-key",
+        executed: true,
+        requiresUserSignature: false,
+        execution: expect.objectContaining({
+          hash: "0xhash",
+          status: "submitted",
+        }),
+      }),
+    );
+    expect(result.deps.recordWalletTradeLedgerEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hash: "0xhash",
+        source: "agent",
+        status: "pending",
+      }),
+    );
+  });
+
+  test("returns 500 when quote freshness assertion fails", async () => {
+    process.env.EVM_PRIVATE_KEY = "abc123";
+    const deps = createDeps();
+    deps.assertQuoteFresh = vi.fn(() => {
+      throw new Error("quote expired");
+    });
+
+    const result = await invoke({
+      method: "POST",
+      pathname: "/api/wallet/trade/execute",
+      body: {
+        side: "buy",
+        tokenAddress: "0x4444444444444444444444444444444444444444",
+        amount: "0.01",
+        confirm: true,
+      },
+      deps,
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.status).toBe(500);
+    expect(result.payload).toEqual({
+      error: "Trade execution failed: quote expired",
+    });
+  });
+});
+

--- a/packages/app-core/src/App.test.ts
+++ b/packages/app-core/src/App.test.ts
@@ -54,6 +54,7 @@ vi.mock("./components", () => {
     AdvancedPageView: stub("AdvancedPageView"),
     AppsPageView: stub("AppsPageView"),
     AvatarLoader: stub("AvatarLoader"),
+    BugReportModal: stub("BugReportModal"),
     CharacterEditor: stub("CharacterEditor"),
     ChatView: stub("ChatView"),
     CompanionShell: stub("CompanionShell"),

--- a/packages/app-core/src/App.tsx
+++ b/packages/app-core/src/App.tsx
@@ -38,6 +38,7 @@ import {
   HeartbeatsView,
   InventoryView,
   KnowledgeView,
+  BugReportModal,
   OnboardingWizard,
   PairingView,
   SaveCommandModal,
@@ -484,7 +485,12 @@ export function App() {
 
   // After loader hooks (stable hook order); do not return startupError before useState above.
   if (startupError) {
-    return <StartupFailureView error={startupError} onRetry={retryStartup} />;
+    return (
+      <BugReportProvider value={bugReport}>
+        <StartupFailureView error={startupError} onRetry={retryStartup} />
+        <BugReportModal />
+      </BugReportProvider>
+    );
   }
 
   if (authRequired && !blockOnboardingForShell) return <PairingView />;

--- a/packages/app-core/src/actions/check-balance.test.ts
+++ b/packages/app-core/src/actions/check-balance.test.ts
@@ -642,4 +642,3 @@ describe("CHECK_BALANCE action", () => {
     expect(data.solana).toBeDefined();
   });
 });
-

--- a/packages/app-core/src/actions/check-balance.test.ts
+++ b/packages/app-core/src/actions/check-balance.test.ts
@@ -160,7 +160,7 @@ describe("CHECK_BALANCE action", () => {
 
     expect(mockFetch).toHaveBeenCalledOnce();
     const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe("http://127.0.0.1:2138/api/wallet/balances");
+    expect(url).toBe("http://127.0.0.1:31337/api/wallet/balances");
   });
 
   // ── Multi-chain response formatting ──────────────────────────────────────
@@ -642,3 +642,4 @@ describe("CHECK_BALANCE action", () => {
     expect(data.solana).toBeDefined();
   });
 });
+

--- a/packages/app-core/src/actions/check-balance.ts
+++ b/packages/app-core/src/actions/check-balance.ts
@@ -20,7 +20,7 @@ import type {
 } from "@miladyai/shared/contracts";
 import {
   buildAuthHeaders,
-  WALLET_ACTION_API_PORT,
+  getWalletActionApiPort,
 } from "./wallet-action-shared.js";
 
 /** Timeout for the balance API call. */
@@ -179,7 +179,7 @@ export const checkBalanceAction: Action = {
 
       // ── Fetch balances from API ──────────────────────────────────────
       const response = await fetch(
-        `http://127.0.0.1:${WALLET_ACTION_API_PORT}/api/wallet/balances`,
+        `http://127.0.0.1:${getWalletActionApiPort()}/api/wallet/balances`,
         {
           headers: {
             ...buildAuthHeaders(),

--- a/packages/app-core/src/actions/execute-trade.test.ts
+++ b/packages/app-core/src/actions/execute-trade.test.ts
@@ -233,7 +233,9 @@ describe("EXECUTE_TRADE action", () => {
     });
 
     expect((result as { success: boolean }).success).toBe(true);
-    expect((result as { text: string }).text).toContain("Action: EXECUTE_TRADE");
+    expect((result as { text: string }).text).toContain(
+      "Action: EXECUTE_TRADE",
+    );
     expect((result as { text: string }).text).toContain("Executed: true");
     expect((result as { text: string }).text).toContain("Tx hash: 0xabc123");
     expect((result as { data: Record<string, unknown> }).data).toMatchObject({
@@ -596,4 +598,3 @@ describe("EXECUTE_TRADE action", () => {
     expect(body.side).toBe("buy");
   });
 });
-

--- a/packages/app-core/src/actions/execute-trade.test.ts
+++ b/packages/app-core/src/actions/execute-trade.test.ts
@@ -248,7 +248,7 @@ describe("EXECUTE_TRADE action", () => {
     // Verify fetch was called with correct args
     expect(mockFetch).toHaveBeenCalledOnce();
     const [url, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe("http://127.0.0.1:2138/api/wallet/trade/execute");
+    expect(url).toBe("http://127.0.0.1:31337/api/wallet/trade/execute");
     expect(opts.method).toBe("POST");
     expect(
       (opts.headers as Record<string, string>)["X-Eliza-Agent-Action"],
@@ -596,3 +596,4 @@ describe("EXECUTE_TRADE action", () => {
     expect(body.side).toBe("buy");
   });
 });
+

--- a/packages/app-core/src/actions/execute-trade.test.ts
+++ b/packages/app-core/src/actions/execute-trade.test.ts
@@ -52,13 +52,14 @@ describe("EXECUTE_TRADE action", () => {
 
   it("has parameter definitions", () => {
     expect(executeTradeAction.parameters).toBeDefined();
-    expect(executeTradeAction.parameters?.length).toBe(4);
+    expect(executeTradeAction.parameters?.length).toBe(5);
 
     const names = executeTradeAction.parameters?.map((p) => p.name);
     expect(names).toContain("side");
     expect(names).toContain("tokenAddress");
     expect(names).toContain("amount");
     expect(names).toContain("slippageBps");
+    expect(names).toContain("routeProvider");
 
     // side, tokenAddress, amount are required; slippageBps is optional
     const slippage = executeTradeAction.parameters?.find(
@@ -232,10 +233,9 @@ describe("EXECUTE_TRADE action", () => {
     });
 
     expect((result as { success: boolean }).success).toBe(true);
-    expect((result as { text: string }).text).toContain(
-      "executed successfully",
-    );
-    expect((result as { text: string }).text).toContain("0xabc123");
+    expect((result as { text: string }).text).toContain("Action: EXECUTE_TRADE");
+    expect((result as { text: string }).text).toContain("Executed: true");
+    expect((result as { text: string }).text).toContain("Tx hash: 0xabc123");
     expect((result as { data: Record<string, unknown> }).data).toMatchObject({
       side: "buy",
       tokenAddress: VALID_TOKEN,
@@ -262,10 +262,11 @@ describe("EXECUTE_TRADE action", () => {
     expect(body.tokenAddress).toBe(VALID_TOKEN);
     expect(body.amount).toBe("0.5");
     expect(body.slippageBps).toBe(300);
+    expect(body.routeProvider).toBe("pancakeswap-v2");
     expect(body.confirm).toBe(true);
   });
 
-  it("calls API and returns success for user-sign mode", async () => {
+  it("returns failure for user-sign mode because no on-chain execution occurred", async () => {
     const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
     mockFetch.mockResolvedValueOnce({
       ok: true,
@@ -286,8 +287,9 @@ describe("EXECUTE_TRADE action", () => {
       amount: "0.5",
     });
 
-    expect((result as { success: boolean }).success).toBe(true);
+    expect((result as { success: boolean }).success).toBe(false);
     expect((result as { text: string }).text).toContain("user-sign");
+    expect((result as { text: string }).text).toContain("Executed: false");
     expect((result as { text: string }).text).toContain(
       "signature is required",
     );

--- a/packages/app-core/src/actions/execute-trade.ts
+++ b/packages/app-core/src/actions/execute-trade.ts
@@ -22,7 +22,7 @@ import type {
 import { logger } from "@elizaos/core";
 import {
   buildAuthHeaders,
-  WALLET_ACTION_API_PORT,
+  getWalletActionApiPort,
 } from "./wallet-action-shared.js";
 
 /** Timeout for the trade API call (includes on-chain confirmation). */
@@ -197,7 +197,7 @@ export const executeTradeAction: Action = {
       );
 
       const response = await fetch(
-        `http://127.0.0.1:${WALLET_ACTION_API_PORT}/api/wallet/trade/execute`,
+        `http://127.0.0.1:${getWalletActionApiPort()}/api/wallet/trade/execute`,
         {
           method: "POST",
           headers: {
@@ -400,3 +400,4 @@ export const executeTradeAction: Action = {
     },
   ],
 };
+

--- a/packages/app-core/src/actions/execute-trade.ts
+++ b/packages/app-core/src/actions/execute-trade.ts
@@ -1,5 +1,5 @@
 /**
- * EXECUTE_TRADE action — executes a BSC token trade (buy or sell).
+ * EXECUTE_TRADE action � executes a BSC token trade (buy or sell).
  *
  * When triggered the action:
  *   1. Validates parameters (side, tokenAddress format, amount > 0)
@@ -8,12 +8,17 @@
  *      if executed, or unsigned TX info if user-sign mode
  *
  * All business logic (permissions, safety caps, signing) is handled
- * server-side — this action is a thin wrapper.
+ * server-side � this action is a thin wrapper.
  *
  * @module actions/execute-trade
  */
 
-import type { Action, HandlerOptions, IAgentRuntime } from "@elizaos/core";
+import type {
+  Action,
+  HandlerCallback,
+  HandlerOptions,
+  IAgentRuntime,
+} from "@elizaos/core";
 import { logger } from "@elizaos/core";
 import {
   buildAuthHeaders,
@@ -39,6 +44,60 @@ function isValidParam(val: unknown): val is string {
   );
 }
 
+function walletNetworkLabel(): string {
+  return process.env.MILADY_WALLET_NETWORK?.trim().toLowerCase() === "testnet"
+    ? "BSC testnet"
+    : "BSC";
+}
+
+function buildTradeSuccessText(args: {
+  side: string;
+  amount: string;
+  tokenAddress: string;
+  routeProvider: string;
+  mode: string;
+  txHash: string;
+  explorerUrl: string;
+  status: string;
+}): string {
+  return [
+    "Action: EXECUTE_TRADE",
+    `Chain: ${walletNetworkLabel()}`,
+    `Side: ${args.side}`,
+    `Amount: ${args.amount} BNB`,
+    `Token: ${args.tokenAddress}`,
+    `Route provider: ${args.routeProvider}`,
+    `Execution mode: ${args.mode}`,
+    "Executed: true",
+    `Tx hash: ${args.txHash}`,
+    `Explorer: ${args.explorerUrl}`,
+    `Status: ${args.status}`,
+  ].join("\n");
+}
+
+function buildTradeFailureText(args: {
+  side: string;
+  amount: string;
+  tokenAddress: string;
+  routeProvider: string;
+  mode: string;
+  requiresUserSignature: boolean;
+  reason: string;
+}): string {
+  return [
+    "Action: EXECUTE_TRADE",
+    `Chain: ${walletNetworkLabel()}`,
+    `Side: ${args.side}`,
+    `Amount: ${args.amount} BNB`,
+    `Token: ${args.tokenAddress}`,
+    `Route provider: ${args.routeProvider}`,
+    `Execution mode: ${args.mode}`,
+    "Executed: false",
+    `Requires user signature: ${args.requiresUserSignature ? "true" : "false"}`,
+    `Reason: ${args.reason}`,
+  ].join("\n");
+}
+
 export const executeTradeAction: Action = {
   name: "EXECUTE_TRADE",
 
@@ -53,11 +112,17 @@ export const executeTradeAction: Action = {
     const hasWallet =
       runtime.getSetting("EVM_PRIVATE_KEY") ||
       runtime.getSetting("PRIVY_APP_ID") ||
-      runtime.getSetting("STEWARD_API_URL"); // Steward provides the wallet
+      runtime.getSetting("STEWARD_API_URL");
     return Boolean(hasWallet);
   },
 
-  handler: async (_runtime, _message, _state, options) => {
+  handler: async (
+    _runtime,
+    _message,
+    _state,
+    options,
+    callback?: HandlerCallback,
+  ) => {
     try {
       const params = (options as HandlerOptions | undefined)?.parameters;
       logger.debug(
@@ -65,7 +130,6 @@ export const executeTradeAction: Action = {
         JSON.stringify(params ?? {}),
       );
 
-      // ── Resolve side ─────────────────────────────────────────────────
       const rawSide = isValidParam(params?.side as string)
         ? (params?.side as string)
         : undefined;
@@ -73,13 +137,11 @@ export const executeTradeAction: Action = {
         typeof rawSide === "string" ? rawSide.trim().toLowerCase() : undefined;
 
       if (side !== "buy" && side !== "sell") {
-        return {
-          text: 'I need a valid trade side ("buy" or "sell").',
-          success: false,
-        };
+        const text = 'I need a valid trade side ("buy" or "sell").';
+        callback?.({ text, action: "EXECUTE_TRADE_FAILED" });
+        return { text, success: false };
       }
 
-      // ── Resolve tokenAddress ─────────────────────────────────────────
       const rawAddr = isValidParam(params?.tokenAddress as string)
         ? (params?.tokenAddress as string)
         : undefined;
@@ -87,13 +149,12 @@ export const executeTradeAction: Action = {
         typeof rawAddr === "string" ? rawAddr.trim() : undefined;
 
       if (!tokenAddress || !BSC_ADDRESS_RE.test(tokenAddress)) {
-        return {
-          text: "I need a valid BSC token contract address (0x-prefixed, 40 hex chars).",
-          success: false,
-        };
+        const text =
+          "I need a valid BSC token contract address (0x-prefixed, 40 hex chars).";
+        callback?.({ text, action: "EXECUTE_TRADE_FAILED" });
+        return { text, success: false };
       }
 
-      // ── Resolve amount ───────────────────────────────────────────────
       const rawAmt = isValidParam(params?.amount as string)
         ? (params?.amount as string)
         : typeof params?.amount === "number" && params.amount > 0
@@ -106,13 +167,11 @@ export const executeTradeAction: Action = {
         Number.isNaN(Number(amountRaw)) ||
         Number(amountRaw) <= 0
       ) {
-        return {
-          text: "I need a positive numeric amount for the trade.",
-          success: false,
-        };
+        const text = "I need a positive numeric amount for the trade.";
+        callback?.({ text, action: "EXECUTE_TRADE_FAILED" });
+        return { text, success: false };
       }
 
-      // ── Resolve slippageBps ──────────────────────────────────────────
       const slippageBps =
         typeof params?.slippageBps === "number"
           ? params.slippageBps
@@ -122,17 +181,21 @@ export const executeTradeAction: Action = {
             : 300;
 
       if (Number.isNaN(slippageBps) || slippageBps < 0) {
-        return {
-          text: "slippageBps must be a non-negative number.",
-          success: false,
-        };
+        const text = "slippageBps must be a non-negative number.";
+        callback?.({ text, action: "EXECUTE_TRADE_FAILED" });
+        return { text, success: false };
       }
 
+      const routeProvider =
+        typeof params?.routeProvider === "string" &&
+        params.routeProvider.trim().length > 0
+          ? params.routeProvider.trim()
+          : "pancakeswap-v2";
+
       logger.debug(
-        `[EXECUTE_TRADE] resolved: side=${side} token=${tokenAddress} amount=${amountRaw} slippage=${slippageBps}`,
+        `[EXECUTE_TRADE] resolved: side=${side} token=${tokenAddress} amount=${amountRaw} slippage=${slippageBps} routeProvider=${routeProvider}`,
       );
 
-      // ── POST to trade execution API ──────────────────────────────────
       const response = await fetch(
         `http://127.0.0.1:${WALLET_ACTION_API_PORT}/api/wallet/trade/execute`,
         {
@@ -147,6 +210,7 @@ export const executeTradeAction: Action = {
             tokenAddress,
             amount: amountRaw,
             slippageBps,
+            routeProvider,
             confirm: true,
           }),
           signal: AbortSignal.timeout(TRADE_TIMEOUT_MS),
@@ -158,10 +222,17 @@ export const executeTradeAction: Action = {
           string,
           string
         >;
-        return {
-          text: `Trade failed: ${body.error ?? `HTTP ${response.status}`}`,
-          success: false,
-        };
+        const text = buildTradeFailureText({
+          side,
+          amount: amountRaw,
+          tokenAddress,
+          routeProvider,
+          mode: "unknown",
+          requiresUserSignature: false,
+          reason: body.error ?? `HTTP ${response.status}`,
+        });
+        callback?.({ text, action: "EXECUTE_TRADE_FAILED" });
+        return { text, success: false };
       }
 
       const result = (await response.json()) as {
@@ -194,26 +265,56 @@ export const executeTradeAction: Action = {
         }),
       );
 
+      const resolvedRouteProvider =
+        typeof result.quote?.routeProvider === "string"
+          ? result.quote.routeProvider
+          : routeProvider;
+
       if (!result.ok) {
-        return {
-          text: `Trade failed: ${result.error ?? "unknown error"}`,
-          success: false,
-        };
+        const text = buildTradeFailureText({
+          side,
+          amount: amountRaw,
+          tokenAddress,
+          routeProvider: resolvedRouteProvider,
+          mode: result.mode,
+          requiresUserSignature: result.requiresUserSignature,
+          reason: result.error ?? "unknown error",
+        });
+        callback?.({ text, action: "EXECUTE_TRADE_FAILED" });
+        return { text, success: false };
       }
 
-      // ── Build human-readable response ────────────────────────────────
       if (result.executed && result.execution) {
+        const text = buildTradeSuccessText({
+          side,
+          amount: amountRaw,
+          tokenAddress,
+          routeProvider: resolvedRouteProvider,
+          mode: result.mode,
+          txHash: result.execution.hash,
+          explorerUrl: result.execution.explorerUrl,
+          status: result.execution.status,
+        });
+        callback?.({
+          text,
+          action: "EXECUTE_TRADE_SUCCESS",
+          txHash: result.execution.hash,
+          explorerUrl: result.execution.explorerUrl,
+          executionMode: result.mode,
+          routeProvider: resolvedRouteProvider,
+          executed: true,
+          tokenAddress,
+          side,
+        });
         return {
-          text:
-            `Trade executed successfully! ${side.toUpperCase()} via ${result.mode} mode.\n` +
-            `TX: ${result.execution.explorerUrl}\n` +
-            `Status: ${result.execution.status}`,
+          text,
           success: true,
           data: {
             side,
             tokenAddress,
             amount: amountRaw,
             mode: result.mode,
+            routeProvider: resolvedRouteProvider,
             txHash: result.execution.hash,
             explorerUrl: result.execution.explorerUrl,
             executed: true,
@@ -221,27 +322,45 @@ export const executeTradeAction: Action = {
         };
       }
 
-      // user-sign mode — trade was quoted but not executed on-chain
+      const text = buildTradeFailureText({
+        side,
+        amount: amountRaw,
+        tokenAddress,
+        routeProvider: resolvedRouteProvider,
+        mode: result.mode,
+        requiresUserSignature: result.requiresUserSignature,
+        reason: result.requiresUserSignature
+          ? `User signature is required to complete the ${side}.`
+          : "Trade was prepared but not executed on-chain.",
+      });
+      callback?.({
+        text,
+        action: "EXECUTE_TRADE_FAILED",
+        executionMode: result.mode,
+        routeProvider: resolvedRouteProvider,
+        executed: false,
+        tokenAddress,
+        side,
+        requiresUserSignature: result.requiresUserSignature,
+      });
       return {
-        text:
-          `Trade prepared in ${result.mode} mode. ` +
-          `A user signature is required to complete the ${side}.`,
-        success: true,
+        text,
+        success: false,
         data: {
           side,
           tokenAddress,
           amount: amountRaw,
           mode: result.mode,
-          requiresUserSignature: true,
+          routeProvider: resolvedRouteProvider,
+          requiresUserSignature: result.requiresUserSignature,
           executed: false,
           unsignedTx: result.unsignedTx,
         },
       };
     } catch (err) {
-      return {
-        text: `Trade failed: ${err instanceof Error ? err.message : String(err)}`,
-        success: false,
-      };
+      const text = `Trade failed: ${err instanceof Error ? err.message : String(err)}`;
+      callback?.({ text, action: "EXECUTE_TRADE_FAILED" });
+      return { text, success: false };
     }
   },
 
@@ -271,6 +390,13 @@ export const executeTradeAction: Action = {
       description: "Slippage tolerance in basis points (default 300 = 3%)",
       required: false,
       schema: { type: "number" as const },
+    },
+    {
+      name: "routeProvider",
+      description:
+        'Route provider preference for the swap: "pancakeswap-v2" or "0x". Defaults to "pancakeswap-v2".',
+      required: false,
+      schema: { type: "string" as const },
     },
   ],
 };

--- a/packages/app-core/src/actions/execute-trade.ts
+++ b/packages/app-core/src/actions/execute-trade.ts
@@ -1,5 +1,5 @@
 /**
- * EXECUTE_TRADE action — executes a BSC token trade (buy or sell).
+ * EXECUTE_TRADE action ï¿½ executes a BSC token trade (buy or sell).
  *
  * When triggered the action:
  *   1. Validates parameters (side, tokenAddress format, amount > 0)
@@ -8,7 +8,7 @@
  *      if executed, or unsigned TX info if user-sign mode
  *
  * All business logic (permissions, safety caps, signing) is handled
- * server-side — this action is a thin wrapper.
+ * server-side ï¿½ this action is a thin wrapper.
  *
  * @module actions/execute-trade
  */
@@ -400,4 +400,3 @@ export const executeTradeAction: Action = {
     },
   ],
 };
-

--- a/packages/app-core/src/actions/transfer-token.test.ts
+++ b/packages/app-core/src/actions/transfer-token.test.ts
@@ -301,7 +301,9 @@ describe("TRANSFER_TOKEN action", () => {
     });
 
     expect((result as { success: boolean }).success).toBe(true);
-    expect((result as { text: string }).text).toContain("Action: TRANSFER_TOKEN");
+    expect((result as { text: string }).text).toContain(
+      "Action: TRANSFER_TOKEN",
+    );
     expect((result as { text: string }).text).toContain("Executed: true");
     expect((result as { text: string }).text).toContain("1.5");
     expect((result as { text: string }).text).toContain("BNB");
@@ -676,4 +678,3 @@ describe("TRANSFER_TOKEN action", () => {
     expect((result as { success: boolean }).success).toBe(false);
   });
 });
-

--- a/packages/app-core/src/actions/transfer-token.test.ts
+++ b/packages/app-core/src/actions/transfer-token.test.ts
@@ -318,7 +318,7 @@ describe("TRANSFER_TOKEN action", () => {
     // Verify fetch was called with correct args
     expect(mockFetch).toHaveBeenCalledOnce();
     const [url, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe("http://127.0.0.1:2138/api/wallet/transfer/execute");
+    expect(url).toBe("http://127.0.0.1:31337/api/wallet/transfer/execute");
     expect(opts.method).toBe("POST");
     expect(
       (opts.headers as Record<string, string>)["X-Eliza-Agent-Action"],
@@ -676,3 +676,4 @@ describe("TRANSFER_TOKEN action", () => {
     expect((result as { success: boolean }).success).toBe(false);
   });
 });
+

--- a/packages/app-core/src/actions/transfer-token.test.ts
+++ b/packages/app-core/src/actions/transfer-token.test.ts
@@ -301,12 +301,11 @@ describe("TRANSFER_TOKEN action", () => {
     });
 
     expect((result as { success: boolean }).success).toBe(true);
-    expect((result as { text: string }).text).toContain(
-      "executed successfully",
-    );
+    expect((result as { text: string }).text).toContain("Action: TRANSFER_TOKEN");
+    expect((result as { text: string }).text).toContain("Executed: true");
     expect((result as { text: string }).text).toContain("1.5");
     expect((result as { text: string }).text).toContain("BNB");
-    expect((result as { text: string }).text).toContain("0xabc123");
+    expect((result as { text: string }).text).toContain("Tx hash: 0xabc123");
     expect((result as { data: Record<string, unknown> }).data).toMatchObject({
       toAddress: VALID_ADDRESS,
       amount: "1.5",
@@ -370,7 +369,7 @@ describe("TRANSFER_TOKEN action", () => {
     );
   });
 
-  it("calls API and returns success for user-sign mode", async () => {
+  it("returns failure for user-sign mode because no on-chain execution occurred", async () => {
     const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
     mockFetch.mockResolvedValueOnce({
       ok: true,
@@ -392,8 +391,9 @@ describe("TRANSFER_TOKEN action", () => {
       assetSymbol: "BNB",
     });
 
-    expect((result as { success: boolean }).success).toBe(true);
+    expect((result as { success: boolean }).success).toBe(false);
     expect((result as { text: string }).text).toContain("user-sign");
+    expect((result as { text: string }).text).toContain("Executed: false");
     expect((result as { text: string }).text).toContain(
       "signature is required",
     );
@@ -401,6 +401,37 @@ describe("TRANSFER_TOKEN action", () => {
       requiresUserSignature: true,
       executed: false,
     });
+  });
+
+  it("fires TRANSFER_TOKEN_FAILED callback when transfer is not executed", async () => {
+    const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        mode: "user-sign",
+        executed: false,
+        requiresUserSignature: true,
+        toAddress: VALID_ADDRESS,
+        amount: "1.5",
+        assetSymbol: "BNB",
+        unsignedTx: { chainId: 56, to: VALID_ADDRESS, data: "0x..." },
+      }),
+    });
+
+    const callback = vi.fn();
+    await callHandlerWithCallback(
+      {
+        toAddress: VALID_ADDRESS,
+        amount: "1.5",
+        assetSymbol: "BNB",
+      },
+      callback,
+    );
+
+    expect(callback).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "TRANSFER_TOKEN_FAILED" }),
+    );
   });
 
   it("accepts numeric amount parameter", async () => {

--- a/packages/app-core/src/actions/transfer-token.ts
+++ b/packages/app-core/src/actions/transfer-token.ts
@@ -21,7 +21,7 @@ import type {
 } from "@elizaos/core";
 import {
   buildAuthHeaders,
-  WALLET_ACTION_API_PORT,
+  getWalletActionApiPort,
 } from "./wallet-action-shared.js";
 
 /** Timeout for the transfer API call (includes on-chain confirmation). */
@@ -238,7 +238,7 @@ export const transferTokenAction: Action = {
       }
 
       const response = await fetch(
-        `http://127.0.0.1:${WALLET_ACTION_API_PORT}/api/wallet/transfer/execute`,
+        `http://127.0.0.1:${getWalletActionApiPort()}/api/wallet/transfer/execute`,
         {
           method: "POST",
           headers: {

--- a/packages/app-core/src/actions/transfer-token.ts
+++ b/packages/app-core/src/actions/transfer-token.ts
@@ -29,6 +29,95 @@ const TRANSFER_TIMEOUT_MS = 60_000;
 
 /** Matches a 0x-prefixed 40-hex-char EVM address. */
 const EVM_ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
+const EVM_ADDRESS_CAPTURE_RE = /\b0x[a-fA-F0-9]{40}\b/g;
+const DECIMAL_AMOUNT_CAPTURE_RE = /\b(\d+(?:\.\d+)?)\b/;
+const ASSET_SYMBOL_CAPTURE_RE =
+  /\b(?:t?bnb|bnb|eth|usdt|usdc|busd|dai|weth|wbtc)\b/i;
+
+function extractMessageText(message: unknown): string {
+  if (
+    !message ||
+    typeof message !== "object" ||
+    !("content" in message) ||
+    !message.content ||
+    typeof message.content !== "object" ||
+    !("text" in message.content) ||
+    typeof message.content.text !== "string"
+  ) {
+    return "";
+  }
+  return message.content.text.trim();
+}
+
+function inferTransferParamsFromMessage(message: unknown): {
+  toAddress?: string;
+  amount?: string;
+  assetSymbol?: string;
+} {
+  const text = extractMessageText(message);
+  const addressMatches = text.match(EVM_ADDRESS_CAPTURE_RE) ?? [];
+  const toAddress = addressMatches[addressMatches.length - 1];
+  const amount = text.match(DECIMAL_AMOUNT_CAPTURE_RE)?.[1];
+  const assetSymbol = text.match(ASSET_SYMBOL_CAPTURE_RE)?.[0];
+  return {
+    toAddress,
+    amount,
+    assetSymbol:
+      typeof assetSymbol === "string"
+        ? assetSymbol.trim().toUpperCase() === "TBNB"
+          ? "BNB"
+          : assetSymbol.trim().toUpperCase()
+        : undefined,
+  };
+}
+
+function walletNetworkLabel(): string {
+  return process.env.MILADY_WALLET_NETWORK?.trim().toLowerCase() === "testnet"
+    ? "BSC testnet"
+    : "BSC";
+}
+
+function buildTransferSuccessText(args: {
+  amount: string;
+  assetSymbol: string;
+  toAddress: string;
+  mode: string;
+  txHash: string;
+  explorerUrl: string;
+  status: string;
+}): string {
+  return [
+    "Action: TRANSFER_TOKEN",
+    `Chain: ${walletNetworkLabel()}`,
+    `Amount: ${args.amount} ${args.assetSymbol}`,
+    `Recipient: ${args.toAddress}`,
+    `Execution mode: ${args.mode}`,
+    "Executed: true",
+    `Tx hash: ${args.txHash}`,
+    `Explorer: ${args.explorerUrl}`,
+    `Status: ${args.status}`,
+  ].join("\n");
+}
+
+function buildTransferFailureText(args: {
+  amount: string;
+  assetSymbol: string;
+  toAddress: string;
+  mode: string;
+  requiresUserSignature: boolean;
+  reason: string;
+}): string {
+  return [
+    "Action: TRANSFER_TOKEN",
+    `Chain: ${walletNetworkLabel()}`,
+    `Amount: ${args.amount} ${args.assetSymbol}`,
+    `Recipient: ${args.toAddress}`,
+    `Execution mode: ${args.mode}`,
+    "Executed: false",
+    `Requires user signature: ${args.requiresUserSignature ? "true" : "false"}`,
+    `Reason: ${args.reason}`,
+  ].join("\n");
+}
 
 export const transferTokenAction: Action = {
   name: "TRANSFER_TOKEN",
@@ -56,12 +145,15 @@ export const transferTokenAction: Action = {
   ) => {
     try {
       const params = (options as HandlerOptions | undefined)?.parameters;
+      const inferredParams = inferTransferParamsFromMessage(_message);
 
       // ── Validate toAddress ─────────────────────────────────────────────
       const toAddress =
         typeof params?.toAddress === "string"
-          ? params.toAddress.trim()
-          : undefined;
+          ? EVM_ADDRESS_RE.test(params.toAddress.trim())
+            ? params.toAddress.trim()
+            : inferredParams.toAddress
+          : inferredParams.toAddress;
 
       if (!toAddress || !EVM_ADDRESS_RE.test(toAddress)) {
         const text =
@@ -76,10 +168,12 @@ export const transferTokenAction: Action = {
       // ── Validate amount ────────────────────────────────────────────────
       const amountRaw =
         typeof params?.amount === "string"
-          ? params.amount.trim()
+          ? Number(params.amount.trim()) > 0
+            ? params.amount.trim()
+            : inferredParams.amount
           : typeof params?.amount === "number"
             ? String(params.amount)
-            : undefined;
+            : inferredParams.amount;
 
       if (
         !amountRaw ||
@@ -97,8 +191,10 @@ export const transferTokenAction: Action = {
       // ── Validate assetSymbol ───────────────────────────────────────────
       const assetSymbol =
         typeof params?.assetSymbol === "string"
-          ? params.assetSymbol.trim()
-          : undefined;
+          ? params.assetSymbol.trim().length > 0
+            ? params.assetSymbol.trim()
+            : inferredParams.assetSymbol
+          : inferredParams.assetSymbol;
 
       if (!assetSymbol) {
         const text =
@@ -197,11 +293,26 @@ export const transferTokenAction: Action = {
 
       // ── Build human-readable response ──────────────────────────────────
       if (result.executed && result.execution) {
-        const text =
-          `Transfer executed successfully! Sent ${amountRaw} ${assetSymbol} to ${toAddress} via ${result.mode} mode.\n` +
-          `TX: ${result.execution.explorerUrl}\n` +
-          `Status: ${result.execution.status}`;
-        if (callback) callback({ text, action: "TRANSFER_TOKEN_SUCCESS" });
+        const text = buildTransferSuccessText({
+          amount: amountRaw,
+          assetSymbol,
+          toAddress,
+          mode: result.mode,
+          txHash: result.execution.hash,
+          explorerUrl: result.execution.explorerUrl,
+          status: result.execution.status,
+        });
+        if (callback) {
+          callback({
+            text,
+            action: "TRANSFER_TOKEN_SUCCESS",
+            txHash: result.execution.hash,
+            explorerUrl: result.execution.explorerUrl,
+            executionMode: result.mode,
+            executed: true,
+            recipient: toAddress,
+          });
+        }
         return {
           text,
           success: true,
@@ -217,20 +328,37 @@ export const transferTokenAction: Action = {
         };
       }
 
-      // user-sign mode — transfer was prepared but not executed on-chain
-      const text =
-        `Transfer prepared in ${result.mode} mode. ` +
-        `A user signature is required to send ${amountRaw} ${assetSymbol} to ${toAddress}.`;
-      if (callback) callback({ text, action: "TRANSFER_TOKEN_SUCCESS" });
+      // For agent automation, reporting "success" without an on-chain execution
+      // leads to false-positive heartbeat status.
+      const text = buildTransferFailureText({
+        amount: amountRaw,
+        assetSymbol,
+        toAddress,
+        mode: result.mode,
+        requiresUserSignature: result.requiresUserSignature,
+        reason: result.requiresUserSignature
+          ? "User signature is required before the transfer can be broadcast."
+          : "Transfer was prepared but not executed on-chain.",
+      });
+      if (callback) {
+        callback({
+          text,
+          action: "TRANSFER_TOKEN_FAILED",
+          executionMode: result.mode,
+          executed: false,
+          recipient: toAddress,
+          requiresUserSignature: result.requiresUserSignature,
+        });
+      }
       return {
         text,
-        success: true,
+        success: false,
         data: {
           toAddress,
           amount: amountRaw,
           assetSymbol,
           mode: result.mode,
-          requiresUserSignature: true,
+          requiresUserSignature: result.requiresUserSignature,
           executed: false,
           unsignedTx: result.unsignedTx,
         },

--- a/packages/app-core/src/actions/wallet-action-shared.ts
+++ b/packages/app-core/src/actions/wallet-action-shared.ts
@@ -5,9 +5,16 @@
  * @module actions/wallet-action-shared
  */
 
-/** API port for loopback wallet API calls. Shared across all wallet actions. */
-export const WALLET_ACTION_API_PORT =
-  process.env.MILADY_API_PORT || process.env.MILADY_PORT || "2138";
+/** Resolve the loopback API port for wallet action calls at runtime. */
+export function getWalletActionApiPort(): string {
+  return (
+    process.env.MILADY_API_PORT ||
+    process.env.MILADY_PORT ||
+    process.env.ELIZA_PORT ||
+    process.env.API_PORT ||
+    "31337"
+  );
+}
 
 /**
  * Build Authorization headers for loopback API calls.

--- a/packages/app-core/src/api/server.package-root.test.ts
+++ b/packages/app-core/src/api/server.package-root.test.ts
@@ -7,7 +7,12 @@ import { findOwnPackageRoot } from "./server";
 const tempDirs: string[] = [];
 
 function makeTempDir(prefix: string): string {
-  const dir = mkdtempSync(path.join(os.tmpdir(), prefix));
+  const preferredBase = path.join(
+    process.env.LOCALAPPDATA ?? os.tmpdir(),
+    "milady-package-root-tests",
+  );
+  mkdirSync(preferredBase, { recursive: true });
+  const dir = mkdtempSync(path.join(preferredBase, prefix));
   tempDirs.push(dir);
   return dir;
 }

--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -2743,7 +2743,8 @@ async function handleMiladyCompatRoute(
             return true;
           }
 
-          approvalHash = "txHash" in approvalResult ? approvalResult.txHash : "";
+          approvalHash =
+            "txHash" in approvalResult ? approvalResult.txHash : "";
 
           if (approvalResult.mode === "steward" && rpcUrl) {
             const provider = new ethers.JsonRpcProvider(rpcUrl);

--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -2644,20 +2644,108 @@ async function handleMiladyCompatRoute(
       });
 
       let approvalHash: string | undefined;
-      if (requiresApproval && unsignedApprovalTx) {
-        const approvalResult = await signTransactionWithOptionalSteward({
-          evmAddress: walletAddress,
-          tx: {
+      let finalHash = "";
+      let finalNonce: number | null = null;
+      let finalGasLimit = "0";
+      let finalMode: "local-key" | "steward" = hasLocalKey
+        ? "local-key"
+        : "steward";
+
+      if (hasLocalKey && canExecuteLocally) {
+        if (!rpcUrl) {
+          sendJsonErrorResponse(
+            res,
+            503,
+            "BSC RPC not configured for local execution",
+          );
+          return true;
+        }
+
+        if (requiresApproval && unsignedApprovalTx) {
+          const approvalResult = await _sendLocalWalletTransaction(rpcUrl, {
             to: unsignedApprovalTx.to,
             data: unsignedApprovalTx.data,
-            value: unsignedApprovalTx.valueWei,
+            value: BigInt(unsignedApprovalTx.valueWei),
             chainId: unsignedApprovalTx.chainId,
+          });
+          approvalHash = approvalResult.hash;
+          const provider = new ethers.JsonRpcProvider(rpcUrl);
+          try {
+            await provider.waitForTransaction(approvalHash, 1);
+          } finally {
+            provider.destroy();
+          }
+        }
+
+        const localExecution = await _sendLocalWalletTransaction(rpcUrl, {
+          to: unsignedTx.to,
+          data: unsignedTx.data,
+          value: BigInt(unsignedTx.valueWei),
+          chainId: unsignedTx.chainId,
+        });
+        finalHash = localExecution.hash;
+        finalNonce = localExecution.nonce;
+        finalGasLimit = localExecution.gasLimit;
+      } else {
+        finalMode = "steward";
+        if (requiresApproval && unsignedApprovalTx) {
+          const approvalResult = await signTransactionWithOptionalSteward({
+            evmAddress: walletAddress,
+            tx: {
+              to: unsignedApprovalTx.to,
+              data: unsignedApprovalTx.data,
+              value: unsignedApprovalTx.valueWei,
+              chainId: unsignedApprovalTx.chainId,
+            },
+          });
+
+          if (
+            approvalResult.mode === "steward" &&
+            approvalResult.pendingApproval
+          ) {
+            sendJsonResponse(res, 200, {
+              ok: true,
+              side: quote.side,
+              mode: "steward",
+              quote,
+              executed: false,
+              requiresUserSignature: false,
+              unsignedTx,
+              unsignedApprovalTx,
+              requiresApproval,
+              approval: {
+                status: "pending_approval",
+                policyResults: approvalResult.policyResults,
+              },
+            });
+            return true;
+          }
+
+          approvalHash = "txHash" in approvalResult ? approvalResult.txHash : "";
+
+          if (approvalResult.mode === "steward" && rpcUrl) {
+            const provider = new ethers.JsonRpcProvider(rpcUrl);
+            try {
+              await provider.waitForTransaction(approvalHash, 1);
+            } finally {
+              provider.destroy();
+            }
+          }
+        }
+
+        const executionResult = await signTransactionWithOptionalSteward({
+          evmAddress: walletAddress,
+          tx: {
+            to: unsignedTx.to,
+            data: unsignedTx.data,
+            value: unsignedTx.valueWei,
+            chainId: unsignedTx.chainId,
           },
         });
 
         if (
-          approvalResult.mode === "steward" &&
-          approvalResult.pendingApproval
+          executionResult.mode === "steward" &&
+          executionResult.pendingApproval
         ) {
           sendJsonResponse(res, 200, {
             ok: true,
@@ -2669,64 +2757,17 @@ async function handleMiladyCompatRoute(
             unsignedTx,
             unsignedApprovalTx,
             requiresApproval,
-            approval: {
+            approvalHash,
+            execution: {
               status: "pending_approval",
-              policyResults: approvalResult.policyResults,
+              policyResults: executionResult.policyResults,
             },
           });
           return true;
         }
 
-        approvalHash = "txHash" in approvalResult ? approvalResult.txHash : "";
-
-        if (approvalResult.mode === "steward" && rpcUrl) {
-          const provider = new ethers.JsonRpcProvider(rpcUrl);
-          try {
-            await provider.waitForTransaction(approvalHash, 1);
-          } finally {
-            provider.destroy();
-          }
-        }
+        finalHash = "txHash" in executionResult ? executionResult.txHash : "";
       }
-
-      const executionResult = await signTransactionWithOptionalSteward({
-        evmAddress: walletAddress,
-        tx: {
-          to: unsignedTx.to,
-          data: unsignedTx.data,
-          value: unsignedTx.valueWei,
-          chainId: unsignedTx.chainId,
-        },
-      });
-
-      if (
-        executionResult.mode === "steward" &&
-        executionResult.pendingApproval
-      ) {
-        sendJsonResponse(res, 200, {
-          ok: true,
-          side: quote.side,
-          mode: "steward",
-          quote,
-          executed: false,
-          requiresUserSignature: false,
-          unsignedTx,
-          unsignedApprovalTx,
-          requiresApproval,
-          approvalHash,
-          execution: {
-            status: "pending_approval",
-            policyResults: executionResult.policyResults,
-          },
-        });
-        return true;
-      }
-
-      const finalHash =
-        "txHash" in executionResult ? executionResult.txHash : "";
-      const finalNonce = null;
-      const finalGasLimit = "0";
-      const finalMode = executionResult.mode;
 
       try {
         const tradeSource =
@@ -2929,46 +2970,72 @@ async function handleMiladyCompatRoute(
     });
 
     try {
-      const executionResult = await signTransactionWithOptionalSteward({
-        evmAddress: addresses.evmAddress,
-        tx: {
+      let finalHash = "";
+      let finalNonce: number | null = null;
+      let finalGasLimit = "0";
+      let finalMode: "local-key" | "steward" = hasLocalKey
+        ? "local-key"
+        : "steward";
+
+      if (hasLocalKey && canExecuteLocally) {
+        if (!_rpcUrl) {
+          sendJsonErrorResponse(
+            res,
+            503,
+            "BSC RPC not configured for local execution",
+          );
+          return true;
+        }
+
+        const localExecution = await _sendLocalWalletTransaction(_rpcUrl, {
           to: unsignedTx.to,
           data: unsignedTx.data,
-          value: unsignedTx.valueWei,
+          value: BigInt(unsignedTx.valueWei),
           chainId: unsignedTx.chainId,
-        },
-      });
-
-      if (
-        executionResult.mode === "steward" &&
-        executionResult.pendingApproval
-      ) {
-        sendJsonResponse(res, 200, {
-          ok: true,
-          mode: "steward",
-          executed: false,
-          requiresUserSignature: false,
-          toAddress,
-          amount,
-          assetSymbol,
-          tokenAddress: unsignedTx.tokenAddress,
-          unsignedTx,
-          execution: {
-            status: "pending_approval",
-            policyResults: executionResult.policyResults,
+        });
+        finalHash = localExecution.hash;
+        finalNonce = localExecution.nonce;
+        finalGasLimit = localExecution.gasLimit;
+      } else {
+        finalMode = "steward";
+        const executionResult = await signTransactionWithOptionalSteward({
+          evmAddress: addresses.evmAddress,
+          tx: {
+            to: unsignedTx.to,
+            data: unsignedTx.data,
+            value: unsignedTx.valueWei,
+            chainId: unsignedTx.chainId,
           },
         });
-        return true;
-      }
 
-      const finalHash =
-        "txHash" in executionResult ? executionResult.txHash : "";
-      const finalNonce = null;
-      const finalGasLimit = "0";
+        if (
+          executionResult.mode === "steward" &&
+          executionResult.pendingApproval
+        ) {
+          sendJsonResponse(res, 200, {
+            ok: true,
+            mode: "steward",
+            executed: false,
+            requiresUserSignature: false,
+            toAddress,
+            amount,
+            assetSymbol,
+            tokenAddress: unsignedTx.tokenAddress,
+            unsignedTx,
+            execution: {
+              status: "pending_approval",
+              policyResults: executionResult.policyResults,
+            },
+          });
+          return true;
+        }
+
+        finalHash = "txHash" in executionResult ? executionResult.txHash : "";
+      }
 
       sendJsonResponse(res, 200, {
         ok: true,
-        mode: executionResult.mode,
+        mode: finalMode,
         executed: true,
         requiresUserSignature: false,
         toAddress,

--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -1953,6 +1953,27 @@ async function _sendLocalWalletTransaction(
   }
 }
 
+function resolveBscExecutionNetwork(): {
+  chainId: number;
+  explorerBaseUrl: string;
+} {
+  if (process.env.MILADY_WALLET_NETWORK?.trim().toLowerCase() === "testnet") {
+    const parsedChainId = Number.parseInt(
+      process.env.BSC_TESTNET_CHAIN_ID?.trim() ?? "97",
+      10,
+    );
+    return {
+      chainId: Number.isNaN(parsedChainId) ? 97 : parsedChainId,
+      explorerBaseUrl: "https://testnet.bscscan.com",
+    };
+  }
+
+  return {
+    chainId: 56,
+    explorerBaseUrl: "https://bscscan.com",
+  };
+}
+
 /**
  * Load config from disk and backfill cloud.apiKey from sealed secrets
  * if it's missing. This handles the case where the API key was persisted
@@ -2573,6 +2594,7 @@ async function handleMiladyCompatRoute(
     const hasStewardSigner = isStewardConfigured();
     const canSign = hasLocalKey || hasStewardSigner;
     const rpcReadiness = resolveWalletRpcReadiness(config);
+    const bscExecutionNetwork = resolveBscExecutionNetwork();
 
     try {
       const quote = await buildBscTradeQuote({
@@ -2798,7 +2820,7 @@ async function handleMiladyCompatRoute(
           blockNumber: null,
           gasUsed: null,
           effectiveGasPriceWei: null,
-          explorerUrl: `https://bscscan.com/tx/${finalHash}`,
+          explorerUrl: `${bscExecutionNetwork.explorerBaseUrl}/tx/${finalHash}`,
         });
       } catch (ledgerErr) {
         logger.warn(
@@ -2821,7 +2843,7 @@ async function handleMiladyCompatRoute(
           nonce: finalNonce,
           gasLimit: finalGasLimit,
           valueWei: unsignedTx.valueWei,
-          explorerUrl: `https://bscscan.com/tx/${finalHash}`,
+          explorerUrl: `${bscExecutionNetwork.explorerBaseUrl}/tx/${finalHash}`,
           blockNumber: null,
           status: "pending",
           approvalHash,
@@ -2888,6 +2910,7 @@ async function handleMiladyCompatRoute(
     const canSign = hasLocalKey || hasStewardSigner;
     const addresses = getWalletAddresses();
     const rpcReadiness = resolveWalletRpcReadiness(config);
+    const bscExecutionNetwork = resolveBscExecutionNetwork();
 
     let toAddress: string;
     try {
@@ -2923,7 +2946,7 @@ async function handleMiladyCompatRoute(
     }
 
     const unsignedTx = {
-      chainId: 56,
+      chainId: bscExecutionNetwork.chainId,
       from: addresses.evmAddress ?? null,
       to:
         isBnb || typeof body.tokenAddress !== "string"
@@ -2938,7 +2961,7 @@ async function handleMiladyCompatRoute(
             ethers.parseUnits(amount, decimals),
           ]),
       valueWei: isBnb ? ethers.parseEther(amount).toString() : "0",
-      explorerUrl: "https://bscscan.com",
+      explorerUrl: bscExecutionNetwork.explorerBaseUrl,
       assetSymbol,
       amount,
       tokenAddress:
@@ -3048,7 +3071,7 @@ async function handleMiladyCompatRoute(
           nonce: finalNonce,
           gasLimit: finalGasLimit,
           valueWei: unsignedTx.valueWei,
-          explorerUrl: `https://bscscan.com/tx/${finalHash}`,
+          explorerUrl: `${bscExecutionNetwork.explorerBaseUrl}/tx/${finalHash}`,
           blockNumber: null,
           status: "pending",
         },

--- a/packages/app-core/src/components/BugReportModal.tsx
+++ b/packages/app-core/src/components/BugReportModal.tsx
@@ -65,7 +65,7 @@ const subtleMonoDescriptionClassName = "font-mono text-[11px] text-muted";
 export function BugReportModal() {
   const { copyToClipboard, t } = useApp();
   const branding = useBranding();
-  const { isOpen, close } = useBugReport();
+  const { isOpen, draft, close } = useBugReport();
   const [form, setForm] = useState<BugReportForm>(EMPTY_FORM);
   const [submitting, setSubmitting] = useState(false);
   const [resultUrl, setResultUrl] = useState<string | null>(null);
@@ -91,20 +91,22 @@ export function BugReportModal() {
       .checkBugReportInfo()
       .then((info) => {
         if (cancelled) return;
-        if (info.nodeVersion)
-          setForm((f) => ({ ...f, nodeVersion: info.nodeVersion ?? "" }));
-        if (info.platform)
-          setForm((f) => ({
-            ...f,
-            environment:
-              info.platform === "darwin"
-                ? "macOS"
-                : info.platform === "win32"
-                  ? "Windows"
-                  : info.platform === "linux"
-                    ? "Linux"
-                    : "Other",
-          }));
+        setForm((f) => ({
+          ...f,
+          ...(info.nodeVersion ? { nodeVersion: info.nodeVersion ?? "" } : {}),
+          ...(info.platform
+            ? {
+                environment:
+                  info.platform === "darwin"
+                    ? "macOS"
+                    : info.platform === "win32"
+                      ? "Windows"
+                      : info.platform === "linux"
+                        ? "Linux"
+                        : "Other",
+              }
+            : {}),
+        }));
       })
       .catch((err: unknown) => {
         console.warn("[BugReportModal] Failed to fetch bug report info:", err);
@@ -114,6 +116,14 @@ export function BugReportModal() {
       cancelled = true;
     };
   }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen || !draft) return;
+    setForm((f) => ({
+      ...f,
+      ...draft,
+    }));
+  }, [draft, isOpen]);
 
   useEffect(() => {
     if (!resultUrl) return;

--- a/packages/app-core/src/components/ChatModalView.test.tsx
+++ b/packages/app-core/src/components/ChatModalView.test.tsx
@@ -74,14 +74,17 @@ vi.mock("./ConversationsSidebar.js", () => ({
   ConversationsSidebar: ({
     mobile,
     variant,
+    showNewChatButton,
   }: {
     mobile?: boolean;
     variant?: string;
+    showNewChatButton?: boolean;
   }) =>
     React.createElement("div", {
       "data-testid": "conversations-sidebar",
       "data-mobile": mobile ?? false,
       "data-variant": variant ?? "default",
+      "data-show-new-chat-button": showNewChatButton ?? true,
     }),
 }));
 
@@ -140,6 +143,12 @@ describe("ChatModalView", () => {
       "data-chat-game-thread": true,
     });
     expect(String(thread.props.className)).toContain("pointer-events-auto");
+
+    const sidebar = testRenderer.root.findByProps({
+      "data-testid": "conversations-sidebar",
+      "data-variant": "game-modal",
+    });
+    expect(sidebar.props["data-show-new-chat-button"]).toBe(false);
   });
 
   it("renders a mobile conversations overlay when the companion rail is toggled on a narrow viewport", async () => {
@@ -177,6 +186,13 @@ describe("ChatModalView", () => {
 
     expect(
       sidebarInstances.some((node) => node.props["data-mobile"] === true),
+    ).toBe(true);
+    expect(
+      sidebarInstances.some(
+        (node) =>
+          node.props["data-mobile"] === true &&
+          node.props["data-show-new-chat-button"] === false,
+      ),
     ).toBe(true);
 
     const mobileOverlay = testRenderer.root.findByProps({

--- a/packages/app-core/src/components/ChatModalView.tsx
+++ b/packages/app-core/src/components/ChatModalView.tsx
@@ -76,7 +76,11 @@ export const ChatModalView = memo(function ChatModalView({
               <DrawerSheetHeader className="sr-only">
                 <DrawerSheetTitle>Chats</DrawerSheetTitle>
               </DrawerSheetHeader>
-              <ConversationsSidebar mobile onClose={onSidebarClose} />
+              <ConversationsSidebar
+                mobile
+                onClose={onSidebarClose}
+                showNewChatButton={!isCompanionDock}
+              />
             </DrawerSheetContent>
           </DrawerSheet>
         )}
@@ -91,7 +95,10 @@ export const ChatModalView = memo(function ChatModalView({
             } ${isCompanionDock ? "pointer-events-auto" : ""}`}
             data-chat-game-sidebar
           >
-            <ConversationsSidebar variant="game-modal" />
+            <ConversationsSidebar
+              variant="game-modal"
+              showNewChatButton={!isCompanionDock}
+            />
           </aside>
           <section
             className={`flex-1 flex flex-col min-w-0 bg-transparent relative ${

--- a/packages/app-core/src/components/ConversationsSidebar.tsx
+++ b/packages/app-core/src/components/ConversationsSidebar.tsx
@@ -60,12 +60,14 @@ interface ConversationsSidebarProps {
   mobile?: boolean;
   onClose?: () => void;
   variant?: ConversationsSidebarVariant;
+  showNewChatButton?: boolean;
 }
 
 export function ConversationsSidebar({
   mobile = false,
   onClose,
   variant = "default",
+  showNewChatButton = true,
 }: ConversationsSidebarProps) {
   const {
     conversations,
@@ -334,20 +336,22 @@ export function ConversationsSidebar({
                   ) : null}
                 </div>
               </div>
-              <Button
-                variant="outline"
-                className={
-                  isGameModal
-                    ? "h-11 w-full rounded-xl border-[color:var(--onboarding-accent-border)] bg-[color:var(--onboarding-accent-bg)] px-3 py-2 text-sm font-medium text-[color:var(--onboarding-text-strong)] shadow-[0_12px_28px_rgba(0,0,0,0.18)] hover:border-[color:var(--onboarding-accent-border-hover)] hover:bg-[color:var(--onboarding-accent-bg-hover)] active:scale-[0.98]"
-                    : `min-h-[44px] w-full rounded-[14px] px-3 py-2.5 text-[12px] font-medium ${DESKTOP_CONTROL_SURFACE_ACCENT_CLASSNAME}`
-                }
-                onClick={() => {
-                  handleNewConversation();
-                  onClose?.();
-                }}
-              >
-                {t("conversations.newChat")}
-              </Button>
+              {showNewChatButton ? (
+                <Button
+                  variant="outline"
+                  className={
+                    isGameModal
+                      ? "h-11 w-full rounded-xl border-[color:var(--onboarding-accent-border)] bg-[color:var(--onboarding-accent-bg)] px-3 py-2 text-sm font-medium text-[color:var(--onboarding-text-strong)] shadow-[0_12px_28px_rgba(0,0,0,0.18)] hover:border-[color:var(--onboarding-accent-border-hover)] hover:bg-[color:var(--onboarding-accent-bg-hover)] active:scale-[0.98]"
+                      : `min-h-[44px] w-full rounded-[14px] px-3 py-2.5 text-[12px] font-medium ${DESKTOP_CONTROL_SURFACE_ACCENT_CLASSNAME}`
+                  }
+                  onClick={() => {
+                    handleNewConversation();
+                    onClose?.();
+                  }}
+                >
+                  {t("conversations.newChat")}
+                </Button>
+              ) : null}
             </>
           )}
         </div>

--- a/packages/app-core/src/components/StartupFailureView.test.tsx
+++ b/packages/app-core/src/components/StartupFailureView.test.tsx
@@ -3,9 +3,10 @@
 import TestRenderer, { act } from "react-test-renderer";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockUseApp, mockUseBranding } = vi.hoisted(() => ({
+const { mockUseApp, mockUseBranding, openBugReportMock } = vi.hoisted(() => ({
   mockUseApp: vi.fn(),
   mockUseBranding: vi.fn(),
+  openBugReportMock: vi.fn(),
 }));
 
 vi.mock("../state", () => ({
@@ -14,6 +15,10 @@ vi.mock("../state", () => ({
 
 vi.mock("../config/branding", () => ({
   useBranding: () => mockUseBranding(),
+}));
+
+vi.mock("../hooks", () => ({
+  useBugReport: () => ({ open: openBugReportMock }),
 }));
 
 import { StartupFailureView } from "./StartupFailureView";
@@ -32,9 +37,11 @@ describe("StartupFailureView", () => {
               "This origin does not host the agent backend.",
             "startupfailureview.RetryStartup": "Retry Startup",
             "startupfailureview.OpenApp": "Open App",
+            "bugreportmodal.ReportABug": "Report Bug",
           }) as Record<string, string>
         )[key] ?? key,
     });
+    openBugReportMock.mockReset();
   });
 
   it("renders retry controls and details for startup failures", async () => {
@@ -59,6 +66,44 @@ describe("StartupFailureView", () => {
     expect(snapshot).toContain("The agent process exited unexpectedly.");
     expect(snapshot).toContain("stack trace");
     expect(snapshot).toContain("Retry Startup");
+    expect(snapshot).toContain("Report Bug");
+  });
+
+  it("opens bug report with startup diagnostics", async () => {
+    const onRetry = vi.fn();
+
+    let tree: TestRenderer.ReactTestRenderer | undefined;
+    await act(async () => {
+      tree = TestRenderer.create(
+        <StartupFailureView
+          error={{
+            reason: "backend-unreachable",
+            phase: "starting-backend",
+            message: "Failed to reach backend",
+            detail: "HTTP 404",
+            status: 404,
+            path: "/api/onboarding/status",
+          }}
+          onRetry={onRetry}
+        />,
+      );
+    });
+
+    const buttons = tree?.root.findAllByType("button") ?? [];
+    const reportButton = buttons.find((button) =>
+      button.children.join("").includes("Report Bug"),
+    );
+    await act(async () => {
+      reportButton?.props.onClick();
+    });
+
+    expect(openBugReportMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: "Backend Unreachable: Failed to reach backend",
+        actualBehavior: "Failed to reach backend",
+        logs: expect.stringContaining("Path: /api/onboarding/status"),
+      }),
+    );
   });
 
   it("shows the open-app action when the backend is unreachable", async () => {

--- a/packages/app-core/src/components/StartupFailureView.tsx
+++ b/packages/app-core/src/components/StartupFailureView.tsx
@@ -7,6 +7,7 @@ import {
   StatusBadge,
 } from "@miladyai/ui";
 import { useBranding } from "../config/branding";
+import { useBugReport } from "../hooks";
 import type { StartupErrorState } from "../state";
 import { useApp } from "../state";
 
@@ -34,8 +35,18 @@ export function StartupFailureView({
 }: StartupFailureViewProps) {
   const { t } = useApp();
   const branding = useBranding();
+  const { open: openBugReport } = useBugReport();
   const isBackendUnreachable = error.reason === "backend-unreachable";
   const reasonLabel = REASON_LABELS[error.reason];
+  const startupDetail = [
+    `Reason: ${error.reason}`,
+    `Phase: ${error.phase}`,
+    typeof error.status === "number" ? `Status: ${error.status}` : null,
+    error.path ? `Path: ${error.path}` : null,
+    error.detail ? `Detail: ${error.detail}` : null,
+  ]
+    .filter(Boolean)
+    .join("\n");
 
   return (
     <div className={SCREEN_SHELL_CLASS}>
@@ -92,6 +103,24 @@ export function StartupFailureView({
               className="w-full sm:w-auto sm:min-w-[11rem]"
             >
               {t("startupfailureview.RetryStartup")}
+            </Button>
+            <Button
+              variant="outline"
+              size="lg"
+              onClick={() =>
+                openBugReport({
+                  description: `${reasonLabel}: ${error.message}`.slice(0, 80),
+                  stepsToReproduce:
+                    "1. Launch the desktop app.\n2. Wait for startup to fail.\n3. Observe the startup failure screen.",
+                  expectedBehavior:
+                    "The app should finish startup and show the main shell.",
+                  actualBehavior: error.message,
+                  logs: startupDetail,
+                })
+              }
+              className="w-full sm:w-auto sm:min-w-[10rem]"
+            >
+              {t("bugreportmodal.ReportABug")}
             </Button>
             {isBackendUnreachable ? (
               <Button

--- a/packages/app-core/src/hooks/useBugReport.tsx
+++ b/packages/app-core/src/hooks/useBugReport.tsx
@@ -6,9 +6,21 @@ import {
   useState,
 } from "react";
 
+export interface BugReportDraft {
+  description?: string;
+  stepsToReproduce?: string;
+  expectedBehavior?: string;
+  actualBehavior?: string;
+  environment?: string;
+  nodeVersion?: string;
+  modelProvider?: string;
+  logs?: string;
+}
+
 interface BugReportContextValue {
   isOpen: boolean;
-  open: () => void;
+  draft: BugReportDraft | null;
+  open: (draft?: BugReportDraft) => void;
   close: () => void;
 }
 
@@ -23,9 +35,16 @@ export function useBugReport(): BugReportContextValue {
 
 export function useBugReportState(): BugReportContextValue {
   const [isOpen, setIsOpen] = useState(false);
-  const open = useCallback(() => setIsOpen(true), []);
-  const close = useCallback(() => setIsOpen(false), []);
-  return { isOpen, open, close };
+  const [draft, setDraft] = useState<BugReportDraft | null>(null);
+  const open = useCallback((nextDraft?: BugReportDraft) => {
+    setDraft(nextDraft ?? null);
+    setIsOpen(true);
+  }, []);
+  const close = useCallback(() => {
+    setIsOpen(false);
+    setDraft(null);
+  }, []);
+  return { isOpen, draft, open, close };
 }
 
 export function BugReportProvider({

--- a/packages/app-core/test/app/bug-report-modal.test.tsx
+++ b/packages/app-core/test/app/bug-report-modal.test.tsx
@@ -124,7 +124,7 @@ let closeFn: ReturnType<typeof vi.fn>;
 
 function setupMock(isOpen: boolean) {
   closeFn = vi.fn();
-  mockUseBugReport.mockReturnValue({ isOpen, close: closeFn });
+  mockUseBugReport.mockReturnValue({ isOpen, draft: null, close: closeFn });
 }
 
 function getButtons(root: TestRenderer.ReactTestInstance) {
@@ -234,6 +234,28 @@ describe("BugReportModal", () => {
       await new Promise(r => globalThis.setTimeout(r, 60));
     });
     expect(mockClient.checkBugReportInfo).toHaveBeenCalledOnce();
+  });
+
+  it("prefills the form from bug report draft data", async () => {
+    closeFn = vi.fn();
+    mockUseBugReport.mockReturnValue({
+      isOpen: true,
+      draft: {
+        description: "Startup failed on Windows",
+        actualBehavior: "App never got past startup",
+        logs: "Reason: backend-unreachable",
+      },
+      close: closeFn,
+    });
+    let tree: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      tree = TestRenderer.create(React.createElement(BugReportModal));
+      await new Promise((r) => globalThis.setTimeout(r, 60));
+    });
+
+    const textareas = getTextareas(tree!.root);
+    expect(textareas[0].props.value).toBe("Startup failed on Windows");
+    expect(textareas[3].props.value).toBe("App never got past startup");
   });
 
   // --- validation ---

--- a/packages/app-core/test/app/conversations-sidebar-game-modal.test.tsx
+++ b/packages/app-core/test/app/conversations-sidebar-game-modal.test.tsx
@@ -414,4 +414,25 @@ describe("ConversationsSidebar game-modal variant", () => {
     expect(content).toContain("conversations.chats");
     expect(content).toContain("1");
   });
+
+  it("can hide the duplicate new-chat button in game-modal variant", async () => {
+    mockUseApp.mockReturnValue(createContext());
+
+    let tree: TestRenderer.ReactTestRenderer | undefined;
+    await act(async () => {
+      tree = TestRenderer.create(
+        React.createElement(ConversationsSidebar, {
+          variant: "game-modal",
+          showNewChatButton: false,
+        }),
+      );
+    });
+
+    const newChatButtons = tree?.root.findAll(
+      (node) =>
+        node.type === "button" &&
+        textOf(node).trim() === "conversations.newChat",
+    );
+    expect(newChatButtons?.length ?? 0).toBe(0);
+  });
 });

--- a/packages/app-core/test/app/startup-failure-view.test.tsx
+++ b/packages/app-core/test/app/startup-failure-view.test.tsx
@@ -2,6 +2,11 @@ import { StartupFailureView } from "@miladyai/app-core/components";
 import React from "react";
 import TestRenderer, { act } from "react-test-renderer";
 import { describe, expect, it, vi } from "vitest";
+import { textOf } from "../../../../test/helpers/react-test";
+
+const { openBugReportMock } = vi.hoisted(() => ({
+  openBugReportMock: vi.fn(),
+}));
 
 vi.mock("@miladyai/app-core/state", () => ({
   CUSTOM_ONBOARDING_STEPS: [],
@@ -15,6 +20,10 @@ vi.mock("@miladyai/app-core/state", () => ({
       return k;
     },
   }),
+}));
+
+vi.mock("@miladyai/app-core/hooks", () => ({
+  useBugReport: () => ({ open: openBugReportMock }),
 }));
 
 describe("StartupFailureView", () => {
@@ -51,7 +60,7 @@ describe("StartupFailureView", () => {
     expect(openAppLink.props.href).toBe("https://app.elizaos.ai");
     expect(openAppLink.children.join("")).toContain("Open App");
 
-    const retryButton = tree.root.findByType("button");
+    const retryButton = tree.root.findAllByType("button")[0];
     await act(async () => {
       retryButton.props.onClick();
     });

--- a/packages/shared/src/contracts/wallet.ts
+++ b/packages/shared/src/contracts/wallet.ts
@@ -257,6 +257,7 @@ export interface BscTradeQuoteRequest {
   tokenAddress: string;
   amount: string;
   slippageBps?: number;
+  routeProvider?: "auto" | "pancakeswap-v2" | "0x";
 }
 
 export interface BscTradeQuoteLeg {

--- a/packages/shared/src/contracts/wallet.ts
+++ b/packages/shared/src/contracts/wallet.ts
@@ -213,6 +213,13 @@ export interface WalletConfigStatus {
   evmChains: string[];
   evmAddress: string | null;
   solanaAddress: string | null;
+  walletSource?: "local" | "managed" | "none";
+  walletNetwork?: "mainnet" | "testnet";
+  automationMode?: "full" | "connectors-only";
+  pluginEvmLoaded?: boolean;
+  pluginEvmRequired?: boolean;
+  executionReady?: boolean;
+  executionBlockedReason?: string | null;
 }
 
 export type TradePermissionMode =


### PR DESCRIPTION
﻿## Summary
- cherry-pick wallet conversation hardening from `codex/integration-all`
- include live BSC testnet conversational send path fix
- align current `develop` wallet RPC/config surfaces so the cherry-picked wallet tests pass on the release branch

## Included wallet commits
- `1ee6680a` Harden wallet conversation execution
- `8004ff75` Fix live BSC wallet send path

## Additional release-prep compatibility
- restore `wallet-trade-routes` on `develop`
- add wallet capability fields to `/api/wallet/config`
- treat `BSC_TESTNET_RPC_URL` as testnet readiness when explicit network is unset

## Focused verification
- `bunx vitest run --config vitest.e2e.config.ts packages/agent/test/api-server.e2e.test.ts -t "wallet mode guidance fallback"`
- `bunx vitest run packages/app-core/src/actions/check-balance.test.ts packages/app-core/src/actions/transfer-token.test.ts packages/app-core/src/actions/execute-trade.test.ts packages/agent/test/api/wallet-trade-routes.test.ts`

## Release notes boundaries
- conversational BSC testnet send works live with tx-hash reply/log proof
- swap is still in progress
- Steward is not the sole wallet backend in this release
