### PR TITLE
fix: configure coding agent CLIs to proxy through ElizaCloud

### DIFF
--- a/packages/agent/src/api/__tests__/elizacloud-coding-credentials.test.ts
+++ b/packages/agent/src/api/__tests__/elizacloud-coding-credentials.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Verifies that switching to ElizaCloud inference configures coding agent
+ * CLI credentials to proxy through ElizaCloud's API endpoints, and that
+ * switching away clears the proxy base URLs.
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const serverSource = readFileSync(
+	path.resolve(import.meta.dirname, "..", "server.ts"),
+	"utf-8",
+);
+
+describe("ElizaCloud coding agent credentials", () => {
+	it("sets ANTHROPIC_BASE_URL when switching to elizacloud", () => {
+		const cloudSection = serverSource.slice(
+			serverSource.indexOf('normalizedProvider === "elizacloud"'),
+			serverSource.indexOf("else if", serverSource.indexOf('normalizedProvider === "elizacloud"') + 50),
+		);
+		expect(cloudSection).toContain("ANTHROPIC_BASE_URL");
+		expect(cloudSection).toContain("ANTHROPIC_API_KEY");
+		expect(cloudSection).toContain("/api/v1");
+	});
+
+	it("sets OPENAI_BASE_URL when switching to elizacloud", () => {
+		const cloudSection = serverSource.slice(
+			serverSource.indexOf('normalizedProvider === "elizacloud"'),
+			serverSource.indexOf("else if", serverSource.indexOf('normalizedProvider === "elizacloud"') + 50),
+		);
+		expect(cloudSection).toContain("OPENAI_BASE_URL");
+		expect(cloudSection).toContain("OPENAI_API_KEY");
+	});
+
+	it("uses the cloud API key for both Anthropic and OpenAI proxying", () => {
+		const cloudSection = serverSource.slice(
+			serverSource.indexOf("Configure coding agent CLIs"),
+			serverSource.indexOf("Gemini CLI and Aider"),
+		);
+		// Both should use cloudApiKey, not separate keys
+		expect(cloudSection).toContain("ANTHROPIC_API_KEY = cloudApiKey");
+		expect(cloudSection).toContain("OPENAI_API_KEY = cloudApiKey");
+	});
+
+	it("clears proxy base URLs when switching away from elizacloud", () => {
+		const disableSection = serverSource.slice(
+			serverSource.indexOf("const disableCloudInference"),
+			serverSource.indexOf("const enableCloudInference"),
+		);
+		expect(disableSection).toContain("delete process.env.ANTHROPIC_BASE_URL");
+		expect(disableSection).toContain("delete process.env.OPENAI_BASE_URL");
+	});
+
+	it("documents that Gemini/Aider are unavailable through ElizaCloud", () => {
+		const cloudSection = serverSource.slice(
+			serverSource.indexOf('normalizedProvider === "elizacloud"'),
+			serverSource.indexOf("else if", serverSource.indexOf('normalizedProvider === "elizacloud"') + 50),
+		);
+		expect(cloudSection).toContain("Gemini CLI and Aider");
+		expect(cloudSection).toContain("no");
+	});
+});

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -7859,6 +7859,12 @@ async function handleRequest(
       // model calls — user's own keys handle models.
       delete process.env.ELIZAOS_CLOUD_SMALL_MODEL;
       delete process.env.ELIZAOS_CLOUD_LARGE_MODEL;
+      // Clear ElizaCloud proxy base URLs so coding agents use direct
+      // provider APIs with the user's own keys.
+      delete process.env.ANTHROPIC_BASE_URL;
+      delete process.env.OPENAI_BASE_URL;
+      delete envCfg.ANTHROPIC_BASE_URL;
+      delete envCfg.OPENAI_BASE_URL;
     };
 
     // Helper: enable cloud inference (switching TO cloud)
@@ -7980,6 +7986,33 @@ async function handleRequest(
         if (config.cloud.apiKey) {
           process.env.ELIZAOS_CLOUD_API_KEY = config.cloud.apiKey;
           process.env.ELIZAOS_CLOUD_ENABLED = "true";
+
+          // Configure coding agent CLIs to proxy through ElizaCloud.
+          // ElizaCloud provides Anthropic-compatible (/api/v1/messages) and
+          // OpenAI-compatible (/api/v1/chat/completions) proxy endpoints
+          // that bill to the user's cloud credits.
+          const cloudBaseUrl =
+            (config.cloud as Record<string, unknown>).baseUrl ??
+            process.env.ELIZAOS_CLOUD_BASE_URL ??
+            "https://www.elizacloud.ai";
+          const cloudApiKey = config.cloud.apiKey;
+
+          // Claude Code: Anthropic-compatible proxy
+          process.env.ANTHROPIC_API_KEY = cloudApiKey;
+          process.env.ANTHROPIC_BASE_URL = `${cloudBaseUrl}/api/v1`;
+          envCfg.ANTHROPIC_API_KEY = cloudApiKey;
+          envCfg.ANTHROPIC_BASE_URL = `${cloudBaseUrl}/api/v1`;
+
+          // Codex: OpenAI-compatible proxy
+          process.env.OPENAI_API_KEY = cloudApiKey;
+          process.env.OPENAI_BASE_URL = `${cloudBaseUrl}/api/v1`;
+          envCfg.OPENAI_API_KEY = cloudApiKey;
+          envCfg.OPENAI_BASE_URL = `${cloudBaseUrl}/api/v1`;
+
+          // Gemini CLI and Aider use direct Google/provider APIs — no
+          // ElizaCloud proxy exists for those. Their keys were already
+          // cleared by clearOtherApiKeys() above, so they'll show as
+          // unavailable in the coding agent settings.
         }
       } else if (normalizedProvider === "pi-ai") {
         // Switching TO pi-ai credentials mode


### PR DESCRIPTION
When switching to ElizaCloud inference, coding agents (Claude Code, Codex) lost their API keys — clearOtherApiKeys() wiped everything without replacing them with ElizaCloud-proxied credentials. Users got 401 on /api/coding-agents.

ElizaCloud provides Anthropic-compatible and OpenAI-compatible proxy endpoints. Now: ANTHROPIC_API_KEY/BASE_URL and OPENAI_API_KEY/BASE_URL point at ElizaCloud when cloud inference is active. Gemini CLI and Aider remain unavailable (no cloud proxy for those providers).

Switching away from ElizaCloud clears the proxy base URLs so coding agents use direct provider APIs.