### PR TITLE
fix(ui): Eliza Cloud account hint, macOS header inset, shorter i18n

### DIFF
--- a/packages/app-core/src/api/cloud-connection.reason.test.ts
+++ b/packages/app-core/src/api/cloud-connection.reason.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { isCloudStatusReasonApiKeyOnly } from "./cloud-connection";
+
+describe("isCloudStatusReasonApiKeyOnly", () => {
+  it("returns true for API-key-only cloud status reasons", () => {
+    expect(
+      isCloudStatusReasonApiKeyOnly("api_key_present_not_authenticated"),
+    ).toBe(true);
+    expect(
+      isCloudStatusReasonApiKeyOnly("api_key_present_runtime_not_started"),
+    ).toBe(true);
+  });
+
+  it("returns false for other reasons and empty values", () => {
+    expect(isCloudStatusReasonApiKeyOnly("not_authenticated")).toBe(false);
+    expect(isCloudStatusReasonApiKeyOnly("inactive_local_provider")).toBe(
+      false,
+    );
+    expect(isCloudStatusReasonApiKeyOnly("")).toBe(false);
+    expect(isCloudStatusReasonApiKeyOnly(null)).toBe(false);
+    expect(isCloudStatusReasonApiKeyOnly(undefined)).toBe(false);
+  });
+});

--- a/packages/app-core/src/api/cloud-connection.ts
+++ b/packages/app-core/src/api/cloud-connection.ts
@@ -528,3 +528,17 @@ export async function disconnectUnifiedCloudConnection(args: {
   clearCloudEnv();
   await clearRuntimeCloudState(runtime);
 }
+
+/** Matches `reason` from GET /api/cloud/status when connected via API key without CLOUD_AUTH. */
+const CLOUD_STATUS_API_KEY_ONLY_REASONS: ReadonlySet<string> = new Set([
+  "api_key_present_not_authenticated",
+  "api_key_present_runtime_not_started",
+]);
+
+export function isCloudStatusReasonApiKeyOnly(
+  reason: string | null | undefined,
+): boolean {
+  return (
+    typeof reason === "string" && CLOUD_STATUS_API_KEY_ONLY_REASONS.has(reason)
+  );
+}

--- a/packages/app-core/src/components/ElizaCloudDashboard.tsx
+++ b/packages/app-core/src/components/ElizaCloudDashboard.tsx
@@ -32,6 +32,7 @@ import {
   type CloudCompatAgent,
   client,
 } from "../api";
+import { isCloudStatusReasonApiKeyOnly } from "../api/cloud-connection";
 import { useIntervalWhenDocumentVisible } from "../hooks/useDocumentVisibility";
 import { useApp } from "../state";
 import { openDesktopInAppBrowser, openExternalUrl } from "../utils";
@@ -186,6 +187,23 @@ function CloudAgentCard({
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+function resolveCloudAccountIdDisplay(
+  userId: string | null,
+  statusReason: string | null,
+  t: (key: string) => string,
+): { mono: boolean; text: string } {
+  if (userId) {
+    return { mono: true, text: userId };
+  }
+  if (isCloudStatusReasonApiKeyOnly(statusReason)) {
+    return { mono: false, text: t("elizaclouddashboard.AccountIdApiKeyOnly") };
+  }
+  return {
+    mono: false,
+    text: t("elizaclouddashboard.AccountIdSessionNoUserId"),
+  };
 }
 
 function unwrapBillingData<T extends Record<string, unknown>>(value: T): T {
@@ -348,6 +366,7 @@ export function CloudDashboard() {
     elizaCloudAuthRejected,
     elizaCloudTopUpUrl,
     elizaCloudUserId,
+    elizaCloudStatusReason,
     cloudDashboardView,
     elizaCloudLoginBusy,
     handleCloudLogin,
@@ -927,6 +946,11 @@ export function CloudDashboard() {
       : summaryLow
         ? t("elizaclouddashboard.CreditsLow")
         : t("elizaclouddashboard.CreditsHealthy");
+  const cloudAccountIdDisplay = resolveCloudAccountIdDisplay(
+    elizaCloudUserId,
+    elizaCloudStatusReason,
+    t,
+  );
   const hasAgentWallet = Boolean(
     walletAddresses?.evmAddress || walletAddresses?.solanaAddress,
   );
@@ -1365,9 +1389,15 @@ export function CloudDashboard() {
                   {t("elizaclouddashboard.Secure")}
                 </span>
               </div>
-              <code className="break-all font-mono text-[11px] text-muted">
-                {elizaCloudUserId || t("elizaclouddashboard.NotAvailable")}
-              </code>
+              {cloudAccountIdDisplay.mono ? (
+                <code className="break-all font-mono text-[11px] text-muted">
+                  {cloudAccountIdDisplay.text}
+                </code>
+              ) : (
+                <span className="break-words text-[11px] text-muted leading-snug">
+                  {cloudAccountIdDisplay.text}
+                </span>
+              )}
             </div>
             <Button
               variant="ghost"
@@ -1409,9 +1439,15 @@ export function CloudDashboard() {
           {/* ── Account bar ───────────────────────────────────── */}
           <div className="flex flex-col gap-3 py-3 text-xs sm:flex-row sm:items-center sm:justify-between">
             <div className="flex min-w-0 items-center gap-3">
-              <code className="max-w-full break-all font-mono text-muted sm:max-w-[200px] sm:truncate">
-                {elizaCloudUserId || t("elizaclouddashboard.NotAvailable")}
-              </code>
+              {cloudAccountIdDisplay.mono ? (
+                <code className="max-w-full break-all font-mono text-muted sm:max-w-[200px] sm:truncate">
+                  {cloudAccountIdDisplay.text}
+                </code>
+              ) : (
+                <span className="max-w-full break-words text-muted text-[11px] leading-snug sm:max-w-[min(100%,280px)]">
+                  {cloudAccountIdDisplay.text}
+                </span>
+              )}
             </div>
             <div className="flex flex-wrap items-center gap-3">
               <span className={`font-semibold ${creditStatusColor}`}>

--- a/packages/app-core/src/components/Header.tsx
+++ b/packages/app-core/src/components/Header.tsx
@@ -236,7 +236,7 @@ export function Header({
         <div
           className={`px-1.5 sm:px-4 ${useMinimalHeaderChrome ? "" : "pb-1.5 sm:pb-3"}`}
           style={{
-            paddingTop: `calc(var(--safe-area-top, 0px) + ${
+            paddingTop: `calc(var(--safe-area-top, 0px) + var(--milady-macos-frame-top-inset, 0px) + ${
               isDesktopShell ? "0.875rem" : "0.375rem"
             })`,
             paddingLeft: `calc(var(--safe-area-left, 0px) + ${

--- a/packages/app-core/src/components/companion/CompanionHeader.tsx
+++ b/packages/app-core/src/components/companion/CompanionHeader.tsx
@@ -55,7 +55,8 @@ export const CompanionHeader = memo(function CompanionHeader(
       <div
         className="px-1.5 max-[768px]:px-2 sm:px-4"
         style={{
-          paddingTop: "calc(var(--safe-area-top, 0px) + 0.375rem)",
+          paddingTop:
+            "calc(var(--safe-area-top, 0px) + var(--milady-macos-frame-top-inset, 0px) + 0.375rem)",
           paddingLeft: "calc(var(--safe-area-left, 0px) + 0.375rem)",
           paddingRight: "calc(var(--safe-area-right, 0px) + 0.375rem)",
         }}

--- a/packages/app-core/src/i18n/locales/en.json
+++ b/packages/app-core/src/i18n/locales/en.json
@@ -855,6 +855,8 @@
   "subscriptionstatus.ChatGPTSubscriptionTitle": "ChatGPT Subscription",
   "subscriptionstatus.Completing": "Completing...",
   "elizaclouddashboard.NotAvailable": "Not available",
+  "elizaclouddashboard.AccountIdApiKeyOnly": "API key only — connect via browser sign-in to show your cloud user ID.",
+  "elizaclouddashboard.AccountIdSessionNoUserId": "No user ID shown — cloud still works.",
   "elizaclouddashboard.ElizaCloudNotConnectedSettings": "Eliza Cloud not connected - configure in Settings -> AI Model",
   "elizaclouddashboard.NoSetupNeeded": "No setup needed",
   "codingagentsettingssection.NoSupportedCLIs": "No supported coding agent CLIs detected. Install at least one of: Claude, Gemini, Codex, or Aider.",

--- a/packages/app-core/src/i18n/locales/es.json
+++ b/packages/app-core/src/i18n/locales/es.json
@@ -363,6 +363,8 @@
   "elizaclouddashboard.NoAgentWalletDetected": "Aún no se detectó una cartera del agente. Genera o importa una en Configuración antes de usar recargas con cripto.",
   "elizaclouddashboard.NoSetupNeeded": "No requiere configuración",
   "elizaclouddashboard.NotAvailable": "No disponible",
+  "elizaclouddashboard.AccountIdApiKeyOnly": "Solo clave API — conéctate con inicio de sesión en el navegador para ver tu ID de usuario en la nube.",
+  "elizaclouddashboard.AccountIdSessionNoUserId": "Sin ID de usuario — la nube sigue funcionando.",
   "elizaclouddashboard.OpenBrowserBilling": "Abrir facturación en el navegador",
   "elizaclouddashboard.PayWithCard": "Pagar con tarjeta",
   "elizaclouddashboard.PayWithCrypto": "Pagar con cripto",

--- a/packages/app-core/src/i18n/locales/ko.json
+++ b/packages/app-core/src/i18n/locales/ko.json
@@ -363,6 +363,8 @@
   "elizaclouddashboard.NoAgentWalletDetected": "아직 에이전트 지갑이 감지되지 않았습니다. 암호화폐 충전을 사용하기 전에 설정에서 지갑을 생성하거나 가져오세요.",
   "elizaclouddashboard.NoSetupNeeded": "설정 필요 없음",
   "elizaclouddashboard.NotAvailable": "사용 불가",
+  "elizaclouddashboard.AccountIdApiKeyOnly": "API 키만 사용 중 — 브라우저 로그인으로 연결하면 클라우드 사용자 ID가 표시됩니다.",
+  "elizaclouddashboard.AccountIdSessionNoUserId": "사용자 ID 없음 — 클라우드는 정상 동작.",
   "elizaclouddashboard.OpenBrowserBilling": "브라우저 결제 열기",
   "elizaclouddashboard.PayWithCard": "카드로 결제",
   "elizaclouddashboard.PayWithCrypto": "암호화폐로 결제",

--- a/packages/app-core/src/i18n/locales/pt.json
+++ b/packages/app-core/src/i18n/locales/pt.json
@@ -363,6 +363,8 @@
   "elizaclouddashboard.NoAgentWalletDetected": "Nenhuma carteira do agente detectada ainda. Gere ou importe uma em Configurações antes de usar recargas com cripto.",
   "elizaclouddashboard.NoSetupNeeded": "Nenhuma configuração necessária",
   "elizaclouddashboard.NotAvailable": "Não disponível",
+  "elizaclouddashboard.AccountIdApiKeyOnly": "Somente chave de API — conecte-se pelo navegador para exibir seu ID de usuário na nuvem.",
+  "elizaclouddashboard.AccountIdSessionNoUserId": "Sem ID de usuário — a nuvem segue funcionando.",
   "elizaclouddashboard.OpenBrowserBilling": "Abrir faturamento no navegador",
   "elizaclouddashboard.PayWithCard": "Pagar com cartão",
   "elizaclouddashboard.PayWithCrypto": "Pagar com cripto",

--- a/packages/app-core/src/i18n/locales/tl.json
+++ b/packages/app-core/src/i18n/locales/tl.json
@@ -363,6 +363,8 @@
   "elizaclouddashboard.NoAgentWalletDetected": "Wala pang natukoy na agent wallet. Gumawa o mag-import ng isa sa Settings bago gamitin ang crypto top-ups.",
   "elizaclouddashboard.NoSetupNeeded": "Hindi kailangan ng setup",
   "elizaclouddashboard.NotAvailable": "Hindi available",
+  "elizaclouddashboard.AccountIdApiKeyOnly": "API key lang — kumonekta gamit ang browser sign-in para makita ang cloud user ID.",
+  "elizaclouddashboard.AccountIdSessionNoUserId": "Walang user ID — gumagana pa rin ang cloud.",
   "elizaclouddashboard.OpenBrowserBilling": "Buksan ang browser billing",
   "elizaclouddashboard.PayWithCard": "Magbayad gamit ang Card",
   "elizaclouddashboard.PayWithCrypto": "Magbayad gamit ang Crypto",

--- a/packages/app-core/src/i18n/locales/vi.json
+++ b/packages/app-core/src/i18n/locales/vi.json
@@ -363,6 +363,8 @@
   "elizaclouddashboard.NoAgentWalletDetected": "Chưa có ví agent. Tạo hoặc import trong Cài đặt trước khi nạp crypto.",
   "elizaclouddashboard.NoSetupNeeded": "Không cần cài đặt",
   "elizaclouddashboard.NotAvailable": "Không khả dụng",
+  "elizaclouddashboard.AccountIdApiKeyOnly": "Chỉ dùng API key — đăng nhập qua trình duyệt để hiển thị ID người dùng trên cloud.",
+  "elizaclouddashboard.AccountIdSessionNoUserId": "Không hiển thị ID người dùng — cloud vẫn hoạt động.",
   "elizaclouddashboard.OpenBrowserBilling": "Mở thanh toán trên trình duyệt",
   "elizaclouddashboard.PayWithCard": "Trả bằng thẻ",
   "elizaclouddashboard.PayWithCrypto": "Trả bằng crypto",

--- a/packages/app-core/src/i18n/locales/zh-CN.json
+++ b/packages/app-core/src/i18n/locales/zh-CN.json
@@ -363,6 +363,8 @@
   "elizaclouddashboard.NoAgentWalletDetected": "尚未检测到代理钱包。使用加密货币充值前，请先在设置中生成或导入钱包。",
   "elizaclouddashboard.NoSetupNeeded": "无需设置",
   "elizaclouddashboard.NotAvailable": "不可用",
+  "elizaclouddashboard.AccountIdApiKeyOnly": "仅 API 密钥 — 通过浏览器登录后可显示云端用户 ID。",
+  "elizaclouddashboard.AccountIdSessionNoUserId": "未显示用户 ID — 云端仍可用。",
   "elizaclouddashboard.OpenBrowserBilling": "在浏览器中打开计费",
   "elizaclouddashboard.PayWithCard": "银行卡支付",
   "elizaclouddashboard.PayWithCrypto": "加密货币支付",

--- a/packages/app-core/src/state/AppContext.tsx
+++ b/packages/app-core/src/state/AppContext.tsx
@@ -885,6 +885,9 @@ function AppProviderInner({
   const [elizaCloudTopUpUrl, setElizaCloudTopUpUrl] =
     useState("/cloud/billing");
   const [elizaCloudUserId, setElizaCloudUserId] = useState<string | null>(null);
+  const [elizaCloudStatusReason, setElizaCloudStatusReason] = useState<
+    string | null
+  >(null);
   const [cloudDashboardView, setCloudDashboardView] = useState<
     "billing" | "agents"
   >("billing");
@@ -2132,6 +2135,7 @@ function AppProviderInner({
       setElizaCloudCreditsCritical(false);
       setElizaCloudAuthRejected(false);
       setElizaCloudCreditsError(null);
+      setElizaCloudStatusReason(null);
       lastElizaCloudPollConnectedRef.current = false;
       return false;
     }
@@ -2147,6 +2151,13 @@ function AppProviderInner({
     setElizaCloudEnabled(Boolean(cloudStatus.enabled ?? false));
     setElizaCloudConnected(isConnected);
     setElizaCloudUserId(cloudStatus.userId ?? null);
+    setElizaCloudStatusReason(
+      isConnected &&
+        typeof cloudStatus.reason === "string" &&
+        cloudStatus.reason.trim()
+        ? cloudStatus.reason.trim()
+        : null,
+    );
     if (cloudStatus.topUpUrl) setElizaCloudTopUpUrl(cloudStatus.topUpUrl);
     if (isConnected) {
       const credits = await client.getCloudCredits().catch(() => null);
@@ -2188,6 +2199,7 @@ function AppProviderInner({
       setElizaCloudCreditsCritical(false);
       setElizaCloudAuthRejected(false);
       setElizaCloudCreditsError(null);
+      setElizaCloudStatusReason(null);
     }
     lastElizaCloudPollConnectedRef.current = isConnected;
     // Self-manage the recurring poll interval: start when connected, stop when not.
@@ -2737,6 +2749,7 @@ function AppProviderInner({
           setElizaCloudCreditsError(null);
           setElizaCloudTopUpUrl("/cloud/billing");
           setElizaCloudUserId(null);
+          setElizaCloudStatusReason(null);
           setElizaCloudLoginError(null);
         },
         markOnboardingReset: () => {
@@ -5917,6 +5930,7 @@ function AppProviderInner({
       setElizaCloudAuthRejected(false);
       setElizaCloudCreditsError(null);
       setElizaCloudUserId(null);
+      setElizaCloudStatusReason(null);
       lastElizaCloudPollConnectedRef.current = false;
       elizaCloudPreferDisconnectedUntilLoginRef.current = true;
       setActionNotice("Disconnected from Eliza Cloud.", "success");
@@ -7514,6 +7528,7 @@ function AppProviderInner({
     elizaCloudCreditsError,
     elizaCloudTopUpUrl,
     elizaCloudUserId,
+    elizaCloudStatusReason,
     cloudDashboardView,
     elizaCloudLoginBusy,
     elizaCloudLoginError,

--- a/packages/app-core/src/state/types.ts
+++ b/packages/app-core/src/state/types.ts
@@ -427,6 +427,8 @@ export interface AppState {
   elizaCloudCreditsError: string | null;
   elizaCloudTopUpUrl: string;
   elizaCloudUserId: string | null;
+  /** Last `reason` from GET /api/cloud/status (e.g. API-key-only vs OAuth). */
+  elizaCloudStatusReason: string | null;
   cloudDashboardView: "billing" | "agents";
   elizaCloudLoginBusy: boolean;
   elizaCloudLoginError: string | null;

--- a/packages/app-core/src/styles/electrobun-mac-window-drag.css
+++ b/packages/app-core/src/styles/electrobun-mac-window-drag.css
@@ -11,6 +11,14 @@
  * html.milady-electrobun-frameless is toggled from apps/app/src/main.tsx
  * (main macOS Electrobun shell only; detached shells skip it).
  */
+html.milady-electrobun-frameless {
+  /**
+   * Extra top inset so the first interactive row (shell toggle, header) sits below
+   * the traffic lights — hiddenInset draws them over the web view with no title bar.
+   */
+  --milady-macos-frame-top-inset: 26px;
+}
+
 html.milady-electrobun-frameless body {
   -webkit-app-region: drag;
 }


### PR DESCRIPTION
Plumb cloud status reason for API-key vs session when user ID is absent; add frameless macOS top inset so shell controls clear traffic lights; tighten AccountIdSessionNoUserId copy across locales; add reason helper test.

Made-with: Cursor

This PR will be reviewed by an AI agent. Provide clear context to help it assess your changes.