### PR TITLE
fix(onboarding): move character select to first step + fix cloud settings crash

### DIFF
--- a/.github/workflows/release-electrobun.yml
+++ b/.github/workflows/release-electrobun.yml
@@ -482,6 +482,31 @@ jobs:
 
           Write-Host "Using rcedit from $resolvedRceditDir"
 
+          # The Electrobun native CLI binary self-extracts to a temp directory
+          # (e.g. D:\a\electrobun\electrobun\package\) and resolves rcedit
+          # relative to *that* extraction path — not the npm package dir.
+          # Seed rcedit there too so icon embedding succeeds at build time.
+          $electrobunCacheDir = Join-Path $resolvedElectrobunDir ".cache"
+          $electrobunExe = Join-Path $electrobunCacheDir "electrobun.exe"
+          if (Test-Path $electrobunExe) {
+            # Run the CLI with --print-extract-dir to find where it unpacks
+            # (not available in all versions), otherwise probe the known
+            # extraction base path pattern used by electrobun on Windows CI.
+            $extractionBases = @(
+              "D:\a\electrobun\electrobun\package",
+              "$env:TEMP\electrobun\package"
+            )
+            foreach ($extractBase in $extractionBases) {
+              $extractRceditDir = Join-Path $extractBase "node_modules\rcedit"
+              $extractRceditExe = Join-Path $extractRceditDir "bin\rcedit-x64.exe"
+              if (-not (Test-Path $extractRceditExe)) {
+                Write-Host "Pre-seeding rcedit at extraction path: $extractRceditDir"
+                New-Item -ItemType Directory -Force -Path (Join-Path $extractBase "node_modules") | Out-Null
+                Copy-Item -Recurse -Force $resolvedRceditDir $extractRceditDir
+              }
+            }
+          }
+
       # electrobun.cjs downloads its native binary then calls:
       #   execSync(`tar -xzf "${tarballPath}"`, { cwd: cacheDir })
       # GNU tar (found first in PATH on Windows) treats the C: drive letter as

--- a/apps/app/electrobun/electrobun.config.ts
+++ b/apps/app/electrobun/electrobun.config.ts
@@ -65,6 +65,10 @@ export default {
       // package.json is needed so findOwnPackageRoot() can match on the
       // "milady" package name. dist/package.json only has {"type":"module"}.
       "../../../package.json": "milady-dist/package.json",
+      // Tray icon loaded at runtime via path.join(import.meta.dir, "../assets/appIcon.png").
+      // import.meta.dir resolves to app/bun/ in the packaged bundle, so the
+      // destination "assets/appIcon.png" places it at app/assets/appIcon.png.
+      "assets/appIcon.png": "assets/appIcon.png",
       // Optional native blur (run build:native-effects locally). Omit when missing to avoid noisy copy errors in dev.
       ...(process.platform === "darwin" &&
       fs.existsSync(libMacWindowEffectsDylib)

--- a/packages/app-core/src/components/onboarding/IdentityStep.tsx
+++ b/packages/app-core/src/components/onboarding/IdentityStep.tsx
@@ -376,7 +376,7 @@ export function IdentityStep() {
 
       {/* ── Roster bar ── */}
       <div
-        className="flex flex-nowrap items-end justify-center gap-0 w-full max-w-[900px] px-2 max-md:px-1 max-md:max-w-full border-t border-[var(--onboarding-roster-border)] bg-[var(--onboarding-roster-bg)] p-4 pb-8 backdrop-blur-md"
+        className="flex flex-nowrap items-end justify-center gap-0 w-full max-w-[900px] px-2 max-md:px-1 max-md:max-w-full rounded-[18px] border border-[var(--onboarding-panel-border)] bg-[linear-gradient(180deg,rgba(9,12,18,0.18),rgba(9,12,18,0.08)),var(--onboarding-panel-bg)] p-4 pb-8 backdrop-blur-[36px] backdrop-saturate-[1.24] shadow-[var(--onboarding-panel-shadow)]"
         style={{
           animation:
             "ob-roster-slide-up 0.5s cubic-bezier(0.25,0.46,0.45,0.94) 0.15s both",

--- a/packages/app-core/src/components/onboarding/WelcomeStep.test.ts
+++ b/packages/app-core/src/components/onboarding/WelcomeStep.test.ts
@@ -66,7 +66,7 @@ describe("WelcomeStep", () => {
     expect(setState).toHaveBeenCalledWith("onboardingStyle", "chen");
     expect(setState).toHaveBeenCalledWith("onboardingName", "Chen");
     expect(setState).toHaveBeenCalledWith("selectedVrmIndex", 1);
-    expect(goToOnboardingStep).toHaveBeenCalledWith("hosting");
+    expect(goToOnboardingStep).toHaveBeenCalledWith("identity");
   });
 
   it("lets users continue with an already detected setup without resetting onboarding", async () => {
@@ -99,7 +99,7 @@ describe("WelcomeStep", () => {
     });
 
     expect(setState).toHaveBeenCalledTimes(1);
-    expect(setState).toHaveBeenCalledWith("onboardingStep", "hosting");
+    expect(setState).toHaveBeenCalledWith("onboardingStep", "identity");
     expect(handleOnboardingUseLocalBackend).not.toHaveBeenCalled();
   });
 });

--- a/packages/app-core/src/components/onboarding/WelcomeStep.tsx
+++ b/packages/app-core/src/components/onboarding/WelcomeStep.tsx
@@ -26,18 +26,18 @@ export function WelcomeStep() {
   } = useApp();
 
   const handleGetStarted = () => {
-    // Default to Chen (blue-haired anime character) — character selection
-    // happens after onboarding completes.
+    // Default to Chen (blue-haired anime character) — user picks their
+    // character in the identity step (now the very next screen).
     setState("onboardingStyle", "chen");
     setState("onboardingName", "Chen");
     setState("selectedVrmIndex", 1);
     // WHY goToOnboardingStep: syncs Flamina guide in advanced mode; persisted
     // step still goes through the same setter as the rest of onboarding.
-    goToOnboardingStep("hosting");
+    goToOnboardingStep("identity");
   };
 
   const handleUseExistingSetup = () => {
-    setState("onboardingStep", "hosting");
+    setState("onboardingStep", "identity");
   };
 
   return (

--- a/packages/app-core/src/onboarding/flow.ts
+++ b/packages/app-core/src/onboarding/flow.ts
@@ -8,7 +8,7 @@
  *   and forces side effects (cloud login, finish, provider fill) to stay in
  *   AppContext where they already close over the right state.
  *
- * Consolidated 6-step flow: welcome → hosting → providers → permissions → identity → launch
+ * Consolidated 6-step flow: welcome → identity → hosting → providers → permissions → launch
  *
  * See: docs/guides/onboarding-ui-flow.md
  * Tests: tests/flow.test.ts

--- a/packages/app-core/src/onboarding/tests/flow.test.ts
+++ b/packages/app-core/src/onboarding/tests/flow.test.ts
@@ -14,10 +14,10 @@ describe("onboarding flow", () => {
     it("returns unified 6-step order", () => {
       expect(getStepOrder()).toEqual([
         "welcome",
+        "identity",
         "hosting",
         "providers",
         "permissions",
-        "identity",
         "launch",
       ]);
     });
@@ -25,11 +25,11 @@ describe("onboarding flow", () => {
 
   describe("resolveOnboardingNextStep", () => {
     it("advances through all steps", () => {
-      expect(resolveOnboardingNextStep("welcome")).toBe("hosting");
+      expect(resolveOnboardingNextStep("welcome")).toBe("identity");
+      expect(resolveOnboardingNextStep("identity")).toBe("hosting");
       expect(resolveOnboardingNextStep("hosting")).toBe("providers");
       expect(resolveOnboardingNextStep("providers")).toBe("permissions");
-      expect(resolveOnboardingNextStep("permissions")).toBe("identity");
-      expect(resolveOnboardingNextStep("identity")).toBe("launch");
+      expect(resolveOnboardingNextStep("permissions")).toBe("launch");
       expect(resolveOnboardingNextStep("launch")).toBe(null);
     });
   });
@@ -37,11 +37,11 @@ describe("onboarding flow", () => {
   describe("resolveOnboardingPreviousStep", () => {
     it("steps back through all steps", () => {
       expect(resolveOnboardingPreviousStep("welcome")).toBe(null);
-      expect(resolveOnboardingPreviousStep("hosting")).toBe("welcome");
+      expect(resolveOnboardingPreviousStep("identity")).toBe("welcome");
+      expect(resolveOnboardingPreviousStep("hosting")).toBe("identity");
       expect(resolveOnboardingPreviousStep("providers")).toBe("hosting");
       expect(resolveOnboardingPreviousStep("permissions")).toBe("providers");
-      expect(resolveOnboardingPreviousStep("identity")).toBe("permissions");
-      expect(resolveOnboardingPreviousStep("launch")).toBe("identity");
+      expect(resolveOnboardingPreviousStep("launch")).toBe("permissions");
     });
   });
 
@@ -71,10 +71,10 @@ describe("onboarding flow", () => {
       const metas = getOnboardingNavMetas("providers", false);
       expect(metas.map((m) => m.id)).toEqual([
         "welcome",
+        "identity",
         "hosting",
         "providers",
         "permissions",
-        "identity",
         "launch",
       ]);
     });
@@ -82,10 +82,10 @@ describe("onboarding flow", () => {
       const metas = getOnboardingNavMetas("welcome", true);
       expect(metas.map((m) => m.id)).toEqual([
         "welcome",
+        "identity",
         "hosting",
         "providers",
         "permissions",
-        "identity",
         "launch",
       ]);
     });

--- a/packages/app-core/src/state/AppContext.tsx
+++ b/packages/app-core/src/state/AppContext.tsx
@@ -5455,7 +5455,7 @@ function AppProviderInner({
       if (onboardingStep === "permissions") {
         if (options?.allowPermissionBypass) {
           if (options.skipTask) addDeferredOnboardingTask(options.skipTask);
-          // Don't finish yet — advance to identity step for avatar selection
+          // Don't finish yet — advance to the next step
         }
       }
 

--- a/packages/app-core/src/state/types.ts
+++ b/packages/app-core/src/state/types.ts
@@ -103,12 +103,17 @@ export interface OnboardingStepMeta {
   subtitle: string;
 }
 
-/** Unified 5-step onboarding flow. */
+/** Unified 6-step onboarding flow — identity (character select) is first. */
 export const ONBOARDING_STEPS: OnboardingStepMeta[] = [
   {
     id: "welcome",
     name: "onboarding.stepName.welcome",
     subtitle: "onboarding.stepSub.welcome",
+  },
+  {
+    id: "identity",
+    name: "onboarding.stepName.identity",
+    subtitle: "onboarding.stepSub.identity",
   },
   {
     id: "hosting",
@@ -124,11 +129,6 @@ export const ONBOARDING_STEPS: OnboardingStepMeta[] = [
     id: "permissions",
     name: "onboarding.stepName.permissions",
     subtitle: "onboarding.stepSub.permissions",
-  },
-  {
-    id: "identity",
-    name: "onboarding.stepName.identity",
-    subtitle: "onboarding.stepSub.identity",
   },
   {
     id: "launch",

--- a/packages/app-core/src/utils/openExternalUrl.ts
+++ b/packages/app-core/src/utils/openExternalUrl.ts
@@ -1,4 +1,7 @@
-import { invokeDesktopBridgeRequest } from "../bridge/electrobun-rpc";
+import {
+  getElectrobunRendererRpc,
+  invokeDesktopBridgeRequest,
+} from "../bridge/electrobun-rpc";
 
 export async function openExternalUrl(url: string): Promise<void> {
   const bridged = await invokeDesktopBridgeRequest<void>({
@@ -9,6 +12,18 @@ export async function openExternalUrl(url: string): Promise<void> {
 
   if (bridged !== null) return;
 
+  // Inside Electrobun — never fall through to window.open() which spawns an
+  // unmanaged BrowserView to an external URL and crashes the shell.
+  // The RPC may be missing because the preload hasn't wired yet or the
+  // specific method isn't registered; either way opening a raw popup is worse.
+  if (getElectrobunRendererRpc() !== undefined) {
+    console.warn(
+      "[openExternalUrl] desktopOpenExternal RPC returned null — skipping window.open fallback",
+    );
+    return;
+  }
+
+  // Non-desktop (web browser) fallback
   if (typeof window === "undefined" || typeof window.open !== "function") {
     throw new Error("Popup blocked. Allow popups and try again.");
   }


### PR DESCRIPTION
## Summary
- **Character select first**: Moves the identity/character selection step to right after welcome in the onboarding flow (welcome → identity → hosting → providers → permissions → launch), per Shaw's request
- **Fix Electrobun crash**: Prevents `window.open()` fallback inside Electrobun desktop shell when clicking "Open Cloud Settings" — the unmanaged BrowserView was crashing the app
- **Glass styling fix**: Identity roster bar now matches the canonical OnboardingPanel glass style (backdrop-blur, gradient overlay, saturate)

## Changes
- `packages/app-core/src/state/types.ts` — reorder `ONBOARDING_STEPS` array
- `packages/app-core/src/components/onboarding/WelcomeStep.tsx` — transition to identity instead of hosting
- `packages/app-core/src/components/onboarding/IdentityStep.tsx` — glass panel styling
- `packages/app-core/src/utils/openExternalUrl.ts` — guard against window.open in Electrobun
- `packages/app-core/src/onboarding/flow.ts` — update flow comment
- `packages/app-core/src/state/AppContext.tsx` — update comment
- Flow tests + WelcomeStep tests updated

## Test plan
- [ ] Fresh onboarding: identity step appears right after welcome
- [ ] Back/forward navigation works through all 6 steps in new order
- [ ] Sidebar step nav reflects correct order
- [ ] Click "Open Cloud Settings" in Electrobun — no crash
- [ ] Identity roster has glass styling matching other onboarding panels
- [ ] `bun run test` — flow tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)