### PR TITLE
fix(ui): toggles, dropdowns, scrolling, knowledge text

### DIFF
--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -182,6 +182,7 @@ import {
 // ---------------------------------------------------------------------------
 
 import {
+  ensureCloudTtsApiKeyAlias,
   handleCloudTtsPreviewRoute as _handleCloudTtsPreviewRoute,
   mirrorCompatHeaders,
 } from "./server-cloud-tts";
@@ -3387,6 +3388,9 @@ export function patchHttpCreateServerForMiladyCompat(
     const wrappedListener: http.RequestListener = async (req, res) => {
       syncMiladyEnvToEliza();
       syncElizaEnvToMilady();
+      // Re-check cloud TTS key alias on each request so sign-in mid-session
+      // is picked up without a restart.
+      ensureCloudTtsApiKeyAlias();
       mirrorCompatHeaders(req);
       if (state) {
         patchCompatStatusResponse(req, res, state);
@@ -3498,6 +3502,10 @@ export async function startApiServer(
 ): Promise<Awaited<ReturnType<typeof upstreamStartApiServer>>> {
   syncMiladyEnvToEliza();
   syncElizaEnvToMilady();
+  // Ensure cloud-backed ElevenLabs key is available as ELEVENLABS_API_KEY so
+  // the upstream Eliza TTS handler can use it (the `/api/tts/elevenlabs` route
+  // passes through to upstream which checks this env var).
+  ensureCloudTtsApiKeyAlias();
   await hydrateWalletKeysFromNodePlatformSecureStore();
   const compatState: CompatRuntimeState = {
     current: (args[0]?.runtime as AgentRuntime | null) ?? null,

--- a/packages/app-core/src/components/InventoryView.tsx
+++ b/packages/app-core/src/components/InventoryView.tsx
@@ -51,8 +51,6 @@ import { useInventoryData } from "./inventory/useInventoryData";
 import {
   APP_PANEL_SHELL_CLASSNAME,
   APP_SIDEBAR_CARD_ACTIVE_CLASSNAME,
-  APP_SIDEBAR_CARD_BASE_CLASSNAME,
-  APP_SIDEBAR_CARD_INACTIVE_CLASSNAME,
   APP_SIDEBAR_HEADER_CLASSNAME,
   APP_SIDEBAR_INNER_CLASSNAME,
   APP_SIDEBAR_KICKER_CLASSNAME,
@@ -66,9 +64,7 @@ import {
 const WALLET_SHELL_CLASS = APP_PANEL_SHELL_CLASSNAME;
 const WALLET_SIDEBAR_CLASS = `lg:w-[21rem] lg:max-w-[352px] ${APP_SIDEBAR_RAIL_CLASSNAME}`;
 const WALLET_SIDEBAR_KICKER_CLASS = APP_SIDEBAR_KICKER_CLASSNAME;
-const WALLET_SIDEBAR_ITEM_BASE_CLASS = APP_SIDEBAR_CARD_BASE_CLASSNAME;
 const WALLET_SIDEBAR_ITEM_ACTIVE_CLASS = APP_SIDEBAR_CARD_ACTIVE_CLASSNAME;
-const WALLET_SIDEBAR_ITEM_INACTIVE_CLASS = APP_SIDEBAR_CARD_INACTIVE_CLASSNAME;
 const WALLET_PANEL_CLASS = DESKTOP_SURFACE_PANEL_CLASSNAME;
 
 function countVisibleAssetsForFocus(
@@ -311,14 +307,6 @@ export function InventoryView() {
         ? "Wallet Overview"
         : "NFT Gallery"
       : `${focusedChainLabel ?? "Chain"} ${inventoryView === "tokens" ? "Assets" : "NFTs"}`;
-  const walletPageDescription =
-    chainFocus === "all"
-      ? inventoryView === "tokens"
-        ? "Track balances, managed addresses, and trading readiness in one place."
-        : "Review collectibles across every connected wallet."
-      : inventoryView === "tokens"
-        ? `Balances and watchlist activity for ${focusedChainLabel ?? "the selected chain"}.`
-        : `Collectibles discovered on ${focusedChainLabel ?? "the selected chain"}.`;
   const inlineError =
     chainFocus !== "all" && focusedChainError
       ? {
@@ -543,9 +531,9 @@ export function InventoryView() {
               </div>
             </div>
 
-            <div className="mt-4 flex min-h-0 flex-1 flex-col">
+            <div className="mt-4">
               <div className={WALLET_SIDEBAR_KICKER_CLASS}>Chains</div>
-              <nav className="mt-3 min-h-0 flex-1 space-y-1.5 overflow-y-auto pr-3">
+              <nav className="mt-3 space-y-1">
                 {chainItemMeta.map((item) => {
                   const isActive = chainFocus === item.key;
                   return (
@@ -556,17 +544,17 @@ export function InventoryView() {
                       type="button"
                       onClick={() => setState("inventoryChainFocus", item.key)}
                       aria-current={isActive ? "page" : undefined}
-                      className={`${WALLET_SIDEBAR_ITEM_BASE_CLASS} ${
+                      className={`w-full justify-start gap-2 rounded-lg px-2 py-1.5 text-xs font-semibold ${
                         isActive
-                          ? WALLET_SIDEBAR_ITEM_ACTIVE_CLASS
-                          : WALLET_SIDEBAR_ITEM_INACTIVE_CLASS
+                          ? "border border-accent/30 bg-accent/12 text-txt-strong"
+                          : "text-muted hover:bg-bg/35 hover:text-txt"
                       }`}
                     >
                       <span
-                        className={`mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl border text-sm font-bold ${
+                        className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-[10px] font-bold ${
                           isActive
-                            ? "border-accent/30 bg-accent/18 text-txt-strong"
-                            : "border-border/50 bg-bg-accent/80 text-muted"
+                            ? "bg-accent/18 text-txt-strong"
+                            : "bg-bg-accent/80 text-muted"
                         }`}
                       >
                         {item.key === "all"
@@ -575,14 +563,7 @@ export function InventoryView() {
                               .slice(0, 1)
                               .toUpperCase()}
                       </span>
-                      <span className="min-w-0 flex-1 text-left">
-                        <span className="block text-sm font-semibold leading-snug">
-                          {item.key === "all" ? t("wallet.all") : item.label}
-                        </span>
-                        <span className="mt-1 block line-clamp-2 text-[11px] leading-relaxed text-muted/85">
-                          {item.description}
-                        </span>
-                      </span>
+                      {item.key === "all" ? t("wallet.all") : item.label}
                     </Button>
                   );
                 })}
@@ -633,39 +614,11 @@ export function InventoryView() {
             <section className={`${WALLET_PANEL_CLASS} px-5 py-5 sm:px-6`}>
               <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
                 <div className="min-w-0 flex-1">
-                  <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-muted">
-                    Wallet
-                  </div>
-                  <h1 className="mt-1 text-2xl font-semibold text-txt-strong">
+                  <h1 className="text-lg font-semibold text-txt-strong">
                     {walletPageTitle}
                   </h1>
-                  <p className="mt-2 max-w-2xl text-sm leading-relaxed text-muted">
-                    {walletPageDescription}
-                  </p>
                 </div>
                 <div className="flex flex-wrap items-center gap-2 lg:justify-end">
-                  <Select
-                    value={chainFocus}
-                    onValueChange={(value) =>
-                      setState("inventoryChainFocus", value)
-                    }
-                  >
-                    <SelectTrigger
-                      data-testid="wallet-chain-select"
-                      aria-label={t("wallet.chain")}
-                      className="h-10 min-w-32 rounded-xl border border-border/60 bg-card/88 px-3 text-sm text-txt shadow-sm"
-                    >
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="all">{t("wallet.all")}</SelectItem>
-                      {PRIMARY_CHAIN_KEYS.map((key) => (
-                        <SelectItem key={key} value={key}>
-                          {CHAIN_CONFIGS[key].name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
                   {inventoryView === "tokens" && (
                     <Select
                       value={inventorySort}
@@ -699,9 +652,6 @@ export function InventoryView() {
                       </SelectContent>
                     </Select>
                   )}
-                  <span className="rounded-full border border-border/45 bg-bg/25 px-3 py-1.5 text-[11px] font-semibold text-muted">
-                    {chainFocus === "all" ? t("wallet.all") : focusedChainLabel}
-                  </span>
                 </div>
               </div>
             </section>

--- a/packages/app-core/src/components/KnowledgeView.tsx
+++ b/packages/app-core/src/components/KnowledgeView.tsx
@@ -48,7 +48,6 @@ import {
   APP_SIDEBAR_HEADER_CLASSNAME,
   APP_SIDEBAR_INNER_CLASSNAME,
   APP_SIDEBAR_KICKER_CLASSNAME,
-  APP_SIDEBAR_META_CLASSNAME,
   APP_SIDEBAR_PILL_CLASSNAME,
   APP_SIDEBAR_RAIL_CLASSNAME,
 } from "./sidebar-shell-styles";
@@ -556,8 +555,8 @@ function DocumentViewer({ documentId }: { documentId: string | null }) {
                   </span>
                 </div>
                 {previewText ? (
-                  <pre className="max-h-[18rem] overflow-auto whitespace-pre-wrap break-words text-[13px] leading-relaxed text-txt/88">
-                    {previewText.slice(0, 3000)}
+                  <pre className="max-h-[12rem] overflow-auto whitespace-pre-wrap break-words text-[13px] leading-relaxed text-txt/88 custom-scrollbar">
+                    {previewText.slice(0, 1200)}
                   </pre>
                 ) : (
                   <DesktopInsetEmptyStatePanel
@@ -647,7 +646,7 @@ function DocumentViewer({ documentId }: { documentId: string | null }) {
                         </span>
                       )}
                     </div>
-                    <p className="whitespace-pre-wrap text-[13px] leading-relaxed text-txt/90">
+                    <p className="whitespace-pre-wrap text-[13px] leading-relaxed text-txt/90 line-clamp-6">
                       {fragment.text}
                     </p>
                   </div>
@@ -1148,11 +1147,6 @@ export function KnowledgeView({ inModal }: { inModal?: boolean } = {}) {
           <div className={APP_SIDEBAR_INNER_CLASSNAME}>
             <div className={APP_SIDEBAR_HEADER_CLASSNAME}>
               <div className={KNOWLEDGE_KICKER_CLASS}>Knowledge</div>
-              <div className={APP_SIDEBAR_META_CLASSNAME}>
-                {documents.length > 0
-                  ? `${documents.length} uploaded document${documents.length === 1 ? "" : "s"} indexed`
-                  : "Upload docs and explore indexed fragments"}
-              </div>
             </div>
 
             <div className="mt-4 flex flex-wrap gap-2 px-1">
@@ -1181,9 +1175,6 @@ export function KnowledgeView({ inModal }: { inModal?: boolean } = {}) {
             <div className="mt-4 border-b border-border/25 pb-4">
               <div className="px-1">
                 <div className={KNOWLEDGE_SECTION_LABEL_CLASS}>Search</div>
-                <div className="mt-1 text-[11px] leading-relaxed text-muted">
-                  Jump to a known document by searching fragment text.
-                </div>
               </div>
               <form
                 className="mt-3 w-full max-w-[500px] flex-[1_1_500px]"
@@ -1243,11 +1234,6 @@ export function KnowledgeView({ inModal }: { inModal?: boolean } = {}) {
                     {isShowingSearchResults
                       ? t("knowledgeview.SearchResults")
                       : t("knowledgeview.Documents")}
-                  </div>
-                  <div className="mt-1 text-[11px] text-muted">
-                    {isShowingSearchResults
-                      ? "Search hits replace the document list until you clear them."
-                      : "Uploaded docs live here for quick review."}
                   </div>
                 </div>
                 <Button
@@ -1343,34 +1329,18 @@ export function KnowledgeView({ inModal }: { inModal?: boolean } = {}) {
               </div>
             )}
 
-            <section className={`${KNOWLEDGE_PANEL_CLASS} px-5 py-5 sm:px-6`}>
-              <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-                <div className="min-w-0 flex-1">
-                  <div className={KNOWLEDGE_KICKER_CLASS}>Knowledge</div>
-                  <h1 className="mt-1 text-2xl font-semibold text-txt-strong">
-                    {selectedDoc?.filename || "Knowledge workspace"}
-                  </h1>
-                  <p className="mt-2 max-w-2xl text-sm leading-relaxed text-muted">
-                    {selectedDoc
-                      ? `${getKnowledgeDocumentSummary(selectedDoc)}. Open search results, inspect fragments, and keep uploads close at hand in the sidebar.`
-                      : "Keep uploads, search, and document review in one workspace so the knowledge base is easier to manage and inspect."}
-                  </p>
-                </div>
-                <div className="flex flex-wrap items-center gap-2 lg:justify-end">
-                  <span className="rounded-full border border-border/45 bg-bg/25 px-3 py-1.5 text-[11px] font-semibold text-muted">
-                    {documents.length} docs
+            {selectedDoc && (
+              <section className={`${KNOWLEDGE_PANEL_CLASS} px-5 py-4 sm:px-6`}>
+                <div className="flex items-center justify-between gap-4">
+                  <h2 className="min-w-0 truncate text-lg font-semibold text-txt-strong">
+                    {selectedDoc.filename}
+                  </h2>
+                  <span className="shrink-0 text-[11px] font-semibold text-muted">
+                    {getKnowledgeDocumentSummary(selectedDoc)}
                   </span>
-                  <span className="rounded-full border border-border/45 bg-bg/25 px-3 py-1.5 text-[11px] font-semibold text-muted">
-                    {totalFragments} fragments
-                  </span>
-                  {searchResults !== null && (
-                    <span className="rounded-full border border-accent/25 bg-accent/8 px-3 py-1.5 text-[11px] font-semibold text-txt-strong">
-                      {searchResults.length} results
-                    </span>
-                  )}
                 </div>
-              </div>
-            </section>
+              </section>
+            )}
 
             <div className="mt-4">
               <DocumentViewer documentId={selectedDocId} />

--- a/packages/app-core/src/components/SettingsView.tsx
+++ b/packages/app-core/src/components/SettingsView.tsx
@@ -61,7 +61,7 @@ const SETTINGS_CONTENT_CLASS =
   "settings-page-content flex-1 min-w-0 overflow-y-auto scroll-smooth bg-bg/10 px-4 pb-6 pt-4 sm:px-6 sm:pb-8 sm:pt-5 lg:px-7 lg:pb-10 lg:pt-6";
 const SETTINGS_CONTENT_WIDTH_CLASS = "mx-auto w-full max-w-[82rem]";
 const SETTINGS_SECTION_STACK_CLASS = "space-y-6 pb-14 sm:space-y-8 sm:pb-16";
-const SETTINGS_SECTION_CARD_CLASS = `overflow-hidden ${DESKTOP_SURFACE_PANEL_CLASSNAME}`;
+const SETTINGS_SECTION_CARD_CLASS = `overflow-visible ${DESKTOP_SURFACE_PANEL_CLASSNAME}`;
 
 const SETTINGS_SECTIONS: SettingsSectionDef[] = [
   {

--- a/packages/app-core/src/components/desktop-surface-primitives.tsx
+++ b/packages/app-core/src/components/desktop-surface-primitives.tsx
@@ -15,7 +15,7 @@ export const DESKTOP_TEXT_DEPTH_MUTED_CLASSNAME =
 export const DESKTOP_SURFACE_PANEL_CLASSNAME =
   "rounded-[28px] border border-border/34 bg-[linear-gradient(180deg,color-mix(in_srgb,var(--card)_82%,transparent),color-mix(in_srgb,var(--bg)_96%,transparent))] shadow-[inset_0_1px_0_rgba(255,255,255,0.12),0_22px_34px_-26px_rgba(15,23,42,0.14)] ring-1 ring-border/8 backdrop-blur-md dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.04),0_24px_36px_-26px_rgba(0,0,0,0.32)]";
 
-export const DESKTOP_SECTION_SHELL_CLASSNAME = `overflow-hidden ${DESKTOP_SURFACE_PANEL_CLASSNAME}`;
+export const DESKTOP_SECTION_SHELL_CLASSNAME = `overflow-visible ${DESKTOP_SURFACE_PANEL_CLASSNAME}`;
 
 export const DESKTOP_PADDED_SURFACE_PANEL_CLASSNAME = `${DESKTOP_SURFACE_PANEL_CLASSNAME} px-5 py-4 sm:px-6 sm:py-5`;
 

--- a/packages/app-core/src/hooks/useVoiceChat.ts
+++ b/packages/app-core/src/hooks/useVoiceChat.ts
@@ -33,6 +33,7 @@ import {
 import { resolveApiUrl } from "../utils";
 import { getElizaApiToken } from "../utils/eliza-globals";
 import { mergeStreamingText } from "../utils/streaming-text";
+import { hasConfiguredApiKey } from "../voice";
 
 // ── Speech Recognition types ──────────────────────────────────────────
 
@@ -1156,8 +1157,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
 
         const trimmedApiKey =
           typeof elConfig.apiKey === "string" ? elConfig.apiKey.trim() : "";
-        const hasDirectKey =
-          trimmedApiKey.length > 0 && !isRedactedSecret(trimmedApiKey);
+        const hasDirectKey = hasConfiguredApiKey(trimmedApiKey);
 
         let res: Response;
         if (hasDirectKey) {

--- a/packages/app-core/src/hooks/useVoiceChat.ts
+++ b/packages/app-core/src/hooks/useVoiceChat.ts
@@ -33,7 +33,6 @@ import {
 import { resolveApiUrl } from "../utils";
 import { getElizaApiToken } from "../utils/eliza-globals";
 import { mergeStreamingText } from "../utils/streaming-text";
-import { hasConfiguredApiKey } from "../voice";
 
 // ── Speech Recognition types ──────────────────────────────────────────
 
@@ -180,11 +179,14 @@ const globalAudioCache = new Map<string, Uint8Array>();
 
 function resolveVoiceMode(
   mode: VoiceMode | undefined,
-  cloudConnected: boolean,
-  apiKey?: string | null,
+  _cloudConnected: boolean,
+  _apiKey?: string | null,
 ): VoiceMode {
   if (mode) return mode;
-  if (cloudConnected && !hasConfiguredApiKey(apiKey)) return "cloud";
+  // Always use the ElevenLabs proxy path ("own-key") — the server aliases the
+  // cloud API key to ELEVENLABS_API_KEY at startup so upstream Eliza can use
+  // it.  The "cloud" path converts ElevenLabs voice IDs to OpenAI-style names
+  // (nova, alloy, etc.) which produces wrong audio (default sample clips).
   return "own-key";
 }
 

--- a/packages/app-core/test/app/character-editor-voice-cloud.e2e.test.ts
+++ b/packages/app-core/test/app/character-editor-voice-cloud.e2e.test.ts
@@ -262,7 +262,7 @@ describe("CharacterEditor voice cloud fallback (e2e)", () => {
     vi.unstubAllGlobals();
   });
 
-  it("speaks the character greeting through cloud TTS when only a masked ElevenLabs key is present", async () => {
+  it("speaks the character greeting through the ElevenLabs server proxy when only a masked key is present", async () => {
     await act(async () => {
       tree = TestRenderer.create(React.createElement(CharacterEditor));
     });
@@ -277,7 +277,7 @@ describe("CharacterEditor voice cloud fallback (e2e)", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe("/api/tts/cloud");
+    expect(url).toBe("/api/tts/elevenlabs");
     expect(JSON.parse(String(init.body))).toMatchObject({
       text: "Hello from Chen.",
       voiceId: "voice-123",

--- a/packages/app-core/test/app/voice-cloud-default.e2e.test.ts
+++ b/packages/app-core/test/app/voice-cloud-default.e2e.test.ts
@@ -71,7 +71,7 @@ describe("voice cloud default (e2e)", () => {
     vi.unstubAllGlobals();
   });
 
-  it("uses cloud TTS when cloud is available and the stored ElevenLabs key is only a masked placeholder", async () => {
+  it("uses the ElevenLabs server proxy when cloud is available and the stored key is only a masked placeholder", async () => {
     const { result } = renderHook(() =>
       useVoiceChat({
         cloudConnected: true,
@@ -95,7 +95,7 @@ describe("voice cloud default (e2e)", () => {
     });
 
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe("/api/tts/cloud");
+    expect(url).toBe("/api/tts/elevenlabs");
     expect(init.method).toBe("POST");
     expect(JSON.parse(String(init.body))).toMatchObject({
       text: "Hello from the cloud voice path.",

--- a/packages/app-core/test/avatar/voice-chat-streaming-text.test.ts
+++ b/packages/app-core/test/avatar/voice-chat-streaming-text.test.ts
@@ -52,14 +52,14 @@ describe("useVoiceChat streaming text helpers", () => {
     expect(queued.length).toBeLessThan(longText.length);
   });
 
-  it("defaults to ElevenLabs cloud config when Cloud auth is present", () => {
+  it("defaults to ElevenLabs own-key proxy config when Cloud auth is present", () => {
     expect(
       resolveEffectiveVoiceConfig(null, {
         cloudConnected: true,
       }),
     ).toEqual({
       provider: "elevenlabs",
-      mode: "cloud",
+      mode: "own-key",
       elevenlabs: {
         voiceId: "EXAVITQu4vr4xnSDxMaL",
         modelId: "eleven_flash_v2_5",

--- a/packages/app-core/test/avatar/voice-chat-streaming-text.test.ts
+++ b/packages/app-core/test/avatar/voice-chat-streaming-text.test.ts
@@ -70,14 +70,18 @@ describe("useVoiceChat streaming text helpers", () => {
     });
   });
 
-  it("defaults the saved voice mode to cloud when Cloud auth is present", () => {
-    expect(resolveVoiceMode(undefined, true)).toBe("cloud");
-    expect(resolveVoiceMode(undefined, true, "")).toBe("cloud");
+  it("always defaults to own-key so ElevenLabs voices route through the server proxy", () => {
+    // Cloud-connected but no explicit mode — server aliases cloud key to
+    // ELEVENLABS_API_KEY so the upstream proxy handles it.
+    expect(resolveVoiceMode(undefined, true)).toBe("own-key");
+    expect(resolveVoiceMode(undefined, true, "")).toBe("own-key");
     expect(resolveVoiceMode(undefined, true, "sk-test")).toBe("own-key");
-    expect(resolveVoiceMode(undefined, true, "[REDACTED]")).toBe("cloud");
-    expect(resolveVoiceMode(undefined, true, "sk-t...1234")).toBe("cloud");
+    expect(resolveVoiceMode(undefined, true, "[REDACTED]")).toBe("own-key");
+    expect(resolveVoiceMode(undefined, true, "sk-t...1234")).toBe("own-key");
     expect(resolveVoiceMode(undefined, false)).toBe("own-key");
+    // Explicit mode is always respected.
     expect(resolveVoiceMode("own-key", true, "")).toBe("own-key");
+    expect(resolveVoiceMode("cloud", true, "")).toBe("cloud");
   });
 
   it("uses the cloud TTS proxy when ElevenLabs is in cloud mode", () => {

--- a/packages/ui/src/components/ui/switch.tsx
+++ b/packages/ui/src/components/ui/switch.tsx
@@ -9,7 +9,7 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      "peer inline-flex h-[24px] w-[44px] shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      "peer inline-flex h-[24px] w-[44px] shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-[var(--ok)] data-[state=unchecked]:bg-input",
       className,
     )}
     {...props}
@@ -17,7 +17,7 @@ const Switch = React.forwardRef<
   >
     <SwitchPrimitives.Thumb
       className={cn(
-        "pointer-events-none block h-5 w-5 rounded-full bg-bg shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0",
+        "pointer-events-none block h-5 w-5 rounded-full bg-white shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0",
       )}
     />
   </SwitchPrimitives.Root>


### PR DESCRIPTION
## Summary
Addresses Shaw's UI feedback from the screenshot bug list + fixes cloud TTS playing wrong audio:

- **Settings toggles**: Checked state now green (`--ok: #03a66d`) instead of gold — clear active indicator, white thumb for contrast. No more "black holes"
- **Dropdowns cut off**: `overflow-hidden` → `overflow-visible` on section card containers so model selection and other dropdowns aren't clipped by their parent
- **Wallet sidebar de-slopped**: Removed scroll wrapper (only 4 chains, no scroll needed), compacted chain buttons to single-line with small icons, removed verbose description text. Removed duplicate chain filter dropdown from main content area (sidebar handles it). Trimmed redundant header chrome
- **Knowledge workspace text**: Removed redundant "KNOWLEDGE" kicker + "Knowledge workspace" heading from main content (already on the tab). Stripped verbose sidebar descriptions. Preview capped at 1200 chars (was 3000), height reduced, fragments clamped to 6 lines
- **Cloud TTS playing ElevenLabs sample audio**: `resolveVoiceMode()` was routing cloud-connected users to `/api/tts/cloud` which converts ElevenLabs voice IDs to OpenAI-style names (nova, alloy) and returned default sample clips ("washington is more divided than ever"). Fix: always route through `/api/tts/elevenlabs` and call `ensureCloudTtsApiKeyAlias()` at server startup + per-request so the upstream handler has a valid key from the cloud account

## Test plan
- [ ] Settings toggles show green when enabled, grey when off
- [ ] Model selection dropdown fully visible (not cut off by card edge)
- [ ] Wallet sidebar shows chains as compact flat list, no scroll
- [ ] No duplicate chain dropdown in wallet main content area
- [ ] Knowledge workspace shows only filename header when doc selected, no redundant titles
- [ ] Knowledge sidebar has no verbose description text under section labels
- [ ] Cloud-connected user with ElevenLabs voice hears actual agent text, not sample audio
- [ ] Agent greeting plays the correct character greeting, not "washington is more divided than ever"
- [ ] No visual regressions on other panels using `DESKTOP_SECTION_SHELL_CLASSNAME`

🤖 Generated with [Claude Code](https://claude.com/claude-code)