### PR TITLE
fix(ui): cloud model selector dropdown clipped by overflow:hidden

### DIFF
--- a/packages/app-core/src/components/ProviderSwitcher.tsx
+++ b/packages/app-core/src/components/ProviderSwitcher.tsx
@@ -745,10 +745,20 @@ export function ProviderSwitcher(props: ProviderSwitcherProps = {}) {
                     small: {
                       label: t("providerswitcher.smallModelLabel"),
                       width: "half",
+                      options: modelOptions.small.map((m) => ({
+                        value: m.id,
+                        label: m.name,
+                        description: `${m.provider} — ${m.description}`,
+                      })),
                     },
                     large: {
                       label: t("providerswitcher.largeModelLabel"),
                       width: "half",
+                      options: modelOptions.large.map((m) => ({
+                        value: m.id,
+                        label: m.name,
+                        description: `${m.provider} — ${m.description}`,
+                      })),
                     },
                   };
                   const modelValues: Record<string, unknown> = {};

--- a/packages/app-core/src/config/config-field.tsx
+++ b/packages/app-core/src/config/config-field.tsx
@@ -545,6 +545,7 @@ function SearchableSelectInner({
             {/* Search input */}
             <div className="p-1.5 border-b border-[var(--border)]">
               <input
+                // biome-ignore lint/a11y/noAutofocus: dropdown search needs immediate focus
                 autoFocus
                 className="w-full px-2 py-1.5 border border-[var(--border)] bg-[var(--bg)] text-[12px] font-[var(--mono)] focus:border-[var(--accent)] focus:outline-none rounded-sm"
                 type="text"

--- a/packages/app-core/src/config/config-field.tsx
+++ b/packages/app-core/src/config/config-field.tsx
@@ -20,7 +20,8 @@ import {
   Switch,
 } from "@miladyai/ui";
 import { ChevronDown, X } from "lucide-react";
-import React, { useCallback, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { useApp } from "../state";
 import type { DynamicValue } from "../types";
 import type { FieldRenderer, FieldRenderProps } from "./config-catalog";
@@ -445,8 +446,9 @@ function SearchableSelectInner({
   );
   const [open, setOpen] = useState(false);
   const [filter, setFilter] = useState("");
-  const containerRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const [dropdownStyle, setDropdownStyle] = useState<React.CSSProperties>({});
 
   const filtered = filter
     ? options.filter(
@@ -467,26 +469,52 @@ function SearchableSelectInner({
     [props],
   );
 
+  // Position the portal dropdown below the trigger button
+  useEffect(() => {
+    if (!open || !triggerRef.current) return;
+    const rect = triggerRef.current.getBoundingClientRect();
+    setDropdownStyle({
+      position: "fixed",
+      top: rect.bottom + 4,
+      left: rect.left,
+      width: rect.width,
+      zIndex: 9999,
+    });
+  }, [open]);
+
   // Close on click outside
-  React.useEffect(() => {
+  useEffect(() => {
     if (!open) return;
     const handler = (e: MouseEvent) => {
+      const target = e.target as Node;
       if (
-        containerRef.current &&
-        !containerRef.current.contains(e.target as Node)
-      ) {
-        setOpen(false);
-        setFilter("");
-      }
+        triggerRef.current?.contains(target) ||
+        dropdownRef.current?.contains(target)
+      )
+        return;
+      setOpen(false);
+      setFilter("");
     };
     document.addEventListener("mousedown", handler);
     return () => document.removeEventListener("mousedown", handler);
   }, [open]);
 
+  // Close on scroll of any ancestor (position shifts)
+  useEffect(() => {
+    if (!open) return;
+    const handler = () => {
+      setOpen(false);
+      setFilter("");
+    };
+    window.addEventListener("scroll", handler, true);
+    return () => window.removeEventListener("scroll", handler, true);
+  }, [open]);
+
   return (
-    <div className="relative" ref={containerRef}>
+    <div>
       {/* Trigger button that looks like a select */}
       <Button
+        ref={triggerRef}
         type="button"
         variant="outline"
         className={`${inputCls(!!props.errors?.length)} text-left flex items-center justify-between gap-2 cursor-pointer`}
@@ -506,80 +534,86 @@ function SearchableSelectInner({
         </span>
       </Button>
 
-      {/* Dropdown panel */}
-      {open && (
-        <div className="absolute z-50 left-0 right-0 mt-1 border border-[var(--border)] bg-[var(--card)] shadow-lg max-h-[280px] flex flex-col rounded-sm">
-          {/* Search input */}
-          <div className="p-1.5 border-b border-[var(--border)]">
-            <input
-              ref={inputRef}
-              className="w-full px-2 py-1.5 border border-[var(--border)] bg-[var(--bg)] text-[12px] font-[var(--mono)] focus:border-[var(--accent)] focus:outline-none rounded-sm"
-              type="text"
-              value={filter}
-              placeholder={`Search ${options.length} models...`}
-              onChange={(e) => setFilter(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Escape") {
-                  setOpen(false);
-                  setFilter("");
-                } else if (e.key === "Enter" && filtered.length === 1) {
-                  select(filtered[0]);
-                }
-              }}
-            />
-          </div>
-          {/* Options list */}
-          <div className="overflow-y-auto flex-1">
-            {!props.required && (
-              <Button
-                type="button"
-                variant="ghost"
-                className="w-full text-left px-3 py-1.5 text-[12px] text-[var(--muted)] hover:bg-[var(--bg-hover)] transition-colors italic rounded-none justify-start h-auto"
-                onClick={() => {
-                  props.onChange("");
-                  setInputVal("");
-                  setOpen(false);
-                  setFilter("");
-                  fireAction(props, "change");
+      {/* Dropdown panel — rendered as portal to escape overflow:hidden ancestors */}
+      {open &&
+        createPortal(
+          <div
+            ref={dropdownRef}
+            style={dropdownStyle}
+            className="border border-[var(--border)] bg-[var(--card)] shadow-lg rounded-sm"
+          >
+            {/* Search input */}
+            <div className="p-1.5 border-b border-[var(--border)]">
+              <input
+                autoFocus
+                className="w-full px-2 py-1.5 border border-[var(--border)] bg-[var(--bg)] text-[12px] font-[var(--mono)] focus:border-[var(--accent)] focus:outline-none rounded-sm"
+                type="text"
+                value={filter}
+                placeholder={`Search ${options.length} options...`}
+                onChange={(e) => setFilter(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Escape") {
+                    setOpen(false);
+                    setFilter("");
+                  } else if (e.key === "Enter" && filtered.length === 1) {
+                    select(filtered[0]);
+                  }
                 }}
-              >
-                {t("config-field.None", { defaultValue: "None" })}
-              </Button>
-            )}
-            {filtered.length === 0 && (
-              <div className="px-3 py-3 text-[12px] text-[var(--muted)] text-center">
-                {t("config-field.NoMatches", {
-                  defaultValue: "No matches",
-                })}
-              </div>
-            )}
-            {filtered.map((opt) => (
-              <Button
-                key={opt.value}
-                type="button"
-                variant="ghost"
-                className={`w-full text-left px-3 py-1.5 text-[12px] hover:bg-[var(--bg-hover)] transition-colors rounded-none justify-start h-auto ${
-                  opt.value === effectiveValue
-                    ? "bg-[color-mix(in_srgb,var(--accent)_10%,var(--card))] text-[var(--accent)] font-medium"
-                    : ""
-                }`}
-                onClick={() => select(opt)}
-              >
-                {opt.label}
-                {opt.description && (
-                  <span className="text-[var(--muted)] ml-1.5 text-[11px]">
-                    {opt.description}
-                  </span>
-                )}
-              </Button>
-            ))}
-          </div>
-          <div className="px-3 py-1 border-t border-[var(--border)] text-[10px] text-[var(--muted)]">
-            {filtered.length} of {options.length}{" "}
-            {t("config-field.models", { defaultValue: "models" })}
-          </div>
-        </div>
-      )}
+              />
+            </div>
+            {/* Options list */}
+            <div className="overflow-y-auto max-h-[220px]">
+              {!props.required && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  className="w-full text-left px-3 py-1.5 text-[12px] text-[var(--muted)] hover:bg-[var(--bg-hover)] transition-colors italic rounded-none justify-start h-auto"
+                  onClick={() => {
+                    props.onChange("");
+                    setInputVal("");
+                    setOpen(false);
+                    setFilter("");
+                    fireAction(props, "change");
+                  }}
+                >
+                  {t("config-field.None", { defaultValue: "None" })}
+                </Button>
+              )}
+              {filtered.length === 0 && (
+                <div className="px-3 py-3 text-[12px] text-[var(--muted)] text-center">
+                  {t("config-field.NoMatches", {
+                    defaultValue: "No matches",
+                  })}
+                </div>
+              )}
+              {filtered.map((opt) => (
+                <Button
+                  key={opt.value}
+                  type="button"
+                  variant="ghost"
+                  className={`w-full text-left px-3 py-1.5 text-[12px] hover:bg-[var(--bg-hover)] transition-colors rounded-none justify-start h-auto ${
+                    opt.value === effectiveValue
+                      ? "bg-[color-mix(in_srgb,var(--accent)_10%,var(--card))] text-[var(--accent)] font-medium"
+                      : ""
+                  }`}
+                  onClick={() => select(opt)}
+                >
+                  {opt.label}
+                  {opt.description && (
+                    <span className="text-[var(--muted)] ml-1.5 text-[11px]">
+                      {opt.description}
+                    </span>
+                  )}
+                </Button>
+              ))}
+            </div>
+            <div className="px-3 py-1 border-t border-[var(--border)] text-[10px] text-[var(--muted)]">
+              {filtered.length} of {options.length}{" "}
+              {t("config-field.options", { defaultValue: "options" })}
+            </div>
+          </div>,
+          document.body,
+        )}
     </div>
   );
 }

--- a/packages/app-core/src/config/searchable-select-portal.test.ts
+++ b/packages/app-core/src/config/searchable-select-portal.test.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const configFieldSource = readFileSync(
+	path.resolve(import.meta.dirname, "config-field.tsx"),
+	"utf-8",
+);
+
+const providerSwitcherSource = readFileSync(
+	path.resolve(
+		import.meta.dirname,
+		"..",
+		"components",
+		"ProviderSwitcher.tsx",
+	),
+	"utf-8",
+);
+
+describe("SearchableSelectInner portal rendering", () => {
+	it("imports createPortal from react-dom", () => {
+		expect(configFieldSource).toContain(
+			'import { createPortal } from "react-dom"',
+		);
+	});
+
+	it("renders dropdown via createPortal to escape overflow clipping", () => {
+		expect(configFieldSource).toContain("createPortal(");
+		expect(configFieldSource).toContain("document.body");
+	});
+
+	it("uses fixed positioning for the dropdown", () => {
+		expect(configFieldSource).toContain('position: "fixed"');
+	});
+
+	it("closes on ancestor scroll since fixed position does not track it", () => {
+		expect(configFieldSource).toContain(
+			'window.addEventListener("scroll"',
+		);
+	});
+
+	it("does NOT use position:absolute (would be clipped by overflow:hidden)", () => {
+		// The dropdown style should use fixed, not absolute
+		const dropdownStyleBlock = configFieldSource.match(
+			/setDropdownStyle\(\{[\s\S]*?\}\)/,
+		);
+		expect(dropdownStyleBlock).toBeTruthy();
+		expect(dropdownStyleBlock![0]).not.toContain('"absolute"');
+		expect(dropdownStyleBlock![0]).toContain('"fixed"');
+	});
+});
+
+describe("ProviderSwitcher passes enhanced model options", () => {
+	it("passes hint.options with value, label, and description for small models", () => {
+		expect(providerSwitcherSource).toMatch(
+			/small:\s*\{[\s\S]*?options:\s*modelOptions\.small\.map/,
+		);
+	});
+
+	it("passes hint.options with value, label, and description for large models", () => {
+		expect(providerSwitcherSource).toMatch(
+			/large:\s*\{[\s\S]*?options:\s*modelOptions\.large\.map/,
+		);
+	});
+
+	it("maps model name to label for human-readable dropdown entries", () => {
+		// Both small and large should map m.name → label
+		const optionMappings = providerSwitcherSource.match(
+			/label:\s*m\.name/g,
+		);
+		expect(optionMappings).toBeTruthy();
+		expect(optionMappings!.length).toBeGreaterThanOrEqual(2);
+	});
+});

--- a/packages/app-core/src/config/searchable-select-portal.test.ts
+++ b/packages/app-core/src/config/searchable-select-portal.test.ts
@@ -3,72 +3,63 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 const configFieldSource = readFileSync(
-	path.resolve(import.meta.dirname, "config-field.tsx"),
-	"utf-8",
+  path.resolve(import.meta.dirname, "config-field.tsx"),
+  "utf-8",
 );
 
 const providerSwitcherSource = readFileSync(
-	path.resolve(
-		import.meta.dirname,
-		"..",
-		"components",
-		"ProviderSwitcher.tsx",
-	),
-	"utf-8",
+  path.resolve(import.meta.dirname, "..", "components", "ProviderSwitcher.tsx"),
+  "utf-8",
 );
 
 describe("SearchableSelectInner portal rendering", () => {
-	it("imports createPortal from react-dom", () => {
-		expect(configFieldSource).toContain(
-			'import { createPortal } from "react-dom"',
-		);
-	});
+  it("imports createPortal from react-dom", () => {
+    expect(configFieldSource).toContain(
+      'import { createPortal } from "react-dom"',
+    );
+  });
 
-	it("renders dropdown via createPortal to escape overflow clipping", () => {
-		expect(configFieldSource).toContain("createPortal(");
-		expect(configFieldSource).toContain("document.body");
-	});
+  it("renders dropdown via createPortal to escape overflow clipping", () => {
+    expect(configFieldSource).toContain("createPortal(");
+    expect(configFieldSource).toContain("document.body");
+  });
 
-	it("uses fixed positioning for the dropdown", () => {
-		expect(configFieldSource).toContain('position: "fixed"');
-	});
+  it("uses fixed positioning for the dropdown", () => {
+    expect(configFieldSource).toContain('position: "fixed"');
+  });
 
-	it("closes on ancestor scroll since fixed position does not track it", () => {
-		expect(configFieldSource).toContain(
-			'window.addEventListener("scroll"',
-		);
-	});
+  it("closes on ancestor scroll since fixed position does not track it", () => {
+    expect(configFieldSource).toContain('window.addEventListener("scroll"');
+  });
 
-	it("does NOT use position:absolute (would be clipped by overflow:hidden)", () => {
-		// The dropdown style should use fixed, not absolute
-		const dropdownStyleBlock = configFieldSource.match(
-			/setDropdownStyle\(\{[\s\S]*?\}\)/,
-		);
-		expect(dropdownStyleBlock).toBeTruthy();
-		expect(dropdownStyleBlock![0]).not.toContain('"absolute"');
-		expect(dropdownStyleBlock![0]).toContain('"fixed"');
-	});
+  it("does NOT use position:absolute (would be clipped by overflow:hidden)", () => {
+    // The dropdown style should use fixed, not absolute
+    const dropdownStyleBlock = configFieldSource.match(
+      /setDropdownStyle\(\{[\s\S]*?\}\)/,
+    );
+    expect(dropdownStyleBlock).toBeTruthy();
+    expect(dropdownStyleBlock?.[0]).not.toContain('"absolute"');
+    expect(dropdownStyleBlock?.[0]).toContain('"fixed"');
+  });
 });
 
 describe("ProviderSwitcher passes enhanced model options", () => {
-	it("passes hint.options with value, label, and description for small models", () => {
-		expect(providerSwitcherSource).toMatch(
-			/small:\s*\{[\s\S]*?options:\s*modelOptions\.small\.map/,
-		);
-	});
+  it("passes hint.options with value, label, and description for small models", () => {
+    expect(providerSwitcherSource).toMatch(
+      /small:\s*\{[\s\S]*?options:\s*modelOptions\.small\.map/,
+    );
+  });
 
-	it("passes hint.options with value, label, and description for large models", () => {
-		expect(providerSwitcherSource).toMatch(
-			/large:\s*\{[\s\S]*?options:\s*modelOptions\.large\.map/,
-		);
-	});
+  it("passes hint.options with value, label, and description for large models", () => {
+    expect(providerSwitcherSource).toMatch(
+      /large:\s*\{[\s\S]*?options:\s*modelOptions\.large\.map/,
+    );
+  });
 
-	it("maps model name to label for human-readable dropdown entries", () => {
-		// Both small and large should map m.name → label
-		const optionMappings = providerSwitcherSource.match(
-			/label:\s*m\.name/g,
-		);
-		expect(optionMappings).toBeTruthy();
-		expect(optionMappings!.length).toBeGreaterThanOrEqual(2);
-	});
+  it("maps model name to label for human-readable dropdown entries", () => {
+    // Both small and large should map m.name → label
+    const optionMappings = providerSwitcherSource.match(/label:\s*m\.name/g);
+    expect(optionMappings).toBeTruthy();
+    expect(optionMappings?.length).toBeGreaterThanOrEqual(2);
+  });
 });


### PR DESCRIPTION
## Summary
- **SearchableSelectInner** dropdown was invisible because the settings modal uses `overflow:hidden` + `overflow-y:auto`, clipping the absolutely-positioned options list
- Fixed by rendering the dropdown via `createPortal` to `document.body` with `position: fixed` so it escapes all overflow clipping
- **ProviderSwitcher** now passes enhanced `hint.options` with human-readable model names and provider descriptions instead of raw IDs like `moonshotai/kimi-k2-0905`

## Test plan
- [x] New source-verification test (`searchable-select-portal.test.ts`, 8 assertions)
- [ ] Open Settings → AI Provider → select Eliza Cloud → verify both Small Model and Large Model dropdowns show all options with readable names
- [ ] Search filtering works (type partial model name)
- [ ] Selecting a model updates the config

🤖 Generated with [Claude Code](https://claude.com/claude-code)