### PR TITLE
docs: add missing plugin/provider/connector pages and fix navigation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -155,7 +155,16 @@
               "connectors/feishu",
               "connectors/nostr",
               "connectors/lens",
-              "connectors/retake"
+              "connectors/retake",
+              "connectors/bluesky",
+              "connectors/instagram",
+              "connectors/line",
+              "connectors/zalo",
+              "connectors/twilio",
+              "connectors/github",
+              "connectors/gmail-watch",
+              "connectors/nextcloud-talk",
+              "connectors/tlon"
             ]
           },
           {
@@ -244,6 +253,7 @@
               "plugin-registry/llm/openai",
               "plugin-registry/llm/anthropic",
               "plugin-registry/llm/google-genai",
+              "plugin-registry/llm/google-antigravity",
               "plugin-registry/llm/groq",
               "plugin-registry/llm/ollama",
               "plugin-registry/llm/openrouter",
@@ -253,7 +263,11 @@
               "plugin-registry/llm/cohere",
               "plugin-registry/llm/together",
               "plugin-registry/llm/perplexity",
-              "plugin-registry/llm/vercel-ai-gateway"
+              "plugin-registry/llm/vercel-ai-gateway",
+              "plugin-registry/llm/qwen",
+              "plugin-registry/llm/minimax",
+              "plugin-registry/llm/pi-ai",
+              "plugin-registry/llm/zai"
             ]
           },
           {
@@ -278,7 +292,16 @@
               "plugin-registry/platform/feishu",
               "plugin-registry/platform/nostr",
               "plugin-registry/platform/lens",
-              "plugin-registry/platform/retake"
+              "plugin-registry/platform/retake",
+              "plugin-registry/platform/bluesky",
+              "plugin-registry/platform/instagram",
+              "plugin-registry/platform/line",
+              "plugin-registry/platform/zalo",
+              "plugin-registry/platform/twilio",
+              "plugin-registry/platform/github",
+              "plugin-registry/platform/gmail-watch",
+              "plugin-registry/platform/nextcloud-talk",
+              "plugin-registry/platform/tlon"
             ]
           },
           {
@@ -291,8 +314,15 @@
               "plugin-registry/browser",
               "plugin-registry/image-generation",
               "plugin-registry/tts",
+              "plugin-registry/stt",
+              "plugin-registry/vision",
               "plugin-registry/computeruse",
-              "plugin-registry/cron"
+              "plugin-registry/cron",
+              "plugin-registry/obsidian",
+              "plugin-registry/webhooks",
+              "plugin-registry/fal",
+              "plugin-registry/suno",
+              "plugin-registry/x402"
             ]
           }
         ]

--- a/docs/plugin-registry/fal.md
+++ b/docs/plugin-registry/fal.md
@@ -1,0 +1,38 @@
+---
+title: "FAL Plugin"
+sidebarTitle: "FAL"
+description: "FAL media generation plugin for Milady — access FAL.ai's suite of image, video, and audio generation models."
+---
+
+The FAL plugin connects Milady agents to [FAL.ai](https://fal.ai)'s media generation platform, providing access to fast inference for image, video, and audio generation models.
+
+**Package:** `@elizaos/plugin-fal`
+
+## Installation
+
+```bash
+milady plugins install fal
+```
+
+## Enable via Features
+
+```json
+{
+  "features": {
+    "fal": true
+  }
+}
+```
+
+## Features
+
+- Image generation via FAL.ai models
+- Video generation
+- Audio generation
+- Fast inference on serverless GPU infrastructure
+
+## Related
+
+- [Image Generation Plugin](/plugin-registry/image-generation) — General image generation
+- [Suno Plugin](/plugin-registry/suno) — Music generation
+- [Media Generation Guide](/guides/media-generation) — Overview of media capabilities

--- a/docs/plugin-registry/llm/google-antigravity.md
+++ b/docs/plugin-registry/llm/google-antigravity.md
@@ -1,0 +1,55 @@
+---
+title: "Google Antigravity Plugin"
+sidebarTitle: "Google Antigravity"
+description: "Google Cloud AI model provider for Milady — access Google Cloud AI Platform models via the Antigravity integration."
+---
+
+The Google Antigravity plugin connects Milady agents to Google Cloud AI Platform, providing access to Google's cloud-hosted AI models through the Google Cloud API.
+
+**Package:** `@elizaos/plugin-google-antigravity`
+
+## Installation
+
+```bash
+milady plugins install google-antigravity
+```
+
+## Auto-Enable
+
+The plugin auto-enables when `GOOGLE_CLOUD_API_KEY` is present:
+
+```bash
+export GOOGLE_CLOUD_API_KEY=your-google-cloud-api-key
+```
+
+## Configuration
+
+| Environment Variable | Required | Description |
+|---------------------|----------|-------------|
+| `GOOGLE_CLOUD_API_KEY` | Yes | Google Cloud API key with AI Platform access |
+
+### milady.json Example
+
+```json
+{
+  "auth": {
+    "profiles": {
+      "default": {
+        "provider": "google-antigravity"
+      }
+    }
+  }
+}
+```
+
+## Features
+
+- Google Cloud AI Platform model access
+- Streaming responses
+- Tool use / function calling
+
+## Related
+
+- [Google Gemini Plugin](/plugin-registry/llm/google-genai) — Google AI Studio / Gemini models
+- [OpenAI Plugin](/plugin-registry/llm/openai) — GPT-4o models
+- [Model Providers](/runtime/models) — Compare all providers

--- a/docs/plugin-registry/llm/minimax.md
+++ b/docs/plugin-registry/llm/minimax.md
@@ -1,0 +1,48 @@
+---
+title: "MiniMax Plugin"
+sidebarTitle: "MiniMax"
+description: "MiniMax model provider for Milady — access MiniMax's language and multimodal models."
+---
+
+The MiniMax plugin connects Milady agents to MiniMax's language models, providing access to their text generation and multimodal capabilities.
+
+**Package:** `@elizaos/plugin-minimax`
+
+## Installation
+
+```bash
+milady plugins install minimax
+```
+
+## Configuration
+
+MiniMax does not have an env-var auto-enable trigger. Enable it explicitly in your config:
+
+### milady.json Example
+
+```json
+{
+  "auth": {
+    "profiles": {
+      "default": {
+        "provider": "minimax"
+      }
+    }
+  },
+  "plugins": {
+    "allow": ["@elizaos/plugin-minimax"]
+  }
+}
+```
+
+## Features
+
+- Text generation
+- Multimodal capabilities
+- Streaming responses
+
+## Related
+
+- [OpenAI Plugin](/plugin-registry/llm/openai) — GPT-4o models
+- [OpenRouter Plugin](/plugin-registry/llm/openrouter) — Route between multiple providers
+- [Model Providers](/runtime/models) — Compare all providers

--- a/docs/plugin-registry/llm/pi-ai.md
+++ b/docs/plugin-registry/llm/pi-ai.md
@@ -1,0 +1,54 @@
+---
+title: "Pi AI Plugin"
+sidebarTitle: "Pi AI"
+description: "Pi AI model provider for Milady — access Inflection AI's Pi conversational models."
+---
+
+The Pi AI plugin connects Milady agents to Inflection AI's Pi models, known for their empathetic and conversational capabilities.
+
+**Package:** `@elizaos/plugin-pi-ai`
+
+## Installation
+
+```bash
+milady plugins install pi-ai
+```
+
+## Auto-Enable
+
+The plugin auto-enables when `ELIZA_USE_PI_AI` is set:
+
+```bash
+export ELIZA_USE_PI_AI=1
+```
+
+## Configuration
+
+| Environment Variable | Required | Description |
+|---------------------|----------|-------------|
+| `ELIZA_USE_PI_AI` | Yes | Set to `1` to enable the Pi AI provider |
+
+### milady.json Example
+
+```json
+{
+  "auth": {
+    "profiles": {
+      "default": {
+        "provider": "pi-ai"
+      }
+    }
+  }
+}
+```
+
+## Features
+
+- Conversational AI optimized for empathetic interactions
+- Streaming responses
+
+## Related
+
+- [Anthropic Plugin](/plugin-registry/llm/anthropic) — Claude models
+- [OpenAI Plugin](/plugin-registry/llm/openai) — GPT-4o models
+- [Model Providers](/runtime/models) — Compare all providers

--- a/docs/plugin-registry/llm/qwen.md
+++ b/docs/plugin-registry/llm/qwen.md
@@ -1,0 +1,48 @@
+---
+title: "Qwen Plugin"
+sidebarTitle: "Qwen"
+description: "Qwen model provider for Milady — access Alibaba Cloud's Qwen language models."
+---
+
+The Qwen plugin connects Milady agents to Alibaba Cloud's Qwen (Tongyi Qianwen) language models, providing access to multilingual models with strong Chinese and English capabilities.
+
+**Package:** `@elizaos/plugin-qwen`
+
+## Installation
+
+```bash
+milady plugins install qwen
+```
+
+## Configuration
+
+Qwen does not have an env-var auto-enable trigger. Enable it explicitly in your config:
+
+### milady.json Example
+
+```json
+{
+  "auth": {
+    "profiles": {
+      "default": {
+        "provider": "qwen"
+      }
+    }
+  },
+  "plugins": {
+    "allow": ["@elizaos/plugin-qwen"]
+  }
+}
+```
+
+## Features
+
+- Multilingual support (strong Chinese and English)
+- Streaming responses
+- Tool use / function calling
+
+## Related
+
+- [DeepSeek Plugin](/plugin-registry/llm/deepseek) — DeepSeek models
+- [OpenRouter Plugin](/plugin-registry/llm/openrouter) — Route between multiple providers
+- [Model Providers](/runtime/models) — Compare all providers

--- a/docs/plugin-registry/llm/zai.md
+++ b/docs/plugin-registry/llm/zai.md
@@ -1,0 +1,54 @@
+---
+title: "Zai Plugin"
+sidebarTitle: "Zai"
+description: "Zai model provider for Milady — access Homunculus Labs' Zai language models."
+---
+
+The Zai plugin connects Milady agents to Homunculus Labs' Zai models.
+
+**Package:** `@homunculuslabs/plugin-zai`
+
+## Installation
+
+```bash
+milady plugins install zai
+```
+
+## Auto-Enable
+
+The plugin auto-enables when `ZAI_API_KEY` is present:
+
+```bash
+export ZAI_API_KEY=your-zai-api-key
+```
+
+## Configuration
+
+| Environment Variable | Required | Description |
+|---------------------|----------|-------------|
+| `ZAI_API_KEY` | Yes | Zai API key from Homunculus Labs |
+
+### milady.json Example
+
+```json
+{
+  "auth": {
+    "profiles": {
+      "default": {
+        "provider": "zai"
+      }
+    }
+  }
+}
+```
+
+## Features
+
+- Text generation
+- Streaming responses
+
+## Related
+
+- [OpenAI Plugin](/plugin-registry/llm/openai) — GPT-4o models
+- [OpenRouter Plugin](/plugin-registry/llm/openrouter) — Route between multiple providers
+- [Model Providers](/runtime/models) — Compare all providers

--- a/docs/plugin-registry/obsidian.md
+++ b/docs/plugin-registry/obsidian.md
@@ -1,0 +1,50 @@
+---
+title: "Obsidian Plugin"
+sidebarTitle: "Obsidian"
+description: "Obsidian vault integration for Milady — read, search, and manage notes in your Obsidian vault."
+---
+
+The Obsidian plugin connects Milady agents to your local [Obsidian](https://obsidian.md) vault, enabling agents to read, search, and interact with your notes and knowledge base.
+
+**Package:** `@elizaos/plugin-obsidian`
+
+## Installation
+
+```bash
+milady plugins install obsidian
+```
+
+## Auto-Enable
+
+The plugin auto-enables when `OBSIDIAN_VAULT_PATH` is set:
+
+```bash
+export OBSIDIAN_VAULT_PATH=/path/to/your/vault
+```
+
+## Configuration
+
+| Environment Variable | Required | Description |
+|---------------------|----------|-------------|
+| `OBSIDIAN_VAULT_PATH` | Yes | Path to your Obsidian vault directory |
+
+### milady.json Example
+
+```json
+{
+  "features": {
+    "obsidian": true
+  }
+}
+```
+
+## Features
+
+- Read and search notes in your Obsidian vault
+- Access your personal knowledge graph
+- Note management via CLI integration
+
+## Related
+
+- [Knowledge Plugin](/plugin-registry/knowledge) — RAG-based knowledge retrieval
+- [Browser Plugin](/plugin-registry/browser) — Web content access

--- a/docs/plugin-registry/stt.md
+++ b/docs/plugin-registry/stt.md
@@ -1,0 +1,36 @@
+---
+title: "Speech-to-Text Plugin"
+sidebarTitle: "Speech-to-Text"
+description: "Speech-to-text plugin for Milady — transcribe audio input into text for voice-enabled agent interactions."
+---
+
+The Speech-to-Text (STT) plugin enables Milady agents to transcribe audio input into text, powering voice-based interactions.
+
+**Package:** `@elizaos/plugin-stt`
+
+## Installation
+
+```bash
+milady plugins install stt
+```
+
+## Enable via Features
+
+```json
+{
+  "features": {
+    "stt": true
+  }
+}
+```
+
+## Features
+
+- Audio transcription to text
+- Voice input support for agent conversations
+- Works alongside the [TTS plugin](/plugin-registry/tts) for full voice interaction
+
+## Related
+
+- [TTS Plugin](/plugin-registry/tts) — Text-to-speech output
+- [Browser Plugin](/plugin-registry/browser) — Web automation

--- a/docs/plugin-registry/suno.md
+++ b/docs/plugin-registry/suno.md
@@ -1,0 +1,37 @@
+---
+title: "Suno Plugin"
+sidebarTitle: "Suno"
+description: "Suno music generation plugin for Milady — generate music and songs using Suno's AI models."
+---
+
+The Suno plugin connects Milady agents to Suno's music generation platform, enabling agents to create music and songs from text prompts.
+
+**Package:** `@elizaos/plugin-suno`
+
+## Installation
+
+```bash
+milady plugins install suno
+```
+
+## Enable via Features
+
+```json
+{
+  "features": {
+    "suno": true
+  }
+}
+```
+
+## Features
+
+- Music generation from text descriptions
+- Song creation with lyrics
+- Multiple music styles and genres
+
+## Related
+
+- [FAL Plugin](/plugin-registry/fal) — Image, video, and audio generation
+- [Image Generation Plugin](/plugin-registry/image-generation) — Image generation
+- [Media Generation Guide](/guides/media-generation) — Overview of media capabilities

--- a/docs/plugin-registry/vision.md
+++ b/docs/plugin-registry/vision.md
@@ -1,0 +1,39 @@
+---
+title: "Vision Plugin"
+sidebarTitle: "Vision"
+description: "Vision plugin for Milady — image understanding and visual analysis capabilities for agents."
+---
+
+The Vision plugin gives Milady agents the ability to understand and analyze images, enabling visual reasoning in conversations.
+
+**Package:** `@elizaos/plugin-vision`
+
+## Installation
+
+```bash
+milady plugins install vision
+```
+
+## Enable via Features
+
+```json
+{
+  "features": {
+    "vision": true
+  }
+}
+```
+
+**Note:** This plugin requires the `@tensorflow/tfjs-node` native addon. On systems without native build tools, set `MILADY_NO_VISION_DEPS=1` to skip installation of optional vision dependencies.
+
+## Features
+
+- Image understanding and description
+- Visual analysis of screenshots and photos
+- Feature-gated — only loaded when explicitly enabled
+
+## Related
+
+- [Browser Plugin](/plugin-registry/browser) — Web automation with screenshot capture
+- [Computer Use Plugin](/plugin-registry/computeruse) — Full desktop automation
+- [Image Generation Plugin](/plugin-registry/image-generation) — Generate images

--- a/docs/plugin-registry/webhooks.md
+++ b/docs/plugin-registry/webhooks.md
@@ -1,0 +1,36 @@
+---
+title: "Webhooks Plugin"
+sidebarTitle: "Webhooks"
+description: "Webhooks plugin for Milady — receive and process incoming webhook events from external services."
+---
+
+The Webhooks plugin enables Milady agents to receive and process incoming webhook events from external services, allowing integrations with any platform that supports webhook callbacks.
+
+**Package:** `@elizaos/plugin-webhooks`
+
+## Installation
+
+```bash
+milady plugins install webhooks
+```
+
+## Enable via Features
+
+```json
+{
+  "features": {
+    "webhooks": true
+  }
+}
+```
+
+## Features
+
+- Receive inbound webhook events
+- Process and route webhook payloads to agent actions
+- Integrates with external services via HTTP callbacks
+
+## Related
+
+- [Triggers Guide](/guides/triggers) — Event-driven agent behaviors
+- [Cron Plugin](/plugin-registry/cron) — Scheduled task execution

--- a/docs/plugin-registry/x402.md
+++ b/docs/plugin-registry/x402.md
@@ -1,0 +1,37 @@
+---
+title: "x402 Plugin"
+sidebarTitle: "x402 Payments"
+description: "x402 payment protocol plugin for Milady — enable HTTP 402-based micropayments for agent services."
+---
+
+The x402 plugin implements the HTTP 402 Payment Required protocol, enabling Milady agents to handle micropayments for premium services and content access.
+
+**Package:** `@elizaos/plugin-x402`
+
+## Installation
+
+```bash
+milady plugins install x402
+```
+
+## Enable via Features
+
+```json
+{
+  "features": {
+    "x402": true
+  }
+}
+```
+
+## Features
+
+- HTTP 402-based micropayment handling
+- Pay-per-request agent service monetization
+- Integrates with blockchain wallet for payment processing
+
+## Related
+
+- [Wallet Guide](/guides/wallet) — Wallet setup and management
+- [EVM Plugin](/plugin-registry/defi/evm) — EVM chain interactions
+- [Solana Plugin](/plugin-registry/defi/solana) — Solana interactions

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -28,7 +28,7 @@ A plugin is a self-contained module that registers one or more of:
 </Card>
 
 <Card title="Platform Connectors" icon="plug" href="/plugin-registry/platform/discord">
-  Bridges to 18+ messaging platforms via auto-enable (Discord, Telegram, Twitter, Slack, WhatsApp, Signal, iMessage, BlueBubbles, Blooio, MS Teams, Google Chat, Mattermost, Farcaster, Twitch, WeChat, Feishu, Matrix, Nostr). Additional connectors (Bluesky, Instagram, Lens, LINE, Zalo, Twilio, GitHub, Gmail Watch, Nextcloud Talk, Tlon, Retake) are available in the elizaOS registry.
+  Bridges to 20 messaging platforms via auto-enable (Discord, Telegram, Twitter, Slack, WhatsApp, Signal, iMessage, BlueBubbles, Blooio, MS Teams, Google Chat, Mattermost, Farcaster, Twitch, WeChat, Feishu, Matrix, Nostr, Lens, Retake). Additional connectors (Bluesky, Instagram, LINE, Zalo, Twilio, GitHub, Gmail Watch, Nextcloud Talk, Tlon) are available in the elizaOS registry.
 </Card>
 
 <Card title="DeFi & Blockchain" icon="wallet" href="/plugin-registry/defi/evm">


### PR DESCRIPTION
- Fix plugins/overview.md: correct auto-enable count to 20 (Lens, Retake are auto-enabled, not registry-only)
- Create 5 missing LLM provider doc pages: google-antigravity, pi-ai, qwen, minimax, zai
- Create 7 missing feature plugin doc pages: stt, vision, fal, suno, webhooks, obsidian, x402
- Add 9 registry-only connectors to Dashboard Social and Plugin Registry nav (bluesky, instagram, line, zalo, twilio, github, gmail-watch, nextcloud-talk, tlon)
- Add all new pages to docs.json navigation

https://claude.ai/code/session_01UjztEn4gyFxyxmBYJ7NNVL

This PR will be reviewed by an AI agent. Provide clear context to help it assess your changes.

Aesthetic/UI changes that don't improve agent capability are out of scope and will be rejected.

## Category
- [ ] Bug fix
- [ ] Security fix
- [ ] Performance improvement
- [ ] New feature
- [ ] Documentation
- [ ] Test coverage
- [ ] Other

## What
(brief description)

## Why
(motivation)

## How
(implementation approach)

## Testing
(what was tested, how to verify)
