### PR TITLE
fix: cloud container env var support for base URL, autonomy, and CORS

### DIFF
--- a/packages/agent/src/api/server.cors-origin.test.ts
+++ b/packages/agent/src/api/server.cors-origin.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveCorsOrigin } from "./server";
+
+describe("resolveCorsOrigin", () => {
+  const envKeys = [
+    "MILADY_CLOUD_PROVISIONED",
+    "ELIZA_CLOUD_PROVISIONED",
+    "ELIZA_API_BIND",
+    "MILADY_API_BIND",
+    "ELIZA_ALLOWED_ORIGINS",
+    "CORS_ORIGINS",
+  ] as const;
+  const savedEnv = new Map<(typeof envKeys)[number], string | undefined>();
+
+  beforeEach(() => {
+    for (const key of envKeys) savedEnv.set(key, process.env[key]);
+  });
+
+  afterEach(() => {
+    for (const [key, value] of savedEnv) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it.each([
+    "MILADY_CLOUD_PROVISIONED",
+    "ELIZA_CLOUD_PROVISIONED",
+  ] as const)("allows arbitrary origins for cloud-provisioned containers when %s=1", (envKey) => {
+    process.env[envKey] = "1";
+
+    expect(resolveCorsOrigin("https://evil.example.com")).toBe(
+      "https://evil.example.com",
+    );
+  });
+
+  it("accepts CORS_ORIGINS as an alias for ELIZA_ALLOWED_ORIGINS", () => {
+    process.env.ELIZA_API_BIND = "127.0.0.1";
+    delete process.env.ELIZA_ALLOWED_ORIGINS;
+    process.env.CORS_ORIGINS =
+      "https://proxy.example.com, https://other.example.com";
+
+    expect(resolveCorsOrigin("https://proxy.example.com")).toBe(
+      "https://proxy.example.com",
+    );
+    expect(resolveCorsOrigin("https://blocked.example.com")).toBeNull();
+  });
+});

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -6394,6 +6394,15 @@ export function resolveCorsOrigin(origin?: string): string | null {
   const trimmed = origin.trim();
   if (!trimmed) return null;
 
+  // Cloud-provisioned containers default to allowing all origins so the
+  // browser web UI can reach the agent API without extra config.
+  if (
+    process.env.MILADY_CLOUD_PROVISIONED === "1" ||
+    process.env.ELIZA_CLOUD_PROVISIONED === "1"
+  ) {
+    return trimmed;
+  }
+
   // When bound to a wildcard address, allow any origin. Non-loopback binds still
   // require an explicit token, so this only relaxes the browser origin check.
   const bindHost = (
@@ -6406,7 +6415,7 @@ export function resolveCorsOrigin(origin?: string): string | null {
   if (WILDCARD_BIND_RE.test(stripPort(bindHost))) return trimmed;
 
   // Explicit allowlist via env (comma-separated)
-  const extra = process.env.ELIZA_ALLOWED_ORIGINS;
+  const extra = process.env.ELIZA_ALLOWED_ORIGINS ?? process.env.CORS_ORIGINS;
   if (extra) {
     const allow = extra
       .split(",")

--- a/packages/agent/src/cloud/base-url.test.ts
+++ b/packages/agent/src/cloud/base-url.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { normalizeCloudSiteUrl, resolveCloudApiBaseUrl } from "./base-url";
+
+const previousCloudBaseUrl = process.env.ELIZAOS_CLOUD_BASE_URL;
+
+afterEach(() => {
+  if (previousCloudBaseUrl === undefined) {
+    delete process.env.ELIZAOS_CLOUD_BASE_URL;
+  } else {
+    process.env.ELIZAOS_CLOUD_BASE_URL = previousCloudBaseUrl;
+  }
+});
+
+describe("normalizeCloudSiteUrl", () => {
+  it("lets ELIZAOS_CLOUD_BASE_URL override configured cloud URLs", () => {
+    process.env.ELIZAOS_CLOUD_BASE_URL =
+      "http://cloud.example.internal:8080/api/v1/";
+
+    expect(normalizeCloudSiteUrl("https://www.elizacloud.ai")).toBe(
+      "https://cloud.example.internal",
+    );
+    expect(resolveCloudApiBaseUrl("https://www.elizacloud.ai")).toBe(
+      "https://cloud.example.internal/api/v1",
+    );
+  });
+
+  it("still normalizes legacy elizacloud aliases when no env override is set", () => {
+    delete process.env.ELIZAOS_CLOUD_BASE_URL;
+
+    expect(normalizeCloudSiteUrl("https://elizacloud.ai/api/v1/")).toBe(
+      "https://www.elizacloud.ai",
+    );
+  });
+});

--- a/packages/agent/src/cloud/base-url.ts
+++ b/packages/agent/src/cloud/base-url.ts
@@ -18,7 +18,7 @@ function trimApiPath(pathname: string): string {
 export function normalizeCloudSiteUrl(rawUrl?: string): string {
   // Allow cloud-provisioned containers to override the base URL via env var
   const envOverride = process.env.ELIZAOS_CLOUD_BASE_URL?.trim();
-  const candidate = rawUrl?.trim() || envOverride || DEFAULT_CLOUD_SITE_URL;
+  const candidate = envOverride || rawUrl?.trim() || DEFAULT_CLOUD_SITE_URL;
 
   try {
     const parsed = new URL(candidate);

--- a/packages/agent/src/cloud/base-url.ts
+++ b/packages/agent/src/cloud/base-url.ts
@@ -16,7 +16,9 @@ function trimApiPath(pathname: string): string {
 }
 
 export function normalizeCloudSiteUrl(rawUrl?: string): string {
-  const candidate = rawUrl?.trim() || DEFAULT_CLOUD_SITE_URL;
+  // Allow cloud-provisioned containers to override the base URL via env var
+  const envOverride = process.env.ELIZAOS_CLOUD_BASE_URL?.trim();
+  const candidate = rawUrl?.trim() || envOverride || DEFAULT_CLOUD_SITE_URL;
 
   try {
     const parsed = new URL(candidate);

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -4380,7 +4380,12 @@ export async function startEliza(
 
     // 8b. Ensure AutonomyService is available for trigger dispatch.
     // registers this service) from loading, so we start it explicitly.
-    if (!runtime.getService("AUTONOMY")) {
+    // Respect ENABLE_AUTONOMY env var — cloud-provisioned containers may
+    // disable this to prevent runaway autonomous actions.
+    const autonomyEnabled =
+      (process.env.ENABLE_AUTONOMY ?? "true").toLowerCase() !== "false";
+
+    if (autonomyEnabled && !runtime.getService("AUTONOMY")) {
       try {
         await AutonomyService.start(runtime);
         logger.info("[eliza] AutonomyService started for trigger dispatch");
@@ -4389,12 +4394,16 @@ export async function startEliza(
           `[eliza] AutonomyService failed to start: ${formatError(err)}`,
         );
       }
+    } else if (!autonomyEnabled) {
+      logger.info(
+        "[eliza] AutonomyService skipped — ENABLE_AUTONOMY=false",
+      );
     }
 
     // Enable the autonomy loop so trigger/heartbeat instructions are
     // actually processed. Without this, memories created by
     // dispatchInstruction() sit in the DB and are never acted on.
-    {
+    if (autonomyEnabled) {
       const autonomySvc = (runtime.getService("AUTONOMY") ??
         runtime.getService("autonomy")) as unknown as
         | { enableAutonomy(): Promise<void> }
@@ -4697,8 +4706,11 @@ export async function startEliza(
             "hot-reload runtime.initialize()",
           );
 
-          // Ensure AutonomyService survives hot-reload
-          if (!newRuntime.getService("AUTONOMY")) {
+          // Ensure AutonomyService survives hot-reload (respects ENABLE_AUTONOMY)
+          const hotReloadAutonomyEnabled =
+            (process.env.ENABLE_AUTONOMY ?? "true").toLowerCase() !== "false";
+
+          if (hotReloadAutonomyEnabled && !newRuntime.getService("AUTONOMY")) {
             try {
               await AutonomyService.start(newRuntime);
             } catch (err) {
@@ -4709,7 +4721,7 @@ export async function startEliza(
           }
 
           // Enable the autonomy loop after hot-reload (same as initial boot)
-          {
+          if (hotReloadAutonomyEnabled) {
             const svc = (newRuntime.getService("AUTONOMY") ??
               newRuntime.getService("autonomy")) as unknown as
               | { enableAutonomy(): Promise<void> }

--- a/packages/agent/src/triggers/autonomy-enablement.test.ts
+++ b/packages/agent/src/triggers/autonomy-enablement.test.ts
@@ -5,7 +5,8 @@ import { describe, expect, it, vi } from "vitest";
 /**
  * Contract tests for autonomy enablement.
  * Test 1: mirrors the API route logic to catch handler regressions.
- * Test 2: verifies all three code paths call enableAutonomy().
+ * Test 2: verifies all three runtime code paths enable autonomy, while the
+ * agent runtime still respects ENABLE_AUTONOMY guards.
  */
 describe("autonomy enablement for triggers", () => {
   it("API toggle calls service methods and syncs the property", async () => {
@@ -38,27 +39,33 @@ describe("autonomy enablement for triggers", () => {
     expect(runtime.enableAutonomy).toBe(false);
   });
 
-  it("all three runtime paths call enableAutonomy after AutonomyService.start", () => {
+  it("all three runtime paths enable autonomy after startup guards", () => {
+    const expectEnableBlock = (source: string, anchor: string): string => {
+      const start = source.indexOf(anchor);
+      expect(start).toBeGreaterThan(-1);
+      const after = source.slice(start, start + 1_600);
+      expect(after).toContain("enableAutonomy()");
+      return after;
+    };
+
     // Agent runtime (initial boot)
     const agentEliza = readFileSync(
       path.resolve(import.meta.dirname, "..", "runtime", "eliza.ts"),
       "utf-8",
     );
-    const bootStart = agentEliza.indexOf("AutonomyService.start(runtime)");
-    expect(bootStart).toBeGreaterThan(-1);
-    const afterBoot = agentEliza.slice(bootStart, bootStart + 800);
-    expect(afterBoot).toContain(".enableAutonomy()");
+    expect(agentEliza).toContain('process.env.ENABLE_AUTONOMY ?? "true"');
+    const afterBoot = expectEnableBlock(
+      agentEliza,
+      "AutonomyService.start(runtime)",
+    );
+    expect(afterBoot).toContain("ENABLE_AUTONOMY=false");
 
     // Agent runtime (hot-reload)
-    const hotReloadStart = agentEliza.indexOf(
+    const afterHotReload = expectEnableBlock(
+      agentEliza,
       "AutonomyService.start(newRuntime)",
     );
-    expect(hotReloadStart).toBeGreaterThan(-1);
-    const afterHotReload = agentEliza.slice(
-      hotReloadStart,
-      hotReloadStart + 800,
-    );
-    expect(afterHotReload).toContain(".enableAutonomy()");
+    expect(afterHotReload).toContain("hotReloadAutonomyEnabled");
 
     // Desktop runtime (app-core)
     const desktopEliza = readFileSync(
@@ -74,9 +81,6 @@ describe("autonomy enablement for triggers", () => {
       ),
       "utf-8",
     );
-    const desktopStart = desktopEliza.indexOf("AutonomyService.start(runtime)");
-    expect(desktopStart).toBeGreaterThan(-1);
-    const afterDesktop = desktopEliza.slice(desktopStart, desktopStart + 800);
-    expect(afterDesktop).toContain(".enableAutonomy()");
+    expectEnableBlock(desktopEliza, "AutonomyService.start(runtime)");
   });
 });


### PR DESCRIPTION
## Summary

Cloud-provisioned containers need runtime-configurable behavior without patching files post-boot. This adds three env var controls:

### 1. `ELIZAOS_CLOUD_BASE_URL` — Cloud API endpoint override
Currently the provisioner patches `eliza.json` post-boot to set the cloud base URL. This adds env var support so containers can set `ELIZAOS_CLOUD_BASE_URL=https://dev.elizacloud.ai` instead.

### 2. `ENABLE_AUTONOMY` — Disable autonomous actions
Currently disabled via fragile `sed -i` post-boot. Now set `ENABLE_AUTONOMY=false` to skip AutonomyService startup entirely. Defaults to `true` (no behavior change for existing setups). Applies to both initial boot and hot-reload paths.

### 3. CORS for cloud containers
Cloud containers now auto-allow all CORS origins when `MILADY_CLOUD_PROVISIONED=1` is set, so the browser web UI can reach the agent API. Also adds `CORS_ORIGINS` as an alias for `ELIZA_ALLOWED_ORIGINS`.

### Files changed
- `packages/agent/src/cloud/base-url.ts` — env var override in `normalizeCloudSiteUrl()`
- `packages/agent/src/runtime/eliza.ts` — ENABLE_AUTONOMY check (boot + hot-reload)
- `packages/agent/src/api/server.ts` — CORS auto-allow for cloud containers