### PR TITLE
fix(ui): select checkmark overlap + searchable dropdown flicker

### DIFF
--- a/packages/app-core/src/config/config-field.tsx
+++ b/packages/app-core/src/config/config-field.tsx
@@ -469,18 +469,19 @@ function SearchableSelectInner({
     [props],
   );
 
-  // Position the portal dropdown below the trigger button
-  useEffect(() => {
-    if (!open || !triggerRef.current) return;
+  // Compute portal position synchronously from the trigger rect.
+  // Called in the click handler so the style is set before the portal renders.
+  const computeDropdownStyle = useCallback(() => {
+    if (!triggerRef.current) return {};
     const rect = triggerRef.current.getBoundingClientRect();
-    setDropdownStyle({
-      position: "fixed",
+    return {
+      position: "fixed" as const,
       top: rect.bottom + 4,
       left: rect.left,
       width: rect.width,
       zIndex: 9999,
-    });
-  }, [open]);
+    };
+  }, []);
 
   // Close on click outside
   useEffect(() => {
@@ -520,6 +521,7 @@ function SearchableSelectInner({
         className={`${inputCls(!!props.errors?.length)} text-left flex items-center justify-between gap-2 cursor-pointer`}
         disabled={props.readonly}
         onClick={() => {
+          if (!open) setDropdownStyle(computeDropdownStyle());
           setOpen(!open);
           setFilter("");
         }}

--- a/packages/app-core/src/config/searchable-select-portal.test.ts
+++ b/packages/app-core/src/config/searchable-select-portal.test.ts
@@ -33,13 +33,22 @@ describe("SearchableSelectInner portal rendering", () => {
   });
 
   it("does NOT use position:absolute (would be clipped by overflow:hidden)", () => {
-    // The dropdown style should use fixed, not absolute
-    const dropdownStyleBlock = configFieldSource.match(
-      /setDropdownStyle\(\{[\s\S]*?\}\)/,
+    // The computeDropdownStyle function should return fixed, not absolute
+    const styleBlock = configFieldSource.match(
+      /computeDropdownStyle[\s\S]*?position:\s*"fixed"/,
     );
-    expect(dropdownStyleBlock).toBeTruthy();
-    expect(dropdownStyleBlock?.[0]).not.toContain('"absolute"');
-    expect(dropdownStyleBlock?.[0]).toContain('"fixed"');
+    expect(styleBlock).toBeTruthy();
+    expect(configFieldSource).not.toMatch(
+      /computeDropdownStyle[\s\S]*?position:\s*"absolute"/,
+    );
+  });
+
+  it("computes position synchronously on click (no flicker)", () => {
+    // Position must be computed in onClick, not in useEffect, to avoid
+    // the portal rendering with empty style for one frame
+    expect(configFieldSource).toContain(
+      "setDropdownStyle(computeDropdownStyle())",
+    );
   });
 });
 

--- a/packages/app-core/src/config/select-checkmark-spacing.test.ts
+++ b/packages/app-core/src/config/select-checkmark-spacing.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+// packages/app-core/src/config/ → packages/ui/src/components/ui/
+const selectSource = readFileSync(
+  path.resolve(
+    import.meta.dirname,
+    "..",
+    "..",
+    "..",
+    "ui",
+    "src",
+    "components",
+    "ui",
+    "select.tsx",
+  ),
+  "utf-8",
+);
+
+describe("SelectItem checkmark spacing", () => {
+  it("uses flex layout (not absolute positioning) to prevent overlap", () => {
+    // The checkmark span must NOT be absolute — it should be a flex child
+    // so it always occupies space and never overlaps the text.
+    const itemBlock = selectSource.match(
+      /SelectPrimitive\.Item[\s\S]*?<\/SelectPrimitive\.Item>/,
+    );
+    expect(itemBlock).toBeTruthy();
+    expect(itemBlock?.[0]).not.toContain("absolute");
+    expect(itemBlock?.[0]).toContain("shrink-0");
+  });
+
+  it("check icon is h-3 w-3 to fit within compact item rows", () => {
+    expect(selectSource).toContain('Check className="h-3 w-3"');
+  });
+
+  it("uses gap between checkmark and text instead of padding hack", () => {
+    expect(selectSource).toMatch(/SelectPrimitive\.Item[\s\S]*?gap-1\.5/);
+  });
+});

--- a/packages/ui/src/components/ui/select.tsx
+++ b/packages/ui/src/components/ui/select.tsx
@@ -103,7 +103,7 @@ const SelectLabel = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Label
     ref={ref}
-    className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)}
+    className={cn("py-1.5 pl-2 pr-2 text-sm font-semibold", className)}
     {...props}
   />
 ));
@@ -116,14 +116,14 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-fg data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "flex w-full cursor-default select-none items-center gap-1.5 rounded-sm py-1.5 pl-2 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-fg data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className,
     )}
     {...props}
   >
-    <span className="absolute left-2 flex h-4 w-4 items-center justify-center">
+    <span className="flex h-4 w-4 shrink-0 items-center justify-center">
       <SelectPrimitive.ItemIndicator>
-        <Check className="h-3.5 w-3.5" />
+        <Check className="h-3 w-3" />
       </SelectPrimitive.ItemIndicator>
     </span>
 


### PR DESCRIPTION
## Summary
- **SelectItem** checkmark indicator was overlapping text content in all settings dropdowns (coding agents, provider switcher, etc). Replaced absolute-positioned checkmark with flex layout so indicator and text never overlap regardless of font size, zoom, or rendering engine.
- **SearchableSelectInner** portal flicker on first open — position was computed in `useEffect` (after paint), causing the dropdown to render unstyled for one frame. Now computed synchronously in the click handler.

## Test plan
- [x] `select-checkmark-spacing.test.ts` — verifies flex layout, no absolute positioning, gap spacing
- [x] `searchable-select-portal.test.ts` — verifies portal, fixed positioning, sync position compute
- [ ] Open Settings → Coding Agents → verify checkmark doesn't overlap text in strategy/permission/model dropdowns
- [ ] Open Settings → AI Provider → Eliza Cloud → verify model dropdowns open without flicker

🤖 Generated with [Claude Code](https://claude.com/claude-code)