### PR TITLE
feat: add remote bug report intake and startup failure sharing

### DIFF
--- a/docs/rest/bug-report.md
+++ b/docs/rest/bug-report.md
@@ -10,11 +10,15 @@ description: REST API endpoints for submitting bug reports from the dashboard.
 GET /api/bug-report/info
 ```
 
-Returns the server's Node.js version and OS platform, used by the frontend to pre-fill environment fields in the bug report form.
+Returns the server's Node.js version, OS platform, and active submission mode, used by the frontend to pre-fill environment fields and decide whether reports go to a remote intake, GitHub, or the fallback URL.
 
 **Response:**
 ```json
-{ "nodeVersion": "v20.11.0", "platform": "linux" }
+{
+  "nodeVersion": "v20.11.0",
+  "platform": "linux",
+  "submissionMode": "remote"
+}
 ```
 
 ## Submit Bug Report
@@ -23,7 +27,12 @@ Returns the server's Node.js version and OS platform, used by the frontend to pr
 POST /api/bug-report
 ```
 
-Submits a bug report. If `GITHUB_TOKEN` is set in the environment, creates a GitHub issue on the project repository with labels `bug`, `triage`, `user-reported`. Without the token, returns a pre-filled GitHub issue URL as a fallback.
+Submits a bug report.
+
+Submission priority:
+1. If `MILADY_BUG_REPORT_API_URL` is set, forwards the report there as structured JSON.
+2. Else if `GITHUB_TOKEN` is set, creates a GitHub issue on the project repository with labels `bug`, `triage`, `user-reported`.
+3. Else returns a pre-filled GitHub issue URL as a fallback.
 
 Rate-limited to **5 submissions per IP per 10-minute window**.
 
@@ -39,12 +48,52 @@ Rate-limited to **5 submissions per IP per 10-minute window**.
 | `nodeVersion` | string | no | 200 chars |
 | `modelProvider` | string | no | 200 chars |
 | `logs` | string | no | 50,000 chars |
+| `category` | `"general"` or `"startup-failure"` | no | - |
+| `appVersion` | string | no | 200 chars |
+| `releaseChannel` | string | no | 200 chars |
+| `startup` | object | no | structured startup diagnostics |
 
-All fields are HTML-stripped before use.
+Logs and startup diagnostics are HTML-stripped and basic secret-like tokens are redacted before forwarding.
+
+**Remote intake body example**
+```json
+{
+  "source": "milady-desktop",
+  "submittedAt": "2026-03-26T23:30:00.000Z",
+  "category": "startup-failure",
+  "description": "Milady startup failed: Backend Unreachable",
+  "stepsToReproduce": "1. Launch Milady\n2. Wait for startup to complete\n3. Observe the startup failure screen",
+  "environment": "Windows",
+  "nodeVersion": "v22.14.0",
+  "logs": "reason=backend-unreachable\nphase=starting-backend\nstatus=404",
+  "startup": {
+    "reason": "backend-unreachable",
+    "phase": "starting-backend",
+    "message": "Backend unavailable",
+    "detail": "GET /api/status returned 404",
+    "status": 404,
+    "path": "/api/status"
+  }
+}
+```
+
+**Remote intake response example**
+```json
+{
+  "accepted": true,
+  "id": "rpt_123",
+  "url": "https://cloud.example/reports/rpt_123"
+}
+```
 
 **Response — with GitHub token:**
 ```json
 { "url": "https://github.com/milady-ai/milady/issues/42" }
+```
+
+**Response — with remote intake:**
+```json
+{ "accepted": true, "id": "rpt_123", "destination": "remote" }
 ```
 
 **Response — without GitHub token:**
@@ -53,3 +102,14 @@ All fields are HTML-stripped before use.
 ```
 
 **Errors:** `400` missing required fields; `429` rate limit exceeded; `502` GitHub API error.
+
+## Environment Variables
+
+- `MILADY_BUG_REPORT_API_URL`
+  Preferred structured report intake endpoint. Intended for services like Eliza Cloud.
+- `MILADY_BUG_REPORT_API_TOKEN`
+  Optional bearer token sent to the remote intake endpoint.
+- `ELIZA_CLOUD_BUG_REPORT_URL`
+  Alias for `MILADY_BUG_REPORT_API_URL`
+- `ELIZA_CLOUD_BUG_REPORT_TOKEN`
+  Alias for `MILADY_BUG_REPORT_API_TOKEN`

--- a/packages/agent/src/api/bug-report-routes.ts
+++ b/packages/agent/src/api/bug-report-routes.ts
@@ -77,10 +77,35 @@ interface BugReportBody {
   nodeVersion?: string;
   modelProvider?: string;
   logs?: string;
+  category?: "general" | "startup-failure";
+  appVersion?: string;
+  releaseChannel?: string;
+  startup?: {
+    reason?: string;
+    phase?: string;
+    message?: string;
+    detail?: string;
+    status?: number;
+    path?: string;
+  };
 }
 
 export function sanitize(input: string, maxLen = 10_000): string {
   return input.replace(/<[^>]*>/g, "").slice(0, maxLen);
+}
+
+function redactSecrets(input: string, maxLen = 10_000): string {
+  const sanitized = sanitize(input, maxLen);
+  return sanitized
+    .replace(
+      /\b(0x[a-fA-F0-9]{64}|[A-Za-z0-9+/]{80,}={0,2})\b/g,
+      "[redacted-secret]",
+    )
+    .replace(
+      /\b(sk-[A-Za-z0-9_-]{10,}|ghp_[A-Za-z0-9]{20,}|xox[baprs]-[A-Za-z0-9-]{10,})\b/g,
+      "[redacted-token]",
+    )
+    .replace(/\b(mnemonic|private[_ -]?key|seed phrase)\b\s*[:=]\s*.+/gi, "$1: [redacted]");
 }
 
 function formatIssueBody(body: BugReportBody): string {
@@ -105,9 +130,121 @@ function formatIssueBody(body: BugReportBody): string {
     sections.push(`### Model Provider\n\n${sanitize(body.modelProvider, 200)}`);
   }
   if (body.logs) {
-    sections.push(`### Logs\n\n\`\`\`\n${sanitize(body.logs, 50_000)}\n\`\`\``);
+    sections.push(`### Logs\n\n\`\`\`\n${redactSecrets(body.logs, 50_000)}\n\`\`\``);
+  }
+  if (body.startup) {
+    sections.push(
+      `### Startup Context\n\n\`\`\`json\n${JSON.stringify(
+        {
+          reason: body.startup.reason,
+          phase: body.startup.phase,
+          status: body.startup.status,
+          path: body.startup.path,
+        },
+        null,
+        2,
+      )}\n\`\`\``,
+    );
   }
   return sections.join("\n\n");
+}
+
+function getBugReportMode(): "remote" | "github" | "fallback" {
+  if (getRemoteBugReportUrl()) return "remote";
+  if (process.env.GITHUB_TOKEN) return "github";
+  return "fallback";
+}
+
+function getRemoteBugReportUrl(): string | undefined {
+  return (
+    process.env.MILADY_BUG_REPORT_API_URL ??
+    process.env.ELIZA_CLOUD_BUG_REPORT_URL ??
+    process.env.BUG_REPORT_API_URL
+  );
+}
+
+function getRemoteBugReportToken(): string | undefined {
+  return (
+    process.env.MILADY_BUG_REPORT_API_TOKEN ??
+    process.env.ELIZA_CLOUD_BUG_REPORT_TOKEN ??
+    process.env.BUG_REPORT_API_TOKEN
+  );
+}
+
+async function submitToRemoteBugIntake(body: BugReportBody) {
+  const remoteBugReportUrl = getRemoteBugReportUrl();
+  if (!remoteBugReportUrl) return null;
+  const payload = {
+    source: "milady-desktop",
+    submittedAt: new Date().toISOString(),
+    category: body.category ?? "general",
+    description: sanitize(body.description, 500),
+    stepsToReproduce: sanitize(body.stepsToReproduce, 10_000),
+    expectedBehavior: body.expectedBehavior
+      ? sanitize(body.expectedBehavior, 10_000)
+      : undefined,
+    actualBehavior: body.actualBehavior
+      ? sanitize(body.actualBehavior, 10_000)
+      : undefined,
+    environment: body.environment ? sanitize(body.environment, 200) : undefined,
+    nodeVersion: body.nodeVersion ? sanitize(body.nodeVersion, 200) : undefined,
+    modelProvider: body.modelProvider
+      ? sanitize(body.modelProvider, 200)
+      : undefined,
+    appVersion: body.appVersion ? sanitize(body.appVersion, 200) : undefined,
+    releaseChannel: body.releaseChannel
+      ? sanitize(body.releaseChannel, 200)
+      : undefined,
+    logs: body.logs ? redactSecrets(body.logs, 50_000) : undefined,
+    startup: body.startup
+      ? {
+          reason: body.startup.reason
+            ? sanitize(body.startup.reason, 120)
+            : undefined,
+          phase: body.startup.phase ? sanitize(body.startup.phase, 120) : undefined,
+          message: body.startup.message
+            ? redactSecrets(body.startup.message, 1_000)
+            : undefined,
+          detail: body.startup.detail
+            ? redactSecrets(body.startup.detail, 10_000)
+            : undefined,
+          status: body.startup.status,
+          path: body.startup.path ? sanitize(body.startup.path, 500) : undefined,
+        }
+      : undefined,
+  };
+
+  const response = await fetch(remoteBugReportUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(getRemoteBugReportToken()
+        ? { Authorization: `Bearer ${getRemoteBugReportToken()}` }
+        : {}),
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Remote intake error (${response.status})`);
+  }
+
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    const data = (await response.json()) as {
+      id?: string;
+      url?: string;
+      accepted?: boolean;
+    };
+    return {
+      accepted: data.accepted ?? true,
+      id: data.id,
+      url: data.url,
+      destination: "remote" as const,
+    };
+  }
+
+  return { accepted: true, destination: "remote" as const };
 }
 
 export async function handleBugReportRoutes(
@@ -122,6 +259,7 @@ export async function handleBugReportRoutes(
     json(res, {
       nodeVersion: process.version,
       platform: os.platform(),
+      submissionMode: getBugReportMode(),
     });
     return true;
   }
@@ -137,6 +275,20 @@ export async function handleBugReportRoutes(
 
     if (!body.description?.trim() || !body.stepsToReproduce?.trim()) {
       error(res, "description and stepsToReproduce are required", 400);
+      return true;
+    }
+
+    if (getRemoteBugReportUrl()) {
+      try {
+        const result = await submitToRemoteBugIntake(body);
+        if (!result) {
+          error(res, "Failed to submit bug report", 502);
+          return true;
+        }
+        json(res, result);
+      } catch {
+        error(res, "Failed to submit bug report", 502);
+      }
       return true;
     }
 

--- a/packages/agent/src/api/bug-report-routes.ts
+++ b/packages/agent/src/api/bug-report-routes.ts
@@ -105,7 +105,10 @@ function redactSecrets(input: string, maxLen = 10_000): string {
       /\b(sk-[A-Za-z0-9_-]{10,}|ghp_[A-Za-z0-9]{20,}|xox[baprs]-[A-Za-z0-9-]{10,})\b/g,
       "[redacted-token]",
     )
-    .replace(/\b(mnemonic|private[_ -]?key|seed phrase)\b\s*[:=]\s*.+/gi, "$1: [redacted]");
+    .replace(
+      /\b(mnemonic|private[_ -]?key|seed phrase)\b\s*[:=]\s*.+/gi,
+      "$1: [redacted]",
+    );
 }
 
 function formatIssueBody(body: BugReportBody): string {
@@ -130,7 +133,9 @@ function formatIssueBody(body: BugReportBody): string {
     sections.push(`### Model Provider\n\n${sanitize(body.modelProvider, 200)}`);
   }
   if (body.logs) {
-    sections.push(`### Logs\n\n\`\`\`\n${redactSecrets(body.logs, 50_000)}\n\`\`\``);
+    sections.push(
+      `### Logs\n\n\`\`\`\n${redactSecrets(body.logs, 50_000)}\n\`\`\``,
+    );
   }
   if (body.startup) {
     sections.push(
@@ -158,16 +163,14 @@ function getBugReportMode(): "remote" | "github" | "fallback" {
 function getRemoteBugReportUrl(): string | undefined {
   return (
     process.env.MILADY_BUG_REPORT_API_URL ??
-    process.env.ELIZA_CLOUD_BUG_REPORT_URL ??
-    process.env.BUG_REPORT_API_URL
+    process.env.ELIZA_CLOUD_BUG_REPORT_URL
   );
 }
 
 function getRemoteBugReportToken(): string | undefined {
   return (
     process.env.MILADY_BUG_REPORT_API_TOKEN ??
-    process.env.ELIZA_CLOUD_BUG_REPORT_TOKEN ??
-    process.env.BUG_REPORT_API_TOKEN
+    process.env.ELIZA_CLOUD_BUG_REPORT_TOKEN
   );
 }
 
@@ -201,7 +204,9 @@ async function submitToRemoteBugIntake(body: BugReportBody) {
           reason: body.startup.reason
             ? sanitize(body.startup.reason, 120)
             : undefined,
-          phase: body.startup.phase ? sanitize(body.startup.phase, 120) : undefined,
+          phase: body.startup.phase
+            ? sanitize(body.startup.phase, 120)
+            : undefined,
           message: body.startup.message
             ? redactSecrets(body.startup.message, 1_000)
             : undefined,
@@ -209,7 +214,9 @@ async function submitToRemoteBugIntake(body: BugReportBody) {
             ? redactSecrets(body.startup.detail, 10_000)
             : undefined,
           status: body.startup.status,
-          path: body.startup.path ? sanitize(body.startup.path, 500) : undefined,
+          path: body.startup.path
+            ? sanitize(body.startup.path, 500)
+            : undefined,
         }
       : undefined,
   };

--- a/packages/app-core/src/App.test.ts
+++ b/packages/app-core/src/App.test.ts
@@ -54,6 +54,7 @@ vi.mock("./components", () => {
     AdvancedPageView: stub("AdvancedPageView"),
     AppsPageView: stub("AppsPageView"),
     AvatarLoader: stub("AvatarLoader"),
+    BugReportModal: stub("BugReportModal"),
     CharacterEditor: stub("CharacterEditor"),
     ChatView: stub("ChatView"),
     CompanionShell: stub("CompanionShell"),

--- a/packages/app-core/src/App.tsx
+++ b/packages/app-core/src/App.tsx
@@ -38,6 +38,7 @@ import {
   HeartbeatsView,
   InventoryView,
   KnowledgeView,
+  BugReportModal,
   OnboardingWizard,
   PairingView,
   SaveCommandModal,
@@ -484,7 +485,12 @@ export function App() {
 
   // After loader hooks (stable hook order); do not return startupError before useState above.
   if (startupError) {
-    return <StartupFailureView error={startupError} onRetry={retryStartup} />;
+    return (
+      <BugReportProvider value={bugReport}>
+        <StartupFailureView error={startupError} onRetry={retryStartup} />
+        <BugReportModal />
+      </BugReportProvider>
+    );
   }
 
   if (authRequired && !blockOnboardingForShell) return <PairingView />;

--- a/packages/app-core/src/api/__tests__/bug-report-routes.test.ts
+++ b/packages/app-core/src/api/__tests__/bug-report-routes.test.ts
@@ -174,9 +174,25 @@ describe("POST /api/bug-report", () => {
     beforeEach(() => {
       delete process.env.GITHUB_TOKEN;
       delete process.env.MILADY_BUG_REPORT_API_URL;
+      delete process.env.ELIZA_CLOUD_BUG_REPORT_URL;
+      delete process.env.BUG_REPORT_API_URL;
     });
 
     it("returns fallback URL", async () => {
+      const ctx = makeCtx({
+        method: "POST",
+        pathname: "/api/bug-report",
+        readJsonBody: vi.fn().mockResolvedValue(validBody),
+      });
+      const handled = await handleBugReportRoutes(ctx);
+      expect(handled).toBe(true);
+      expect(ctx.json).toHaveBeenCalledWith(ctx.res, {
+        fallback: expect.stringContaining("github.com/milady-ai/milady"),
+      });
+    });
+
+    it("ignores undocumented BUG_REPORT_API_URL fallback", async () => {
+      process.env.BUG_REPORT_API_URL = "https://unexpected.example/reports";
       const ctx = makeCtx({
         method: "POST",
         pathname: "/api/bug-report",

--- a/packages/app-core/src/api/__tests__/bug-report-routes.test.ts
+++ b/packages/app-core/src/api/__tests__/bug-report-routes.test.ts
@@ -93,6 +93,7 @@ describe("GET /api/bug-report/info", () => {
       expect.objectContaining({
         nodeVersion: expect.stringMatching(/^v\d+/),
         platform: expect.any(String),
+        submissionMode: expect.any(String),
       }),
     );
   });
@@ -172,6 +173,7 @@ describe("POST /api/bug-report", () => {
   describe("without GITHUB_TOKEN", () => {
     beforeEach(() => {
       delete process.env.GITHUB_TOKEN;
+      delete process.env.MILADY_BUG_REPORT_API_URL;
     });
 
     it("returns fallback URL", async () => {
@@ -321,6 +323,77 @@ describe("POST /api/bug-report", () => {
         ctx.res,
         "Failed to create GitHub issue",
         500,
+      );
+    });
+  });
+
+  describe("with remote intake configured", () => {
+    beforeEach(() => {
+      delete process.env.GITHUB_TOKEN;
+      process.env.MILADY_BUG_REPORT_API_URL =
+        "https://cloud.elizaos.ai/api/v1/reports/bug";
+      process.env.MILADY_BUG_REPORT_API_TOKEN = "secret";
+    });
+
+    afterEach(() => {
+      delete process.env.MILADY_BUG_REPORT_API_URL;
+      delete process.env.MILADY_BUG_REPORT_API_TOKEN;
+      vi.restoreAllMocks();
+    });
+
+    it("submits to the configured remote endpoint first", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        headers: { get: () => "application/json" },
+        json: () => Promise.resolve({ accepted: true, id: "rpt_123" }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const ctx = makeCtx({
+        method: "POST",
+        pathname: "/api/bug-report",
+        readJsonBody: vi.fn().mockResolvedValue({
+          ...validBody,
+          category: "startup-failure",
+        }),
+      });
+      await handleBugReportRoutes(ctx);
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toBe("https://cloud.elizaos.ai/api/v1/reports/bug");
+      expect(init.headers.Authorization).toBe("Bearer secret");
+      expect(ctx.json).toHaveBeenCalledWith(
+        ctx.res,
+        expect.objectContaining({
+          accepted: true,
+          id: "rpt_123",
+          destination: "remote",
+        }),
+      );
+    });
+
+    it("returns 502 when the remote intake fails", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 503,
+          headers: { get: () => "application/json" },
+        }),
+      );
+
+      const ctx = makeCtx({
+        method: "POST",
+        pathname: "/api/bug-report",
+        readJsonBody: vi.fn().mockResolvedValue(validBody),
+      });
+      await handleBugReportRoutes(ctx);
+
+      expect(ctx.error).toHaveBeenCalledWith(
+        ctx.res,
+        "Failed to submit bug report",
+        502,
       );
     });
   });

--- a/packages/app-core/src/api/client.ts
+++ b/packages/app-core/src/api/client.ts
@@ -5357,6 +5357,7 @@ export class MiladyClient {
   async checkBugReportInfo(): Promise<{
     nodeVersion?: string;
     platform?: string;
+    submissionMode?: "remote" | "github" | "fallback";
   }> {
     return this.fetch("/api/bug-report/info");
   }
@@ -5370,7 +5371,24 @@ export class MiladyClient {
     nodeVersion?: string;
     modelProvider?: string;
     logs?: string;
-  }): Promise<{ url?: string; fallback?: string }> {
+    category?: "general" | "startup-failure";
+    appVersion?: string;
+    releaseChannel?: string;
+    startup?: {
+      reason?: string;
+      phase?: string;
+      message?: string;
+      detail?: string;
+      status?: number;
+      path?: string;
+    };
+  }): Promise<{
+    accepted?: boolean;
+    id?: string;
+    url?: string;
+    fallback?: string;
+    destination?: "remote" | "github" | "fallback";
+  }> {
     return this.fetch("/api/bug-report", {
       method: "POST",
       body: JSON.stringify(report),

--- a/packages/app-core/src/components/BugReportModal.tsx
+++ b/packages/app-core/src/components/BugReportModal.tsx
@@ -70,6 +70,16 @@ const modalTextareaClassName =
 
 const subtleMonoDescriptionClassName = "font-mono text-[11px] text-muted";
 
+function normalizeHttpsResultUrl(url?: string): string | null {
+  if (!url) return null;
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:" ? parsed.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
 export function BugReportModal() {
   const { copyToClipboard, t } = useApp();
   const desktopRuntime = isElectrobunRuntime();
@@ -268,8 +278,9 @@ export function BugReportModal() {
         modelProvider: form.modelProvider,
         logs: buildCombinedLogs(),
       });
-      if (result.url) {
-        setResultUrl(result.url);
+      const safeResultUrl = normalizeHttpsResultUrl(result.url);
+      if (safeResultUrl) {
+        setResultUrl(safeResultUrl);
       } else if (result.accepted) {
         setAcceptedWithoutUrl(true);
       } else if (result.fallback) {

--- a/packages/app-core/src/components/BugReportModal.tsx
+++ b/packages/app-core/src/components/BugReportModal.tsx
@@ -78,6 +78,7 @@ export function BugReportModal() {
   const [form, setForm] = useState<BugReportForm>(EMPTY_FORM);
   const [submitting, setSubmitting] = useState(false);
   const [resultUrl, setResultUrl] = useState<string | null>(null);
+  const [acceptedWithoutUrl, setAcceptedWithoutUrl] = useState(false);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [showLogs, setShowLogs] = useState(false);
   const [copied, setCopied] = useState(false);
@@ -99,6 +100,7 @@ export function BugReportModal() {
     setForm(EMPTY_FORM);
     setSubmitting(false);
     setResultUrl(null);
+    setAcceptedWithoutUrl(false);
     setErrorMsg(null);
     setShowLogs(false);
     setCopied(false);
@@ -268,6 +270,8 @@ export function BugReportModal() {
       });
       if (result.url) {
         setResultUrl(result.url);
+      } else if (result.accepted) {
+        setAcceptedWithoutUrl(true);
       } else if (result.fallback) {
         // No GITHUB_TOKEN on server — copy report and open GitHub manually
         let ok = false;
@@ -346,7 +350,7 @@ export function BugReportModal() {
     form.description.trim() && form.stepsToReproduce.trim() && !submitting;
 
   // Success state
-  if (resultUrl) {
+  if (resultUrl || acceptedWithoutUrl) {
     return (
       <Dialog
         open={isOpen}
@@ -369,16 +373,24 @@ export function BugReportModal() {
           </DialogHeader>
           <div className="space-y-3 px-5 py-6 text-center">
             <p className="text-sm text-txt">
-              {t("bugreportmodal.YourBugReportHas")}
+              {acceptedWithoutUrl
+                ? "Your report was received."
+                : t("bugreportmodal.YourBugReportHas")}
             </p>
-            <a
-              href={resultUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="break-all text-sm font-medium text-accent underline-offset-4 hover:underline"
-            >
-              {resultUrl}
-            </a>
+            {resultUrl ? (
+              <a
+                href={resultUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="break-all text-sm font-medium text-accent underline-offset-4 hover:underline"
+              >
+                {resultUrl}
+              </a>
+            ) : (
+              <p className="text-xs text-muted">
+                Diagnostics were shared successfully.
+              </p>
+            )}
           </div>
           <DialogFooter className="border-t border-border/70 px-5 py-4 sm:justify-end">
             <Button variant="outline" size="sm" onClick={close}>

--- a/packages/app-core/src/components/BugReportModal.tsx
+++ b/packages/app-core/src/components/BugReportModal.tsx
@@ -74,7 +74,7 @@ export function BugReportModal() {
   const { copyToClipboard, t } = useApp();
   const desktopRuntime = isElectrobunRuntime();
   const branding = useBranding();
-  const { isOpen, close } = useBugReport();
+  const { isOpen, draft, close } = useBugReport();
   const [form, setForm] = useState<BugReportForm>(EMPTY_FORM);
   const [submitting, setSubmitting] = useState(false);
   const [resultUrl, setResultUrl] = useState<string | null>(null);
@@ -113,20 +113,22 @@ export function BugReportModal() {
       .checkBugReportInfo()
       .then((info) => {
         if (cancelled) return;
-        if (info.nodeVersion)
-          setForm((f) => ({ ...f, nodeVersion: info.nodeVersion ?? "" }));
-        if (info.platform)
-          setForm((f) => ({
-            ...f,
-            environment:
-              info.platform === "darwin"
-                ? "macOS"
-                : info.platform === "win32"
-                  ? "Windows"
-                  : info.platform === "linux"
-                    ? "Linux"
-                    : "Other",
-          }));
+        setForm((f) => ({
+          ...f,
+          ...(info.nodeVersion ? { nodeVersion: info.nodeVersion ?? "" } : {}),
+          ...(info.platform
+            ? {
+                environment:
+                  info.platform === "darwin"
+                    ? "macOS"
+                    : info.platform === "win32"
+                      ? "Windows"
+                      : info.platform === "linux"
+                        ? "Linux"
+                        : "Other",
+              }
+            : {}),
+        }));
       })
       .catch((err: unknown) => {
         console.warn("[BugReportModal] Failed to fetch bug report info:", err);
@@ -161,6 +163,14 @@ export function BugReportModal() {
       cancelled = true;
     };
   }, [desktopRuntime, isOpen]);
+
+  useEffect(() => {
+    if (!isOpen || !draft) return;
+    setForm((f) => ({
+      ...f,
+      ...draft,
+    }));
+  }, [draft, isOpen]);
 
   useEffect(() => {
     if (!resultUrl) return;

--- a/packages/app-core/src/components/StartupFailureView.test.tsx
+++ b/packages/app-core/src/components/StartupFailureView.test.tsx
@@ -3,10 +3,16 @@
 import TestRenderer, { act } from "react-test-renderer";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockUseApp, mockUseBranding, openBugReportMock } = vi.hoisted(() => ({
+const {
+  mockUseApp,
+  mockUseBranding,
+  openBugReportMock,
+  optionalBugReportMock,
+} = vi.hoisted(() => ({
   mockUseApp: vi.fn(),
   mockUseBranding: vi.fn(),
   openBugReportMock: vi.fn(),
+  optionalBugReportMock: vi.fn(),
 }));
 
 vi.mock("../api", () => ({
@@ -28,7 +34,7 @@ vi.mock("../config/branding", () => ({
 }));
 
 vi.mock("../hooks", () => ({
-  useBugReport: () => ({ open: openBugReportMock }),
+  useOptionalBugReport: () => optionalBugReportMock(),
 }));
 
 import { StartupFailureView } from "./StartupFailureView";
@@ -52,6 +58,7 @@ describe("StartupFailureView", () => {
         )[key] ?? key,
     });
     openBugReportMock.mockReset();
+    optionalBugReportMock.mockReturnValue({ open: openBugReportMock });
   });
 
   it("renders retry controls and details for startup failures", async () => {
@@ -78,6 +85,27 @@ describe("StartupFailureView", () => {
     expect(snapshot).toContain("stack trace");
     expect(snapshot).toContain("Retry Startup");
     expect(snapshot).toContain("Report Bug");
+  });
+
+  it("does not render the report button when no bug report provider is present", async () => {
+    optionalBugReportMock.mockReturnValue(null);
+
+    let tree: TestRenderer.ReactTestRenderer | undefined;
+    await act(async () => {
+      tree = TestRenderer.create(
+        <StartupFailureView
+          error={{
+            reason: "agent-error",
+            phase: "initializing-agent",
+            message: "The agent process exited unexpectedly.",
+          }}
+          onRetry={vi.fn()}
+        />,
+      );
+    });
+
+    const snapshot = JSON.stringify(tree?.toJSON());
+    expect(snapshot).not.toContain("Report Bug");
   });
 
   it("opens bug report with startup diagnostics", async () => {

--- a/packages/app-core/src/components/StartupFailureView.test.tsx
+++ b/packages/app-core/src/components/StartupFailureView.test.tsx
@@ -9,6 +9,16 @@ const { mockUseApp, mockUseBranding, openBugReportMock } = vi.hoisted(() => ({
   openBugReportMock: vi.fn(),
 }));
 
+vi.mock("../api", () => ({
+  client: {
+    checkBugReportInfo: vi.fn().mockResolvedValue({
+      nodeVersion: "v22.0.0",
+      platform: "win32",
+    }),
+    submitBugReport: vi.fn().mockResolvedValue({ accepted: true }),
+  },
+}));
+
 vi.mock("../state", () => ({
   useApp: () => mockUseApp(),
 }));
@@ -53,6 +63,7 @@ describe("StartupFailureView", () => {
         <StartupFailureView
           error={{
             reason: "agent-error",
+            phase: "initializing-agent",
             message: "The agent process exited unexpectedly.",
             detail: "stack trace",
           }}
@@ -113,6 +124,7 @@ describe("StartupFailureView", () => {
         <StartupFailureView
           error={{
             reason: "backend-unreachable",
+            phase: "starting-backend",
             message: "Failed to reach the app backend.",
             detail: null,
           }}

--- a/packages/app-core/src/components/StartupFailureView.test.tsx
+++ b/packages/app-core/src/components/StartupFailureView.test.tsx
@@ -3,9 +3,10 @@
 import TestRenderer, { act } from "react-test-renderer";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockUseApp, mockUseBranding } = vi.hoisted(() => ({
+const { mockUseApp, mockUseBranding, openBugReportMock } = vi.hoisted(() => ({
   mockUseApp: vi.fn(),
   mockUseBranding: vi.fn(),
+  openBugReportMock: vi.fn(),
 }));
 
 vi.mock("../state", () => ({
@@ -14,6 +15,10 @@ vi.mock("../state", () => ({
 
 vi.mock("../config/branding", () => ({
   useBranding: () => mockUseBranding(),
+}));
+
+vi.mock("../hooks", () => ({
+  useBugReport: () => ({ open: openBugReportMock }),
 }));
 
 import { StartupFailureView } from "./StartupFailureView";
@@ -32,9 +37,11 @@ describe("StartupFailureView", () => {
               "This origin does not host the agent backend.",
             "startupfailureview.RetryStartup": "Retry Startup",
             "startupfailureview.OpenApp": "Open App",
+            "bugreportmodal.ReportABug": "Report Bug",
           }) as Record<string, string>
         )[key] ?? key,
     });
+    openBugReportMock.mockReset();
   });
 
   it("renders retry controls and details for startup failures", async () => {
@@ -59,6 +66,44 @@ describe("StartupFailureView", () => {
     expect(snapshot).toContain("The agent process exited unexpectedly.");
     expect(snapshot).toContain("stack trace");
     expect(snapshot).toContain("Retry Startup");
+    expect(snapshot).toContain("Report Bug");
+  });
+
+  it("opens bug report with startup diagnostics", async () => {
+    const onRetry = vi.fn();
+
+    let tree: TestRenderer.ReactTestRenderer | undefined;
+    await act(async () => {
+      tree = TestRenderer.create(
+        <StartupFailureView
+          error={{
+            reason: "backend-unreachable",
+            phase: "starting-backend",
+            message: "Failed to reach backend",
+            detail: "HTTP 404",
+            status: 404,
+            path: "/api/onboarding/status",
+          }}
+          onRetry={onRetry}
+        />,
+      );
+    });
+
+    const buttons = tree?.root.findAllByType("button") ?? [];
+    const reportButton = buttons.find((button) =>
+      button.children.join("").includes("Report Bug"),
+    );
+    await act(async () => {
+      reportButton?.props.onClick();
+    });
+
+    expect(openBugReportMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: "Backend Unreachable: Failed to reach backend",
+        actualBehavior: "Failed to reach backend",
+        logs: expect.stringContaining("Path: /api/onboarding/status"),
+      }),
+    );
   });
 
   it("shows the open-app action when the backend is unreachable", async () => {

--- a/packages/app-core/src/components/StartupFailureView.tsx
+++ b/packages/app-core/src/components/StartupFailureView.tsx
@@ -7,6 +7,7 @@ import {
   StatusBadge,
 } from "@miladyai/ui";
 import { useBranding } from "../config/branding";
+import { useBugReport } from "../hooks";
 import type { StartupErrorState } from "../state";
 import { useApp } from "../state";
 
@@ -34,8 +35,18 @@ export function StartupFailureView({
 }: StartupFailureViewProps) {
   const { t } = useApp();
   const branding = useBranding();
+  const { open: openBugReport } = useBugReport();
   const isBackendUnreachable = error.reason === "backend-unreachable";
   const reasonLabel = REASON_LABELS[error.reason];
+  const startupDetail = [
+    `Reason: ${error.reason}`,
+    `Phase: ${error.phase}`,
+    typeof error.status === "number" ? `Status: ${error.status}` : null,
+    error.path ? `Path: ${error.path}` : null,
+    error.detail ? `Detail: ${error.detail}` : null,
+  ]
+    .filter(Boolean)
+    .join("\n");
 
   return (
     <div className={SCREEN_SHELL_CLASS}>
@@ -92,6 +103,24 @@ export function StartupFailureView({
               className="w-full sm:w-auto sm:min-w-[11rem]"
             >
               {t("startupfailureview.RetryStartup")}
+            </Button>
+            <Button
+              variant="outline"
+              size="lg"
+              onClick={() =>
+                openBugReport({
+                  description: `${reasonLabel}: ${error.message}`.slice(0, 80),
+                  stepsToReproduce:
+                    "1. Launch the desktop app.\n2. Wait for startup to fail.\n3. Observe the startup failure screen.",
+                  expectedBehavior:
+                    "The app should finish startup and show the main shell.",
+                  actualBehavior: error.message,
+                  logs: startupDetail,
+                })
+              }
+              className="w-full sm:w-auto sm:min-w-[10rem]"
+            >
+              {t("bugreportmodal.ReportABug")}
             </Button>
             {isBackendUnreachable ? (
               <Button

--- a/packages/app-core/src/components/StartupFailureView.tsx
+++ b/packages/app-core/src/components/StartupFailureView.tsx
@@ -10,7 +10,7 @@ import {
 import { useState } from "react";
 import { client } from "../api";
 import { useBranding } from "../config/branding";
-import { useBugReport } from "../hooks";
+import { type BugReportDraft, useOptionalBugReport } from "../hooks";
 import type { StartupErrorState } from "../state";
 import { useApp } from "../state";
 
@@ -32,20 +32,11 @@ interface StartupFailureViewProps {
   onRetry: () => void;
 }
 
-export function StartupFailureView({
-  error,
-  onRetry,
-}: StartupFailureViewProps) {
-  const { t } = useApp();
-  const branding = useBranding();
-  const { open: openBugReport } = useBugReport();
-  const [reportState, setReportState] = useState<
-    "idle" | "submitting" | "success" | "error"
-  >("idle");
-  const [reportMessage, setReportMessage] = useState<string | null>(null);
-  const isBackendUnreachable = error.reason === "backend-unreachable";
-  const reasonLabel = REASON_LABELS[error.reason];
-  const startupDetail = [
+function buildStartupBugReportDraft(
+  reasonLabel: string,
+  error: StartupErrorState,
+): BugReportDraft {
+  const logs = [
     `Reason: ${error.reason}`,
     `Phase: ${error.phase}`,
     typeof error.status === "number" ? `Status: ${error.status}` : null,
@@ -54,6 +45,41 @@ export function StartupFailureView({
   ]
     .filter(Boolean)
     .join("\n");
+
+  return {
+    description: `${reasonLabel}: ${error.message}`.slice(0, 80),
+    stepsToReproduce:
+      "1. Launch the desktop app.\n2. Wait for startup to fail.\n3. Observe the startup failure screen.",
+    expectedBehavior: "The app should finish startup and show the main shell.",
+    actualBehavior: error.message,
+    logs,
+  };
+}
+
+function normalizeReportUrl(url?: string): string | null {
+  if (!url) return null;
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:" ? parsed.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
+export function StartupFailureView({
+  error,
+  onRetry,
+}: StartupFailureViewProps) {
+  const { t } = useApp();
+  const branding = useBranding();
+  const bugReport = useOptionalBugReport();
+  const [reportState, setReportState] = useState<
+    "idle" | "submitting" | "success" | "error"
+  >("idle");
+  const [reportMessage, setReportMessage] = useState<string | null>(null);
+  const isBackendUnreachable = error.reason === "backend-unreachable";
+  const reasonLabel = REASON_LABELS[error.reason];
+  const startupDraft = buildStartupBugReportDraft(reasonLabel, error);
 
   async function handleShareReport() {
     setReportState("submitting");
@@ -93,12 +119,28 @@ export function StartupFailureView({
           path: error.path,
         },
       });
-      setReportState("success");
-      setReportMessage(
-        result.url
-          ? `Report shared: ${result.url}`
-          : "Diagnostic report shared successfully.",
-      );
+      const safeResultUrl = normalizeReportUrl(result.url);
+      if (safeResultUrl) {
+        setReportState("success");
+        setReportMessage(`Report shared: ${safeResultUrl}`);
+        return;
+      }
+      if (result.accepted) {
+        setReportState("success");
+        setReportMessage("Diagnostic report shared successfully.");
+        return;
+      }
+      if (result.fallback) {
+        setReportState("error");
+        setReportMessage(
+          bugReport
+            ? "Automatic sharing is unavailable. Use Report Bug to review and submit it manually."
+            : "Automatic sharing is unavailable on this screen.",
+        );
+        return;
+      }
+      setReportState("error");
+      setReportMessage("Failed to share diagnostic report.");
     } catch (submitError) {
       setReportState("error");
       setReportMessage(
@@ -173,24 +215,16 @@ export function StartupFailureView({
             >
               {t("startupfailureview.RetryStartup")}
             </Button>
-            <Button
-              variant="outline"
-              size="lg"
-              onClick={() =>
-                openBugReport({
-                  description: `${reasonLabel}: ${error.message}`.slice(0, 80),
-                  stepsToReproduce:
-                    "1. Launch the desktop app.\n2. Wait for startup to fail.\n3. Observe the startup failure screen.",
-                  expectedBehavior:
-                    "The app should finish startup and show the main shell.",
-                  actualBehavior: error.message,
-                  logs: startupDetail,
-                })
-              }
-              className="w-full sm:w-auto sm:min-w-[10rem]"
-            >
-              {t("bugreportmodal.ReportABug")}
-            </Button>
+            {bugReport ? (
+              <Button
+                variant="outline"
+                size="lg"
+                onClick={() => bugReport.open(startupDraft)}
+                className="w-full sm:w-auto sm:min-w-[10rem]"
+              >
+                {t("bugreportmodal.ReportABug")}
+              </Button>
+            ) : null}
             <Button
               variant="outline"
               size="lg"

--- a/packages/app-core/src/components/StartupFailureView.tsx
+++ b/packages/app-core/src/components/StartupFailureView.tsx
@@ -1,4 +1,5 @@
 import {
+  Banner,
   Button,
   Card,
   CardContent,
@@ -6,6 +7,8 @@ import {
   CardHeader,
   StatusBadge,
 } from "@miladyai/ui";
+import { useState } from "react";
+import { client } from "../api";
 import { useBranding } from "../config/branding";
 import { useBugReport } from "../hooks";
 import type { StartupErrorState } from "../state";
@@ -36,6 +39,10 @@ export function StartupFailureView({
   const { t } = useApp();
   const branding = useBranding();
   const { open: openBugReport } = useBugReport();
+  const [reportState, setReportState] = useState<
+    "idle" | "submitting" | "success" | "error"
+  >("idle");
+  const [reportMessage, setReportMessage] = useState<string | null>(null);
   const isBackendUnreachable = error.reason === "backend-unreachable";
   const reasonLabel = REASON_LABELS[error.reason];
   const startupDetail = [
@@ -47,6 +54,60 @@ export function StartupFailureView({
   ]
     .filter(Boolean)
     .join("\n");
+
+  async function handleShareReport() {
+    setReportState("submitting");
+    setReportMessage(null);
+    try {
+      const info = await client.checkBugReportInfo();
+      const result = await client.submitBugReport({
+        category: "startup-failure",
+        description: `${branding.appName} startup failed: ${reasonLabel}`,
+        stepsToReproduce: `1. Launch ${branding.appName}\n2. Wait for startup to complete\n3. Observe the startup failure screen`,
+        expectedBehavior: `${branding.appName} should finish startup successfully.`,
+        actualBehavior: error.message,
+        environment:
+          info.platform === "darwin"
+            ? "macOS"
+            : info.platform === "win32"
+              ? "Windows"
+              : info.platform === "linux"
+                ? "Linux"
+                : info.platform || "Unknown",
+        nodeVersion: info.nodeVersion,
+        logs: [
+          `reason=${error.reason}`,
+          `phase=${error.phase}`,
+          error.status ? `status=${error.status}` : null,
+          error.path ? `path=${error.path}` : null,
+          error.detail ? `detail=${error.detail}` : null,
+        ]
+          .filter(Boolean)
+          .join("\n"),
+        startup: {
+          reason: error.reason,
+          phase: error.phase,
+          message: error.message,
+          detail: error.detail,
+          status: error.status,
+          path: error.path,
+        },
+      });
+      setReportState("success");
+      setReportMessage(
+        result.url
+          ? `Report shared: ${result.url}`
+          : "Diagnostic report shared successfully.",
+      );
+    } catch (submitError) {
+      setReportState("error");
+      setReportMessage(
+        submitError instanceof Error
+          ? submitError.message
+          : "Failed to share diagnostic report.",
+      );
+    }
+  }
 
   return (
     <div className={SCREEN_SHELL_CLASS}>
@@ -80,6 +141,14 @@ export function StartupFailureView({
         </CardHeader>
 
         <CardContent className="flex flex-col gap-5 pt-6">
+          {reportMessage ? (
+            <Banner
+              variant={reportState === "success" ? "info" : "error"}
+              className="rounded-xl text-xs"
+            >
+              {reportMessage}
+            </Banner>
+          ) : null}
           {error.detail ? (
             <section className="space-y-2 rounded-2xl border border-border/50 bg-bg/35 p-4 shadow-sm">
               <div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-muted">
@@ -121,6 +190,19 @@ export function StartupFailureView({
               className="w-full sm:w-auto sm:min-w-[10rem]"
             >
               {t("bugreportmodal.ReportABug")}
+            </Button>
+            <Button
+              variant="outline"
+              size="lg"
+              onClick={() => {
+                void handleShareReport();
+              }}
+              disabled={reportState === "submitting"}
+              className="w-full sm:w-auto sm:min-w-[12rem]"
+            >
+              {reportState === "submitting"
+                ? "Sharing report..."
+                : "Share diagnostic report"}
             </Button>
             {isBackendUnreachable ? (
               <Button

--- a/packages/app-core/src/hooks/useBugReport.tsx
+++ b/packages/app-core/src/hooks/useBugReport.tsx
@@ -26,8 +26,12 @@ interface BugReportContextValue {
 
 const BugReportContext = createContext<BugReportContextValue | null>(null);
 
+export function useOptionalBugReport(): BugReportContextValue | null {
+  return useContext(BugReportContext);
+}
+
 export function useBugReport(): BugReportContextValue {
-  const ctx = useContext(BugReportContext);
+  const ctx = useOptionalBugReport();
   if (!ctx)
     throw new Error("useBugReport must be used within BugReportProvider");
   return ctx;

--- a/packages/app-core/src/hooks/useBugReport.tsx
+++ b/packages/app-core/src/hooks/useBugReport.tsx
@@ -6,9 +6,21 @@ import {
   useState,
 } from "react";
 
+export interface BugReportDraft {
+  description?: string;
+  stepsToReproduce?: string;
+  expectedBehavior?: string;
+  actualBehavior?: string;
+  environment?: string;
+  nodeVersion?: string;
+  modelProvider?: string;
+  logs?: string;
+}
+
 interface BugReportContextValue {
   isOpen: boolean;
-  open: () => void;
+  draft: BugReportDraft | null;
+  open: (draft?: BugReportDraft) => void;
   close: () => void;
 }
 
@@ -23,9 +35,16 @@ export function useBugReport(): BugReportContextValue {
 
 export function useBugReportState(): BugReportContextValue {
   const [isOpen, setIsOpen] = useState(false);
-  const open = useCallback(() => setIsOpen(true), []);
-  const close = useCallback(() => setIsOpen(false), []);
-  return { isOpen, open, close };
+  const [draft, setDraft] = useState<BugReportDraft | null>(null);
+  const open = useCallback((nextDraft?: BugReportDraft) => {
+    setDraft(nextDraft ?? null);
+    setIsOpen(true);
+  }, []);
+  const close = useCallback(() => {
+    setIsOpen(false);
+    setDraft(null);
+  }, []);
+  return { isOpen, draft, open, close };
 }
 
 export function BugReportProvider({

--- a/packages/app-core/test/app/bug-report-modal.test.tsx
+++ b/packages/app-core/test/app/bug-report-modal.test.tsx
@@ -180,7 +180,7 @@ let closeFn: ReturnType<typeof vi.fn>;
 
 function setupMock(isOpen: boolean) {
   closeFn = vi.fn();
-  mockUseBugReport.mockReturnValue({ isOpen, close: closeFn });
+  mockUseBugReport.mockReturnValue({ isOpen, draft: null, close: closeFn });
 }
 
 function getButtons(root: TestRenderer.ReactTestInstance) {
@@ -299,6 +299,28 @@ describe("BugReportModal", () => {
       await new Promise((r) => globalThis.setTimeout(r, 60));
     });
     expect(mockClient.checkBugReportInfo).toHaveBeenCalledOnce();
+  });
+
+  it("prefills the form from bug report draft data", async () => {
+    closeFn = vi.fn();
+    mockUseBugReport.mockReturnValue({
+      isOpen: true,
+      draft: {
+        description: "Startup failed on Windows",
+        actualBehavior: "App never got past startup",
+        logs: "Reason: backend-unreachable",
+      },
+      close: closeFn,
+    });
+    let tree: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      tree = TestRenderer.create(React.createElement(BugReportModal));
+      await new Promise((r) => globalThis.setTimeout(r, 60));
+    });
+
+    const textareas = getTextareas(tree!.root);
+    expect(textareas[0].props.value).toBe("Startup failed on Windows");
+    expect(textareas[3].props.value).toBe("App never got past startup");
   });
 
   // --- validation ---

--- a/packages/app-core/test/app/bug-report-modal.test.tsx
+++ b/packages/app-core/test/app/bug-report-modal.test.tsx
@@ -432,6 +432,27 @@ describe("BugReportModal", () => {
     expect(link?.props.href).toBe(issueUrl);
   });
 
+  it("shows success state when remote intake accepts without returning a URL", async () => {
+    mockClient.submitBugReport.mockResolvedValue({ accepted: true });
+    setupMock(true);
+    let tree: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      tree = TestRenderer.create(React.createElement(BugReportModal));
+      await new Promise(r => globalThis.setTimeout(r, 60));
+    });
+
+    await fillRequired(tree?.root);
+
+    const submitBtn = findButton(tree?.root, "bugreportmodal.submit");
+    await act(async () => {
+      submitBtn?.props.onClick();
+    });
+
+    const snapshot = JSON.stringify(tree?.toJSON());
+    expect(snapshot).toContain("bugreportmodal.BugReportSubmitted");
+    expect(snapshot).toContain("Your report was received.");
+  });
+
   it("shows error message on submit failure", async () => {
     mockClient.submitBugReport.mockRejectedValue(new Error("Network error"));
     setupMock(true);

--- a/packages/app-core/test/app/bug-report-modal.test.tsx
+++ b/packages/app-core/test/app/bug-report-modal.test.tsx
@@ -12,19 +12,14 @@ vi.mock("@miladyai/ui", () => {
   }: React.PropsWithChildren<Record<string, unknown>>) =>
     React.createElement("div", props, children);
   return {
-    Banner: ({
-      children,
-      ...props
-    }: React.HTMLAttributes<HTMLDivElement>) =>
+    Banner: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) =>
       React.createElement("div", { role: "alert", ...props }, children),
     Button: ({
       children,
       ...props
     }: React.ButtonHTMLAttributes<HTMLButtonElement>) =>
       React.createElement("button", { type: "button", ...props }, children),
-    Dialog: ({
-      children,
-    }: React.PropsWithChildren<Record<string, unknown>>) =>
+    Dialog: ({ children }: React.PropsWithChildren<Record<string, unknown>>) =>
       React.createElement(React.Fragment, null, children),
     DialogContent: ({
       children,
@@ -318,7 +313,7 @@ describe("BugReportModal", () => {
       await new Promise((r) => globalThis.setTimeout(r, 60));
     });
 
-    const textareas = getTextareas(tree!.root);
+    const textareas = getTextareas(tree?.root);
     expect(textareas[0].props.value).toBe("Startup failed on Windows");
     expect(textareas[3].props.value).toBe("App never got past startup");
   });
@@ -349,13 +344,12 @@ describe("BugReportModal", () => {
       submitBtn?.props.onClick();
     });
 
-    const errorDivs = tree?.root.findAll(
-      (node) =>
-        node.children.some(
-          (c) =>
-            typeof c === "string" &&
-            c.includes("bugreportmodal.descriptionRequired"),
-        ),
+    const errorDivs = tree?.root.findAll((node) =>
+      node.children.some(
+        (c) =>
+          typeof c === "string" &&
+          c.includes("bugreportmodal.descriptionRequired"),
+      ),
     );
     expect(errorDivs?.length).toBeGreaterThan(0);
   });
@@ -438,7 +432,7 @@ describe("BugReportModal", () => {
     let tree: TestRenderer.ReactTestRenderer;
     await act(async () => {
       tree = TestRenderer.create(React.createElement(BugReportModal));
-      await new Promise(r => globalThis.setTimeout(r, 60));
+      await new Promise((r) => globalThis.setTimeout(r, 60));
     });
 
     await fillRequired(tree?.root);
@@ -451,6 +445,31 @@ describe("BugReportModal", () => {
     const snapshot = JSON.stringify(tree?.toJSON());
     expect(snapshot).toContain("bugreportmodal.BugReportSubmitted");
     expect(snapshot).toContain("Your report was received.");
+  });
+
+  it("ignores non-https URLs returned by remote intake", async () => {
+    mockClient.submitBugReport.mockResolvedValue({
+      accepted: true,
+      url: "data:text/html,phish",
+    });
+    setupMock(true);
+    let tree: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      tree = TestRenderer.create(React.createElement(BugReportModal));
+      await new Promise((r) => globalThis.setTimeout(r, 60));
+    });
+
+    await fillRequired(tree?.root);
+
+    const submitBtn = findButton(tree?.root, "bugreportmodal.submit");
+    await act(async () => {
+      submitBtn?.props.onClick();
+    });
+
+    const snapshot = JSON.stringify(tree?.toJSON());
+    expect(snapshot).toContain("bugreportmodal.BugReportSubmitted");
+    expect(snapshot).toContain("Your report was received.");
+    expect(snapshot).not.toContain("data:text/html,phish");
   });
 
   it("shows error message on submit failure", async () => {
@@ -469,11 +488,10 @@ describe("BugReportModal", () => {
       submitBtn?.props.onClick();
     });
 
-    const errorDivs = tree?.root.findAll(
-      (node) =>
-        node.children.some(
-          (c) => typeof c === "string" && c.includes("Network error"),
-        ),
+    const errorDivs = tree?.root.findAll((node) =>
+      node.children.some(
+        (c) => typeof c === "string" && c.includes("Network error"),
+      ),
     );
     expect(errorDivs?.length).toBe(1);
   });

--- a/packages/app-core/test/app/startup-failure-view.test.tsx
+++ b/packages/app-core/test/app/startup-failure-view.test.tsx
@@ -2,6 +2,11 @@ import { StartupFailureView } from "@miladyai/app-core/components";
 import React from "react";
 import TestRenderer, { act } from "react-test-renderer";
 import { describe, expect, it, vi } from "vitest";
+import { textOf } from "../../../../test/helpers/react-test";
+
+const { openBugReportMock } = vi.hoisted(() => ({
+  openBugReportMock: vi.fn(),
+}));
 
 vi.mock("@miladyai/app-core/state", () => ({
   CUSTOM_ONBOARDING_STEPS: [],
@@ -15,6 +20,10 @@ vi.mock("@miladyai/app-core/state", () => ({
       return k;
     },
   }),
+}));
+
+vi.mock("@miladyai/app-core/hooks", () => ({
+  useBugReport: () => ({ open: openBugReportMock }),
 }));
 
 describe("StartupFailureView", () => {
@@ -51,7 +60,7 @@ describe("StartupFailureView", () => {
     expect(openAppLink.props.href).toBe("https://app.elizaos.ai");
     expect(openAppLink.children.join("")).toContain("Open App");
 
-    const retryButton = tree.root.findByType("button");
+    const retryButton = tree.root.findAllByType("button")[0];
     await act(async () => {
       retryButton.props.onClick();
     });

--- a/packages/app-core/test/app/startup-failure-view.test.tsx
+++ b/packages/app-core/test/app/startup-failure-view.test.tsx
@@ -8,6 +8,20 @@ const { openBugReportMock } = vi.hoisted(() => ({
   openBugReportMock: vi.fn(),
 }));
 
+const { mockClient } = vi.hoisted(() => ({
+  mockClient: {
+    checkBugReportInfo: vi.fn().mockResolvedValue({
+      nodeVersion: "v22.0.0",
+      platform: "win32",
+    }),
+    submitBugReport: vi.fn().mockResolvedValue({ accepted: true }),
+  },
+}));
+
+vi.mock("@miladyai/app-core/api", () => ({
+  client: mockClient,
+}));
+
 vi.mock("@miladyai/app-core/state", () => ({
   CUSTOM_ONBOARDING_STEPS: [],
   useApp: () => ({
@@ -61,6 +75,7 @@ describe("StartupFailureView", () => {
     expect(openAppLink.children.join("")).toContain("Open App");
 
     const retryButton = tree.root.findAllByType("button")[0];
+    if (!retryButton) throw new Error("missing retry button");
     await act(async () => {
       retryButton.props.onClick();
     });
@@ -109,5 +124,93 @@ describe("StartupFailureView", () => {
     if (!tree) throw new Error("failed to render StartupFailureView");
     const heading = tree.root.findByType("h1").children.join("");
     expect(heading).toContain("Asset Missing");
+  });
+
+  it("opens the local bug report modal with startup context", async () => {
+    openBugReportMock.mockClear();
+
+    let tree: TestRenderer.ReactTestRenderer | null = null;
+    await act(async () => {
+      tree = TestRenderer.create(
+        React.createElement(StartupFailureView, {
+          error: {
+            reason: "agent-error",
+            phase: "initializing-agent",
+            message: "Agent boot failed",
+            detail: "stack trace",
+            path: "/api/status",
+          },
+          onRetry: vi.fn(),
+        }),
+      );
+    });
+
+    if (!tree) throw new Error("failed to render StartupFailureView");
+
+    const reportButton = tree.root
+      .findAllByType("button")
+      .find((button) =>
+        button.children.join("").includes("bugreportmodal.ReportABug"),
+      );
+    if (!reportButton) throw new Error("missing local report button");
+
+    await act(async () => {
+      reportButton.props.onClick();
+    });
+
+    expect(openBugReportMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actualBehavior: "Agent boot failed",
+        logs: expect.stringContaining("Reason: agent-error"),
+      }),
+    );
+  });
+
+  it("submits a one-click diagnostic report", async () => {
+    mockClient.checkBugReportInfo.mockClear();
+    mockClient.submitBugReport.mockClear().mockResolvedValue({ accepted: true });
+
+    let tree: TestRenderer.ReactTestRenderer | null = null;
+    await act(async () => {
+      tree = TestRenderer.create(
+        React.createElement(StartupFailureView, {
+          error: {
+            reason: "agent-error",
+            phase: "initializing-agent",
+            message: "Agent boot failed",
+            detail: "stack trace",
+            path: "/api/status",
+          },
+          onRetry: vi.fn(),
+        }),
+      );
+    });
+
+    if (!tree) throw new Error("failed to render StartupFailureView");
+
+    const shareButton = tree.root
+      .findAllByType("button")
+      .find((button) =>
+        button.children.join("").includes("Share diagnostic report"),
+      );
+    if (!shareButton) throw new Error("missing share button");
+
+    await act(async () => {
+      await shareButton.props.onClick();
+    });
+
+    expect(mockClient.checkBugReportInfo).toHaveBeenCalledOnce();
+    expect(mockClient.submitBugReport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: "startup-failure",
+        startup: expect.objectContaining({
+          reason: "agent-error",
+          phase: "initializing-agent",
+          path: "/api/status",
+        }),
+      }),
+    );
+    const snapshot = JSON.stringify(tree.toJSON());
+    expect(snapshot).toContain("Diagnostic report shared successfully.");
   });
 });

--- a/packages/app-core/test/app/startup-failure-view.test.tsx
+++ b/packages/app-core/test/app/startup-failure-view.test.tsx
@@ -1,11 +1,11 @@
 import { StartupFailureView } from "@miladyai/app-core/components";
 import React from "react";
 import TestRenderer, { act } from "react-test-renderer";
-import { describe, expect, it, vi } from "vitest";
-import { textOf } from "../../../../test/helpers/react-test";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { openBugReportMock } = vi.hoisted(() => ({
+const { openBugReportMock, optionalBugReportMock } = vi.hoisted(() => ({
   openBugReportMock: vi.fn(),
+  optionalBugReportMock: vi.fn(),
 }));
 
 const { mockClient } = vi.hoisted(() => ({
@@ -37,10 +37,14 @@ vi.mock("@miladyai/app-core/state", () => ({
 }));
 
 vi.mock("@miladyai/app-core/hooks", () => ({
-  useBugReport: () => ({ open: openBugReportMock }),
+  useOptionalBugReport: () => optionalBugReportMock(),
 }));
 
 describe("StartupFailureView", () => {
+  beforeEach(() => {
+    optionalBugReportMock.mockReturnValue({ open: openBugReportMock });
+  });
+
   it("renders backend-unreachable hint and open-app CTA, then triggers retry", async () => {
     const onRetry = vi.fn();
     let tree: TestRenderer.ReactTestRenderer | null = null;
@@ -168,7 +172,9 @@ describe("StartupFailureView", () => {
 
   it("submits a one-click diagnostic report", async () => {
     mockClient.checkBugReportInfo.mockClear();
-    mockClient.submitBugReport.mockClear().mockResolvedValue({ accepted: true });
+    mockClient.submitBugReport
+      .mockClear()
+      .mockResolvedValue({ accepted: true });
 
     let tree: TestRenderer.ReactTestRenderer | null = null;
     await act(async () => {
@@ -212,5 +218,73 @@ describe("StartupFailureView", () => {
     );
     const snapshot = JSON.stringify(tree.toJSON());
     expect(snapshot).toContain("Diagnostic report shared successfully.");
+  });
+
+  it("does not render the local report action without bug report context", async () => {
+    optionalBugReportMock.mockReturnValue(null);
+
+    let tree: TestRenderer.ReactTestRenderer | null = null;
+    await act(async () => {
+      tree = TestRenderer.create(
+        React.createElement(StartupFailureView, {
+          error: {
+            reason: "agent-error",
+            phase: "initializing-agent",
+            message: "Agent boot failed",
+          },
+          onRetry: vi.fn(),
+        }),
+      );
+    });
+
+    if (!tree) throw new Error("failed to render StartupFailureView");
+    const reportButton = tree.root
+      .findAllByType("button")
+      .find((button) =>
+        button.children.join("").includes("bugreportmodal.ReportABug"),
+      );
+    expect(reportButton).toBeUndefined();
+  });
+
+  it("does not claim success when the share flow falls back to manual submission", async () => {
+    mockClient.checkBugReportInfo.mockClear();
+    mockClient.submitBugReport.mockClear().mockResolvedValue({
+      fallback: "https://github.com/milady-ai/milady/issues/new",
+    });
+
+    let tree: TestRenderer.ReactTestRenderer | null = null;
+    await act(async () => {
+      tree = TestRenderer.create(
+        React.createElement(StartupFailureView, {
+          error: {
+            reason: "agent-error",
+            phase: "initializing-agent",
+            message: "Agent boot failed",
+            detail: "stack trace",
+            path: "/api/status",
+          },
+          onRetry: vi.fn(),
+        }),
+      );
+    });
+
+    if (!tree) throw new Error("failed to render StartupFailureView");
+
+    const shareButton = tree.root
+      .findAllByType("button")
+      .find((button) =>
+        button.children.join("").includes("Share diagnostic report"),
+      );
+    if (!shareButton) throw new Error("missing share button");
+
+    await act(async () => {
+      await shareButton.props.onClick();
+    });
+
+    const snapshot = JSON.stringify(tree.toJSON());
+    expect(snapshot).toContain(
+      "Use Report Bug to review and submit it manually.",
+    );
+    expect(snapshot).not.toContain("Diagnostic report shared successfully.");
   });
 });


### PR DESCRIPTION
## Summary
- add remote bug report intake on top of the merged local desktop bug report flow
- preserve the local startup failure bug-report modal while also allowing remote diagnostic sharing
- salvage the worthwhile startup failure / remote intake work from #1383 after #1386 landed

## Testing
- bunx vitest run packages/app-core/src/api/__tests__/bug-report-routes.test.ts packages/app-core/test/app/bug-report-modal.test.tsx packages/app-core/test/app/startup-failure-view.test.tsx packages/app-core/src/components/StartupFailureView.test.tsx
- bun install --frozen-lockfile
