### PR TITLE
docs: fix plugin function name, add missing env vars, clarify connect…

### DIFF
--- a/docs/cli/environment.md
+++ b/docs/cli/environment.md
@@ -38,9 +38,12 @@ These variables control the API server and network behavior.
 | `MILADY_API_TOKEN` | Static API token for authenticating requests to the agent API server. When set, all API requests must include this token. Auto-generated if unset and bind is non-loopback. | (unset) |
 | `MILADY_ALLOW_WS_QUERY_TOKEN` | When set to `1`, allows the API token to be passed as a WebSocket query parameter (less secure; useful for some clients). | (unset) |
 | `MILADY_PAIRING_DISABLED` | When set to `1`, disables the pairing endpoint on the API server (requires `MILADY_API_TOKEN` to be set). | (unset) |
+| `MILADY_API_PORT` | API server port in dev mode (used by `bun run dev`). In production (`milady start`), the API shares `MILADY_PORT`. | `31337` |
 | `MILADY_ALLOWED_ORIGINS` | Comma-separated list of additional CORS origins allowed by the API server. | (unset) |
 | `MILADY_ALLOW_NULL_ORIGIN` | When set to `1`, allows the `null` origin in CORS (useful for file:// or desktop clients). | (unset) |
 | `MILADY_WALLET_EXPORT_TOKEN` | Auth token for the wallet export API endpoint. When unset, wallet exports are disabled. | (unset) |
+| `MILADY_HOME_PORT` | Home dashboard port. | `2142` |
+| `MILADY_WECHAT_WEBHOOK_PORT` | WeChat webhook receiver port. | `18790` |
 | `API_PORT` / `SERVER_PORT` | Alternative port overrides used by some runtime actions. Prefer `MILADY_PORT`. | (unset) |
 
 ---
@@ -96,9 +99,11 @@ These variables configure access to AI model providers. Set at least one to enab
 | `ZAI_API_KEY` | Zai | Zai model provider |
 | `Z_AI_API_KEY` | Zai | Alias -- automatically copied to `ZAI_API_KEY` at startup if `ZAI_API_KEY` is unset |
 | `OLLAMA_BASE_URL` | Ollama (local) | Base URL for a local Ollama server (not an API key) |
+| `GOOGLE_CLOUD_API_KEY` | Google Antigravity | Google Cloud API for Antigravity model provider |
 | `ELIZAOS_CLOUD_API_KEY` | elizaOS Cloud | Cloud-hosted model inference via elizaOS |
 | `ELIZAOS_CLOUD_ENABLED` | elizaOS Cloud | Set to `1` to enable elizaOS Cloud (requires API key) |
 | `ELIZAOS_CLOUD_BASE_URL` | elizaOS Cloud | Override the elizaOS Cloud endpoint URL. Set automatically from config when cloud is enabled. |
+| `ELIZA_USE_PI_AI` | Pi AI | Set to `1` to enable the Pi AI model provider |
 
 Use `milady models` to check which providers are currently configured.
 
@@ -172,6 +177,21 @@ These variables control elizaOS runtime initialization behavior.
 | `MILADY_DISABLE_WORKSPACE_PLUGIN_OVERRIDES` | When set to `1`, disables loading plugin overrides from workspace directories. | (unset) |
 | `MILADY_BUNDLED_VERSION` | Override the bundled version string returned by the version resolver. Used in special packaging scenarios. | (unset) |
 | `MILADY_DISABLE_EDGE_TTS` | When set to `1`, `true`, or `yes`, Milady does **not** auto-load `@elizaos/plugin-edge-tts` when `@elizaos/plugin-agent-orchestrator` is enabled (orchestrator-driven flows use `TEXT_TO_SPEECH`). Without this, the bundled `node-edge-tts` client **contacts Microsoft’s Edge TTS cloud service** even though no API key is required—there is still an outbound network call to Microsoft. To opt out while keeping other plugins: set this variable, or set `plugins.entries["edge-tts"].enabled` to `false` in `milady.json`. Alias: `ELIZA_DISABLE_EDGE_TTS`. | (unset — Edge TTS is auto-loaded with the agent orchestrator) |
+
+---
+
+## Feature Plugin Activation
+
+These environment variables auto-enable their associated plugins when set. They are checked by the plugin auto-enable layer during runtime startup.
+
+| Variable | Plugin | Description |
+|----------|--------|-------------|
+| `CUA_API_KEY` | `@elizaos/plugin-cua` | CUA cloud sandbox automation API key |
+| `CUA_HOST` | `@elizaos/plugin-cua` | CUA host URL (alternative trigger to API key) |
+| `OBSIDIAN_VAULT_PATH` | `@elizaos/plugin-obsidian` | Path to Obsidian vault — auto-enables Obsidian plugin |
+| `REPOPROMPT_CLI_PATH` | `@elizaos/plugin-repoprompt` | Path to RepoPrompt CLI — auto-enables RepoPrompt plugin |
+| `CLAUDE_CODE_WORKBENCH_ENABLED` | `@elizaos/plugin-claude-code-workbench` | Set to `1` to enable Claude Code Workbench workflows |
+| `STEWARD_API_URL` | `@stwd/eliza-plugin` | Steward wallet plugin API URL (Milady-specific) |
 
 ---
 

--- a/docs/guides/connectors.md
+++ b/docs/guides/connectors.md
@@ -1,7 +1,7 @@
 ---
 title: "Platform Connectors"
 sidebarTitle: "Connectors"
-description: "Platform bridges for 30+ messaging platforms including Discord, Telegram, Slack, WhatsApp, Signal, iMessage, BlueBubbles, Blooio, MS Teams, Google Chat, Twitter, Farcaster, Bluesky, Instagram, Twitch, Mattermost, WeChat, Matrix, Feishu, Nostr, LINE, Zalo, Twilio, GitHub, Gmail Watch, Nextcloud Talk, Tlon, Lens, and Retake."
+description: "Platform bridges for 29 messaging platforms — 20 auto-enabled from config (Discord, Telegram, Slack, WhatsApp, Signal, iMessage, BlueBubbles, Blooio, MS Teams, Google Chat, Twitter, Farcaster, Twitch, Mattermost, WeChat, Matrix, Feishu, Nostr, Lens, Retake) plus 9 installable from the registry (Bluesky, Instagram, LINE, Zalo, Twilio, GitHub, Gmail Watch, Nextcloud Talk, Tlon)."
 ---
 
 Connectors are platform bridges that allow your agent to communicate across messaging platforms and social networks. Each connector handles authentication, message routing, session management, and platform-specific features.
@@ -47,37 +47,39 @@ Connectors are platform bridges that allow your agent to communicate across mess
 
 ## Supported Platforms
 
-| Platform | Auth Method | DM Support | Group Support | Multi-Account |
-|----------|------------|------------|---------------|---------------|
-| Discord | Bot token | Yes | Yes (guilds/channels) | Yes |
-| Telegram | Bot token | Yes | Yes (groups/topics) | Yes |
-| Slack | Bot + App tokens | Yes | Yes (channels/threads) | Yes |
-| WhatsApp | QR code (Baileys) or Cloud API | Yes | Yes | Yes |
-| Signal | signal-cli HTTP API | Yes | Yes | Yes |
-| iMessage | Native CLI (macOS) | Yes | Yes | Yes |
-| BlueBubbles | Server URL + password | Yes | Yes | Yes |
-| Blooio | API key + webhook | Yes | Yes | No |
-| Microsoft Teams | App ID + password | Yes | Yes (teams/channels) | No |
-| Google Chat | Service account | Yes | Yes (spaces) | Yes |
-| Twitter | API keys + tokens | DMs | N/A | No |
-| Farcaster | Neynar API key + signer | Casts | Yes (channels) | No |
-| Bluesky | Account credentials | Posts | N/A | No |
-| Instagram | Username + password | DMs | N/A | No |
-| Twitch | Client ID + access token | Yes (chat) | Yes (channels) | No |
-| Mattermost | Bot token | Yes | Yes (channels) | No |
-| WeChat | Proxy API key + QR code | Yes | Yes | Yes |
-| Matrix | Access token | Yes | Yes (rooms) | No |
-| Feishu / Lark | App ID + secret | Yes | Yes (group chats) | No |
-| Nostr | Private key (nsec/hex) | Yes (NIP-04) | N/A | No |
-| LINE | Channel access token + secret | Yes | Yes | No |
-| Zalo | Access token | Yes | Yes | No |
-| Twilio | Account SID + auth token | SMS/Voice | N/A | No |
-| GitHub | API token | Issues/PRs | Yes (repos) | No |
-| Gmail Watch | Service account / OAuth | N/A | N/A | No |
-| Nextcloud Talk | Server credentials | Yes | Yes (rooms) | No |
-| Tlon | Ship credentials | Yes | Yes (Urbit chats) | No |
-| Lens | API key | Yes | N/A | No |
-| Retake | Access token | Yes | Yes | No |
+Connectors marked **Auto** load automatically when their config is present in `milady.json`. Connectors marked **Registry** must be installed first with `milady plugins install <package>`.
+
+| Platform | Auth Method | DM Support | Group Support | Multi-Account | Availability |
+|----------|------------|------------|---------------|---------------|-------------|
+| Discord | Bot token | Yes | Yes (guilds/channels) | Yes | Auto |
+| Telegram | Bot token | Yes | Yes (groups/topics) | Yes | Auto |
+| Slack | Bot + App tokens | Yes | Yes (channels/threads) | Yes | Auto |
+| WhatsApp | QR code (Baileys) or Cloud API | Yes | Yes | Yes | Auto |
+| Signal | signal-cli HTTP API | Yes | Yes | Yes | Auto |
+| iMessage | Native CLI (macOS) | Yes | Yes | Yes | Auto |
+| BlueBubbles | Server URL + password | Yes | Yes | Yes | Auto |
+| Blooio | API key + webhook | Yes | Yes | No | Auto |
+| Microsoft Teams | App ID + password | Yes | Yes (teams/channels) | No | Auto |
+| Google Chat | Service account | Yes | Yes (spaces) | Yes | Auto |
+| Twitter | API keys + tokens | DMs | N/A | No | Auto |
+| Farcaster | Neynar API key + signer | Casts | Yes (channels) | No | Auto |
+| Twitch | Client ID + access token | Yes (chat) | Yes (channels) | No | Auto |
+| Mattermost | Bot token | Yes | Yes (channels) | No | Auto |
+| WeChat | Proxy API key + QR code | Yes | Yes | Yes | Auto |
+| Matrix | Access token | Yes | Yes (rooms) | No | Auto |
+| Feishu / Lark | App ID + secret | Yes | Yes (group chats) | No | Auto |
+| Nostr | Private key (nsec/hex) | Yes (NIP-04) | N/A | No | Auto |
+| Lens | API key | Yes | N/A | No | Auto |
+| Retake | Access token | Yes | Yes | No | Auto |
+| Bluesky | Account credentials | Posts | N/A | No | Registry |
+| Instagram | Username + password | DMs | N/A | No | Registry |
+| LINE | Channel access token + secret | Yes | Yes | No | Registry |
+| Zalo | Access token | Yes | Yes | No | Registry |
+| Twilio | Account SID + auth token | SMS/Voice | N/A | No | Registry |
+| GitHub | API token | Issues/PRs | Yes (repos) | No | Registry |
+| Gmail Watch | Service account / OAuth | N/A | N/A | No | Registry |
+| Nextcloud Talk | Server credentials | Yes | Yes (rooms) | No | Registry |
+| Tlon | Ship credentials | Yes | Yes (Urbit chats) | No | Registry |
 
 ---
 

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -45,7 +45,7 @@ A plugin is a self-contained module that registers one or more of:
 
 Plugins are loaded during runtime initialization in this order:
 
-1. **Milady plugin** — The bridge plugin (`createMiladyPlugin()`) providing workspace context, session keys, emotes, custom actions, and lifecycle actions. Always first in the plugins array.
+1. **Milady plugin** — The bridge plugin (`createElizaPlugin()`) providing workspace context, session keys, emotes, custom actions, and lifecycle actions. Always first in the plugins array.
 2. **Pre-registered plugins** — `@elizaos/plugin-sql` and `@elizaos/plugin-local-embedding` are pre-registered before `runtime.initialize()` to prevent race conditions.
 3. **Core plugins** — Always loaded: `sql`, `local-embedding`, `form`, `knowledge`, `trajectory-logger`, `agent-orchestrator`, `cron`, `shell`, `agent-skills` (see `packages/agent/src/runtime/core-plugins.ts`). Additional plugins like `pdf`, `cua`, `browser`, `computeruse`, `obsidian`, `code`, `repoprompt`, `claude-code-workbench`, `vision`, `cli`, `edge-tts`, `elevenlabs`, `discord`, `telegram`, and `twitch` are optional and loaded when their feature flags or environment variables are configured.
 4. **Auto-enabled plugins** — Connector, provider, feature, and streaming plugins are auto-enabled based on config and environment variables (see [Architecture](/plugins/architecture) for the full maps).


### PR DESCRIPTION
…or availability

- Fix createMiladyPlugin() → createElizaPlugin() in plugins overview (validated against source)
- Add Availability column to connectors table distinguishing 20 auto-enabled vs 9 registry-only
- Add missing env vars to environment reference: MILADY_API_PORT, MILADY_HOME_PORT, MILADY_WECHAT_WEBHOOK_PORT, GOOGLE_CLOUD_API_KEY, ELIZA_USE_PI_AI
- Add Feature Plugin Activation section documenting CUA, Obsidian, RepoPrompt, Claude Code Workbench, and Steward env var triggers

https://claude.ai/code/session_01RFdLy5vVc73ySE8h6WNr9d

This PR will be reviewed by an AI agent. Provide clear context to help it assess your changes.

Aesthetic/UI changes that don't improve agent capability are out of scope and will be rejected.

## Category
- [ ] Bug fix
- [ ] Security fix
- [ ] Performance improvement
- [ ] New feature
- [ ] Documentation
- [ ] Test coverage
- [ ] Other

## What
(brief description)

## Why
(motivation)

## How
(implementation approach)

## Testing
(what was tested, how to verify)
