### PR TITLE
fix: register coding agents with coordinator even without task text

### DIFF
--- a/packages/agent/src/api/__tests__/coding-agent-coordinator-register.test.ts
+++ b/packages/agent/src/api/__tests__/coding-agent-coordinator-register.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+// Read the patched plugin dist to verify the coordinator registration fix
+const pluginSource = readFileSync(
+  path.resolve(
+    import.meta.dirname,
+    "..",
+    "..",
+    "..",
+    "..",
+    "..",
+    "node_modules",
+    "@elizaos",
+    "plugin-coding-agent",
+    "dist",
+    "index.js",
+  ),
+  "utf-8",
+);
+
+describe("coding-agent coordinator registration (patch)", () => {
+  it("registers task with coordinator even when task param is empty", () => {
+    // The upstream plugin had `if (coordinator && task)` which skipped
+    // registration when no task text was provided. This caused the
+    // coordinator to discard buffered events and the UI to show no output.
+    const guards = pluginSource.match(/if \(coordinator && task\)/g);
+    expect(guards).toBeNull();
+  });
+
+  it("uses coordinator-only guard for registerTask calls", () => {
+    // All registerTask calls should be guarded by `if (coordinator)` only
+    const registerCalls = pluginSource.match(/coordinator\.registerTask\(/g);
+    expect(registerCalls).toBeTruthy();
+    expect(registerCalls!.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("defaults originalTask to empty string when task is undefined", () => {
+    // Prevent undefined from being stored in the coordinator task context
+    expect(pluginSource).toContain('originalTask: task || ""');
+    const defaults = pluginSource.match(/originalTask: task \|\| ""/g);
+    expect(defaults!.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/patches/@elizaos%2Fplugin-coding-agent@0.1.0-next.1.patch
+++ b/patches/@elizaos%2Fplugin-coding-agent@0.1.0-next.1.patch
@@ -1,6 +1,53 @@
-diff --git a/Users/shawwalters/eliza-workspace/milady/node_modules/@elizaos/plugin-coding-agent/.bun-tag-382009ea4b173d55 b/.bun-tag-382009ea4b173d55
+diff --git a/node_modules/@elizaos/plugin-coding-agent/.bun-tag-183878086aa825fb b/.bun-tag-183878086aa825fb
 new file mode 100644
 index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/dist/index.js b/dist/index.js
+index 9e43bfe2e952af9a4d7566cc5ee8174874dfa89c..8cf075274e949ebea9a056cd3657dca48c8fbf7d 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -3377,11 +3377,11 @@ var spawnAgentAction = {
+           unsubscribe();
+         }
+       });
+-      if (coordinator && task) {
++      if (coordinator) {
+         coordinator.registerTask(session.id, {
+           agentType,
+           label: `agent-${session.id.slice(-8)}`,
+-          originalTask: task,
++          originalTask: task || "",
+           workdir
+         });
+       }
+@@ -3834,11 +3834,11 @@ Docs: ${preflight.docsUrl}`
+     const isScratchWorkspace = !repo;
+     const scratchDir = isScratchWorkspace ? workdir : null;
+     registerSessionEvents(ptyService, runtime, session.id, label, scratchDir, callback, !!coordinator);
+-    if (coordinator && task) {
++    if (coordinator) {
+       coordinator.registerTask(session.id, {
+         agentType,
+         label,
+-        originalTask: task,
++        originalTask: task || "",
+         workdir
+       });
+     }
+@@ -5200,12 +5200,12 @@ async function handleAgentRoutes(req, res, pathname, ctx) {
+           }
+         }
+       });
+-      if (coordinator && task) {
++      if (coordinator) {
+         const label = metadata?.label;
+         coordinator.registerTask(session.id, {
+           agentType: agentStr,
+           label: label || `agent-${session.id.slice(-8)}`,
+-          originalTask: task,
++          originalTask: task || "",
+           workdir: session.workdir
+         });
+       }
 diff --git a/package.json b/package.json
 index 5822b64f2690da5dbbd4a1bd95e207f49d3f718e..a7f6b645c8e2f78e63d905c2a047104fed212cba 100644
 --- a/package.json


### PR DESCRIPTION
## Summary
- Coding agents spawned via ElizaCloud but showed no output in the UI
- Root cause: upstream `plugin-coding-agent` guarded `registerTask()` with `if (coordinator && task)` — when the LLM invoked `START_CODING_TASK` without a `task` parameter, registration was skipped
- The coordinator received PTY events but discarded them after 2s buffer timeout: `Discarding 2 buffered events for unregistered session`
- Patch changes all 3 instances to `if (coordinator)` and defaults `originalTask` to `""` when undefined

## Test plan
- [x] `coding-agent-coordinator-register.test.ts` — verifies no `coordinator && task` guards remain, all registerTask calls use coordinator-only guard, originalTask defaults to empty string
- [ ] Spawn coding agent via chat without explicit task text → verify output appears in UI
- [ ] Spawn coding agent with task text → verify output + coordinator tracks task

🤖 Generated with [Claude Code](https://claude.com/claude-code)