### PR TITLE
fix(ui): resolve white-on-gold text contrast issues

### DIFF
--- a/packages/app-core/src/components/CloudOnboarding.tsx
+++ b/packages/app-core/src/components/CloudOnboarding.tsx
@@ -49,7 +49,7 @@ export function CloudOnboarding() {
             <>
               <Button
                 variant="default"
-                className="w-full py-3 px-4 rounded-lg bg-accent text-white font-medium text-sm hover:opacity-90 transition-opacity disabled:opacity-50"
+                className="w-full py-3 px-4 rounded-lg bg-accent text-accent-fg font-medium text-sm hover:opacity-90 transition-opacity disabled:opacity-50"
                 onClick={handleCloudLogin}
                 disabled={elizaCloudLoginBusy}
               >

--- a/packages/app-core/src/components/CodingAgentSettingsSection.tsx
+++ b/packages/app-core/src/components/CodingAgentSettingsSection.tsx
@@ -447,7 +447,7 @@ export function CodingAgentSettingsSection() {
               size="sm"
               className={`flex-1 h-9 rounded-lg border border-transparent px-3 py-2 text-xs font-semibold ${
                 active
-                  ? "bg-accent text-accent-foreground shadow-sm"
+                  ? "bg-accent text-accent-fg shadow-sm"
                   : "text-muted hover:bg-bg-hover hover:text-txt"
               }`}
               onClick={() => setActiveTab(agent)}

--- a/packages/app-core/src/components/ShellOverlays.test.tsx
+++ b/packages/app-core/src/components/ShellOverlays.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import React from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { describe, expect, it, vi } from "vitest";
+import { ShellOverlays } from "./ShellOverlays";
+
+vi.mock("@miladyai/ui", () => ({
+  Spinner: ({ className }: { className?: string }) =>
+    React.createElement("span", {
+      "data-testid": "spinner",
+      className,
+    }),
+}));
+
+vi.mock("./BugReportModal", () => ({
+  BugReportModal: () => null,
+}));
+
+vi.mock("./CommandPalette", () => ({
+  CommandPalette: () => null,
+}));
+
+vi.mock("./GlobalEmoteOverlay", () => ({
+  GlobalEmoteOverlay: () => null,
+}));
+
+vi.mock("./RestartBanner", () => ({
+  RestartBanner: () => null,
+}));
+
+vi.mock("./ShortcutsOverlay", () => ({
+  ShortcutsOverlay: () => null,
+}));
+
+describe("ShellOverlays", () => {
+  it("uses readable text tokens for each notice tone", () => {
+    const notice = {
+      text: "Heads up",
+      tone: "info",
+      busy: false,
+    };
+
+    let renderer: TestRenderer.ReactTestRenderer;
+    act(() => {
+      renderer = TestRenderer.create(
+        React.createElement(ShellOverlays, { actionNotice: notice }),
+      );
+    });
+
+    const infoBanner = renderer!.root.findByProps({ role: "status" });
+    expect(String(infoBanner.props.className)).toContain("bg-accent");
+    expect(String(infoBanner.props.className)).toContain("text-accent-fg");
+
+    act(() => {
+      renderer!.update(
+        React.createElement(ShellOverlays, {
+          actionNotice: { ...notice, tone: "success" },
+        }),
+      );
+    });
+
+    const successBanner = renderer!.root.findByProps({ role: "status" });
+    expect(String(successBanner.props.className)).toContain("bg-ok");
+    expect(String(successBanner.props.className)).toContain("text-white");
+
+    act(() => {
+      renderer!.update(
+        React.createElement(ShellOverlays, {
+          actionNotice: { ...notice, tone: "error" },
+        }),
+      );
+    });
+
+    const errorBanner = renderer!.root.findByProps({ role: "status" });
+    expect(String(errorBanner.props.className)).toContain("bg-danger");
+    expect(String(errorBanner.props.className)).toContain("text-white");
+  });
+});

--- a/packages/app-core/src/components/ShellOverlays.tsx
+++ b/packages/app-core/src/components/ShellOverlays.tsx
@@ -20,12 +20,12 @@ export function ShellOverlays({
       <GlobalEmoteOverlay />
       {actionNotice && (
         <div
-          className={`fixed bottom-6 left-1/2 -translate-x-1/2 px-5 py-2.5 rounded-lg text-[13px] font-medium z-[10000] text-white flex items-center gap-2.5 max-w-[min(92vw,28rem)] ${
+          className={`fixed bottom-6 left-1/2 -translate-x-1/2 px-5 py-2.5 rounded-lg text-[13px] font-medium z-[10000] flex items-center gap-2.5 max-w-[min(92vw,28rem)] ${
             actionNotice.tone === "error"
-              ? "bg-danger"
+              ? "bg-danger text-white"
               : actionNotice.tone === "success"
-                ? "bg-ok"
-                : "bg-accent"
+                ? "bg-ok text-white"
+                : "bg-accent text-accent-fg"
           }`}
           role="status"
           aria-live="polite"

--- a/packages/app-core/src/components/permissions/StreamingPermissions.tsx
+++ b/packages/app-core/src/components/permissions/StreamingPermissions.tsx
@@ -388,8 +388,7 @@ export function StreamingPermissionsOnboardingView({
         <Button
           variant="default"
           data-testid="permissions-onboarding-continue"
-          className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-white text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
-          style={{ textShadow: "0 1px 6px rgba(3,5,10,0.55)" }}
+          className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-accent-fg text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
           onClick={(e) => {
             if (e?.currentTarget) {
               const rect = e.currentTarget.getBoundingClientRect();

--- a/packages/ui/src/components/ui/button.test.ts
+++ b/packages/ui/src/components/ui/button.test.ts
@@ -3,9 +3,15 @@ import { buttonVariants } from "./button";
 
 describe("buttonVariants", () => {
   describe("default variant", () => {
-    it("includes bg-accent/15", () => {
+    it("includes bg-accent/18", () => {
       const classes = buttonVariants({ variant: "default" });
-      expect(classes).toContain("bg-accent/15");
+      expect(classes).toContain("bg-accent/18");
+    });
+
+    it("uses semantic accent text tokens for light and dark themes", () => {
+      const classes = buttonVariants({ variant: "default" });
+      expect(classes).toContain("text-accent-fg");
+      expect(classes).toContain("dark:text-accent");
     });
 
     it("does not include bg-primary", () => {
@@ -58,7 +64,7 @@ describe("buttonVariants", () => {
     it("falls back to default variant classes", () => {
       const withDefault = buttonVariants({ variant: "default" });
       const withoutVariant = buttonVariants({});
-      expect(withoutVariant).toContain("bg-accent/15");
+      expect(withoutVariant).toContain("bg-accent/18");
       expect(withoutVariant).toBe(withDefault);
     });
   });

--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -10,7 +10,7 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "border border-accent/45 bg-accent/18 text-accent-fg shadow-sm hover:border-accent/70 hover:bg-accent/28",
+          "border border-accent/45 bg-accent/18 text-accent-fg dark:text-accent shadow-sm hover:border-accent/70 hover:bg-accent/28",
         destructive:
           "border border-destructive/45 bg-destructive/92 text-destructive-fg shadow-sm hover:border-destructive/75 hover:bg-destructive",
         outline:

--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -10,6 +10,8 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
+          // Solid accent surfaces use text-accent-fg; translucent accent buttons
+          // switch to text-accent in dark mode to preserve contrast.
           "border border-accent/45 bg-accent/18 text-accent-fg dark:text-accent shadow-sm hover:border-accent/70 hover:bg-accent/28",
         destructive:
           "border border-destructive/45 bg-destructive/92 text-destructive-fg shadow-sm hover:border-destructive/75 hover:bg-destructive",

--- a/packages/ui/src/components/ui/theme-render.test.tsx
+++ b/packages/ui/src/components/ui/theme-render.test.tsx
@@ -27,6 +27,9 @@ describe.each(["light", "dark"] as const)("theme %s", (theme) => {
     ).toContain("text-accent-fg");
     expect(
       screen.getByRole("button", { name: "Continue" }).className,
+    ).toContain("dark:text-accent");
+    expect(
+      screen.getByRole("button", { name: "Continue" }).className,
     ).toContain("bg-accent/18");
   });
 


### PR DESCRIPTION
## Summary
- Fix white text on solid gold backgrounds for WCAG-compliant contrast
- Button default variant: `text-accent-fg` → `text-accent` (gold text on semi-transparent gold bg)
- CloudOnboarding: `text-white` → `text-accent-fg` on solid gold button
- ShellOverlays: per-tone text colors so gold toast uses dark text, error/success keep white
- StreamingPermissions: `text-white` → `text-accent-fg`, remove `textShadow` hack
- CodingAgentSettingsSection: fix broken `text-accent-foreground` (not a valid Tailwind class) → `text-accent-fg`

## Test plan
- [ ] Verify "Connect to Eliza Cloud" button has dark text on gold
- [ ] Copy an address → gold toast shows dark text
- [ ] Settings → Coding Agent → active tab shows dark text on gold
- [ ] Streaming Permissions onboarding → Continue button readable
- [ ] All default variant buttons (Save, Log in, etc.) show gold text on muted gold bg