### PR TITLE
fix(ui): cover shell toggle segmented styles

### DIFF
--- a/packages/app-core/src/components/companion/ShellHeaderControls.test.tsx
+++ b/packages/app-core/src/components/companion/ShellHeaderControls.test.tsx
@@ -231,4 +231,54 @@ describe("ShellHeaderControls", () => {
     );
     expect(newChatButtons.length).toBe(0);
   });
+
+  it("uses a shared segmented inset and uniform inner rounding for all shell buttons", () => {
+    mockUseMediaQuery.mockReturnValue(false);
+
+    const tree = renderControls({ activeShellView: "desktop" });
+    const root = tree.root;
+    const fieldset = root.findByProps({ "data-testid": "ui-shell-toggle" });
+    const companionButton = root.findByProps({
+      "data-testid": "ui-shell-toggle-companion",
+    });
+    const characterButton = root.findByProps({
+      "data-testid": "ui-shell-toggle-character",
+    });
+    const desktopButton = root.findByProps({
+      "data-testid": "ui-shell-toggle-desktop",
+    });
+
+    expect(String(fieldset.props.className)).toContain("rounded-[14px]");
+    expect(String(fieldset.props.className)).toContain("p-1");
+    for (const button of [companionButton, characterButton, desktopButton]) {
+      expect(String(button.props.className)).toContain("rounded-[10px]");
+      expect(String(button.props.className)).not.toContain("rounded-l");
+      expect(String(button.props.className)).not.toContain("rounded-r");
+    }
+  });
+
+  it("gives inactive shell segments a visible baseline fill", () => {
+    mockUseMediaQuery.mockReturnValue(false);
+
+    const tree = renderControls({ activeShellView: "character" });
+    const root = tree.root;
+    const companionButton = root.findByProps({
+      "data-testid": "ui-shell-toggle-companion",
+    });
+    const characterButton = root.findByProps({
+      "data-testid": "ui-shell-toggle-character",
+    });
+    const desktopButton = root.findByProps({
+      "data-testid": "ui-shell-toggle-desktop",
+    });
+
+    expect(String(companionButton.props.className)).toContain("bg-white/[0.03]");
+    expect(String(desktopButton.props.className)).toContain("bg-white/[0.03]");
+    expect(String(characterButton.props.className)).toContain(
+      "border-[color:color-mix",
+    );
+    expect(characterButton.props["aria-pressed"]).toBe(true);
+    expect(companionButton.props["aria-pressed"]).toBe(false);
+    expect(desktopButton.props["aria-pressed"]).toBe(false);
+  });
 });

--- a/packages/app-core/src/components/companion/ShellHeaderControls.tsx
+++ b/packages/app-core/src/components/companion/ShellHeaderControls.tsx
@@ -244,21 +244,15 @@ export function ShellHeaderControls({
           aria-label="Switch shell view"
         >
           <legend className="sr-only">Switch shell view</legend>
-          {shellOptions.map(({ view, label, Icon }, index) => {
+          {shellOptions.map(({ view, label, Icon }) => {
             const selected = activeShellView === view;
-            const edgeClass =
-              index === 0
-                ? "rounded-l-xl rounded-r-none"
-                : index === shellOptions.length - 1
-                  ? "rounded-l-none rounded-r-xl"
-                  : "rounded-none";
             return (
               <Button
                 key={view}
                 size="icon"
                 onClick={() => onShellViewChange(view)}
                 onPointerDown={(event) => event.stopPropagation()}
-                className={`h-11 min-h-[44px] min-w-[44px] px-3 transition-all duration-200 ${edgeClass} ${
+                className={`h-11 min-h-[44px] min-w-[44px] rounded-[10px] px-3 transition-all duration-200 ${
                   selected
                     ? SHELL_SEGMENT_ACTIVE_CLASSNAME
                     : SHELL_SEGMENT_INACTIVE_CLASSNAME

--- a/packages/app-core/src/components/companion/shell-control-styles.ts
+++ b/packages/app-core/src/components/companion/shell-control-styles.ts
@@ -6,13 +6,13 @@ export const SHELL_ICON_BUTTON_CLASSNAME = `inline-flex h-11 w-11 min-h-[44px] m
 export const SHELL_EXPANDED_BUTTON_CLASSNAME = `inline-flex h-11 min-h-[44px] min-w-[44px] items-center justify-center rounded-xl px-3.5 py-0 ${SHELL_CONTROL_BASE_CLASSNAME}`;
 
 export const SHELL_SEGMENTED_CONTROL_CLASSNAME =
-  "inline-flex items-center gap-0.5 rounded-xl border border-border/45 bg-[linear-gradient(180deg,color-mix(in_srgb,var(--card)_52%,transparent),color-mix(in_srgb,var(--bg)_34%,transparent))] p-0.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.14),0_12px_28px_rgba(3,5,10,0.12)] ring-1 ring-inset ring-white/6 backdrop-blur-xl";
+  "inline-flex items-center gap-0.5 rounded-[14px] border border-border/45 bg-[linear-gradient(180deg,color-mix(in_srgb,var(--card)_52%,transparent),color-mix(in_srgb,var(--bg)_34%,transparent))] p-1 shadow-[inset_0_1px_0_rgba(255,255,255,0.14),0_12px_28px_rgba(3,5,10,0.12)] ring-1 ring-inset ring-white/6 backdrop-blur-xl";
 
 export const SHELL_SEGMENT_ACTIVE_CLASSNAME =
   "border-[color:color-mix(in_srgb,var(--accent)_34%,var(--border))] bg-[linear-gradient(180deg,color-mix(in_srgb,var(--accent)_20%,var(--card)),color-mix(in_srgb,var(--accent)_10%,var(--bg)))] text-[color:color-mix(in_srgb,var(--text-strong)_78%,var(--accent)_22%)] shadow-[inset_0_1px_0_rgba(255,255,255,0.12),0_8px_20px_rgba(3,5,10,0.12)]";
 
 export const SHELL_SEGMENT_INACTIVE_CLASSNAME =
-  "border border-transparent bg-transparent text-muted-strong hover:border-border/60 hover:bg-bg-hover/80 hover:text-txt";
+  "border border-transparent bg-white/[0.03] text-muted-strong hover:border-border/60 hover:bg-bg-hover/80 hover:text-txt";
 
 export const HEADER_BUTTON_STYLE = {
   clipPath: "none",


### PR DESCRIPTION
## Summary
- salvage the original #1389 shell toggle styling change onto current develop
- add focused regression tests for the segmented inset, shared rounding, and inactive baseline fill
- satisfy pre-review on the behavioral UI change without broadening the PR scope

## Testing
- bunx vitest run packages/app-core/src/components/companion/ShellHeaderControls.test.tsx
- bun run pre-review:local

Supersedes #1389.