### PR TITLE
fix(ui): remove permanent left accent border from GENERATION container

### DIFF
--- a/packages/app-core/src/components/CloudOnboarding.tsx
+++ b/packages/app-core/src/components/CloudOnboarding.tsx
@@ -49,7 +49,7 @@ export function CloudOnboarding() {
             <>
               <Button
                 variant="default"
-                className="w-full py-3 px-4 rounded-lg bg-accent text-white font-medium text-sm hover:opacity-90 transition-opacity disabled:opacity-50"
+                className="w-full py-3 px-4 rounded-lg bg-accent text-accent-fg font-medium text-sm hover:opacity-90 transition-opacity disabled:opacity-50"
                 onClick={handleCloudLogin}
                 disabled={elizaCloudLoginBusy}
               >

--- a/packages/app-core/src/components/CodingAgentSettingsSection.tsx
+++ b/packages/app-core/src/components/CodingAgentSettingsSection.tsx
@@ -447,7 +447,7 @@ export function CodingAgentSettingsSection() {
               size="sm"
               className={`flex-1 h-9 rounded-lg border border-transparent px-3 py-2 text-xs font-semibold ${
                 active
-                  ? "bg-accent text-accent-foreground shadow-sm"
+                  ? "bg-accent text-accent-fg shadow-sm"
                   : "text-muted hover:bg-bg-hover hover:text-txt"
               }`}
               onClick={() => setActiveTab(agent)}

--- a/packages/app-core/src/components/MediaSettingsSection.tsx
+++ b/packages/app-core/src/components/MediaSettingsSection.tsx
@@ -1177,7 +1177,7 @@ export function MediaSettingsSection() {
 
       {/* biome-ignore lint/a11y/useSemanticElements: existing pattern */}
       <div
-        className="flex flex-col gap-4 rounded-xl border border-border/70 border-l-[3px] border-l-accent bg-card/85 px-3 py-3 shadow-sm"
+        className="flex flex-col gap-4 rounded-xl border border-border/70 bg-card/85 px-3 py-3 shadow-sm"
         data-testid="settings-media-generate-group"
         role="region"
         aria-label={t("mediasettingssection.GenerateGroupRegionLabel", {

--- a/packages/app-core/src/components/ShellOverlays.test.tsx
+++ b/packages/app-core/src/components/ShellOverlays.test.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { describe, expect, it, vi } from "vitest";
+import { ShellOverlays } from "./ShellOverlays";
+
+vi.mock("@miladyai/ui", () => ({
+  Spinner: (props: Record<string, unknown>) =>
+    React.createElement("div", { "data-testid": "spinner", ...props }),
+}));
+
+vi.mock("./BugReportModal", () => ({
+  BugReportModal: () => null,
+}));
+
+vi.mock("./CommandPalette", () => ({
+  CommandPalette: () => null,
+}));
+
+vi.mock("./GlobalEmoteOverlay", () => ({
+  GlobalEmoteOverlay: () => null,
+}));
+
+vi.mock("./RestartBanner", () => ({
+  RestartBanner: () => null,
+}));
+
+vi.mock("./ShortcutsOverlay", () => ({
+  ShortcutsOverlay: () => null,
+}));
+
+describe("ShellOverlays", () => {
+  it("uses accent foreground text for accent action notices", () => {
+    let tree: TestRenderer.ReactTestRenderer;
+    act(() => {
+      tree = TestRenderer.create(
+        <ShellOverlays
+          actionNotice={{ tone: "info", text: "Cloud login ready" }}
+        />,
+      );
+    });
+
+    const status = tree!.root.findByProps({ role: "status" });
+    const className = String(status.props.className);
+
+    expect(className).toContain("bg-accent text-accent-fg");
+    expect(className).not.toContain("text-white");
+  });
+
+  it.each([
+    ["error", "bg-danger text-white"],
+    ["success", "bg-ok text-white"],
+  ] as const)("keeps white text on %s notices", (tone, expectedClass) => {
+    let tree: TestRenderer.ReactTestRenderer;
+    act(() => {
+      tree = TestRenderer.create(
+        <ShellOverlays
+          actionNotice={{ tone, text: `${tone} message`, busy: true }}
+        />,
+      );
+    });
+
+    const status = tree!.root.findByProps({ role: "status" });
+    const className = String(status.props.className);
+
+    expect(className).toContain(expectedClass);
+    expect(tree!.root.findByProps({ "data-testid": "spinner" })).toBeTruthy();
+  });
+});

--- a/packages/app-core/src/components/ShellOverlays.tsx
+++ b/packages/app-core/src/components/ShellOverlays.tsx
@@ -20,12 +20,12 @@ export function ShellOverlays({
       <GlobalEmoteOverlay />
       {actionNotice && (
         <div
-          className={`fixed bottom-6 left-1/2 -translate-x-1/2 px-5 py-2.5 rounded-lg text-[13px] font-medium z-[10000] text-white flex items-center gap-2.5 max-w-[min(92vw,28rem)] ${
+          className={`fixed bottom-6 left-1/2 -translate-x-1/2 px-5 py-2.5 rounded-lg text-[13px] font-medium z-[10000] flex items-center gap-2.5 max-w-[min(92vw,28rem)] ${
             actionNotice.tone === "error"
-              ? "bg-danger"
+              ? "bg-danger text-white"
               : actionNotice.tone === "success"
-                ? "bg-ok"
-                : "bg-accent"
+                ? "bg-ok text-white"
+                : "bg-accent text-accent-fg"
           }`}
           role="status"
           aria-live="polite"

--- a/packages/app-core/src/components/permissions/StreamingPermissions.tsx
+++ b/packages/app-core/src/components/permissions/StreamingPermissions.tsx
@@ -388,8 +388,7 @@ export function StreamingPermissionsOnboardingView({
         <Button
           variant="default"
           data-testid="permissions-onboarding-continue"
-          className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-white text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
-          style={{ textShadow: "0 1px 6px rgba(3,5,10,0.55)" }}
+          className="group relative inline-flex items-center justify-center gap-[8px] px-[32px] py-[12px] min-h-[44px] bg-[rgba(240,185,11,0.18)] border border-[rgba(240,185,11,0.35)] rounded-[6px] text-accent-fg text-[11px] font-semibold tracking-[0.18em] uppercase cursor-pointer transition-all duration-300 overflow-hidden hover:bg-[rgba(240,185,11,0.28)] hover:border-[rgba(240,185,11,0.6)] disabled:opacity-40 disabled:cursor-not-allowed"
           onClick={(e) => {
             if (e?.currentTarget) {
               const rect = e.currentTarget.getBoundingClientRect();

--- a/packages/ui/src/components/ui/button.test.ts
+++ b/packages/ui/src/components/ui/button.test.ts
@@ -3,9 +3,15 @@ import { buttonVariants } from "./button";
 
 describe("buttonVariants", () => {
   describe("default variant", () => {
-    it("includes bg-accent/15", () => {
+    it("includes bg-accent/18", () => {
       const classes = buttonVariants({ variant: "default" });
-      expect(classes).toContain("bg-accent/15");
+      expect(classes).toContain("bg-accent/18");
+    });
+
+    it("uses text-accent on translucent gold buttons", () => {
+      const classes = buttonVariants({ variant: "default" });
+      expect(classes).toContain("text-accent");
+      expect(classes).not.toContain("text-accent-fg");
     });
 
     it("does not include bg-primary", () => {
@@ -58,7 +64,7 @@ describe("buttonVariants", () => {
     it("falls back to default variant classes", () => {
       const withDefault = buttonVariants({ variant: "default" });
       const withoutVariant = buttonVariants({});
-      expect(withoutVariant).toContain("bg-accent/15");
+      expect(withoutVariant).toContain("bg-accent/18");
       expect(withoutVariant).toBe(withDefault);
     });
   });

--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -10,7 +10,7 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "border border-accent/45 bg-accent/18 text-accent-fg shadow-sm hover:border-accent/70 hover:bg-accent/28",
+          "border border-accent/45 bg-accent/18 text-accent shadow-sm hover:border-accent/70 hover:bg-accent/28",
         destructive:
           "border border-destructive/45 bg-destructive/92 text-destructive-fg shadow-sm hover:border-destructive/75 hover:bg-destructive",
         outline:

--- a/packages/ui/src/components/ui/theme-render.test.tsx
+++ b/packages/ui/src/components/ui/theme-render.test.tsx
@@ -24,7 +24,7 @@ describe.each(["light", "dark"] as const)("theme %s", (theme) => {
 
     expect(
       screen.getByRole("button", { name: "Continue" }).className,
-    ).toContain("text-accent-fg");
+    ).toContain("text-accent");
     expect(
       screen.getByRole("button", { name: "Continue" }).className,
     ).toContain("bg-accent/18");


### PR DESCRIPTION
## Summary
- Remove decorative `border-l-[3px] border-l-accent` from the GENERATION settings container
- The gold left border pattern should only indicate enabled/active state (as used in PluginsView), not permanent decoration

## Test plan
- [ ] Settings → GENERATION section has uniform border (no gold left accent)
- [ ] Plugins sidebar still shows gold left border on enabled plugins