### PR TITLE
docs: fix stale port, connector count, and WeChat availability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ All `@elizaos/*` packages use the `alpha` dist-tag. When developing locally, `bu
 |---------|----------|--------------|
 | API + WebSocket | 31337 | `MILADY_API_PORT` |
 | Dashboard UI | 2138 | `MILADY_PORT` |
-| Gateway | 18789 | `MILADY_GATEWAY_PORT` |
+| Gateway | 19001 | `MILADY_GATEWAY_PORT` |
 | Home Dashboard | 2142 | `MILADY_HOME_PORT` |
 | WeChat Webhook | 18790 | `MILADY_WECHAT_WEBHOOK_PORT` |
 

--- a/docs/cli/environment.md
+++ b/docs/cli/environment.md
@@ -34,7 +34,7 @@ These variables control the API server and network behavior.
 |----------|-------------|---------|
 | `MILADY_PORT` | API server port when running `milady start`. | `2138` |
 | `MILADY_API_BIND` | Bind address for the API server. Set to `0.0.0.0` to accept external connections (requires `MILADY_API_TOKEN` for security). | `127.0.0.1` |
-| `MILADY_GATEWAY_PORT` | Gateway port. Automatically set to `19001` when the `--dev` flag is used. | (unset) |
+| `MILADY_GATEWAY_PORT` | Gateway port. Automatically set to `19001` when `--profile dev` is active. | (unset) |
 | `MILADY_API_TOKEN` | Static API token for authenticating requests to the agent API server. When set, all API requests must include this token. Auto-generated if unset and bind is non-loopback. | (unset) |
 | `MILADY_ALLOW_WS_QUERY_TOKEN` | When set to `1`, allows the API token to be passed as a WebSocket query parameter (less secure; useful for some clients). | (unset) |
 | `MILADY_PAIRING_DISABLED` | When set to `1`, disables the pairing endpoint on the API server (requires `MILADY_API_TOKEN` to be set). | (unset) |

--- a/docs/guides/connectors.md
+++ b/docs/guides/connectors.md
@@ -1,7 +1,7 @@
 ---
 title: "Platform Connectors"
 sidebarTitle: "Connectors"
-description: "Platform bridges for 29 messaging platforms — 19 auto-enabled from config (Discord, Telegram, Slack, WhatsApp, Signal, iMessage, BlueBubbles, Blooio, MS Teams, Google Chat, Twitter, Farcaster, Twitch, Mattermost, Matrix, Feishu, Nostr, Lens, Retake) plus 10 installable from the registry (Bluesky, Instagram, LINE, Zalo, Twilio, GitHub, Gmail Watch, Nextcloud Talk, Tlon, WeChat)."
+description: "Platform bridges for 29 messaging platforms — 20 auto-enabled from config (Discord, Telegram, Slack, WhatsApp, Signal, iMessage, BlueBubbles, Blooio, MS Teams, Google Chat, Twitter, Farcaster, Twitch, Mattermost, Matrix, Feishu, Nostr, Lens, Retake, WeChat) plus 9 installable from the registry (Bluesky, Instagram, LINE, Zalo, Twilio, GitHub, Gmail Watch, Nextcloud Talk, Tlon)."
 ---
 
 Connectors are platform bridges that allow your agent to communicate across messaging platforms and social networks. Each connector handles authentication, message routing, session management, and platform-specific features.
@@ -65,7 +65,7 @@ Connectors marked **Auto** load automatically when their config is present in `m
 | Farcaster | Neynar API key + signer | Casts | Yes (channels) | No | Auto |
 | Twitch | Client ID + access token | Yes (chat) | Yes (channels) | No | Auto |
 | Mattermost | Bot token | Yes | Yes (channels) | No | Auto |
-| WeChat | Proxy API key + QR code | Yes | Yes | Yes | Registry |
+| WeChat | Proxy API key + QR code | Yes | Yes | Yes | Auto |
 | Matrix | Access token | Yes | Yes (rooms) | No | Auto |
 | Feishu / Lark | App ID + secret | Yes | Yes (group chats) | No | Auto |
 | Nostr | Private key (nsec/hex) | Yes (NIP-04) | N/A | No | Auto |

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -28,7 +28,7 @@ A plugin is a self-contained module that registers one or more of:
 </Card>
 
 <Card title="Platform Connectors" icon="plug" href="/plugin-registry/platform/discord">
-  Bridges to 19 messaging platforms via auto-enable (Discord, Telegram, Twitter, Slack, WhatsApp, Signal, iMessage, BlueBubbles, Blooio, MS Teams, Google Chat, Mattermost, Farcaster, Twitch, Feishu, Matrix, Nostr, Lens, Retake). Additional connectors (Bluesky, Instagram, LINE, Zalo, Twilio, GitHub, Gmail Watch, Nextcloud Talk, Tlon, WeChat) are available in the elizaOS registry.
+  Bridges to 20 messaging platforms via auto-enable (Discord, Telegram, Twitter, Slack, WhatsApp, Signal, iMessage, BlueBubbles, Blooio, MS Teams, Google Chat, Mattermost, Farcaster, Twitch, Feishu, Matrix, Nostr, Lens, Retake, WeChat). Additional connectors (Bluesky, Instagram, LINE, Zalo, Twilio, GitHub, Gmail Watch, Nextcloud Talk, Tlon) are available in the elizaOS registry.
 </Card>
 
 <Card title="DeFi & Blockchain" icon="wallet" href="/plugin-registry/defi/evm">


### PR DESCRIPTION
- CLAUDE.md: gateway dev port 18789 → 19001 (verified in profile.ts)
- cli/environment.md: --dev flag → --profile dev for gateway port
- plugins/overview.md: 19 → 20 auto-enabled connectors (WeChat is auto)
- guides/connectors.md: WeChat Registry → Auto, 19+10 → 20+9

https://claude.ai/code/session_01SajhY2wVJD6FPxmAkA1My5

This PR will be reviewed by an AI agent. Provide clear context to help it assess your changes.

Aesthetic/UI changes that don't improve agent capability are out of scope and will be rejected.

## Category
- [ ] Bug fix
- [ ] Security fix
- [ ] Performance improvement
- [ ] New feature
- [ ] Documentation
- [ ] Test coverage
- [ ] Other

## What
(brief description)

## Why
(motivation)

## How
(implementation approach)

## Testing
(what was tested, how to verify)
