### PR TITLE
fix: de-duplicate connectors sidebar header

### DIFF
--- a/packages/app-core/src/components/PluginsView.tsx
+++ b/packages/app-core/src/components/PluginsView.tsx
@@ -126,6 +126,7 @@ import { autoLabel } from "./labels";
 import { SHOWCASE_PLUGIN } from "./plugins/showcase-data";
 import { SETTINGS_FILTER_CONTROL_CLASSNAME } from "./settings-control-primitives";
 import {
+  APP_SIDEBAR_COMPACT_PILL_CLASSNAME,
   APP_DESKTOP_INLINE_SPLIT_SHELL_CLASSNAME,
   APP_DESKTOP_SIDEBAR_RAIL_STANDARD_CLASSNAME,
   APP_DESKTOP_SPLIT_SHELL_CLASSNAME,
@@ -2157,6 +2158,8 @@ function PluginListView({ label, mode = "all", inModal }: PluginListViewProps) {
       mode === "social"
         ? t("nav.social", { defaultValue: "Connectors" })
         : label;
+    const showSidebarKicker = mode !== "social" || inModal;
+    const showSidebarAvailabilityPill = mode === "social" && !inModal;
     const shellEmptyTitle =
       mode === "social" ? "No connectors available" : "No plugins available";
     const shellEmptyDescription =
@@ -2184,16 +2187,31 @@ function PluginListView({ label, mode = "all", inModal }: PluginListViewProps) {
               className={`flex min-h-0 w-[21rem] max-w-[352px] shrink-0 flex-col ${APP_SIDEBAR_RAIL_CLASSNAME}`}
             >
               <div className={APP_SIDEBAR_INNER_CLASSNAME}>
-                <div className={APP_SIDEBAR_HEADER_CLASSNAME}>
-                  <div className={APP_SIDEBAR_KICKER_CLASSNAME}>
-                    {shellTitle}
+                {showSidebarKicker ? (
+                  <div className={APP_SIDEBAR_HEADER_CLASSNAME}>
+                    <div className={APP_SIDEBAR_KICKER_CLASSNAME}>
+                      {shellTitle}
+                    </div>
+                    <div className={APP_SIDEBAR_META_CLASSNAME}>
+                      {visiblePlugins.length} available
+                    </div>
                   </div>
-                  <div className={APP_SIDEBAR_META_CLASSNAME}>
-                    {visiblePlugins.length} available
+                ) : showSidebarAvailabilityPill ? (
+                  <div className="mb-3 flex items-center justify-end px-1">
+                    <div
+                      data-testid="connectors-available-pill"
+                      className={`${APP_SIDEBAR_COMPACT_PILL_CLASSNAME} text-[10px] font-semibold uppercase tracking-[0.14em] text-txt-strong`}
+                    >
+                      {visiblePlugins.length} available
+                    </div>
                   </div>
-                </div>
+                ) : null}
 
-                <div className="mt-4 grid grid-cols-[minmax(0,1fr)_8.75rem] items-center gap-2">
+                <div
+                  className={`grid grid-cols-[minmax(0,1fr)_8.75rem] items-center gap-2 ${
+                    showSidebarKicker ? "mt-4" : ""
+                  }`}
+                >
                   <Input
                     type="search"
                     value={pluginSearch}

--- a/packages/app-core/test/app/plugins-view-game-modal.test.tsx
+++ b/packages/app-core/test/app/plugins-view-game-modal.test.tsx
@@ -358,6 +358,15 @@ describe("PluginsView game modal", () => {
         (node) => node.props?.["data-testid"] === "connectors-settings-sidebar",
       ).length,
     ).toBe(1);
+    const sidebar = tree?.root.findAll(
+      (node) => node.props?.["data-testid"] === "connectors-settings-sidebar",
+    )[0];
+    expect(
+      tree?.root.findAll(
+        (node) => node.props?.["data-testid"] === "connectors-available-pill",
+      ).length,
+    ).toBe(0);
+    expect(text(sidebar).startsWith("nav.social2 available")).toBe(true);
     const shell = tree?.root.findAll(
       (node) => node.props?.["data-testid"] === "connectors-shell",
     )[0];
@@ -627,6 +636,16 @@ describe("PluginsView game modal", () => {
     expect(text(tree?.root)).toContain("GitHub");
     expect(text(tree?.root)).toContain("Iq");
     expect(text(tree?.root)).not.toContain("Retake.tv");
+    const sidebar = tree?.root.findAll(
+      (node) => node.props?.["data-testid"] === "connectors-settings-sidebar",
+    )[0];
+    expect(sidebar).toBeDefined();
+    const availabilityPill = tree?.root.findAll(
+      (node) => node.props?.["data-testid"] === "connectors-available-pill",
+    )[0];
+    expect(availabilityPill).toBeDefined();
+    expect(text(availabilityPill)).toBe("4 available");
+    expect(text(sidebar).startsWith("4 available")).toBe(true);
 
     const addButtons = tree?.root.findAll(
       (node) =>


### PR DESCRIPTION
## Summary
- remove the redundant desktop Connectors sidebar title when the page is already selected in main nav
- replace the orphaned header row with a compact availability pill so the sidebar still has useful metadata
- keep inline and modal social/connectors renders titled, and add rendered regression coverage for both paths

## Verification
- /Users/mac/.bun/bin/bunx vitest run packages/app-core/test/app/plugins-view-game-modal.test.tsx packages/app-core/test/app/connectors-ui.e2e.test.ts
- git diff --check