### PR TITLE
fix: remove duplicate character save action

### DIFF
--- a/packages/app-core/src/App.tsx
+++ b/packages/app-core/src/App.tsx
@@ -587,9 +587,6 @@ export function App() {
         onToggleVoiceMute={() =>
           setState("chatAgentVoiceMuted", !chatAgentVoiceMuted)
         }
-        onSave={handleSaveCharacter}
-        isSaving={characterSaving}
-        saveSuccess={Boolean(characterSaveSuccess)}
       />
       <main className="flex flex-1 min-h-0 min-w-0 overflow-hidden px-3 xl:px-5 pb-4 pt-2 xl:pb-6">
         <ViewRouter characterSceneVisible />

--- a/packages/app-core/src/components/Header.test.tsx
+++ b/packages/app-core/src/components/Header.test.tsx
@@ -199,6 +199,11 @@ describe("Header", () => {
         "data-testid": "header-cloud-status",
       }),
     ).toHaveLength(0);
+    expect(
+      (testRenderer as ReactTestRenderer).root.findAll(
+        (node) => node.props["aria-label"] === "charactereditor.Save",
+      ),
+    ).toHaveLength(0);
   });
 
   it("uses minimal chrome in companion mode", async () => {

--- a/packages/app-core/src/components/Header.tsx
+++ b/packages/app-core/src/components/Header.tsx
@@ -309,19 +309,6 @@ export function Header({
                   ? undefined
                   : () => void handleNewConversation()
               }
-              onSave={
-                activeShellView === "character"
-                  ? handleSaveCharacter
-                  : undefined
-              }
-              isSaving={
-                activeShellView === "character" ? characterSaving : false
-              }
-              saveSuccess={
-                activeShellView === "character"
-                  ? Boolean(characterSaveSuccess)
-                  : false
-              }
               trailingExtras={
                 showNavigationMenu ? (
                   <Button

--- a/packages/app-core/src/components/companion/companion-header-character.test.ts
+++ b/packages/app-core/src/components/companion/companion-header-character.test.ts
@@ -18,7 +18,7 @@ describe("character editor header", () => {
     const after = source.slice(charBlock, charBlock + 800);
     expect(after).toContain("CompanionHeader");
     expect(after).toContain('activeShellView="character"');
-    expect(after).toContain("onSave");
+    expect(after).not.toContain("onSave");
   });
 
   it("CompanionHeader accepts onSave/isSaving/saveSuccess props", () => {


### PR DESCRIPTION
## Summary
- remove the duplicate header-level Save action from character mode
- keep CharacterEditor as the single owner of save UX in both header and scene-overlay character flows
- update header and companion character tests so this duplication does not regress

## Verification
- /Users/mac/.bun/bin/bunx vitest run packages/app-core/src/components/Header.test.tsx packages/app-core/src/components/companion/companion-header-character.test.ts
- git diff --check