### PR TITLE
fix: abort timed out onboarding imports

### DIFF
--- a/packages/app-core/src/components/onboarding/IdentityStep.tsx
+++ b/packages/app-core/src/components/onboarding/IdentityStep.tsx
@@ -1,20 +1,21 @@
 import { dispatchAppEmoteEvent } from "@miladyai/app-core/events";
 import { useApp } from "@miladyai/app-core/state";
-import { PREMADE_VOICES } from "../../voice/types";
-import { resolveApiUrl } from "../../utils/asset-url";
+import { getStylePresets } from "@miladyai/shared/onboarding-presets";
+import { Button, Input } from "@miladyai/ui";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   fetchWithTimeout,
   resolveCompatApiToken,
 } from "../../utils/api-request";
+import { resolveApiUrl } from "../../utils/asset-url";
 import { getElizaApiToken } from "../../utils/eliza-globals";
-import { getStylePresets } from "@miladyai/shared/onboarding-presets";
-import { Button, Input } from "@miladyai/ui";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { PREMADE_VOICES } from "../../voice/types";
 import {
   CharacterRoster,
   type CharacterRosterEntry,
   resolveRosterEntries,
 } from "../CharacterRoster";
+import { resolvePreviewTtsEndpoints } from "./identity-preview-tts";
 import {
   OnboardingStepHeader,
   onboardingBodyTextShadowStyle,
@@ -26,7 +27,8 @@ import {
   onboardingSecondaryActionTextShadowStyle,
   spawnOnboardingRipple,
 } from "./onboarding-step-chrome";
-import { resolvePreviewTtsEndpoints } from "./identity-preview-tts";
+
+const IMPORT_AGENT_FETCH_TIMEOUT_MS = 60_000;
 
 export function IdentityStep() {
   const { onboardingStyle, handleOnboardingNext, setState, t, uiLanguage } =
@@ -258,6 +260,7 @@ export function IdentityStep() {
           },
           body: envelope,
         },
+        IMPORT_AGENT_FETCH_TIMEOUT_MS,
       );
 
       const responseText = await response.text();

--- a/packages/app-core/src/utils/api-request.test.ts
+++ b/packages/app-core/src/utils/api-request.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_BOOT_CONFIG, setBootConfig } from "../config/boot-config";
+import {
+  DEFAULT_FETCH_TIMEOUT_MS,
+  fetchWithTimeout,
+  resolveCompatApiToken,
+} from "./api-request";
+
+describe("api-request", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    setBootConfig(DEFAULT_BOOT_CONFIG);
+  });
+
+  it("aborts the underlying fetch when the timeout expires", async () => {
+    vi.useFakeTimers();
+    let aborted = false;
+    const fetchMock = vi.fn(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => {
+              aborted = true;
+              reject(
+                new DOMException("The operation was aborted.", "AbortError"),
+              );
+            },
+            { once: true },
+          );
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const pending = fetchWithTimeout("/api/test");
+    const rejection = expect(pending).rejects.toThrow(
+      `Request timed out after ${DEFAULT_FETCH_TIMEOUT_MS}ms`,
+    );
+
+    await vi.advanceTimersByTimeAsync(DEFAULT_FETCH_TIMEOUT_MS + 1);
+
+    await rejection;
+    expect(aborted).toBe(true);
+  });
+
+  it("maps upstream aborts to a stable request aborted error", async () => {
+    const controller = new AbortController();
+    const fetchMock = vi.fn(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => {
+              reject(
+                new DOMException("The operation was aborted.", "AbortError"),
+              );
+            },
+            { once: true },
+          );
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const pending = fetchWithTimeout("/api/test", {
+      signal: controller.signal,
+    });
+    controller.abort();
+
+    await expect(pending).rejects.toThrow("Request aborted");
+  });
+
+  it("prefers session storage tokens over boot config", () => {
+    const storage = new Map<string, string>([
+      ["milady_api_token", " session-token "],
+    ]);
+    vi.stubGlobal("sessionStorage", {
+      getItem: (key: string) => storage.get(key) ?? null,
+    });
+    setBootConfig({
+      ...DEFAULT_BOOT_CONFIG,
+      apiToken: "boot-token",
+      branding: {},
+    });
+
+    expect(resolveCompatApiToken()).toBe("session-token");
+  });
+});

--- a/packages/app-core/src/utils/api-request.ts
+++ b/packages/app-core/src/utils/api-request.ts
@@ -36,39 +36,42 @@ export async function fetchWithTimeout(
   init?: RequestInit,
   timeoutMs = DEFAULT_FETCH_TIMEOUT_MS,
 ): Promise<Response> {
+  const controller = new AbortController();
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  let abortListener: (() => void) | undefined;
-  const fetchPromise = fetch(input, init);
-  const pending: Promise<Response>[] = [fetchPromise];
-
-  pending.push(
-    new Promise<Response>((_, reject) => {
-      timeoutId = setTimeout(() => {
-        reject(new Error(`Request timed out after ${timeoutMs}ms`));
-      }, timeoutMs);
-    }),
-  );
+  let upstreamAbortListener: (() => void) | undefined;
+  let timedOut = false;
+  let aborted = false;
 
   if (init?.signal) {
     if (init.signal.aborted) {
       throw new Error("Request aborted");
     }
-
-    pending.push(
-      new Promise<Response>((_, reject) => {
-        abortListener = () => {
-          reject(new Error("Request aborted"));
-        };
-        init.signal?.addEventListener("abort", abortListener, {
-          once: true,
-        });
-      }),
-    );
+    upstreamAbortListener = () => {
+      aborted = true;
+      controller.abort();
+    };
+    init.signal.addEventListener("abort", upstreamAbortListener, {
+      once: true,
+    });
   }
 
+  timeoutId = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, timeoutMs);
+
   try {
-    return await Promise.race(pending);
+    return await fetch(input, {
+      ...init,
+      signal: controller.signal,
+    });
   } catch (error) {
+    if (timedOut) {
+      throw new Error(`Request timed out after ${timeoutMs}ms`);
+    }
+    if (aborted) {
+      throw new Error("Request aborted");
+    }
     if (error instanceof Error) {
       throw error;
     }
@@ -77,8 +80,8 @@ export async function fetchWithTimeout(
     if (timeoutId !== undefined) {
       clearTimeout(timeoutId);
     }
-    if (init?.signal && abortListener) {
-      init.signal.removeEventListener("abort", abortListener);
+    if (init?.signal && upstreamAbortListener) {
+      init.signal.removeEventListener("abort", upstreamAbortListener);
     }
   }
 }

--- a/packages/app-core/test/app/onboarding-steps.test.tsx
+++ b/packages/app-core/test/app/onboarding-steps.test.tsx
@@ -227,11 +227,12 @@ describe("IdentityStep", () => {
 
   it("shows a friendly status error when import returns a non-JSON 5xx body", async () => {
     mockUseApp.mockReturnValue(baseContext({ onboardingStep: "identity" }));
-    const fetchMock = vi.fn(async () =>
-      new Response("<html>bad gateway</html>", {
-        status: 502,
-        headers: { "Content-Type": "text/html" },
-      }),
+    const fetchMock = vi.fn(
+      async () =>
+        new Response("<html>bad gateway</html>", {
+          status: 502,
+          headers: { "Content-Type": "text/html" },
+        }),
     );
     vi.stubGlobal("fetch", fetchMock);
 
@@ -253,7 +254,9 @@ describe("IdentityStep", () => {
       const inputs = (tree?.root as TestRenderer.ReactTestInstance).findAll(
         (node) => node.type === "input",
       );
-      const fileInput = inputs.find((node) => node.props.accept === ".eliza-agent");
+      const fileInput = inputs.find(
+        (node) => node.props.accept === ".eliza-agent",
+      );
       const passwordInput = inputs.find(
         (node) =>
           node.props.placeholder === "onboarding.decryptionPasswordPlaceholder",
@@ -301,13 +304,15 @@ describe("IdentityStep", () => {
       },
       expectedToken: "boot-token",
     },
-  ])(
-    "sends Authorization header from %s during onboarding import",
-    async ({ setup, expectedToken }) => {
-      mockUseApp.mockReturnValue(baseContext({ onboardingStep: "identity" }));
-      setup();
+  ])("sends Authorization header from %s during onboarding import", async ({
+    setup,
+    expectedToken,
+  }) => {
+    mockUseApp.mockReturnValue(baseContext({ onboardingStep: "identity" }));
+    setup();
 
-      const fetchMock = vi.fn(async () =>
+    const fetchMock = vi.fn(
+      async () =>
         new Response(
           JSON.stringify({
             success: true,
@@ -319,75 +324,86 @@ describe("IdentityStep", () => {
             headers: { "Content-Type": "application/json" },
           },
         ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    let tree: TestRenderer.ReactTestRenderer | undefined;
+    try {
+      await act(async () => {
+        tree = TestRenderer.create(React.createElement(IdentityStep));
+      });
+
+      const restoreBtn = findButtons(
+        tree?.root as TestRenderer.ReactTestInstance,
+      ).find(
+        (button) => collectText(button) === "onboarding.restoreFromBackup",
       );
-      vi.stubGlobal("fetch", fetchMock);
+      expect(restoreBtn).toBeDefined();
 
-      let tree: TestRenderer.ReactTestRenderer | undefined;
-      try {
-        await act(async () => {
-          tree = TestRenderer.create(React.createElement(IdentityStep));
-        });
+      await act(async () => {
+        restoreBtn?.props.onClick();
+      });
 
-        const restoreBtn = findButtons(
-          tree?.root as TestRenderer.ReactTestInstance,
-        ).find((button) => collectText(button) === "onboarding.restoreFromBackup");
-        expect(restoreBtn).toBeDefined();
+      const inputs = (tree?.root as TestRenderer.ReactTestInstance).findAll(
+        (node) => node.type === "input",
+      );
+      const fileInput = inputs.find(
+        (node) => node.props.accept === ".eliza-agent",
+      );
+      const passwordInput = inputs.find(
+        (node) =>
+          node.props.placeholder === "onboarding.decryptionPasswordPlaceholder",
+      );
+      expect(fileInput).toBeDefined();
+      expect(passwordInput).toBeDefined();
 
-        await act(async () => {
-          restoreBtn?.props.onClick();
-        });
+      const mockFile = {
+        arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer,
+      } as File;
 
-        const inputs = (tree?.root as TestRenderer.ReactTestInstance).findAll(
-          (node) => node.type === "input",
-        );
-        const fileInput = inputs.find((node) => node.props.accept === ".eliza-agent");
-        const passwordInput = inputs.find(
-          (node) =>
-            node.props.placeholder === "onboarding.decryptionPasswordPlaceholder",
-        );
-        expect(fileInput).toBeDefined();
-        expect(passwordInput).toBeDefined();
+      await act(async () => {
+        fileInput?.props.onChange({ target: { files: [mockFile] } });
+        passwordInput?.props.onChange({ target: { value: "pass1234" } });
+      });
 
-        const mockFile = {
-          arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer,
-        } as File;
+      const importBtn = findButtons(
+        tree?.root as TestRenderer.ReactTestInstance,
+      ).find((button) => collectText(button) === "onboarding.restore");
+      expect(importBtn).toBeDefined();
 
-        await act(async () => {
-          fileInput?.props.onChange({ target: { files: [mockFile] } });
-          passwordInput?.props.onChange({ target: { value: "pass1234" } });
-        });
+      await act(async () => {
+        await importBtn?.props.onClick(makeButtonClickEvent());
+      });
 
-        const importBtn = findButtons(
-          tree?.root as TestRenderer.ReactTestInstance,
-        ).find((button) => collectText(button) === "onboarding.restore");
-        expect(importBtn).toBeDefined();
-
-        await act(async () => {
-          await importBtn?.props.onClick(makeButtonClickEvent());
-        });
-
-        expect(fetchMock).toHaveBeenCalledWith(
-          "/api/agent/import",
-          expect.objectContaining({
-            headers: expect.objectContaining({
-              Authorization: `Bearer ${expectedToken}`,
-              "Content-Type": "application/octet-stream",
-            }),
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/agent/import",
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: `Bearer ${expectedToken}`,
+            "Content-Type": "application/octet-stream",
           }),
-        );
-      } finally {
-        vi.unstubAllGlobals();
-      }
-    },
-  );
+        }),
+      );
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
 
   it("surfaces a bounded timeout error when onboarding import hangs", async () => {
     vi.useFakeTimers();
     mockUseApp.mockReturnValue(baseContext({ onboardingStep: "identity" }));
     const fetchMock = vi.fn(
-      () =>
-        new Promise<Response>(() => {
-          // Intentionally never resolves.
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => {
+              reject(
+                new DOMException("The operation was aborted.", "AbortError"),
+              );
+            },
+            { once: true },
+          );
         }),
     );
     vi.stubGlobal("fetch", fetchMock);
@@ -400,7 +416,9 @@ describe("IdentityStep", () => {
 
       const restoreBtn = findButtons(
         tree?.root as TestRenderer.ReactTestInstance,
-      ).find((button) => collectText(button) === "onboarding.restoreFromBackup");
+      ).find(
+        (button) => collectText(button) === "onboarding.restoreFromBackup",
+      );
       expect(restoreBtn).toBeDefined();
 
       await act(async () => {
@@ -410,7 +428,9 @@ describe("IdentityStep", () => {
       const inputs = (tree?.root as TestRenderer.ReactTestInstance).findAll(
         (node) => node.type === "input",
       );
-      const fileInput = inputs.find((node) => node.props.accept === ".eliza-agent");
+      const fileInput = inputs.find(
+        (node) => node.props.accept === ".eliza-agent",
+      );
       const passwordInput = inputs.find(
         (node) =>
           node.props.placeholder === "onboarding.decryptionPasswordPlaceholder",
@@ -437,11 +457,12 @@ describe("IdentityStep", () => {
       });
 
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(10_001);
+        await vi.advanceTimersByTimeAsync(60_001);
+        await Promise.resolve();
       });
 
       const text = collectText(tree?.root as TestRenderer.ReactTestInstance);
-      expect(text).toContain("Request timed out after 10000ms");
+      expect(text).toContain("Request timed out after 60000ms");
     } finally {
       vi.useRealTimers();
       vi.unstubAllGlobals();


### PR DESCRIPTION
## Summary
- abort the live onboarding import request when a timeout fires instead of leaving the upload running in the background
- give backup import its own 60s timeout instead of the generic 10s request ceiling
- add deterministic timeout and abort coverage for the fetch helper and onboarding import flow

## Testing
- bunx vitest run packages/app-core/src/utils/api-request.test.ts packages/app-core/test/app/onboarding-steps.test.tsx
- MILADY_PRE_REVIEW_BASE=origin/develop bun run pre-review:local