### PR TITLE
fix: reset onboarding glass readability

### DIFF
--- a/packages/app-core/src/components/onboarding/ActivateStep.tsx
+++ b/packages/app-core/src/components/onboarding/ActivateStep.tsx
@@ -2,12 +2,11 @@ import { useApp } from "@miladyai/app-core/state";
 import { Button } from "@miladyai/ui";
 import { useBranding } from "../../config/branding";
 import {
+  OnboardingSecondaryActionButton,
   OnboardingStepHeader,
   onboardingFooterClass,
   onboardingPrimaryActionClass,
   onboardingPrimaryActionTextShadowStyle,
-  onboardingSecondaryActionClass,
-  onboardingSecondaryActionTextShadowStyle,
   spawnOnboardingRipple,
 } from "./onboarding-step-chrome";
 
@@ -31,15 +30,12 @@ export function ActivateStep() {
         description={t("onboarding.allConfigured")}
       />
       <div className={onboardingFooterClass}>
-        <Button
-          variant="ghost"
-          className={onboardingSecondaryActionClass}
-          style={onboardingSecondaryActionTextShadowStyle}
+        <OnboardingSecondaryActionButton
           onClick={() => handleOnboardingBack()}
           type="button"
         >
           {t("onboarding.back")}
-        </Button>
+        </OnboardingSecondaryActionButton>
         <Button
           className={onboardingPrimaryActionClass}
           style={onboardingPrimaryActionTextShadowStyle}

--- a/packages/app-core/src/components/onboarding/CloudLoginStep.test.tsx
+++ b/packages/app-core/src/components/onboarding/CloudLoginStep.test.tsx
@@ -95,6 +95,42 @@ describe("CloudLoginStep", () => {
     expect(handleOnboardingNext).toHaveBeenCalledTimes(1);
   });
 
+  it("renders the connected state with the shared compact success banner", async () => {
+    useAppMock.mockReturnValue({
+      onboardingStep: "providers",
+      elizaCloudConnected: true,
+      elizaCloudLoginBusy: false,
+      elizaCloudLoginError: "",
+      handleCloudLogin: vi.fn(),
+      handleOnboardingNext: vi.fn(),
+      handleOnboardingBack: vi.fn(),
+      t: (key: string) =>
+        key === "onboarding.cloudLoginConnected"
+          ? "Connected to Eliza Cloud"
+          : key === "onboarding.connected"
+            ? "Connected"
+            : key,
+    });
+
+    let renderer: TestRenderer.ReactTestRenderer | undefined;
+    await act(async () => {
+      renderer = TestRenderer.create(<CloudLoginStep />);
+    });
+
+    if (!renderer) {
+      throw new Error("CloudLoginStep did not render");
+    }
+
+    const statusBanner = renderer.root.findByProps({
+      "data-onboarding-status-layout": "compact",
+    });
+    expect(statusBanner.props.role).toBe("status");
+    expect(statusBanner.props.className).toContain("max-w-[24rem]");
+    expect(statusBanner.findByProps({
+      "data-onboarding-status-content": true,
+    }).children).toContain("Connected to Eliza Cloud");
+  });
+
   it("renders the back action with onboarding-owned secondary styling", async () => {
     useAppMock.mockReturnValue({
       onboardingStep: "providers",
@@ -121,8 +157,12 @@ describe("CloudLoginStep", () => {
       button.children.includes("onboarding.back"),
     );
     expect(backButton).toBeDefined();
+    expect(String(backButton?.props.className)).toContain("min-h-[44px]");
     expect(String(backButton?.props.className)).toContain(
       "hover:bg-[var(--onboarding-secondary-hover-bg)]",
+    );
+    expect(String(backButton?.props.className)).not.toContain(
+      "-webkit-text-stroke",
     );
     expect(String(backButton?.props.className)).not.toContain("bg-bg-accent");
   });

--- a/packages/app-core/src/components/onboarding/CloudLoginStep.test.tsx
+++ b/packages/app-core/src/components/onboarding/CloudLoginStep.test.tsx
@@ -94,4 +94,36 @@ describe("CloudLoginStep", () => {
 
     expect(handleOnboardingNext).toHaveBeenCalledTimes(1);
   });
+
+  it("renders the back action with onboarding-owned secondary styling", async () => {
+    useAppMock.mockReturnValue({
+      onboardingStep: "providers",
+      elizaCloudConnected: false,
+      elizaCloudLoginBusy: false,
+      elizaCloudLoginError: "",
+      handleCloudLogin: vi.fn(),
+      handleOnboardingNext: vi.fn(),
+      handleOnboardingBack: vi.fn(),
+      t: (key: string) => key,
+    });
+
+    let renderer: TestRenderer.ReactTestRenderer | undefined;
+    await act(async () => {
+      renderer = TestRenderer.create(<CloudLoginStep />);
+    });
+
+    if (!renderer) {
+      throw new Error("CloudLoginStep did not render");
+    }
+
+    const buttons = renderer.root.findAllByType("button");
+    const backButton = buttons.find((button) =>
+      button.children.includes("onboarding.back"),
+    );
+    expect(backButton).toBeDefined();
+    expect(String(backButton?.props.className)).toContain(
+      "hover:bg-[var(--onboarding-secondary-hover-bg)]",
+    );
+    expect(String(backButton?.props.className)).not.toContain("bg-bg-accent");
+  });
 });

--- a/packages/app-core/src/components/onboarding/CloudLoginStep.tsx
+++ b/packages/app-core/src/components/onboarding/CloudLoginStep.tsx
@@ -62,7 +62,7 @@ export function CloudLoginStep() {
         descriptionClassName="mx-auto mt-1 max-w-[34ch] text-balance"
       />
       <p
-        className={`${onboardingHelperTextClassName} mx-auto mt-3 max-w-[40ch] text-center text-xs`}
+        className={`${onboardingHelperTextClassName} mx-auto max-w-[40ch] text-center text-xs`}
         style={onboardingBodyTextShadowStyle}
       >
         {t("onboarding.cloudProviderBehaviorHint")}

--- a/packages/app-core/src/components/onboarding/CloudLoginStep.tsx
+++ b/packages/app-core/src/components/onboarding/CloudLoginStep.tsx
@@ -4,14 +4,19 @@ import { useEffect, useRef } from "react";
 import { useBranding } from "../../config";
 import { openExternalUrl } from "../../utils";
 import {
+  onboardingCardSurfaceClassName,
+  onboardingHelperTextClassName,
+  onboardingReadableTextMutedClassName,
+  onboardingSubtleTextClassName,
+} from "./onboarding-form-primitives";
+import {
+  OnboardingLinkActionButton,
+  OnboardingSecondaryActionButton,
   OnboardingStepHeader,
   onboardingBodyTextShadowStyle,
   onboardingFooterClass,
-  onboardingLinkActionClass,
   onboardingPrimaryActionClass,
   onboardingPrimaryActionTextShadowStyle,
-  onboardingSecondaryActionClass,
-  onboardingSecondaryActionTextShadowStyle,
   spawnOnboardingRipple,
 } from "./onboarding-step-chrome";
 
@@ -20,7 +25,7 @@ const statusCardClass =
 
 const connectedCardClass = `${statusCardClass} border-[var(--ok-muted)] bg-[var(--ok-subtle)] text-[var(--ok)]`;
 
-const busyCardClass = `${statusCardClass} border-[var(--onboarding-card-border)] bg-[var(--onboarding-card-bg)] text-[var(--onboarding-text-muted)]`;
+const busyCardClass = `${statusCardClass} ${onboardingCardSurfaceClassName} ${onboardingReadableTextMutedClassName}`;
 
 const errorCardClass = `${statusCardClass} border-[color:color-mix(in_srgb,var(--danger)_42%,transparent)] bg-[color:color-mix(in_srgb,var(--danger)_12%,transparent)] text-[var(--danger)]`;
 
@@ -57,7 +62,7 @@ export function CloudLoginStep() {
         descriptionClassName="mx-auto mt-1 max-w-[34ch] text-balance"
       />
       <p
-        className="mx-auto mt-3 max-w-[40ch] text-center text-xs leading-relaxed text-[var(--onboarding-text-muted)]"
+        className={`${onboardingHelperTextClassName} mx-auto mt-3 max-w-[40ch] text-center text-xs`}
         style={onboardingBodyTextShadowStyle}
       >
         {t("onboarding.cloudProviderBehaviorHint")}
@@ -92,14 +97,13 @@ export function CloudLoginStep() {
               >
                 {elizaCloudLoginError}
               </div>
-              <Button
-                variant="ghost"
+              <OnboardingLinkActionButton
                 type="button"
-                className={`${onboardingLinkActionClass} mx-auto mt-2`}
+                className="mx-auto mt-2"
                 onClick={() => openExternalUrl(branding.bugReportUrl)}
               >
                 {t("onboarding.reportIssue")}
-              </Button>
+              </OnboardingLinkActionButton>
             </>
           ) : null}
           <Button
@@ -119,7 +123,7 @@ export function CloudLoginStep() {
               : t("onboarding.cloudLoginBtn")}
           </Button>
           <p
-            className="mx-auto mt-3 max-w-[40ch] text-center text-xs leading-relaxed text-[var(--onboarding-text-subtle)]"
+            className={`${onboardingSubtleTextClassName} mx-auto mt-3 max-w-[40ch] text-center`}
             style={onboardingBodyTextShadowStyle}
           >
             {t("onboarding.restartAfterProviderChangeHint")}
@@ -128,15 +132,12 @@ export function CloudLoginStep() {
       )}
 
       <div className={onboardingFooterClass}>
-        <Button
-          variant="ghost"
-          className={onboardingSecondaryActionClass}
-          style={onboardingSecondaryActionTextShadowStyle}
+        <OnboardingSecondaryActionButton
           onClick={() => handleOnboardingBack()}
           type="button"
         >
           {t("onboarding.back")}
-        </Button>
+        </OnboardingSecondaryActionButton>
       </div>
     </>
   );

--- a/packages/app-core/src/components/onboarding/CloudLoginStep.tsx
+++ b/packages/app-core/src/components/onboarding/CloudLoginStep.tsx
@@ -6,8 +6,10 @@ import { openExternalUrl } from "../../utils";
 import {
   onboardingCardSurfaceClassName,
   onboardingHelperTextClassName,
+  OnboardingStatusBanner,
   onboardingReadableTextMutedClassName,
   onboardingSubtleTextClassName,
+  onboardingTextSupportClassName,
 } from "./onboarding-form-primitives";
 import {
   OnboardingLinkActionButton,
@@ -23,11 +25,27 @@ import {
 const statusCardClass =
   "mx-auto mt-4 flex w-full max-w-[25rem] items-center justify-center gap-2 rounded-2xl border px-4 py-3 text-sm leading-relaxed shadow-[0_18px_50px_rgba(3,5,10,0.2)] backdrop-blur-sm";
 
-const connectedCardClass = `${statusCardClass} border-[var(--ok-muted)] bg-[var(--ok-subtle)] text-[var(--ok)]`;
-
 const busyCardClass = `${statusCardClass} ${onboardingCardSurfaceClassName} ${onboardingReadableTextMutedClassName}`;
 
 const errorCardClass = `${statusCardClass} border-[color:color-mix(in_srgb,var(--danger)_42%,transparent)] bg-[color:color-mix(in_srgb,var(--danger)_12%,transparent)] text-[var(--danger)]`;
+
+function ConnectedIcon({ title }: { title: string }) {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <title>{title}</title>
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
 
 export function CloudLoginStep() {
   const branding = useBranding();
@@ -62,20 +80,17 @@ export function CloudLoginStep() {
         descriptionClassName="mx-auto mt-1 max-w-[34ch] text-balance"
       />
       <p
-        className={`${onboardingHelperTextClassName} mx-auto max-w-[40ch] text-center text-xs`}
+        className={`${onboardingHelperTextClassName} ${onboardingTextSupportClassName} mx-auto max-w-[40ch] text-center`}
         style={onboardingBodyTextShadowStyle}
       >
         {t("onboarding.cloudProviderBehaviorHint")}
       </p>
 
       {elizaCloudConnected ? (
-        <div
-          className={connectedCardClass}
-          role="status"
-          style={onboardingBodyTextShadowStyle}
-        >
+        <OnboardingStatusBanner tone="success" className="mt-4">
+          <ConnectedIcon title={t("onboarding.connected")} />
           {t("onboarding.cloudLoginConnected")}
-        </div>
+        </OnboardingStatusBanner>
       ) : elizaCloudLoginBusy ? (
         <div
           className={busyCardClass}

--- a/packages/app-core/src/components/onboarding/IdentityStep.tsx
+++ b/packages/app-core/src/components/onboarding/IdentityStep.tsx
@@ -22,14 +22,19 @@ import {
 } from "../CharacterRoster";
 import { resolvePreviewTtsEndpoints } from "./identity-preview-tts";
 import {
+  onboardingInputClassName,
+  onboardingReadableTextMutedClassName,
+  onboardingReadableTextStrongClassName,
+} from "./onboarding-form-primitives";
+import { onboardingPanelSurfaceClassName } from "./OnboardingPanel";
+import {
+  OnboardingLinkActionButton,
+  OnboardingSecondaryActionButton,
   OnboardingStepHeader,
   onboardingBodyTextShadowStyle,
   onboardingFooterClass,
-  onboardingLinkActionClass,
   onboardingPrimaryActionClass,
   onboardingPrimaryActionTextShadowStyle,
-  onboardingSecondaryActionClass,
-  onboardingSecondaryActionTextShadowStyle,
   spawnOnboardingRipple,
 } from "./onboarding-step-chrome";
 
@@ -336,7 +341,7 @@ export function IdentityStep({
             setImportFile(e.target.files?.[0] ?? null);
             setImportError(null);
           }}
-          className="w-full px-[20px] py-[16px] bg-[var(--onboarding-card-bg)] border border-[var(--onboarding-card-border)] rounded-[6px] text-[var(--onboarding-text-primary)] font-inherit outline-none tracking-[0.03em] transition-all duration-300 focus:border-[var(--onboarding-field-focus-border)] focus:shadow-[var(--onboarding-field-focus-shadow)] placeholder:text-[var(--onboarding-text-faint)] text-[13px] text-left"
+          className={`${onboardingInputClassName} h-auto rounded-[6px] px-[20px] py-[16px] text-[13px] font-inherit tracking-[0.03em] text-center`}
         />
 
         <Input
@@ -347,7 +352,7 @@ export function IdentityStep({
             setImportPassword(e.target.value);
             setImportError(null);
           }}
-          className="w-full px-[20px] py-[16px] bg-[var(--onboarding-card-bg)] border border-[var(--onboarding-card-border)] rounded-[6px] text-[var(--onboarding-text-primary)] font-inherit outline-none tracking-[0.03em] text-center transition-all duration-300 focus:border-[var(--onboarding-field-focus-border)] focus:shadow-[var(--onboarding-field-focus-shadow)] placeholder:text-[var(--onboarding-text-faint)]"
+          className={`${onboardingInputClassName} h-auto rounded-[6px] px-[20px] py-[16px] font-inherit tracking-[0.03em] text-center`}
         />
 
         {importError && (
@@ -368,10 +373,7 @@ export function IdentityStep({
         )}
 
         <div className={`${onboardingFooterClass} mt-2 w-full border-t-0 pt-0`}>
-          <Button
-            variant="ghost"
-            className={onboardingSecondaryActionClass}
-            style={onboardingSecondaryActionTextShadowStyle}
+          <OnboardingSecondaryActionButton
             onClick={() => {
               setShowImport(false);
               setImportError(null);
@@ -382,7 +384,7 @@ export function IdentityStep({
             type="button"
           >
             {t("common.cancel")}
-          </Button>
+          </OnboardingSecondaryActionButton>
           <Button
             className={onboardingPrimaryActionClass}
             style={onboardingPrimaryActionTextShadowStyle}
@@ -417,16 +419,16 @@ export function IdentityStep({
         style={{ animation: "onboarding-content-fade-in 0.5s ease 0.1s both" }}
       >
         <div
-          className="mb-2 text-xs font-semibold uppercase tracking-[0.3em] text-[var(--onboarding-text-muted)]"
+          className={`mb-2 text-xs font-semibold uppercase tracking-[0.3em] ${onboardingReadableTextMutedClassName}`}
           style={onboardingBodyTextShadowStyle}
         >
           {t("onboarding.stepSub.identity")}
         </div>
         <div
-          className="text-[28px] font-bold tracking-[0.12em] uppercase text-[var(--onboarding-text-strong)] transition-all duration-300 max-md:text-xl"
+          className={`text-[28px] font-bold tracking-[0.12em] uppercase transition-all duration-300 max-md:text-xl ${onboardingReadableTextStrongClassName}`}
           style={{
             textShadow:
-              "0 0 30px rgba(240,185,11,0.3), 0 2px 12px rgba(3,5,10,0.65)",
+              "0 0 24px rgba(240,185,11,0.18), var(--onboarding-text-shadow-strong)",
           }}
         >
           {selected?.name ?? ""}
@@ -435,7 +437,7 @@ export function IdentityStep({
 
       {/* ── Roster bar ── */}
       <div
-        className="flex flex-nowrap items-end justify-center gap-0 w-full max-w-[900px] px-2 max-md:px-1 max-md:max-w-full rounded-[18px] border border-[var(--onboarding-panel-border)] bg-[linear-gradient(180deg,rgba(9,12,18,0.18),rgba(9,12,18,0.08)),var(--onboarding-panel-bg)] p-4 pb-8 backdrop-blur-[36px] backdrop-saturate-[1.24] shadow-[var(--onboarding-panel-shadow)]"
+        className={`flex w-full max-w-[900px] flex-nowrap items-end justify-center gap-0 rounded-[18px] p-4 pb-8 px-2 backdrop-blur-[36px] backdrop-saturate-[1.24] max-md:max-w-full max-md:px-1 ${onboardingPanelSurfaceClassName}`}
         style={{
           animation:
             "ob-roster-slide-up 0.5s cubic-bezier(0.25,0.46,0.45,0.94) 0.15s both",
@@ -473,14 +475,12 @@ export function IdentityStep({
         >
           Continue
         </Button>
-        <Button
-          variant="link"
+        <OnboardingLinkActionButton
           type="button"
           onClick={() => setShowImport(true)}
-          className={onboardingLinkActionClass}
         >
           {t("onboarding.restoreFromBackup")}
-        </Button>
+        </OnboardingLinkActionButton>
       </div>
     </div>
   );

--- a/packages/app-core/src/components/onboarding/OnboardingPanel.test.tsx
+++ b/packages/app-core/src/components/onboarding/OnboardingPanel.test.tsx
@@ -19,5 +19,11 @@ describe("OnboardingPanel", () => {
       "absolute right-0 top-0 bottom-0",
     );
     expect(String(inner?.props.className)).toContain("max-h-full");
+    expect(String(inner?.props.className)).toContain(
+      "bg-[var(--onboarding-panel-bg)]",
+    );
+    expect(String(inner?.props.className)).toContain(
+      "var(--onboarding-panel-shadow)",
+    );
   });
 });

--- a/packages/app-core/src/components/onboarding/OnboardingPanel.tsx
+++ b/packages/app-core/src/components/onboarding/OnboardingPanel.tsx
@@ -6,6 +6,9 @@ interface OnboardingPanelProps {
   children: ReactNode;
 }
 
+export const onboardingPanelSurfaceClassName =
+  "border border-[var(--onboarding-panel-border)] bg-[var(--onboarding-panel-bg)] shadow-[var(--onboarding-panel-shadow)]";
+
 export function OnboardingPanel({ step, children }: OnboardingPanelProps) {
   const panelRef = useRef<HTMLDivElement>(null);
   const prevStepRef = useRef(step);
@@ -32,7 +35,7 @@ export function OnboardingPanel({ step, children }: OnboardingPanelProps) {
   return (
     <div className="absolute right-0 top-0 bottom-0 z-10 flex min-h-0 w-full max-w-[min(100%,32rem)] flex-col items-end justify-center py-[clamp(1rem,5vh,2.5rem)] pr-[clamp(1rem,4vw,3.5rem)] pl-0 max-lg:max-w-[min(100%,28rem)] max-lg:pr-8 max-md:relative max-md:max-w-none max-md:items-stretch max-md:justify-end max-md:px-4 max-md:pb-4 max-md:pt-2">
       <div
-        className="onboarding-panel relative flex max-h-full min-h-0 w-full max-w-[30rem] flex-col gap-0 overflow-x-hidden overflow-y-auto rounded-[18px] border border-[var(--onboarding-panel-border)] bg-[linear-gradient(180deg,rgba(9,12,18,0.18),rgba(9,12,18,0.08)),var(--onboarding-panel-bg)] py-[clamp(1.5rem,4vw,2.25rem)] px-[clamp(1rem,3vw,1.5rem)] shadow-[var(--onboarding-panel-shadow)] backdrop-blur-[36px] backdrop-saturate-[1.24] animate-[onboarding-panel-enter_0.6s_cubic-bezier(0.25,0.46,0.45,0.94)_both] max-md:max-h-[min(60dvh,calc(100dvh-8.5rem))] max-md:max-w-none max-md:rounded-[16px]"
+        className={`onboarding-panel relative flex max-h-full min-h-0 w-full max-w-[30rem] flex-col gap-0 overflow-x-hidden overflow-y-auto rounded-[18px] py-[clamp(1.5rem,4vw,2.25rem)] px-[clamp(1rem,3vw,1.5rem)] backdrop-blur-[36px] backdrop-saturate-[1.24] animate-[onboarding-panel-enter_0.6s_cubic-bezier(0.25,0.46,0.45,0.94)_both] max-md:max-h-[min(60dvh,calc(100dvh-8.5rem))] max-md:max-w-none max-md:rounded-[16px] ${onboardingPanelSurfaceClassName}`}
         ref={panelRef}
       >
         {children}

--- a/packages/app-core/src/components/onboarding/OnboardingTabs.tsx
+++ b/packages/app-core/src/components/onboarding/OnboardingTabs.tsx
@@ -1,3 +1,10 @@
+import {
+  onboardingCardSurfaceClassName,
+  onboardingCardSurfaceHoverClassName,
+  onboardingReadableTextFaintClassName,
+  onboardingReadableTextStrongClassName,
+} from "./onboarding-form-primitives";
+
 /** Glassmorphic pill-style tab switcher for onboarding panels. */
 export function OnboardingTabs<T extends string>({
   tabs,
@@ -9,7 +16,9 @@ export function OnboardingTabs<T extends string>({
   onChange: (id: T) => void;
 }) {
   return (
-    <div className="flex items-center gap-[4px] p-[3px] rounded-[8px] bg-[var(--onboarding-card-bg)] backdrop-blur-[12px] border border-[var(--onboarding-card-border)] w-fit mx-auto mb-4">
+    <div
+      className={`mx-auto mb-4 flex w-fit items-center gap-[4px] rounded-[8px] p-[3px] backdrop-blur-[12px] ${onboardingCardSurfaceClassName}`}
+    >
       {tabs.map((tab) => {
         const isActive = tab.id === active;
         return (
@@ -19,10 +28,9 @@ export function OnboardingTabs<T extends string>({
             onClick={() => onChange(tab.id)}
             className={`relative px-[20px] py-[7px] rounded-[6px] text-[11px] font-semibold tracking-[0.14em] uppercase cursor-pointer transition-all duration-300 border-none outline-none ${
               isActive
-                ? "bg-[var(--onboarding-accent-bg)] text-[var(--onboarding-text-strong)] shadow-[0_0_8px_rgba(240,185,11,0.12)]"
-                : "bg-transparent text-[var(--onboarding-text-faint)] hover:text-[var(--onboarding-link)] hover:bg-[var(--onboarding-card-bg-hover)]"
+                ? `bg-[var(--onboarding-accent-bg)] shadow-[0_0_8px_rgba(240,185,11,0.12)] ${onboardingReadableTextStrongClassName}`
+                : `bg-transparent hover:text-[var(--onboarding-link)] ${onboardingReadableTextFaintClassName} ${onboardingCardSurfaceHoverClassName}`
             }`}
-            style={{ textShadow: "0 1px 6px rgba(3,5,10,0.5)" }}
           >
             {tab.label}
           </button>

--- a/packages/app-core/src/components/onboarding/RpcStep.tsx
+++ b/packages/app-core/src/components/onboarding/RpcStep.tsx
@@ -2,40 +2,50 @@ import { useApp } from "@miladyai/app-core/state";
 import { Button, Input } from "@miladyai/ui";
 import { useState } from "react";
 import {
+  onboardingCardSurfaceClassName,
+  onboardingCardSurfaceHoverClassName,
+  onboardingFieldLabelClassName,
+  onboardingHelperTextClassName,
+  onboardingInputClassName,
+  onboardingReadableTextPrimaryClassName,
+  onboardingSubtleTextClassName,
+  onboardingRecommendedSurfaceClassName,
+  onboardingRecommendedSurfaceHoverClassName,
+} from "./onboarding-form-primitives";
+import {
+  OnboardingSecondaryActionButton,
   OnboardingStepHeader,
   onboardingBodyTextShadowStyle,
   onboardingFooterClass,
   onboardingPrimaryActionClass,
   onboardingPrimaryActionTextShadowStyle,
-  onboardingSecondaryActionClass,
-  onboardingSecondaryActionTextShadowStyle,
   spawnOnboardingRipple,
 } from "./onboarding-step-chrome";
 
 type RpcMode = "" | "cloud" | "byok";
 
 const rpcModeCardBaseClass =
-  "flex min-h-[76px] w-full items-center justify-center rounded-2xl border px-4 py-3 text-center backdrop-blur-[18px] backdrop-saturate-[1.2] transition-all duration-300";
+  "flex min-h-[76px] w-full items-center justify-center rounded-2xl px-4 py-3 text-center backdrop-blur-[18px] backdrop-saturate-[1.2] transition-all duration-300";
 
 const rpcModeTitleClass =
-  "text-sm font-semibold leading-tight text-[var(--onboarding-text-primary)]";
+  `text-sm font-semibold leading-tight ${onboardingReadableTextPrimaryClassName}`;
 
 const rpcModeDescriptionClass =
-  "mt-1 text-xs leading-[1.45] text-[var(--onboarding-text-subtle)]";
+  `mt-1 text-xs leading-[1.45] ${onboardingSubtleTextClassName}`;
 
 const rpcCalloutClass =
-  "mx-auto mt-4 flex w-full max-w-[25rem] items-center justify-center gap-2 rounded-2xl border px-4 py-3 text-sm leading-relaxed shadow-[0_18px_50px_rgba(3,5,10,0.2)] backdrop-blur-sm";
+  `mx-auto mt-4 flex w-full max-w-[25rem] items-center justify-center gap-2 rounded-2xl px-4 py-3 text-sm leading-relaxed backdrop-blur-sm ${onboardingCardSurfaceClassName}`;
 
 const rpcFieldStackClass = "mx-auto w-full max-w-[27rem] space-y-4 text-left";
 
 const rpcFieldLabelClass =
-  "mb-1.5 block text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--onboarding-text-muted)]";
+  `mb-1.5 block text-[11px] tracking-[0.14em] ${onboardingFieldLabelClassName}`;
 
 const rpcFieldHintClass =
-  "mb-2 text-xs leading-relaxed text-[var(--onboarding-text-subtle)]";
+  `mb-2 ${onboardingSubtleTextClassName}`;
 
 const rpcInputClass =
-  "w-full rounded-xl border border-[var(--onboarding-card-border)] bg-[var(--onboarding-card-bg)] px-4 py-3 text-left text-sm tracking-[0.01em] text-[var(--onboarding-text-primary)] outline-none transition-[border-color,box-shadow,background-color] duration-300 placeholder:text-[var(--onboarding-text-faint)] focus:border-[var(--onboarding-field-focus-border)] focus:shadow-[var(--onboarding-field-focus-shadow)]";
+  `${onboardingInputClassName} h-auto px-4 py-3 text-sm tracking-[0.01em]`;
 
 function RpcModeCard({
   title,
@@ -54,8 +64,8 @@ function RpcModeCard({
       variant={tone === "recommended" ? "default" : "outline"}
       className={`${rpcModeCardBaseClass} ${
         tone === "recommended"
-          ? "border-[var(--onboarding-recommended-border)] bg-[var(--onboarding-recommended-bg)] hover:border-[var(--onboarding-recommended-border-strong)] hover:bg-[var(--onboarding-recommended-bg-hover)]"
-          : "border-[var(--onboarding-card-border)] bg-[var(--onboarding-card-bg)] hover:border-[var(--onboarding-card-border-strong)] hover:bg-[var(--onboarding-card-bg-hover)]"
+          ? `${onboardingRecommendedSurfaceClassName} ${onboardingRecommendedSurfaceHoverClassName}`
+          : `${onboardingCardSurfaceClassName} ${onboardingCardSurfaceHoverClassName}`
       }`}
       onClick={onClick}
     >
@@ -115,7 +125,7 @@ function CloudLoginErrorMessage({ error }: { error: string }) {
   if (urlMatch) {
     return (
       <p
-        className="mt-3 text-sm text-[var(--onboarding-text-strong)]"
+        className={`mt-3 text-sm ${onboardingReadableTextPrimaryClassName}`}
         style={onboardingBodyTextShadowStyle}
       >
         Open this link to log in:{" "}
@@ -209,24 +219,18 @@ export function RpcStep() {
         </div>
 
         <div className={onboardingFooterClass}>
-          <Button
-            variant="ghost"
-            className={onboardingSecondaryActionClass}
-            style={onboardingSecondaryActionTextShadowStyle}
+          <OnboardingSecondaryActionButton
             onClick={handleOnboardingBack}
             type="button"
           >
             {t("onboarding.back")}
-          </Button>
-          <Button
-            variant="ghost"
-            className={onboardingSecondaryActionClass}
-            style={onboardingSecondaryActionTextShadowStyle}
+          </OnboardingSecondaryActionButton>
+          <OnboardingSecondaryActionButton
             onClick={() => void handleOnboardingNext()}
             type="button"
           >
             {t("onboarding.rpcSkip")}
-          </Button>
+          </OnboardingSecondaryActionButton>
         </div>
       </>
     );
@@ -289,7 +293,7 @@ export function RpcStep() {
                 <CloudLoginErrorMessage error={elizaCloudLoginError} />
               ) : null}
               <p
-                className="mt-3 text-sm leading-relaxed text-[var(--onboarding-text-muted)]"
+                className={`mt-3 ${onboardingHelperTextClassName}`}
                 style={onboardingBodyTextShadowStyle}
               >
                 {t("onboarding.freeCredits")}
@@ -299,15 +303,12 @@ export function RpcStep() {
         </div>
 
         <div className={onboardingFooterClass}>
-          <Button
-            variant="ghost"
-            className={onboardingSecondaryActionClass}
-            style={onboardingSecondaryActionTextShadowStyle}
+          <OnboardingSecondaryActionButton
             onClick={() => setMode("")}
             type="button"
           >
             {t("onboarding.back")}
-          </Button>
+          </OnboardingSecondaryActionButton>
           <Button
             className={onboardingPrimaryActionClass}
             style={onboardingPrimaryActionTextShadowStyle}
@@ -362,15 +363,12 @@ export function RpcStep() {
       </div>
 
       <div className={onboardingFooterClass}>
-        <Button
-          variant="ghost"
-          className={onboardingSecondaryActionClass}
-          style={onboardingSecondaryActionTextShadowStyle}
+        <OnboardingSecondaryActionButton
           onClick={() => setMode("")}
           type="button"
         >
           {t("onboarding.back")}
-        </Button>
+        </OnboardingSecondaryActionButton>
         <Button
           className={onboardingPrimaryActionClass}
           style={onboardingPrimaryActionTextShadowStyle}

--- a/packages/app-core/src/components/onboarding/WelcomeStep.test.ts
+++ b/packages/app-core/src/components/onboarding/WelcomeStep.test.ts
@@ -2,6 +2,7 @@
 
 import React from "react";
 import TestRenderer, { act } from "react-test-renderer";
+import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { onboardingHeaderBlockClass } from "./onboarding-step-chrome";
 
@@ -10,14 +11,10 @@ const { useAppMock, useBrandingMock } = vi.hoisted(() => ({
   useBrandingMock: vi.fn(),
 }));
 
-vi.mock("@miladyai/app-core/config", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("@miladyai/app-core/config")>();
-  return {
-    ...actual,
-    useBranding: () => useBrandingMock(),
-  };
-});
+vi.mock("@miladyai/app-core/config", () => ({
+  appNameInterpolationVars: (branding: { appName?: string }) => branding,
+  useBranding: () => useBrandingMock(),
+}));
 
 vi.mock("@miladyai/app-core/state", () => ({
   useApp: () => useAppMock(),
@@ -54,7 +51,7 @@ describe("WelcomeStep", () => {
 
     const headerBlock = renderer.root.findAll(
       (node) =>
-        node.type === "div" &&
+        node.type === "header" &&
         String(node.props.className ?? "").includes(onboardingHeaderBlockClass),
     )[0];
     expect(headerBlock).toBeDefined();
@@ -100,7 +97,7 @@ describe("WelcomeStep", () => {
 
     const headerBlock = renderer.root.findAll(
       (node) =>
-        node.type === "div" &&
+        node.type === "header" &&
         String(node.props.className ?? "").includes(onboardingHeaderBlockClass),
     )[0];
     expect(headerBlock).toBeDefined();
@@ -116,5 +113,27 @@ describe("WelcomeStep", () => {
     expect(setState).toHaveBeenCalledTimes(1);
     expect(setState).toHaveBeenCalledWith("onboardingStep", "identity");
     expect(handleOnboardingUseLocalBackend).not.toHaveBeenCalled();
+  });
+
+  it("uses the welcome prompt as the semantic heading when no explicit title is provided", () => {
+    useAppMock.mockReturnValue({
+      onboardingExistingInstallDetected: true,
+      handleOnboardingUseLocalBackend: vi.fn(),
+      setState: vi.fn(),
+      goToOnboardingStep: vi.fn(),
+      t: (key: string) =>
+        key === "onboarding.existingSetupDesc"
+          ? "Existing setup detected. Continue, or start fresh?"
+          : key,
+    });
+
+    render(React.createElement(WelcomeStep));
+
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: "Existing setup detected. Continue, or start fresh?",
+      }),
+    ).toBeTruthy();
   });
 });

--- a/packages/app-core/src/components/onboarding/WelcomeStep.test.ts
+++ b/packages/app-core/src/components/onboarding/WelcomeStep.test.ts
@@ -3,6 +3,7 @@
 import React from "react";
 import TestRenderer, { act } from "react-test-renderer";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { onboardingHeaderBlockClass } from "./onboarding-step-chrome";
 
 const { useAppMock, useBrandingMock } = vi.hoisted(() => ({
   useAppMock: vi.fn(),
@@ -51,6 +52,13 @@ describe("WelcomeStep", () => {
       throw new Error("WelcomeStep did not render");
     }
 
+    const headerBlock = renderer.root.findAll(
+      (node) =>
+        node.type === "div" &&
+        String(node.props.className ?? "").includes(onboardingHeaderBlockClass),
+    )[0];
+    expect(headerBlock).toBeDefined();
+
     const buttons = renderer.root.findAllByType("button");
     expect(buttons[0]?.children).toContain("onboarding.checkExistingSetup");
     expect(buttons[1]?.children).toContain("onboarding.getStarted");
@@ -89,6 +97,13 @@ describe("WelcomeStep", () => {
     if (!renderer) {
       throw new Error("WelcomeStep did not render");
     }
+
+    const headerBlock = renderer.root.findAll(
+      (node) =>
+        node.type === "div" &&
+        String(node.props.className ?? "").includes(onboardingHeaderBlockClass),
+    )[0];
+    expect(headerBlock).toBeDefined();
 
     const buttons = renderer.root.findAllByType("button");
     expect(buttons[0]?.children).toContain("onboarding.customSetup");

--- a/packages/app-core/src/components/onboarding/WelcomeStep.tsx
+++ b/packages/app-core/src/components/onboarding/WelcomeStep.tsx
@@ -5,12 +5,11 @@ import {
 import { useApp } from "@miladyai/app-core/state";
 import { Button } from "@miladyai/ui";
 import {
+  OnboardingSecondaryActionButton,
   OnboardingStepHeader,
   onboardingFooterClass,
   onboardingPrimaryActionClass,
   onboardingPrimaryActionTextShadowStyle,
-  onboardingSecondaryActionClass,
-  onboardingSecondaryActionTextShadowStyle,
   spawnOnboardingRipple,
 } from "./onboarding-step-chrome";
 
@@ -56,25 +55,19 @@ export function WelcomeStep() {
       />
       <div className={onboardingFooterClass}>
         {onboardingExistingInstallDetected ? (
-          <Button
-            variant="ghost"
-            className={onboardingSecondaryActionClass}
-            style={onboardingSecondaryActionTextShadowStyle}
+          <OnboardingSecondaryActionButton
             onClick={handleGetStarted}
             type="button"
           >
             {t("onboarding.customSetup")}
-          </Button>
+          </OnboardingSecondaryActionButton>
         ) : (
-          <Button
-            variant="ghost"
-            className={onboardingSecondaryActionClass}
-            style={onboardingSecondaryActionTextShadowStyle}
+          <OnboardingSecondaryActionButton
             onClick={() => handleOnboardingUseLocalBackend()}
             type="button"
           >
             {t("onboarding.checkExistingSetup")}
-          </Button>
+          </OnboardingSecondaryActionButton>
         )}
         <Button
           className={onboardingPrimaryActionClass}

--- a/packages/app-core/src/components/onboarding/connection/ConnectionChoiceScreens.test.tsx
+++ b/packages/app-core/src/components/onboarding/connection/ConnectionChoiceScreens.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockUseApp, mockUseBranding } = vi.hoisted(() => ({
+  mockUseApp: vi.fn(),
+  mockUseBranding: vi.fn(() => ({ appName: "Milady" })),
+}));
+
+vi.mock("../../../state", () => ({
+  useApp: () => mockUseApp(),
+}));
+
+vi.mock("../../../config", () => ({
+  appNameInterpolationVars: () => ({ appName: "Milady" }),
+  useBranding: () => mockUseBranding(),
+}));
+
+vi.mock("../../../providers", () => ({
+  getProviderLogo: () => "/logos/provider.png",
+}));
+
+import { ConnectionHostingScreen } from "./ConnectionHostingScreen";
+import { ConnectionProviderGridScreen } from "./ConnectionProviderGridScreen";
+
+describe("Connection choice screens", () => {
+  beforeEach(() => {
+    mockUseApp.mockReset();
+    mockUseBranding.mockReset().mockReturnValue({ appName: "Milady" });
+  });
+
+  it("renders hosting cards with taller targets and readable wrapped descriptions", () => {
+    mockUseApp.mockReturnValue({
+      handleOnboardingBack: vi.fn(),
+      t: (key: string) => key,
+    });
+
+    render(
+      <ConnectionHostingScreen
+        showHostingLocalCard={true}
+        dispatch={vi.fn()}
+      />,
+    );
+
+    const remoteButton = screen.getByRole("button", {
+      name: /onboarding\.hostingRemote onboarding\.hostingRemoteDesc/i,
+    });
+    expect(remoteButton.className).toContain("min-h-[60px]");
+
+    const remoteDescription = screen.getByText("onboarding.hostingRemoteDesc");
+    expect(remoteDescription.className).toContain("line-clamp-2");
+    expect(remoteDescription.className).not.toContain("line-clamp-1");
+  });
+
+  it("renders provider choice descriptions with two-line readable copy instead of truncation", () => {
+    mockUseApp.mockReturnValue({
+      onboardingRemoteConnected: false,
+      t: (key: string) => key,
+    });
+
+    render(
+      <ConnectionProviderGridScreen
+        dispatch={vi.fn()}
+        onTransitionEffect={vi.fn()}
+        sortedProviders={[
+          { id: "openai", name: "OpenAI", description: "GPT API" },
+          {
+            id: "elizacloud",
+            name: "Eliza Cloud",
+            description: "LLMs, RPCs & more included",
+          },
+        ]}
+        getProviderDisplay={(provider) => ({
+          name: provider.name,
+          description: provider.description,
+        })}
+        getCustomLogo={() => undefined}
+        getDetectedLabel={() => null}
+      />,
+    );
+
+    const providerDescription = screen.getByText("GPT API");
+    expect(providerDescription.className).toContain("line-clamp-2");
+    expect(providerDescription.className).not.toContain("truncate");
+  });
+});

--- a/packages/app-core/src/components/onboarding/connection/ConnectionElizaCloudPreProviderScreen.test.tsx
+++ b/packages/app-core/src/components/onboarding/connection/ConnectionElizaCloudPreProviderScreen.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockUseApp, mockUseBranding } = vi.hoisted(() => ({
+  mockUseApp: vi.fn(),
+  mockUseBranding: vi.fn(() => ({ bugReportUrl: "https://example.invalid" })),
+}));
+
+vi.mock("../../../state", () => ({
+  useApp: () => mockUseApp(),
+}));
+
+vi.mock("../../../config", () => ({
+  useBranding: () => mockUseBranding(),
+}));
+
+vi.mock("../../../utils", () => ({
+  openExternalUrl: vi.fn(async () => {}),
+}));
+
+vi.mock("./useAdvanceOnboardingWhenElizaCloudOAuthConnected", () => ({
+  useAdvanceOnboardingWhenElizaCloudOAuthConnected: () => undefined,
+}));
+
+import { ConnectionElizaCloudPreProviderScreen } from "./ConnectionElizaCloudPreProviderScreen";
+
+function t(key: string): string {
+  const translations: Record<string, string> = {
+    "onboarding.connected": "Connected",
+    "onboarding.login": "Login",
+    "onboarding.apiKey": "API Key",
+    "onboarding.freeCredits": "Free credits included.",
+    "onboarding.cloudProviderBehaviorHint":
+      "Milady may restart after provider changes.",
+    "onboarding.confirm": "Confirm",
+    "onboarding.back": "Back",
+  };
+
+  return translations[key] ?? key;
+}
+
+describe("ConnectionElizaCloudPreProviderScreen", () => {
+  beforeEach(() => {
+    mockUseApp.mockReset();
+    mockUseBranding.mockReset().mockReturnValue({
+      bugReportUrl: "https://example.invalid",
+    });
+  });
+
+  it("uses the compact success banner layout once Eliza Cloud is connected", () => {
+    mockUseApp.mockReturnValue({
+      t,
+      onboardingApiKey: "",
+      onboardingElizaCloudTab: "login",
+      onboardingRunMode: "local",
+      onboardingCloudProvider: "",
+      elizaCloudConnected: true,
+      elizaCloudLoginBusy: false,
+      elizaCloudLoginError: "",
+      handleCloudLogin: vi.fn(),
+      handleOnboardingNext: vi.fn(),
+      setState: vi.fn(),
+    });
+
+    render(<ConnectionElizaCloudPreProviderScreen dispatch={vi.fn()} />);
+
+    const banner = screen.getByRole("status");
+    expect(banner.getAttribute("data-onboarding-status-layout")).toBe(
+      "compact",
+    );
+    const content = banner.querySelector("[data-onboarding-status-content]");
+    expect(content?.textContent).toContain("Connected");
+  });
+});

--- a/packages/app-core/src/components/onboarding/connection/ConnectionElizaCloudPreProviderScreen.tsx
+++ b/packages/app-core/src/components/onboarding/connection/ConnectionElizaCloudPreProviderScreen.tsx
@@ -12,14 +12,15 @@ import {
   onboardingDetailStackClassName,
   onboardingHelperTextClassName,
   onboardingInputClassName,
+  onboardingSubtleTextClassName,
 } from "../onboarding-form-primitives";
 import {
+  OnboardingLinkActionButton,
+  OnboardingSecondaryActionButton,
   OnboardingStepHeader,
   onboardingFooterClass,
   onboardingPrimaryActionClass,
   onboardingPrimaryActionTextShadowStyle,
-  onboardingSecondaryActionClass,
-  onboardingSecondaryActionTextShadowStyle,
   spawnOnboardingRipple,
 } from "../onboarding-step-chrome";
 import { useAdvanceOnboardingWhenElizaCloudOAuthConnected } from "./useAdvanceOnboardingWhenElizaCloudOAuthConnected";
@@ -123,14 +124,12 @@ export function ConnectionElizaCloudPreProviderScreen({
                     <OnboardingStatusBanner
                       tone="neutral"
                       action={
-                        <Button
-                          variant="ghost"
+                        <OnboardingLinkActionButton
                           type="button"
-                          className="rounded-md px-2 py-1 text-[11px] text-[var(--onboarding-text-faint)] transition-colors duration-300 hover:text-[var(--onboarding-link)]"
                           onClick={() => openExternalUrl(urlMatch[1])}
                         >
                           Open login page in browser
-                        </Button>
+                        </OnboardingLinkActionButton>
                       }
                     >
                       Open the login page in your browser to continue.
@@ -144,18 +143,18 @@ export function ConnectionElizaCloudPreProviderScreen({
                 );
               })()}
             {elizaCloudLoginError ? (
-              <button
+              <OnboardingLinkActionButton
                 type="button"
-                className="text-xs text-[var(--onboarding-link)] underline mt-1 cursor-pointer bg-transparent border-none font-inherit hover:text-[var(--onboarding-text-strong)] transition-colors duration-200"
+                className="mt-1 text-xs underline"
                 onClick={() => openExternalUrl(branding.bugReportUrl)}
               >
                 {t("onboarding.reportIssue")}
-              </button>
+              </OnboardingLinkActionButton>
             ) : null}
             <p className={`${onboardingHelperTextClassName} text-center`}>
               {t("onboarding.freeCredits")}
             </p>
-            <p className="text-xs text-[var(--onboarding-text-subtle)] text-center leading-relaxed">
+            <p className={`${onboardingSubtleTextClassName} text-center`}>
               {t("onboarding.cloudProviderBehaviorHint")}
             </p>
           </div>
@@ -197,15 +196,12 @@ export function ConnectionElizaCloudPreProviderScreen({
       </div>
 
       <div className={onboardingFooterClass}>
-        <Button
-          variant="ghost"
-          className={onboardingSecondaryActionClass}
-          style={onboardingSecondaryActionTextShadowStyle}
+        <OnboardingSecondaryActionButton
           onClick={() => dispatch({ type: "backElizaCloudPreProvider" })}
           type="button"
         >
           {t("onboarding.back")}
-        </Button>
+        </OnboardingSecondaryActionButton>
         <Button
           className={onboardingPrimaryActionClass}
           style={onboardingPrimaryActionTextShadowStyle}
@@ -222,7 +218,7 @@ export function ConnectionElizaCloudPreProviderScreen({
           {t("onboarding.confirm")}
         </Button>
       </div>
-      <p className="mt-3 text-center text-xs leading-relaxed text-[var(--onboarding-text-subtle)]">
+      <p className={`${onboardingSubtleTextClassName} mt-3 text-center`}>
         {t("onboarding.restartAfterProviderChangeHint")}
       </p>
     </>

--- a/packages/app-core/src/components/onboarding/connection/ConnectionHostingScreen.tsx
+++ b/packages/app-core/src/components/onboarding/connection/ConnectionHostingScreen.tsx
@@ -9,10 +9,9 @@ import {
   onboardingChoiceCardTitleClassName,
 } from "../onboarding-form-primitives";
 import {
+  OnboardingSecondaryActionButton,
   OnboardingStepHeader,
   onboardingFooterClass,
-  onboardingSecondaryActionClass,
-  onboardingSecondaryActionTextShadowStyle,
 } from "../onboarding-step-chrome";
 
 export function ConnectionHostingScreen({
@@ -92,15 +91,12 @@ export function ConnectionHostingScreen({
         </Button>
       </div>
       <div className={onboardingFooterClass}>
-        <Button
-          variant="ghost"
-          className={onboardingSecondaryActionClass}
-          style={onboardingSecondaryActionTextShadowStyle}
+        <OnboardingSecondaryActionButton
           onClick={handleOnboardingBack}
           type="button"
         >
           {t("onboarding.back")}
-        </Button>
+        </OnboardingSecondaryActionButton>
         <span />
       </div>
     </>

--- a/packages/app-core/src/components/onboarding/connection/ConnectionHostingScreen.tsx
+++ b/packages/app-core/src/components/onboarding/connection/ConnectionHostingScreen.tsx
@@ -47,7 +47,7 @@ export function ConnectionHostingScreen({
                 {t("onboarding.hostingLocal")}
               </div>
               <div
-                className={`${onboardingChoiceCardDescriptionClassName} line-clamp-1`}
+                className={`${onboardingChoiceCardDescriptionClassName} line-clamp-2`}
               >
                 {t("onboarding.hostingLocalDesc")}
               </div>
@@ -67,7 +67,7 @@ export function ConnectionHostingScreen({
               {t("onboarding.hostingRemote")}
             </div>
             <div
-              className={`${onboardingChoiceCardDescriptionClassName} line-clamp-1`}
+              className={`${onboardingChoiceCardDescriptionClassName} line-clamp-2`}
             >
               {t("onboarding.hostingRemoteDesc")}
             </div>
@@ -83,7 +83,7 @@ export function ConnectionHostingScreen({
               {t("header.Cloud")}
             </div>
             <div
-              className={`${onboardingChoiceCardDescriptionClassName} line-clamp-1`}
+              className={`${onboardingChoiceCardDescriptionClassName} line-clamp-2`}
             >
               {t("onboarding.hostingElizaCloudDesc")}
             </div>

--- a/packages/app-core/src/components/onboarding/connection/ConnectionProviderDetailScreen.test.tsx
+++ b/packages/app-core/src/components/onboarding/connection/ConnectionProviderDetailScreen.test.tsx
@@ -42,6 +42,7 @@ function t(key: string): string {
     "onboarding.apiKey": "API Key",
     "onboarding.enterApiKey": "Enter API key",
     "onboarding.back": "Back",
+    "onboarding.connected": "Connected",
     "onboarding.confirm": "Confirm",
     "onboarding.login": "Login",
     "onboarding.useExistingKey": "Use an existing key.",
@@ -103,9 +104,13 @@ describe("ConnectionProviderDetailScreen", () => {
     render(<ConnectionProviderDetailScreen dispatch={vi.fn()} />);
 
     expect(screen.getByText("OpenAI")).toBeTruthy();
-    expect(screen.getByLabelText("API Key")).toBeTruthy();
+    const apiKeyInput = screen.getByLabelText("API Key");
+    expect(apiKeyInput).toBeTruthy();
+    expect(apiKeyInput.className).toContain("bg-[var(--onboarding-input-bg)]");
+    expect(apiKeyInput.className).not.toContain("-webkit-text-stroke");
     expect(screen.getByRole("button", { name: "Confirm" })).toBeTruthy();
     const backButton = screen.getByRole("button", { name: "Back" });
+    expect(backButton.className).toContain("min-h-[44px]");
     expect(backButton.className).toContain(
       "hover:bg-[var(--onboarding-secondary-hover-bg)]",
     );
@@ -149,6 +154,25 @@ describe("ConnectionProviderDetailScreen", () => {
       screen.getByRole("button", { name: "onboarding.reportIssue" }),
     );
     expect(mockOpenExternalUrl).toHaveBeenCalledWith("https://example.invalid");
+  });
+
+  it("uses the compact success banner for the Eliza Cloud connected state", () => {
+    mockUseApp.mockReturnValue(
+      createState({
+        onboardingProvider: "elizacloud",
+        onboardingElizaCloudTab: "login",
+        elizaCloudConnected: true,
+      }),
+    );
+
+    render(<ConnectionProviderDetailScreen dispatch={vi.fn()} />);
+
+    const banner = screen.getByRole("status");
+    expect(banner.getAttribute("data-onboarding-status-layout")).toBe(
+      "compact",
+    );
+    const content = banner.querySelector("[data-onboarding-status-content]");
+    expect(content?.textContent).toContain("Connected");
   });
 
   it("exposes openrouter model choices as a radiogroup", () => {

--- a/packages/app-core/src/components/onboarding/connection/ConnectionProviderDetailScreen.test.tsx
+++ b/packages/app-core/src/components/onboarding/connection/ConnectionProviderDetailScreen.test.tsx
@@ -105,6 +105,11 @@ describe("ConnectionProviderDetailScreen", () => {
     expect(screen.getByText("OpenAI")).toBeTruthy();
     expect(screen.getByLabelText("API Key")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Confirm" })).toBeTruthy();
+    const backButton = screen.getByRole("button", { name: "Back" });
+    expect(backButton.className).toContain(
+      "hover:bg-[var(--onboarding-secondary-hover-bg)]",
+    );
+    expect(backButton.className).not.toContain("bg-bg-accent");
   });
 
   it("renders an actionable browser-login recovery control for Eliza Cloud", () => {

--- a/packages/app-core/src/components/onboarding/connection/ConnectionProviderDetailScreen.tsx
+++ b/packages/app-core/src/components/onboarding/connection/ConnectionProviderDetailScreen.tsx
@@ -29,23 +29,26 @@ import {
   getOnboardingChoiceCardClassName,
   OnboardingField,
   OnboardingStatusBanner,
+  onboardingCardSurfaceClassName,
   onboardingCenteredStackClassName,
   onboardingChoiceCardTitleClassName,
   onboardingDetailStackClassName,
+  onboardingFieldLabelClassName,
   onboardingHelperTextClassName,
   onboardingInfoPanelClassName,
+  onboardingInlineSupportClassName,
   onboardingInputClassName,
+  onboardingReadableTextPrimaryClassName,
   onboardingSubtleTextClassName,
 } from "../onboarding-form-primitives";
 import {
+  OnboardingLinkActionButton,
+  OnboardingSecondaryActionButton,
   OnboardingStepHeader,
   onboardingBodyTextShadowStyle,
   onboardingFooterClass,
-  onboardingLinkActionClass,
   onboardingPrimaryActionClass,
   onboardingPrimaryActionTextShadowStyle,
-  onboardingSecondaryActionClass,
-  onboardingSecondaryActionTextShadowStyle,
   spawnOnboardingRipple,
 } from "../onboarding-step-chrome";
 import { useAdvanceOnboardingWhenElizaCloudOAuthConnected } from "./useAdvanceOnboardingWhenElizaCloudOAuthConnected";
@@ -393,7 +396,9 @@ export function ConnectionProviderDetailScreen({
     <>
       {selectedProvider ? (
         <div className="mb-4 flex justify-center">
-          <div className="flex h-14 w-14 items-center justify-center rounded-2xl border border-[var(--onboarding-card-border)] bg-[var(--onboarding-card-bg)]/90 backdrop-blur-[18px] backdrop-saturate-[1.15]">
+          <div
+            className={`flex h-14 w-14 items-center justify-center rounded-2xl backdrop-blur-[18px] backdrop-saturate-[1.15] ${onboardingCardSurfaceClassName}`}
+          >
             <img
               src={getProviderLogo(
                 selectedProvider.id,
@@ -462,14 +467,12 @@ export function ConnectionProviderDetailScreen({
                       <OnboardingStatusBanner
                         tone="neutral"
                         action={
-                          <Button
-                            variant="ghost"
+                          <OnboardingLinkActionButton
                             type="button"
-                            className={onboardingLinkActionClass}
                             onClick={() => openExternalUrl(urlMatch[1])}
                           >
                             Open login page in browser
-                          </Button>
+                          </OnboardingLinkActionButton>
                         }
                       >
                         Open the login page in your browser to continue.
@@ -481,14 +484,12 @@ export function ConnectionProviderDetailScreen({
                       <OnboardingStatusBanner tone="error" live="assertive">
                         {elizaCloudLoginError}
                       </OnboardingStatusBanner>
-                      <Button
-                        variant="ghost"
+                      <OnboardingLinkActionButton
                         type="button"
-                        className={onboardingLinkActionClass}
                         onClick={() => openExternalUrl(branding.bugReportUrl)}
                       >
                         {t("onboarding.reportIssue")}
-                      </Button>
+                      </OnboardingLinkActionButton>
                     </div>
                   );
                 })()}
@@ -690,12 +691,14 @@ export function ConnectionProviderDetailScreen({
           ) : (
             <div className={onboardingDetailStackClassName}>
               <div className={onboardingInfoPanelClassName}>
-                <p className="mb-1 text-sm font-semibold text-[var(--onboarding-text-primary)]">
+                <p
+                  className={`mb-1 text-sm font-semibold ${onboardingReadableTextPrimaryClassName}`}
+                >
                   {t("onboarding.almostThere")}
                 </p>
                 <p className={onboardingHelperTextClassName}>
                   {t("onboarding.redirectInstructions")}{" "}
-                  <code className="rounded bg-[var(--bg-hover)] px-1 py-0.5 text-xs">
+                  <code className={`${onboardingInlineSupportClassName} text-xs`}>
                     localhost:1455
                   </code>
                   {t("onboarding.copyEntireUrl")}
@@ -741,11 +744,8 @@ export function ConnectionProviderDetailScreen({
                 >
                   {t("onboarding.completeLogin")}
                 </Button>
-                <Button
-                  variant="ghost"
+                <OnboardingSecondaryActionButton
                   type="button"
-                  className={onboardingSecondaryActionClass}
-                  style={onboardingSecondaryActionTextShadowStyle}
                   onClick={() => {
                     setOpenaiOAuthStarted(false);
                     setOpenaiCallbackUrl("");
@@ -753,7 +753,7 @@ export function ConnectionProviderDetailScreen({
                   }}
                 >
                   {t("onboarding.startOver")}
-                </Button>
+                </OnboardingSecondaryActionButton>
               </div>
             </div>
           )}
@@ -900,7 +900,7 @@ export function ConnectionProviderDetailScreen({
         <div className={`${onboardingDetailStackClassName} mt-4`}>
           <div
             id="openrouter-models-label"
-            className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--onboarding-text-muted)]"
+            className={onboardingFieldLabelClassName}
           >
             {t("onboarding.selectModel")}
           </div>
@@ -941,15 +941,12 @@ export function ConnectionProviderDetailScreen({
       ) : null}
 
       <div className={onboardingFooterClass}>
-        <Button
-          variant="ghost"
-          className={onboardingSecondaryActionClass}
-          style={onboardingSecondaryActionTextShadowStyle}
+        <OnboardingSecondaryActionButton
           onClick={clearProvider}
           type="button"
         >
           {t("onboarding.back")}
-        </Button>
+        </OnboardingSecondaryActionButton>
         <Button
           className={onboardingPrimaryActionClass}
           style={onboardingPrimaryActionTextShadowStyle}

--- a/packages/app-core/src/components/onboarding/connection/ConnectionProviderGridScreen.tsx
+++ b/packages/app-core/src/components/onboarding/connection/ConnectionProviderGridScreen.tsx
@@ -59,7 +59,7 @@ export function ConnectionProviderGridScreen({
       />
       {onboardingRemoteConnected && (
         <p
-          className={`${onboardingHelperTextClassName} mx-auto mb-3 mt-1.5 max-w-[32ch] text-center text-[12px] leading-[1.35]`}
+          className={`${onboardingHelperTextClassName} mx-auto mb-3 max-w-[32ch] text-center text-[12px] leading-[1.35]`}
           style={onboardingBodyTextShadowStyle}
         >
           {t(

--- a/packages/app-core/src/components/onboarding/connection/ConnectionProviderGridScreen.tsx
+++ b/packages/app-core/src/components/onboarding/connection/ConnectionProviderGridScreen.tsx
@@ -15,6 +15,7 @@ import {
   onboardingChoiceCardRecommendedLabelClassName,
   onboardingChoiceCardTitleClassName,
   onboardingHelperTextClassName,
+  onboardingTextSupportClassName,
 } from "../onboarding-form-primitives";
 import {
   OnboardingSecondaryActionButton,
@@ -59,7 +60,7 @@ export function ConnectionProviderGridScreen({
       />
       {onboardingRemoteConnected && (
         <p
-          className={`${onboardingHelperTextClassName} mx-auto mb-3 max-w-[32ch] text-center text-[12px] leading-[1.35]`}
+          className={`${onboardingHelperTextClassName} ${onboardingTextSupportClassName} mx-auto mb-3 max-w-[32ch] text-center leading-[1.35]`}
           style={onboardingBodyTextShadowStyle}
         >
           {t(
@@ -85,34 +86,34 @@ export function ConnectionProviderGridScreen({
                 dispatch({ type: "selectProvider", providerId: p.id })
               }
             >
-              <div className="flex min-h-[46px] w-full items-center gap-2">
+              <div className="flex min-h-[52px] w-full items-start gap-2.5">
                 <img
                   src={getProviderLogo(p.id, true, getCustomLogo(p.id))}
                   alt=""
-                  className="h-[22px] w-[22px] shrink-0 rounded-md object-contain"
+                  className="mt-0.5 h-[22px] w-[22px] shrink-0 rounded-md object-contain"
                 />
                 <div className="min-w-0 flex-1">
-                  <div
-                    className={`${onboardingChoiceCardTitleClassName} truncate`}
-                  >
+                  <div className={`${onboardingChoiceCardTitleClassName} line-clamp-2`}>
                     {display.name}
                   </div>
                   {display.description && (
                     <div
-                      className={`${onboardingChoiceCardDescriptionClassName} truncate`}
+                      className={`${onboardingChoiceCardDescriptionClassName} line-clamp-2`}
                     >
                       {display.description}
                     </div>
                   )}
                 </div>
                 {detectedLabel && (
-                  <span className={onboardingChoiceCardDetectedBadgeClassName}>
+                  <span
+                    className={`${onboardingChoiceCardDetectedBadgeClassName} self-start`}
+                  >
                     {detectedLabel}
                   </span>
                 )}
                 {isRecommended && !detectedLabel && (
                   <span
-                    className={onboardingChoiceCardRecommendedLabelClassName}
+                    className={`${onboardingChoiceCardRecommendedLabelClassName} self-start`}
                   >
                     {t("onboarding.recommended") ?? "Recommended"}
                   </span>

--- a/packages/app-core/src/components/onboarding/connection/ConnectionProviderGridScreen.tsx
+++ b/packages/app-core/src/components/onboarding/connection/ConnectionProviderGridScreen.tsx
@@ -14,13 +14,13 @@ import {
   onboardingChoiceCardDetectedBadgeClassName,
   onboardingChoiceCardRecommendedLabelClassName,
   onboardingChoiceCardTitleClassName,
+  onboardingHelperTextClassName,
 } from "../onboarding-form-primitives";
 import {
+  OnboardingSecondaryActionButton,
   OnboardingStepHeader,
   onboardingBodyTextShadowStyle,
   onboardingFooterClass,
-  onboardingSecondaryActionClass,
-  onboardingSecondaryActionTextShadowStyle,
 } from "../onboarding-step-chrome";
 
 const recommendedIds = new Set<string>(CONNECTION_RECOMMENDED_PROVIDER_IDS);
@@ -59,7 +59,7 @@ export function ConnectionProviderGridScreen({
       />
       {onboardingRemoteConnected && (
         <p
-          className="mx-auto mb-3 mt-1.5 max-w-[32ch] text-center text-[12px] leading-[1.35] text-[var(--onboarding-text-muted)]"
+          className={`${onboardingHelperTextClassName} mx-auto mb-3 mt-1.5 max-w-[32ch] text-center text-[12px] leading-[1.35]`}
           style={onboardingBodyTextShadowStyle}
         >
           {t(
@@ -123,10 +123,7 @@ export function ConnectionProviderGridScreen({
         })}
       </div>
       <div className={`${onboardingFooterClass} pb-1`}>
-        <Button
-          variant="ghost"
-          className={onboardingSecondaryActionClass}
-          style={onboardingSecondaryActionTextShadowStyle}
+        <OnboardingSecondaryActionButton
           onClick={() => {
             if (onboardingRemoteConnected) {
               onTransitionEffect("useLocalBackend");
@@ -137,7 +134,7 @@ export function ConnectionProviderGridScreen({
           type="button"
         >
           {t("onboarding.back")}
-        </Button>
+        </OnboardingSecondaryActionButton>
         <span />
       </div>
     </>

--- a/packages/app-core/src/components/onboarding/connection/ConnectionRemoteBackendScreen.tsx
+++ b/packages/app-core/src/components/onboarding/connection/ConnectionRemoteBackendScreen.tsx
@@ -12,12 +12,11 @@ import {
   onboardingInputClassName,
 } from "../onboarding-form-primitives";
 import {
+  OnboardingSecondaryActionButton,
   OnboardingStepHeader,
   onboardingFooterClass,
   onboardingPrimaryActionClass,
   onboardingPrimaryActionTextShadowStyle,
-  onboardingSecondaryActionClass,
-  onboardingSecondaryActionTextShadowStyle,
   spawnOnboardingRipple,
 } from "../onboarding-step-chrome";
 
@@ -96,10 +95,7 @@ export function ConnectionRemoteBackendScreen({
         ) : null}
       </div>
       <div className={onboardingFooterClass}>
-        <Button
-          variant="ghost"
-          className={onboardingSecondaryActionClass}
-          style={onboardingSecondaryActionTextShadowStyle}
+        <OnboardingSecondaryActionButton
           onClick={() => {
             if (onboardingRemoteConnected) {
               onTransitionEffect("useLocalBackend");
@@ -110,7 +106,7 @@ export function ConnectionRemoteBackendScreen({
           type="button"
         >
           {t("onboarding.back")}
-        </Button>
+        </OnboardingSecondaryActionButton>
         <Button
           className={onboardingPrimaryActionClass}
           style={onboardingPrimaryActionTextShadowStyle}

--- a/packages/app-core/src/components/onboarding/onboarding-form-primitives.test.tsx
+++ b/packages/app-core/src/components/onboarding/onboarding-form-primitives.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { OnboardingStatusBanner } from "./onboarding-form-primitives";
+
+describe("OnboardingStatusBanner", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders success banners without actions in the compact centered layout", () => {
+    render(
+      <OnboardingStatusBanner tone="success">
+        <svg aria-hidden="true" />
+        Connected
+      </OnboardingStatusBanner>,
+    );
+
+    const banner = screen.getByRole("status");
+    expect(banner.getAttribute("data-onboarding-status-layout")).toBe(
+      "compact",
+    );
+
+    const content = banner.querySelector("[data-onboarding-status-content]");
+    expect(content).toBeTruthy();
+    expect(content?.className).toContain("inline-flex");
+    expect(content?.className).not.toContain("flex-1");
+    expect(
+      banner.querySelector("[data-onboarding-status-action]"),
+    ).toBeNull();
+  });
+
+  it("keeps action-bearing neutral banners in the split layout", () => {
+    render(
+      <OnboardingStatusBanner
+        tone="neutral"
+        action={<button type="button">Open login page in browser</button>}
+      >
+        Open the login page in your browser to continue.
+      </OnboardingStatusBanner>,
+    );
+
+    const banner = screen.getByRole("status");
+    expect(banner.getAttribute("data-onboarding-status-layout")).toBe("split");
+
+    const content = banner.querySelector("[data-onboarding-status-content]");
+    expect(content).toBeTruthy();
+    expect(content?.className).toContain("flex-1");
+    expect(
+      banner.querySelector("[data-onboarding-status-action]"),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Open login page in browser" }),
+    ).toBeTruthy();
+  });
+});

--- a/packages/app-core/src/components/onboarding/onboarding-form-primitives.tsx
+++ b/packages/app-core/src/components/onboarding/onboarding-form-primitives.tsx
@@ -11,22 +11,46 @@ export const onboardingDetailStackClassName =
   "flex w-full flex-col gap-4 text-left";
 export const onboardingCenteredStackClassName =
   "flex w-full flex-col items-center gap-3 text-center";
+export const onboardingReadableTextStrongClassName =
+  "text-[var(--onboarding-text-strong)] [text-shadow:var(--onboarding-text-shadow-strong)] [-webkit-text-stroke:0.35px_var(--onboarding-text-stroke)]";
+export const onboardingReadableTextPrimaryClassName =
+  "text-[var(--onboarding-text-primary)] [text-shadow:var(--onboarding-text-shadow-primary)] [-webkit-text-stroke:0.25px_var(--onboarding-text-stroke-soft)]";
+export const onboardingReadableTextMutedClassName =
+  "text-[var(--onboarding-text-muted)] [text-shadow:var(--onboarding-text-shadow-muted)] [-webkit-text-stroke:0.25px_var(--onboarding-text-stroke-soft)]";
+export const onboardingReadableTextSubtleClassName =
+  "text-[var(--onboarding-text-subtle)] [text-shadow:var(--onboarding-text-shadow-muted)] [-webkit-text-stroke:0.25px_var(--onboarding-text-stroke-soft)]";
+export const onboardingReadableTextFaintClassName =
+  "text-[var(--onboarding-text-faint)] [text-shadow:var(--onboarding-text-shadow-muted)] [-webkit-text-stroke:0.25px_var(--onboarding-text-stroke-soft)]";
 export const onboardingHelperTextClassName =
-  "text-sm leading-relaxed text-[var(--onboarding-text-muted)]";
+  `text-sm leading-relaxed ${onboardingReadableTextMutedClassName}`;
 export const onboardingSubtleTextClassName =
-  "text-xs leading-relaxed text-[var(--onboarding-text-subtle)]";
+  `text-xs leading-relaxed ${onboardingReadableTextSubtleClassName}`;
+export const onboardingFieldLabelClassName =
+  `text-[11px] font-semibold uppercase tracking-[0.16em] ${onboardingReadableTextMutedClassName}`;
+export const onboardingInlineSupportClassName =
+  "rounded-md border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-1 py-0.5 backdrop-blur-[10px]";
+export const onboardingCardSurfaceClassName =
+  "border border-[var(--onboarding-card-border)] bg-[var(--onboarding-card-bg)] shadow-[var(--onboarding-card-shadow)]";
+export const onboardingCardSurfaceHoverClassName =
+  "hover:border-[var(--onboarding-card-border-strong)] hover:bg-[var(--onboarding-card-bg-hover)]";
+export const onboardingRecommendedSurfaceClassName =
+  "border border-[var(--onboarding-recommended-border)] bg-[var(--onboarding-recommended-bg)] shadow-[var(--onboarding-card-shadow)]";
+export const onboardingRecommendedSurfaceHoverClassName =
+  "hover:border-[var(--onboarding-recommended-border-strong)] hover:bg-[var(--onboarding-recommended-bg-hover)]";
+export const onboardingInputSurfaceClassName =
+  "border border-[var(--onboarding-card-border)] bg-[var(--onboarding-card-bg)] shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]";
 export const onboardingInfoPanelClassName =
-  "rounded-2xl border border-[var(--onboarding-card-border)] bg-[var(--onboarding-card-bg)]/90 px-4 py-4 backdrop-blur-[18px] backdrop-saturate-[1.15]";
+  `rounded-2xl px-4 py-4 backdrop-blur-[18px] backdrop-saturate-[1.15] ${onboardingCardSurfaceClassName}`;
 export const onboardingInputClassName =
-  "h-12 w-full rounded-xl border border-[var(--onboarding-card-border)] bg-[var(--onboarding-card-bg)] px-4 text-left text-[var(--onboarding-text-primary)] transition-[border-color,box-shadow,background-color] duration-200 placeholder:text-[var(--onboarding-text-faint)] focus-visible:border-[var(--onboarding-field-focus-border)] focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:shadow-[var(--onboarding-field-focus-shadow)]";
+  `h-12 w-full rounded-xl px-4 text-left ${onboardingReadableTextPrimaryClassName} transition-[border-color,box-shadow,background-color] duration-200 placeholder:text-[var(--onboarding-text-faint)] focus-visible:border-[var(--onboarding-field-focus-border)] focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:shadow-[var(--onboarding-field-focus-shadow)] ${onboardingInputSurfaceClassName}`;
 export const onboardingChoiceCardTitleClassName =
-  "text-[11px] font-medium leading-[1.2] text-[var(--onboarding-text-primary)] [text-shadow:0_1px_8px_rgba(3,5,10,0.6)]";
+  `text-[11px] font-medium leading-[1.2] ${onboardingReadableTextPrimaryClassName}`;
 export const onboardingChoiceCardDescriptionClassName =
-  "mt-0.5 text-[9px] leading-[1.2] text-[var(--onboarding-text-subtle)] [text-shadow:0_1px_8px_rgba(3,5,10,0.5)]";
+  `mt-0.5 text-[9px] leading-[1.2] ${onboardingReadableTextSubtleClassName}`;
 export const onboardingChoiceCardBadgeClassName =
-  "ml-auto shrink-0 whitespace-nowrap rounded-full bg-[var(--onboarding-accent-bg)] px-1.5 py-0.5 text-[8px] font-semibold uppercase tracking-[0.08em] text-[var(--onboarding-accent-foreground)] [text-shadow:0_1px_6px_rgba(3,5,10,0.45)]";
+  "ml-auto shrink-0 whitespace-nowrap rounded-full bg-[var(--onboarding-accent-bg)] px-1.5 py-0.5 text-[8px] font-semibold uppercase tracking-[0.08em] text-[var(--onboarding-accent-foreground)] [text-shadow:0_1px_6px_rgba(3,5,10,0.45)] [-webkit-text-stroke:0.2px_rgba(5,9,15,0.28)]";
 export const onboardingChoiceCardDetectedBadgeClassName =
-  "ml-auto shrink-0 whitespace-nowrap rounded-full bg-[rgba(34,197,94,0.2)] px-1 py-0.5 text-[8px] font-semibold uppercase tracking-[0.08em] text-[rgba(34,197,94,0.94)] [text-shadow:0_1px_6px_rgba(3,5,10,0.45)]";
+  "ml-auto shrink-0 whitespace-nowrap rounded-full bg-[rgba(34,197,94,0.2)] px-1 py-0.5 text-[8px] font-semibold uppercase tracking-[0.08em] text-[rgba(34,197,94,0.94)] [text-shadow:0_1px_6px_rgba(3,5,10,0.45)] [-webkit-text-stroke:0.2px_rgba(5,9,15,0.28)]";
 export const onboardingChoiceCardRecommendedLabelClassName =
   "ml-auto shrink-0 whitespace-nowrap text-[8px] font-medium uppercase tracking-[0.12em] text-accent";
 
@@ -40,10 +64,10 @@ export function getOnboardingChoiceCardClassName({
   recommended?: boolean;
 }) {
   return cn(
-    "flex min-h-[48px] w-full items-center justify-between gap-[10px] rounded-[10px] border px-[12px] py-[9px] text-left backdrop-blur-[18px] backdrop-saturate-[1.2] transition-[border-color,background-color,box-shadow] duration-200",
+    "flex min-h-[48px] w-full items-center justify-between gap-[10px] rounded-[10px] px-[12px] py-[9px] text-left backdrop-blur-[18px] backdrop-saturate-[1.2] transition-[border-color,background-color,box-shadow] duration-200",
     recommended
-      ? "border-[var(--onboarding-recommended-border)] bg-[var(--onboarding-recommended-bg)] hover:border-[var(--onboarding-recommended-border-strong)] hover:bg-[var(--onboarding-recommended-bg-hover)]"
-      : "border-[var(--onboarding-card-border)] bg-[var(--onboarding-card-bg)] hover:border-[var(--onboarding-card-border-strong)] hover:bg-[var(--onboarding-card-bg-hover)]",
+      ? `${onboardingRecommendedSurfaceClassName} ${onboardingRecommendedSurfaceHoverClassName}`
+      : `${onboardingCardSurfaceClassName} ${onboardingCardSurfaceHoverClassName}`,
     selected &&
       "border-[rgba(240,185,11,0.32)] bg-[rgba(240,185,11,0.12)] shadow-[0_0_0_1px_rgba(240,185,11,0.18)]",
     detected &&
@@ -100,7 +124,7 @@ export function OnboardingField({
         <FieldLabel
           htmlFor={controlId}
           className={cn(
-            "text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--onboarding-text-muted)]",
+            onboardingFieldLabelClassName,
             align === "center" && "text-center",
             labelClassName,
           )}
@@ -152,7 +176,7 @@ export const OnboardingStatusBanner = React.forwardRef<
       ? "border-[var(--ok-muted)] bg-[var(--ok-subtle)] text-[var(--ok)]"
       : tone === "error"
         ? "border-[color:color-mix(in_srgb,var(--danger)_38%,transparent)] bg-[color:color-mix(in_srgb,var(--danger)_12%,transparent)] text-[var(--danger)]"
-        : "border-[var(--onboarding-card-border)] bg-[var(--onboarding-card-bg)] text-[var(--onboarding-text-muted)]";
+        : `${onboardingCardSurfaceClassName} ${onboardingReadableTextMutedClassName}`;
 
   return (
     <div

--- a/packages/app-core/src/components/onboarding/onboarding-form-primitives.tsx
+++ b/packages/app-core/src/components/onboarding/onboarding-form-primitives.tsx
@@ -12,23 +12,25 @@ export const onboardingDetailStackClassName =
 export const onboardingCenteredStackClassName =
   "flex w-full flex-col items-center gap-3 text-center";
 export const onboardingReadableTextStrongClassName =
-  "text-[var(--onboarding-text-strong)] [text-shadow:var(--onboarding-text-shadow-strong)] [-webkit-text-stroke:0.35px_var(--onboarding-text-stroke)]";
+  "text-[var(--onboarding-text-strong)] [text-shadow:var(--onboarding-text-shadow-strong)] [-webkit-text-stroke:0.3px_var(--onboarding-text-stroke)]";
 export const onboardingReadableTextPrimaryClassName =
-  "text-[var(--onboarding-text-primary)] [text-shadow:var(--onboarding-text-shadow-primary)] [-webkit-text-stroke:0.25px_var(--onboarding-text-stroke-soft)]";
+  "text-[var(--onboarding-text-primary)] [text-shadow:var(--onboarding-text-shadow-primary)]";
 export const onboardingReadableTextMutedClassName =
-  "text-[var(--onboarding-text-muted)] [text-shadow:var(--onboarding-text-shadow-muted)] [-webkit-text-stroke:0.25px_var(--onboarding-text-stroke-soft)]";
+  "text-[var(--onboarding-text-muted)] [text-shadow:var(--onboarding-text-shadow-muted)]";
 export const onboardingReadableTextSubtleClassName =
-  "text-[var(--onboarding-text-subtle)] [text-shadow:var(--onboarding-text-shadow-muted)] [-webkit-text-stroke:0.25px_var(--onboarding-text-stroke-soft)]";
+  "text-[var(--onboarding-text-subtle)] [text-shadow:var(--onboarding-text-shadow-muted)]";
 export const onboardingReadableTextFaintClassName =
-  "text-[var(--onboarding-text-faint)] [text-shadow:var(--onboarding-text-shadow-muted)] [-webkit-text-stroke:0.25px_var(--onboarding-text-stroke-soft)]";
+  "text-[var(--onboarding-text-faint)] [text-shadow:var(--onboarding-text-shadow-muted)]";
 export const onboardingHelperTextClassName =
-  `text-sm leading-relaxed ${onboardingReadableTextMutedClassName}`;
+  `text-[12px] leading-relaxed ${onboardingReadableTextMutedClassName}`;
 export const onboardingSubtleTextClassName =
-  `text-xs leading-relaxed ${onboardingReadableTextSubtleClassName}`;
+  `text-[11px] leading-relaxed ${onboardingReadableTextSubtleClassName}`;
 export const onboardingFieldLabelClassName =
-  `text-[11px] font-semibold uppercase tracking-[0.16em] ${onboardingReadableTextMutedClassName}`;
+  `text-xs font-semibold uppercase tracking-[0.14em] ${onboardingReadableTextMutedClassName}`;
 export const onboardingInlineSupportClassName =
   "rounded-md border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-1 py-0.5 backdrop-blur-[10px]";
+export const onboardingTextSupportClassName =
+  "rounded-xl bg-[var(--onboarding-text-support-bg)] px-3 py-2 shadow-[var(--onboarding-text-support-shadow)] backdrop-blur-[14px]";
 export const onboardingCardSurfaceClassName =
   "border border-[var(--onboarding-card-border)] bg-[var(--onboarding-card-bg)] shadow-[var(--onboarding-card-shadow)]";
 export const onboardingCardSurfaceHoverClassName =
@@ -38,21 +40,21 @@ export const onboardingRecommendedSurfaceClassName =
 export const onboardingRecommendedSurfaceHoverClassName =
   "hover:border-[var(--onboarding-recommended-border-strong)] hover:bg-[var(--onboarding-recommended-bg-hover)]";
 export const onboardingInputSurfaceClassName =
-  "border border-[var(--onboarding-card-border)] bg-[var(--onboarding-card-bg)] shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]";
+  "border border-[var(--onboarding-input-border)] bg-[var(--onboarding-input-bg)] shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]";
 export const onboardingInfoPanelClassName =
   `rounded-2xl px-4 py-4 backdrop-blur-[18px] backdrop-saturate-[1.15] ${onboardingCardSurfaceClassName}`;
 export const onboardingInputClassName =
-  `h-12 w-full rounded-xl px-4 text-left ${onboardingReadableTextPrimaryClassName} transition-[border-color,box-shadow,background-color] duration-200 placeholder:text-[var(--onboarding-text-faint)] focus-visible:border-[var(--onboarding-field-focus-border)] focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:shadow-[var(--onboarding-field-focus-shadow)] ${onboardingInputSurfaceClassName}`;
+  `h-12 w-full rounded-xl px-4 text-left ${onboardingReadableTextPrimaryClassName} transition-[border-color,box-shadow,background-color] duration-200 placeholder:text-[var(--onboarding-text-subtle)] focus-visible:border-[var(--onboarding-field-focus-border)] focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:shadow-[var(--onboarding-field-focus-shadow)] ${onboardingInputSurfaceClassName}`;
 export const onboardingChoiceCardTitleClassName =
-  `text-[11px] font-medium leading-[1.2] ${onboardingReadableTextPrimaryClassName}`;
+  `text-[12px] font-medium leading-[1.3] ${onboardingReadableTextPrimaryClassName}`;
 export const onboardingChoiceCardDescriptionClassName =
-  `mt-0.5 text-[9px] leading-[1.2] ${onboardingReadableTextSubtleClassName}`;
+  `mt-1 text-[11px] leading-[1.35] ${onboardingReadableTextMutedClassName}`;
 export const onboardingChoiceCardBadgeClassName =
-  "ml-auto shrink-0 whitespace-nowrap rounded-full bg-[var(--onboarding-accent-bg)] px-1.5 py-0.5 text-[8px] font-semibold uppercase tracking-[0.08em] text-[var(--onboarding-accent-foreground)] [text-shadow:0_1px_6px_rgba(3,5,10,0.45)] [-webkit-text-stroke:0.2px_rgba(5,9,15,0.28)]";
+  "ml-auto shrink-0 whitespace-nowrap rounded-full bg-[var(--onboarding-accent-bg)] px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.08em] text-[var(--onboarding-accent-foreground)] [text-shadow:0_1px_6px_rgba(3,5,10,0.45)]";
 export const onboardingChoiceCardDetectedBadgeClassName =
-  "ml-auto shrink-0 whitespace-nowrap rounded-full bg-[rgba(34,197,94,0.2)] px-1 py-0.5 text-[8px] font-semibold uppercase tracking-[0.08em] text-[rgba(34,197,94,0.94)] [text-shadow:0_1px_6px_rgba(3,5,10,0.45)] [-webkit-text-stroke:0.2px_rgba(5,9,15,0.28)]";
+  "ml-auto shrink-0 whitespace-nowrap rounded-full bg-[rgba(34,197,94,0.2)] px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.08em] text-[rgba(34,197,94,0.94)] [text-shadow:0_1px_6px_rgba(3,5,10,0.45)]";
 export const onboardingChoiceCardRecommendedLabelClassName =
-  "ml-auto shrink-0 whitespace-nowrap text-[8px] font-medium uppercase tracking-[0.12em] text-accent";
+  "ml-auto shrink-0 whitespace-nowrap text-[9px] font-medium uppercase tracking-[0.12em] text-accent";
 
 export function getOnboardingChoiceCardClassName({
   detected = false,
@@ -64,7 +66,7 @@ export function getOnboardingChoiceCardClassName({
   recommended?: boolean;
 }) {
   return cn(
-    "flex min-h-[48px] w-full items-center justify-between gap-[10px] rounded-[10px] px-[12px] py-[9px] text-left backdrop-blur-[18px] backdrop-saturate-[1.2] transition-[border-color,background-color,box-shadow] duration-200",
+    "flex min-h-[60px] w-full items-center justify-between gap-3 rounded-[10px] px-3 py-3 text-left backdrop-blur-[18px] backdrop-saturate-[1.2] transition-[border-color,background-color,box-shadow] duration-200",
     recommended
       ? `${onboardingRecommendedSurfaceClassName} ${onboardingRecommendedSurfaceHoverClassName}`
       : `${onboardingCardSurfaceClassName} ${onboardingCardSurfaceHoverClassName}`,
@@ -171,6 +173,7 @@ export const OnboardingStatusBanner = React.forwardRef<
     tone: "success" | "neutral" | "error";
   }
 >(({ action, children, className, live = "polite", tone, ...props }, ref) => {
+  const compactSuccess = tone === "success" && !action;
   const toneClass =
     tone === "success"
       ? "border-[var(--ok-muted)] bg-[var(--ok-subtle)] text-[var(--ok)]"
@@ -181,18 +184,35 @@ export const OnboardingStatusBanner = React.forwardRef<
   return (
     <div
       ref={ref}
+      data-onboarding-status-layout={compactSuccess ? "compact" : "split"}
       aria-live={live}
       role={tone === "error" ? "alert" : "status"}
       tabIndex={-1}
       className={cn(
-        "flex w-full items-center justify-center gap-2 rounded-xl border px-4 py-3 text-sm",
+        "rounded-xl border text-sm",
+        compactSuccess
+          ? "mx-auto flex w-full max-w-[24rem] items-center justify-center px-5 py-4 text-center"
+          : "flex w-full items-center justify-between gap-3 px-4 py-3",
         toneClass,
         className,
       )}
       {...props}
     >
-      <span className="flex-1">{children}</span>
-      {action}
+      <div
+        data-onboarding-status-content
+        className={cn(
+          compactSuccess
+            ? "inline-flex items-center justify-center gap-2 text-center"
+            : "flex min-w-0 flex-1 items-center gap-2 text-left",
+        )}
+      >
+        {children}
+      </div>
+      {action ? (
+        <div data-onboarding-status-action className="shrink-0">
+          {action}
+        </div>
+      ) : null}
     </div>
   );
 });

--- a/packages/app-core/src/components/onboarding/onboarding-step-chrome.test.tsx
+++ b/packages/app-core/src/components/onboarding/onboarding-step-chrome.test.tsx
@@ -5,6 +5,8 @@ import { describe, expect, it } from "vitest";
 import {
   OnboardingLinkActionButton,
   OnboardingSecondaryActionButton,
+  OnboardingStepHeader,
+  onboardingHeaderBlockClass,
 } from "./onboarding-step-chrome";
 
 describe("onboarding step chrome actions", () => {
@@ -40,5 +42,20 @@ describe("onboarding step chrome actions", () => {
       "[text-shadow:var(--onboarding-text-shadow-muted)]",
     );
     expect(button.className).not.toContain("bg-bg-accent");
+  });
+
+  it("owns a shared bottom rhythm for onboarding headers", () => {
+    const { container } = render(
+      <OnboardingStepHeader
+        eyebrow="Hosting"
+        title="Choose your AI provider"
+        description="Pick a provider to continue."
+      />,
+    );
+
+    expect(container.firstElementChild).toBeTruthy();
+    expect(String(container.firstElementChild?.className)).toContain(
+      onboardingHeaderBlockClass,
+    );
   });
 });

--- a/packages/app-core/src/components/onboarding/onboarding-step-chrome.test.tsx
+++ b/packages/app-core/src/components/onboarding/onboarding-step-chrome.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  OnboardingLinkActionButton,
+  OnboardingSecondaryActionButton,
+} from "./onboarding-step-chrome";
+
+describe("onboarding step chrome actions", () => {
+  it("uses onboarding-owned chrome for secondary actions instead of theme ghost styles", () => {
+    render(<OnboardingSecondaryActionButton>Back</OnboardingSecondaryActionButton>);
+
+    const button = screen.getByRole("button", { name: "Back" });
+    expect(button.className).toContain(
+      "hover:bg-[var(--onboarding-secondary-hover-bg)]",
+    );
+    expect(button.className).toContain(
+      "focus-visible:ring-[var(--onboarding-secondary-focus-ring)]",
+    );
+    expect(button.className).toContain(
+      "[text-shadow:var(--onboarding-text-shadow-muted)]",
+    );
+    expect(button.className).toContain(
+      "[-webkit-text-stroke:0.25px_var(--onboarding-text-stroke-soft)]",
+    );
+    expect(button.className).not.toContain("bg-bg-accent");
+    expect(button.className).not.toContain("text-muted-strong");
+  });
+
+  it("keeps onboarding link actions on onboarding-owned interaction tokens", () => {
+    render(<OnboardingLinkActionButton>Report issue</OnboardingLinkActionButton>);
+
+    const button = screen.getByRole("button", { name: "Report issue" });
+    expect(button.className).toContain(
+      "hover:bg-[var(--onboarding-secondary-hover-bg)]",
+    );
+    expect(button.className).toContain("hover:text-[var(--onboarding-link)]");
+    expect(button.className).toContain(
+      "[text-shadow:var(--onboarding-text-shadow-muted)]",
+    );
+    expect(button.className).not.toContain("bg-bg-accent");
+  });
+});

--- a/packages/app-core/src/components/onboarding/onboarding-step-chrome.test.tsx
+++ b/packages/app-core/src/components/onboarding/onboarding-step-chrome.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import {
   OnboardingLinkActionButton,
@@ -14,6 +14,8 @@ describe("onboarding step chrome actions", () => {
     render(<OnboardingSecondaryActionButton>Back</OnboardingSecondaryActionButton>);
 
     const button = screen.getByRole("button", { name: "Back" });
+    expect(button.className).toContain("min-h-[44px]");
+    expect(button.className).toContain("min-w-[44px]");
     expect(button.className).toContain(
       "hover:bg-[var(--onboarding-secondary-hover-bg)]",
     );
@@ -23,9 +25,7 @@ describe("onboarding step chrome actions", () => {
     expect(button.className).toContain(
       "[text-shadow:var(--onboarding-text-shadow-muted)]",
     );
-    expect(button.className).toContain(
-      "[-webkit-text-stroke:0.25px_var(--onboarding-text-stroke-soft)]",
-    );
+    expect(button.className).not.toContain("-webkit-text-stroke");
     expect(button.className).not.toContain("bg-bg-accent");
     expect(button.className).not.toContain("text-muted-strong");
   });
@@ -41,6 +41,7 @@ describe("onboarding step chrome actions", () => {
     expect(button.className).toContain(
       "[text-shadow:var(--onboarding-text-shadow-muted)]",
     );
+    expect(button.className).toContain("min-h-[44px]");
     expect(button.className).not.toContain("bg-bg-accent");
   });
 
@@ -57,5 +58,36 @@ describe("onboarding step chrome actions", () => {
     expect(String(container.firstElementChild?.className)).toContain(
       onboardingHeaderBlockClass,
     );
+  });
+
+  it("renders the onboarding title as a semantic level-one heading", () => {
+    const { container } = render(
+      <OnboardingStepHeader
+        eyebrow="Hosting"
+        title="Choose your AI provider"
+        description="Pick a provider to continue."
+      />,
+    );
+
+    const heading = within(container).getByRole("heading", {
+      level: 1,
+      name: "Choose your AI provider",
+    });
+    expect(heading).toBeTruthy();
+  });
+
+  it("promotes description-only prompts into the semantic heading slot", () => {
+    const { container } = render(
+      <OnboardingStepHeader
+        eyebrow="Welcome to Milady"
+        description="Existing setup detected. Continue, or start fresh?"
+      />,
+    );
+
+    const heading = within(container).getByRole("heading", {
+      level: 1,
+      name: "Existing setup detected. Continue, or start fresh?",
+    });
+    expect(heading).toBeTruthy();
   });
 });

--- a/packages/app-core/src/components/onboarding/onboarding-step-chrome.tsx
+++ b/packages/app-core/src/components/onboarding/onboarding-step-chrome.tsx
@@ -1,9 +1,11 @@
 import { cn } from "@miladyai/ui";
 import type { ButtonHTMLAttributes, CSSProperties } from "react";
+import { useId } from "react";
 import {
   onboardingReadableTextFaintClassName,
   onboardingReadableTextMutedClassName,
   onboardingReadableTextStrongClassName,
+  onboardingTextSupportClassName,
 } from "./onboarding-form-primitives";
 
 interface OnboardingStepHeaderProps {
@@ -21,7 +23,7 @@ export const onboardingTitleClass =
   `text-center text-xl font-light leading-[1.4] ${onboardingReadableTextStrongClassName}`;
 
 export const onboardingDescriptionClass =
-  `text-center text-sm leading-relaxed ${onboardingReadableTextMutedClassName}`;
+  `mx-auto max-w-[36ch] text-center text-[13px] leading-relaxed ${onboardingReadableTextMutedClassName} ${onboardingTextSupportClassName}`;
 export const onboardingHeaderBlockClass =
   "mb-5 max-md:mb-4";
 
@@ -29,13 +31,13 @@ export const onboardingFooterClass =
   "mt-6 flex flex-wrap items-center justify-between gap-x-6 gap-y-3 border-t border-[var(--onboarding-footer-border)] pt-4";
 
 export const onboardingSecondaryActionClass =
-  `inline-flex min-h-9 items-center justify-center gap-2 rounded-md border border-transparent bg-transparent px-2.5 py-1.5 text-[10px] uppercase tracking-[0.15em] transition-[color,background-color,box-shadow] duration-300 hover:bg-[var(--onboarding-secondary-hover-bg)] hover:text-[var(--onboarding-text-strong)] active:bg-[var(--onboarding-secondary-pressed-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--onboarding-secondary-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent disabled:pointer-events-none disabled:opacity-50 ${onboardingReadableTextMutedClassName}`;
+  `inline-flex min-h-[44px] min-w-[44px] items-center justify-center gap-2 rounded-md border border-transparent bg-transparent px-3 py-2 text-[11px] uppercase tracking-[0.14em] transition-[color,background-color,box-shadow] duration-300 hover:bg-[var(--onboarding-secondary-hover-bg)] hover:text-[var(--onboarding-text-strong)] active:bg-[var(--onboarding-secondary-pressed-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--onboarding-secondary-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent disabled:pointer-events-none disabled:opacity-50 ${onboardingReadableTextMutedClassName}`;
 
 export const onboardingPrimaryActionClass =
   "group relative inline-flex min-h-[44px] items-center justify-center gap-2 overflow-hidden rounded-[8px] border border-[var(--onboarding-accent-border)] bg-[var(--onboarding-accent-bg)] px-8 py-3 text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--onboarding-accent-foreground)] transition-all duration-300 hover:border-[var(--onboarding-accent-border-hover)] hover:bg-[var(--onboarding-accent-bg-hover)] disabled:cursor-not-allowed disabled:opacity-40";
 
 export const onboardingLinkActionClass =
-  `inline-flex min-h-8 items-center justify-center rounded-md border border-transparent bg-transparent px-2 py-1 text-[11px] transition-[color,background-color,box-shadow] duration-300 hover:bg-[var(--onboarding-secondary-hover-bg)] hover:text-[var(--onboarding-link)] active:bg-[var(--onboarding-secondary-pressed-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--onboarding-secondary-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent disabled:pointer-events-none disabled:opacity-50 ${onboardingReadableTextFaintClassName}`;
+  `inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md border border-transparent bg-transparent px-3 py-2 text-[11px] transition-[color,background-color,box-shadow] duration-300 hover:bg-[var(--onboarding-secondary-hover-bg)] hover:text-[var(--onboarding-link)] active:bg-[var(--onboarding-secondary-pressed-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--onboarding-secondary-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent disabled:pointer-events-none disabled:opacity-50 ${onboardingReadableTextFaintClassName}`;
 
 export const onboardingTextShadowStyle = {
   textShadow: "var(--onboarding-text-shadow-strong)",
@@ -43,8 +45,7 @@ export const onboardingTextShadowStyle = {
 } as const;
 
 export const onboardingBodyTextShadowStyle = {
-  textShadow: "var(--onboarding-text-shadow-primary)",
-  WebkitTextStroke: "0.25px var(--onboarding-text-stroke-soft)",
+  textShadow: "var(--onboarding-text-shadow-muted)",
 } as const;
 
 export const onboardingPrimaryActionTextShadowStyle = {
@@ -53,7 +54,6 @@ export const onboardingPrimaryActionTextShadowStyle = {
 
 export const onboardingSecondaryActionTextShadowStyle = {
   textShadow: "var(--onboarding-text-shadow-muted)",
-  WebkitTextStroke: "0.25px var(--onboarding-text-stroke-soft)",
 } as const;
 
 function mergeOnboardingTextShadowStyle(
@@ -117,29 +117,52 @@ export function OnboardingStepHeader({
   titleClassName = "",
   descriptionClassName = "",
 }: OnboardingStepHeaderProps) {
+  const reactId = useId().replace(/:/g, "");
+  const headingId = `onboarding-step-heading-${reactId}`;
+  const descriptionId = `onboarding-step-description-${reactId}`;
+  const headingText = title || description || eyebrow;
+  const usesTitleHeading = Boolean(title);
+  const usesDescriptionHeading = !title && Boolean(description);
+  const hasBodyDescription = Boolean(title && description);
+  const headingClassName = usesTitleHeading || usesDescriptionHeading
+    ? `${onboardingTitleClass} ${
+        usesDescriptionHeading ? descriptionClassName : titleClassName
+      }`.trim()
+    : onboardingEyebrowClass;
+
   return (
-    <div className={onboardingHeaderBlockClass}>
-      <div className={onboardingEyebrowClass} style={onboardingTextShadowStyle}>
-        {eyebrow}
-      </div>
-      <OnboardingStepDivider />
-      {title ? (
-        <div
-          className={`${onboardingTitleClass} ${titleClassName}`.trim()}
-          style={onboardingTextShadowStyle}
-        >
-          {title}
-        </div>
+    <header
+      className={onboardingHeaderBlockClass}
+      aria-labelledby={headingId}
+      aria-describedby={hasBodyDescription ? descriptionId : undefined}
+    >
+      {usesTitleHeading || usesDescriptionHeading ? (
+        <p className={onboardingEyebrowClass} style={onboardingBodyTextShadowStyle}>
+          {eyebrow}
+        </p>
       ) : null}
-      {description ? (
+      <OnboardingStepDivider />
+      <h1
+        id={headingId}
+        className={headingClassName}
+        style={
+          usesTitleHeading || usesDescriptionHeading
+            ? onboardingTextShadowStyle
+            : onboardingBodyTextShadowStyle
+        }
+      >
+        {headingText}
+      </h1>
+      {hasBodyDescription ? (
         <p
+          id={descriptionId}
           className={`${onboardingDescriptionClass} ${descriptionClassName}`.trim()}
           style={onboardingBodyTextShadowStyle}
         >
           {description}
         </p>
       ) : null}
-    </div>
+    </header>
   );
 }
 

--- a/packages/app-core/src/components/onboarding/onboarding-step-chrome.tsx
+++ b/packages/app-core/src/components/onboarding/onboarding-step-chrome.tsx
@@ -1,3 +1,11 @@
+import { cn } from "@miladyai/ui";
+import type { ButtonHTMLAttributes, CSSProperties } from "react";
+import {
+  onboardingReadableTextFaintClassName,
+  onboardingReadableTextMutedClassName,
+  onboardingReadableTextStrongClassName,
+} from "./onboarding-form-primitives";
+
 interface OnboardingStepHeaderProps {
   eyebrow: string;
   title?: string;
@@ -7,32 +15,34 @@ interface OnboardingStepHeaderProps {
 }
 
 export const onboardingEyebrowClass =
-  "text-center text-xs font-semibold uppercase tracking-[0.3em] text-[var(--onboarding-text-muted)]";
+  `text-center text-xs font-semibold uppercase tracking-[0.3em] ${onboardingReadableTextMutedClassName}`;
 
 export const onboardingTitleClass =
-  "text-center text-xl font-light leading-[1.4] text-[var(--onboarding-text-strong)]";
+  `text-center text-xl font-light leading-[1.4] ${onboardingReadableTextStrongClassName}`;
 
 export const onboardingDescriptionClass =
-  "text-center text-sm leading-relaxed text-[var(--onboarding-text-muted)]";
+  `text-center text-sm leading-relaxed ${onboardingReadableTextMutedClassName}`;
 
 export const onboardingFooterClass =
   "mt-6 flex flex-wrap items-center justify-between gap-x-6 gap-y-3 border-t border-[var(--onboarding-footer-border)] pt-4";
 
 export const onboardingSecondaryActionClass =
-  "p-0 text-[10px] uppercase tracking-[0.15em] text-[var(--onboarding-text-muted)] transition-colors duration-300 hover:text-[var(--onboarding-text-strong)]";
+  `inline-flex min-h-9 items-center justify-center gap-2 rounded-md border border-transparent bg-transparent px-2.5 py-1.5 text-[10px] uppercase tracking-[0.15em] transition-[color,background-color,box-shadow] duration-300 hover:bg-[var(--onboarding-secondary-hover-bg)] hover:text-[var(--onboarding-text-strong)] active:bg-[var(--onboarding-secondary-pressed-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--onboarding-secondary-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent disabled:pointer-events-none disabled:opacity-50 ${onboardingReadableTextMutedClassName}`;
 
 export const onboardingPrimaryActionClass =
   "group relative inline-flex min-h-[44px] items-center justify-center gap-2 overflow-hidden rounded-[8px] border border-[var(--onboarding-accent-border)] bg-[var(--onboarding-accent-bg)] px-8 py-3 text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--onboarding-accent-foreground)] transition-all duration-300 hover:border-[var(--onboarding-accent-border-hover)] hover:bg-[var(--onboarding-accent-bg-hover)] disabled:cursor-not-allowed disabled:opacity-40";
 
 export const onboardingLinkActionClass =
-  "rounded-md px-2 py-1 text-[11px] text-[var(--onboarding-text-faint)] transition-colors duration-300 hover:text-[var(--onboarding-link)]";
+  `inline-flex min-h-8 items-center justify-center rounded-md border border-transparent bg-transparent px-2 py-1 text-[11px] transition-[color,background-color,box-shadow] duration-300 hover:bg-[var(--onboarding-secondary-hover-bg)] hover:text-[var(--onboarding-link)] active:bg-[var(--onboarding-secondary-pressed-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--onboarding-secondary-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent disabled:pointer-events-none disabled:opacity-50 ${onboardingReadableTextFaintClassName}`;
 
 export const onboardingTextShadowStyle = {
-  textShadow: "0 2px 10px rgba(3,5,10,0.55)",
+  textShadow: "var(--onboarding-text-shadow-strong)",
+  WebkitTextStroke: "0.35px var(--onboarding-text-stroke)",
 } as const;
 
 export const onboardingBodyTextShadowStyle = {
-  textShadow: "0 2px 10px rgba(3,5,10,0.45)",
+  textShadow: "var(--onboarding-text-shadow-primary)",
+  WebkitTextStroke: "0.25px var(--onboarding-text-stroke-soft)",
 } as const;
 
 export const onboardingPrimaryActionTextShadowStyle = {
@@ -40,8 +50,55 @@ export const onboardingPrimaryActionTextShadowStyle = {
 } as const;
 
 export const onboardingSecondaryActionTextShadowStyle = {
-  textShadow: "0 1px 8px rgba(3,5,10,0.45)",
+  textShadow: "var(--onboarding-text-shadow-muted)",
+  WebkitTextStroke: "0.25px var(--onboarding-text-stroke-soft)",
 } as const;
+
+function mergeOnboardingTextShadowStyle(
+  style?: CSSProperties,
+): CSSProperties | undefined {
+  if (!style) {
+    return onboardingSecondaryActionTextShadowStyle;
+  }
+  return {
+    ...onboardingSecondaryActionTextShadowStyle,
+    ...style,
+  };
+}
+
+type OnboardingActionButtonProps = ButtonHTMLAttributes<HTMLButtonElement>;
+
+export function OnboardingSecondaryActionButton({
+  className,
+  style,
+  type = "button",
+  ...props
+}: OnboardingActionButtonProps) {
+  return (
+    <button
+      type={type}
+      className={cn(onboardingSecondaryActionClass, className)}
+      style={mergeOnboardingTextShadowStyle(style)}
+      {...props}
+    />
+  );
+}
+
+export function OnboardingLinkActionButton({
+  className,
+  style,
+  type = "button",
+  ...props
+}: OnboardingActionButtonProps) {
+  return (
+    <button
+      type={type}
+      className={cn(onboardingLinkActionClass, className)}
+      style={mergeOnboardingTextShadowStyle(style)}
+      {...props}
+    />
+  );
+}
 
 export function OnboardingStepDivider() {
   return (

--- a/packages/app-core/src/components/onboarding/onboarding-step-chrome.tsx
+++ b/packages/app-core/src/components/onboarding/onboarding-step-chrome.tsx
@@ -22,6 +22,8 @@ export const onboardingTitleClass =
 
 export const onboardingDescriptionClass =
   `text-center text-sm leading-relaxed ${onboardingReadableTextMutedClassName}`;
+export const onboardingHeaderBlockClass =
+  "mb-5 max-md:mb-4";
 
 export const onboardingFooterClass =
   "mt-6 flex flex-wrap items-center justify-between gap-x-6 gap-y-3 border-t border-[var(--onboarding-footer-border)] pt-4";
@@ -116,7 +118,7 @@ export function OnboardingStepHeader({
   descriptionClassName = "",
 }: OnboardingStepHeaderProps) {
   return (
-    <>
+    <div className={onboardingHeaderBlockClass}>
       <div className={onboardingEyebrowClass} style={onboardingTextShadowStyle}>
         {eyebrow}
       </div>
@@ -137,7 +139,7 @@ export function OnboardingStepHeader({
           {description}
         </p>
       ) : null}
-    </>
+    </div>
   );
 }
 

--- a/packages/app-core/src/styles/brand-gold.css
+++ b/packages/app-core/src/styles/brand-gold.css
@@ -83,14 +83,14 @@
     0 1px 0 rgba(255, 255, 255, 0.04),
     0 1px 8px rgba(3, 5, 10, 0.5),
     0 0 14px rgba(3, 5, 10, 0.16);
-  --onboarding-card-bg: rgba(10, 10, 12, 0.58);
-  --onboarding-card-bg-hover: rgba(18, 18, 21, 0.68);
-  --onboarding-card-border: rgba(255, 255, 255, 0.08);
+  --onboarding-card-bg: rgba(10, 10, 12, 0.42);
+  --onboarding-card-bg-hover: rgba(18, 18, 21, 0.52);
+  --onboarding-card-border: rgba(255, 255, 255, 0.09);
   --onboarding-card-border-strong: rgba(240, 185, 11, 0.3);
-  --onboarding-card-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
-  --onboarding-panel-bg: rgba(6, 7, 8, 0.64);
-  --onboarding-panel-border: rgba(255, 255, 255, 0.08);
-  --onboarding-panel-shadow: 0 14px 40px rgba(0, 0, 0, 0.26);
+  --onboarding-card-shadow: 0 8px 24px rgba(0, 0, 0, 0.14);
+  --onboarding-panel-bg: rgba(6, 7, 8, 0.46);
+  --onboarding-panel-border: rgba(255, 255, 255, 0.09);
+  --onboarding-panel-shadow: 0 12px 30px rgba(0, 0, 0, 0.2);
   --onboarding-divider: rgba(49, 49, 56, 0.22);
   --onboarding-secondary-hover-bg: rgba(240, 185, 11, 0.08);
   --onboarding-secondary-pressed-bg: rgba(240, 185, 11, 0.14);
@@ -124,11 +124,11 @@
     0 0 14px rgba(3, 5, 10, 0.16);
 
   /* Cards (Remote, Cloud buttons) */
-  --onboarding-card-bg: rgba(10, 10, 12, 0.58);
-  --onboarding-card-bg-hover: rgba(18, 18, 21, 0.68);
-  --onboarding-card-border: rgba(255, 255, 255, 0.08);
+  --onboarding-card-bg: rgba(10, 10, 12, 0.42);
+  --onboarding-card-bg-hover: rgba(18, 18, 21, 0.52);
+  --onboarding-card-border: rgba(255, 255, 255, 0.09);
   --onboarding-card-border-strong: rgba(240, 185, 11, 0.3);
-  --onboarding-card-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
+  --onboarding-card-shadow: 0 8px 24px rgba(0, 0, 0, 0.14);
 
   /* Recommended card (Local button) */
   --onboarding-recommended-bg: rgba(240, 185, 11, 0.12);
@@ -144,9 +144,9 @@
   --onboarding-accent-foreground: var(--highlight-gold);
 
   /* Panel (main onboarding container) */
-  --onboarding-panel-bg: rgba(6, 7, 8, 0.64);
-  --onboarding-panel-border: rgba(255, 255, 255, 0.08);
-  --onboarding-panel-shadow: 0 14px 40px rgba(0, 0, 0, 0.26);
+  --onboarding-panel-bg: rgba(6, 7, 8, 0.46);
+  --onboarding-panel-border: rgba(255, 255, 255, 0.09);
+  --onboarding-panel-shadow: 0 12px 30px rgba(0, 0, 0, 0.2);
 
   /* Misc */
   --onboarding-divider: rgba(49, 49, 56, 0.22);

--- a/packages/app-core/src/styles/brand-gold.css
+++ b/packages/app-core/src/styles/brand-gold.css
@@ -69,14 +69,32 @@
   --onboarding-text-subtle: rgba(210, 208, 220, 0.78);
   --onboarding-text-muted: rgba(186, 184, 198, 0.7);
   --onboarding-text-faint: rgba(160, 158, 176, 0.56);
-  --onboarding-card-bg: rgba(10, 10, 12, 0.8);
-  --onboarding-card-bg-hover: rgba(18, 18, 21, 0.88);
-  --onboarding-card-border: rgba(49, 49, 56, 0.32);
-  --onboarding-card-border-strong: rgba(240, 185, 11, 0.34);
-  --onboarding-panel-bg: rgba(5, 5, 6, 0.88);
-  --onboarding-panel-border: rgba(49, 49, 56, 0.28);
-  --onboarding-panel-shadow: 0 16px 44px rgba(0, 0, 0, 0.42);
+  --onboarding-text-stroke: rgba(4, 8, 14, 0.78);
+  --onboarding-text-stroke-soft: rgba(4, 8, 14, 0.52);
+  --onboarding-text-shadow-strong:
+    0 1px 0 rgba(255, 255, 255, 0.06),
+    0 2px 14px rgba(3, 5, 10, 0.62),
+    0 0 24px rgba(3, 5, 10, 0.24);
+  --onboarding-text-shadow-primary:
+    0 1px 0 rgba(255, 255, 255, 0.05),
+    0 2px 11px rgba(3, 5, 10, 0.56),
+    0 0 18px rgba(3, 5, 10, 0.18);
+  --onboarding-text-shadow-muted:
+    0 1px 0 rgba(255, 255, 255, 0.04),
+    0 1px 8px rgba(3, 5, 10, 0.5),
+    0 0 14px rgba(3, 5, 10, 0.16);
+  --onboarding-card-bg: rgba(10, 10, 12, 0.58);
+  --onboarding-card-bg-hover: rgba(18, 18, 21, 0.68);
+  --onboarding-card-border: rgba(255, 255, 255, 0.08);
+  --onboarding-card-border-strong: rgba(240, 185, 11, 0.3);
+  --onboarding-card-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
+  --onboarding-panel-bg: rgba(6, 7, 8, 0.64);
+  --onboarding-panel-border: rgba(255, 255, 255, 0.08);
+  --onboarding-panel-shadow: 0 14px 40px rgba(0, 0, 0, 0.26);
   --onboarding-divider: rgba(49, 49, 56, 0.22);
+  --onboarding-secondary-hover-bg: rgba(240, 185, 11, 0.08);
+  --onboarding-secondary-pressed-bg: rgba(240, 185, 11, 0.14);
+  --onboarding-secondary-focus-ring: rgba(240, 185, 11, 0.42);
 }
 
 /* ── Onboarding theme variables ────────────────────────────────────────
@@ -90,12 +108,27 @@
   --onboarding-text-subtle: rgba(183, 189, 198, 0.82);
   --onboarding-text-muted: rgba(132, 142, 156, 0.78);
   --onboarding-text-faint: rgba(132, 142, 156, 0.58);
+  --onboarding-text-stroke: rgba(4, 8, 14, 0.78);
+  --onboarding-text-stroke-soft: rgba(4, 8, 14, 0.52);
+  --onboarding-text-shadow-strong:
+    0 1px 0 rgba(255, 255, 255, 0.06),
+    0 2px 14px rgba(3, 5, 10, 0.62),
+    0 0 24px rgba(3, 5, 10, 0.24);
+  --onboarding-text-shadow-primary:
+    0 1px 0 rgba(255, 255, 255, 0.05),
+    0 2px 11px rgba(3, 5, 10, 0.56),
+    0 0 18px rgba(3, 5, 10, 0.18);
+  --onboarding-text-shadow-muted:
+    0 1px 0 rgba(255, 255, 255, 0.04),
+    0 1px 8px rgba(3, 5, 10, 0.5),
+    0 0 14px rgba(3, 5, 10, 0.16);
 
   /* Cards (Remote, Cloud buttons) */
-  --onboarding-card-bg: rgba(10, 10, 12, 0.8);
-  --onboarding-card-bg-hover: rgba(18, 18, 21, 0.88);
-  --onboarding-card-border: rgba(49, 49, 56, 0.32);
-  --onboarding-card-border-strong: rgba(240, 185, 11, 0.34);
+  --onboarding-card-bg: rgba(10, 10, 12, 0.58);
+  --onboarding-card-bg-hover: rgba(18, 18, 21, 0.68);
+  --onboarding-card-border: rgba(255, 255, 255, 0.08);
+  --onboarding-card-border-strong: rgba(240, 185, 11, 0.3);
+  --onboarding-card-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
 
   /* Recommended card (Local button) */
   --onboarding-recommended-bg: rgba(240, 185, 11, 0.12);
@@ -111,42 +144,22 @@
   --onboarding-accent-foreground: var(--highlight-gold);
 
   /* Panel (main onboarding container) */
-  --onboarding-panel-bg: rgba(5, 5, 6, 0.88);
-  --onboarding-panel-border: rgba(49, 49, 56, 0.28);
-  --onboarding-panel-shadow: 0 16px 44px rgba(0, 0, 0, 0.42);
+  --onboarding-panel-bg: rgba(6, 7, 8, 0.64);
+  --onboarding-panel-border: rgba(255, 255, 255, 0.08);
+  --onboarding-panel-shadow: 0 14px 40px rgba(0, 0, 0, 0.26);
 
   /* Misc */
   --onboarding-divider: rgba(49, 49, 56, 0.22);
   --onboarding-footer-border: rgba(49, 49, 56, 0.16);
   --onboarding-link: var(--classic-gold);
   --onboarding-ripple: rgba(240, 185, 11, 0.08);
+  --onboarding-secondary-hover-bg: rgba(240, 185, 11, 0.08);
+  --onboarding-secondary-pressed-bg: rgba(240, 185, 11, 0.14);
+  --onboarding-secondary-focus-ring: rgba(240, 185, 11, 0.42);
   --onboarding-roster-bg: rgba(8, 10, 13, 0.76);
   --onboarding-roster-border: rgba(49, 49, 56, 0.18);
   --onboarding-field-focus-border: rgba(240, 185, 11, 0.42);
   --onboarding-field-focus-shadow: 0 0 0 3px rgba(240, 185, 11, 0.12);
-}
-
-/* Light-mode overrides */
-:root:not(.dark) {
-  --onboarding-text-strong: rgba(30, 35, 41, 0.95);
-  --onboarding-text-primary: rgba(40, 44, 52, 0.9);
-  --onboarding-text-subtle: rgba(52, 58, 67, 0.76);
-  --onboarding-text-muted: rgba(70, 76, 88, 0.72);
-  --onboarding-text-faint: rgba(86, 92, 106, 0.58);
-  --onboarding-card-bg: rgba(252, 253, 253, 0.76);
-  --onboarding-card-bg-hover: rgba(252, 253, 253, 0.88);
-  --onboarding-card-border: rgba(0, 0, 0, 0.1);
-  --onboarding-card-border-strong: rgba(240, 185, 11, 0.28);
-  --onboarding-recommended-bg: rgba(240, 185, 11, 0.1);
-  --onboarding-recommended-bg-hover: rgba(240, 185, 11, 0.16);
-  --onboarding-recommended-border: rgba(240, 185, 11, 0.24);
-  --onboarding-recommended-border-strong: rgba(240, 185, 11, 0.38);
-  --onboarding-panel-bg: rgba(247, 248, 250, 0.92);
-  --onboarding-panel-border: rgba(0, 0, 0, 0.08);
-  --onboarding-panel-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
-  --onboarding-divider: rgba(0, 0, 0, 0.08);
-  --onboarding-roster-bg: rgba(245, 245, 248, 0.7);
-  --onboarding-roster-border: rgba(0, 0, 0, 0.08);
 }
 
 .onboarding-step-list::after {

--- a/packages/app-core/src/styles/brand-gold.css
+++ b/packages/app-core/src/styles/brand-gold.css
@@ -65,32 +65,29 @@
    * in the dark variant even when the surrounding UI theme is light.
    */
   --onboarding-text-strong: rgba(240, 238, 250, 0.95);
-  --onboarding-text-primary: rgba(232, 230, 240, 0.92);
-  --onboarding-text-subtle: rgba(210, 208, 220, 0.78);
-  --onboarding-text-muted: rgba(186, 184, 198, 0.7);
-  --onboarding-text-faint: rgba(160, 158, 176, 0.56);
+  --onboarding-text-primary: rgba(236, 234, 243, 0.94);
+  --onboarding-text-subtle: rgba(220, 218, 228, 0.86);
+  --onboarding-text-muted: rgba(203, 201, 214, 0.82);
+  --onboarding-text-faint: rgba(182, 180, 196, 0.72);
   --onboarding-text-stroke: rgba(4, 8, 14, 0.78);
-  --onboarding-text-stroke-soft: rgba(4, 8, 14, 0.52);
   --onboarding-text-shadow-strong:
     0 1px 0 rgba(255, 255, 255, 0.06),
     0 2px 14px rgba(3, 5, 10, 0.62),
     0 0 24px rgba(3, 5, 10, 0.24);
-  --onboarding-text-shadow-primary:
-    0 1px 0 rgba(255, 255, 255, 0.05),
-    0 2px 11px rgba(3, 5, 10, 0.56),
-    0 0 18px rgba(3, 5, 10, 0.18);
-  --onboarding-text-shadow-muted:
-    0 1px 0 rgba(255, 255, 255, 0.04),
-    0 1px 8px rgba(3, 5, 10, 0.5),
-    0 0 14px rgba(3, 5, 10, 0.16);
-  --onboarding-card-bg: rgba(10, 10, 12, 0.42);
-  --onboarding-card-bg-hover: rgba(18, 18, 21, 0.52);
-  --onboarding-card-border: rgba(255, 255, 255, 0.09);
-  --onboarding-card-border-strong: rgba(240, 185, 11, 0.3);
-  --onboarding-card-shadow: 0 8px 24px rgba(0, 0, 0, 0.14);
-  --onboarding-panel-bg: rgba(6, 7, 8, 0.46);
-  --onboarding-panel-border: rgba(255, 255, 255, 0.09);
-  --onboarding-panel-shadow: 0 12px 30px rgba(0, 0, 0, 0.2);
+  --onboarding-text-shadow-primary: 0 1px 5px rgba(3, 5, 10, 0.34);
+  --onboarding-text-shadow-muted: 0 1px 4px rgba(3, 5, 10, 0.28);
+  --onboarding-card-bg: rgba(10, 10, 12, 0.56);
+  --onboarding-card-bg-hover: rgba(18, 18, 21, 0.64);
+  --onboarding-card-border: rgba(255, 255, 255, 0.11);
+  --onboarding-card-border-strong: rgba(240, 185, 11, 0.32);
+  --onboarding-card-shadow: 0 10px 28px rgba(0, 0, 0, 0.18);
+  --onboarding-panel-bg: rgba(6, 7, 8, 0.6);
+  --onboarding-panel-border: rgba(255, 255, 255, 0.11);
+  --onboarding-panel-shadow: 0 14px 34px rgba(0, 0, 0, 0.22);
+  --onboarding-input-bg: rgba(10, 10, 12, 0.68);
+  --onboarding-input-border: rgba(255, 255, 255, 0.13);
+  --onboarding-text-support-bg: rgba(9, 12, 18, 0.22);
+  --onboarding-text-support-shadow: 0 10px 20px rgba(0, 0, 0, 0.1);
   --onboarding-divider: rgba(49, 49, 56, 0.22);
   --onboarding-secondary-hover-bg: rgba(240, 185, 11, 0.08);
   --onboarding-secondary-pressed-bg: rgba(240, 185, 11, 0.14);
@@ -103,32 +100,25 @@
  */
 :root {
   /* Text hierarchy */
-  --onboarding-text-strong: rgba(255, 255, 255, 0.96);
-  --onboarding-text-primary: rgba(234, 236, 239, 0.92);
-  --onboarding-text-subtle: rgba(183, 189, 198, 0.82);
-  --onboarding-text-muted: rgba(132, 142, 156, 0.78);
-  --onboarding-text-faint: rgba(132, 142, 156, 0.58);
+  --onboarding-text-strong: rgba(255, 255, 255, 0.97);
+  --onboarding-text-primary: rgba(240, 242, 245, 0.94);
+  --onboarding-text-subtle: rgba(209, 214, 221, 0.84);
+  --onboarding-text-muted: rgba(191, 196, 205, 0.82);
+  --onboarding-text-faint: rgba(171, 177, 188, 0.72);
   --onboarding-text-stroke: rgba(4, 8, 14, 0.78);
-  --onboarding-text-stroke-soft: rgba(4, 8, 14, 0.52);
   --onboarding-text-shadow-strong:
     0 1px 0 rgba(255, 255, 255, 0.06),
     0 2px 14px rgba(3, 5, 10, 0.62),
     0 0 24px rgba(3, 5, 10, 0.24);
-  --onboarding-text-shadow-primary:
-    0 1px 0 rgba(255, 255, 255, 0.05),
-    0 2px 11px rgba(3, 5, 10, 0.56),
-    0 0 18px rgba(3, 5, 10, 0.18);
-  --onboarding-text-shadow-muted:
-    0 1px 0 rgba(255, 255, 255, 0.04),
-    0 1px 8px rgba(3, 5, 10, 0.5),
-    0 0 14px rgba(3, 5, 10, 0.16);
+  --onboarding-text-shadow-primary: 0 1px 5px rgba(3, 5, 10, 0.34);
+  --onboarding-text-shadow-muted: 0 1px 4px rgba(3, 5, 10, 0.28);
 
   /* Cards (Remote, Cloud buttons) */
-  --onboarding-card-bg: rgba(10, 10, 12, 0.42);
-  --onboarding-card-bg-hover: rgba(18, 18, 21, 0.52);
-  --onboarding-card-border: rgba(255, 255, 255, 0.09);
-  --onboarding-card-border-strong: rgba(240, 185, 11, 0.3);
-  --onboarding-card-shadow: 0 8px 24px rgba(0, 0, 0, 0.14);
+  --onboarding-card-bg: rgba(10, 10, 12, 0.56);
+  --onboarding-card-bg-hover: rgba(18, 18, 21, 0.64);
+  --onboarding-card-border: rgba(255, 255, 255, 0.11);
+  --onboarding-card-border-strong: rgba(240, 185, 11, 0.32);
+  --onboarding-card-shadow: 0 10px 28px rgba(0, 0, 0, 0.18);
 
   /* Recommended card (Local button) */
   --onboarding-recommended-bg: rgba(240, 185, 11, 0.12);
@@ -144,9 +134,13 @@
   --onboarding-accent-foreground: var(--highlight-gold);
 
   /* Panel (main onboarding container) */
-  --onboarding-panel-bg: rgba(6, 7, 8, 0.46);
-  --onboarding-panel-border: rgba(255, 255, 255, 0.09);
-  --onboarding-panel-shadow: 0 12px 30px rgba(0, 0, 0, 0.2);
+  --onboarding-panel-bg: rgba(6, 7, 8, 0.6);
+  --onboarding-panel-border: rgba(255, 255, 255, 0.11);
+  --onboarding-panel-shadow: 0 14px 34px rgba(0, 0, 0, 0.22);
+  --onboarding-input-bg: rgba(10, 10, 12, 0.68);
+  --onboarding-input-border: rgba(255, 255, 255, 0.13);
+  --onboarding-text-support-bg: rgba(9, 12, 18, 0.22);
+  --onboarding-text-support-shadow: 0 10px 20px rgba(0, 0, 0, 0.1);
 
   /* Misc */
   --onboarding-divider: rgba(49, 49, 56, 0.22);

--- a/packages/app-core/src/styles/brand-gold.test.ts
+++ b/packages/app-core/src/styles/brand-gold.test.ts
@@ -22,14 +22,14 @@ describe("brand-gold onboarding styles", () => {
       "utf8",
     );
 
-    expect(css).toContain("--onboarding-panel-bg: rgba(6, 7, 8, 0.64);");
+    expect(css).toContain("--onboarding-panel-bg: rgba(6, 7, 8, 0.46);");
     expect(css).toContain(
       "--onboarding-text-primary: rgba(234, 236, 239, 0.92);",
     );
     expect(css).toContain("--onboarding-text-stroke: rgba(4, 8, 14, 0.78);");
     expect(css).toContain("--onboarding-text-shadow-strong:");
-    expect(css).toContain("--onboarding-card-bg: rgba(10, 10, 12, 0.58);");
-    expect(css).toContain("--onboarding-card-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);");
+    expect(css).toContain("--onboarding-card-bg: rgba(10, 10, 12, 0.42);");
+    expect(css).toContain("--onboarding-card-shadow: 0 8px 24px rgba(0, 0, 0, 0.14);");
     expect(css).toContain(
       "--onboarding-secondary-hover-bg: rgba(240, 185, 11, 0.08);",
     );

--- a/packages/app-core/src/styles/brand-gold.test.ts
+++ b/packages/app-core/src/styles/brand-gold.test.ts
@@ -22,20 +22,25 @@ describe("brand-gold onboarding styles", () => {
       "utf8",
     );
 
-    expect(css).toContain("--onboarding-panel-bg: rgba(6, 7, 8, 0.46);");
+    expect(css).toContain("--onboarding-panel-bg: rgba(6, 7, 8, 0.6);");
     expect(css).toContain(
-      "--onboarding-text-primary: rgba(234, 236, 239, 0.92);",
+      "--onboarding-text-primary: rgba(240, 242, 245, 0.94);",
     );
     expect(css).toContain("--onboarding-text-stroke: rgba(4, 8, 14, 0.78);");
     expect(css).toContain("--onboarding-text-shadow-strong:");
-    expect(css).toContain("--onboarding-card-bg: rgba(10, 10, 12, 0.42);");
-    expect(css).toContain("--onboarding-card-shadow: 0 8px 24px rgba(0, 0, 0, 0.14);");
+    expect(css).toContain("--onboarding-card-bg: rgba(10, 10, 12, 0.56);");
+    expect(css).toContain("--onboarding-card-shadow: 0 10px 28px rgba(0, 0, 0, 0.18);");
+    expect(css).toContain("--onboarding-input-bg: rgba(10, 10, 12, 0.68);");
+    expect(css).toContain("--onboarding-text-support-bg: rgba(9, 12, 18, 0.22);");
     expect(css).toContain(
       "--onboarding-secondary-hover-bg: rgba(240, 185, 11, 0.08);",
     );
+    expect(css).not.toContain("--onboarding-text-stroke-soft:");
     expect(css).not.toContain("--onboarding-card-scrim-top:");
     expect(css).not.toContain("--onboarding-panel-scrim-top:");
     expect(css).not.toContain("--onboarding-panel-bg: rgba(247, 248, 250, 0.92);");
     expect(css).not.toContain("--onboarding-card-bg: rgba(252, 253, 253, 0.76);");
+    expect(css).not.toContain("--onboarding-panel-bg: rgba(6, 7, 8, 0.46);");
+    expect(css).not.toContain("--onboarding-card-bg: rgba(10, 10, 12, 0.42);");
   });
 });

--- a/packages/app-core/src/styles/brand-gold.test.ts
+++ b/packages/app-core/src/styles/brand-gold.test.ts
@@ -22,9 +22,20 @@ describe("brand-gold onboarding styles", () => {
       "utf8",
     );
 
-    expect(css).toContain("--onboarding-panel-bg: rgba(5, 5, 6, 0.88);");
+    expect(css).toContain("--onboarding-panel-bg: rgba(6, 7, 8, 0.64);");
     expect(css).toContain(
       "--onboarding-text-primary: rgba(234, 236, 239, 0.92);",
     );
+    expect(css).toContain("--onboarding-text-stroke: rgba(4, 8, 14, 0.78);");
+    expect(css).toContain("--onboarding-text-shadow-strong:");
+    expect(css).toContain("--onboarding-card-bg: rgba(10, 10, 12, 0.58);");
+    expect(css).toContain("--onboarding-card-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);");
+    expect(css).toContain(
+      "--onboarding-secondary-hover-bg: rgba(240, 185, 11, 0.08);",
+    );
+    expect(css).not.toContain("--onboarding-card-scrim-top:");
+    expect(css).not.toContain("--onboarding-panel-scrim-top:");
+    expect(css).not.toContain("--onboarding-panel-bg: rgba(247, 248, 250, 0.92);");
+    expect(css).not.toContain("--onboarding-card-bg: rgba(252, 253, 253, 0.76);");
   });
 });

--- a/packages/app-core/test/app/onboarding-steps.test.tsx
+++ b/packages/app-core/test/app/onboarding-steps.test.tsx
@@ -490,6 +490,18 @@ describe("ConnectionStep", () => {
     expect(text).toContain("onboarding.hostingLocal");
     expect(text).toContain("header.Cloud");
     expect(text).toContain("onboarding.back");
+
+    const buttons = findButtons(tree?.root as TestRenderer.ReactTestInstance);
+    const remoteButton = buttons.find((button) =>
+      collectText(button).includes("onboarding.hostingRemote"),
+    );
+    expect(remoteButton).toBeDefined();
+    expect(String(remoteButton?.props.className)).toContain(
+      "bg-[var(--onboarding-card-bg)]",
+    );
+    expect(String(remoteButton?.props.className)).toContain(
+      "var(--onboarding-card-shadow)",
+    );
   });
 
   it("calls handleOnboardingBack from hosting selection", async () => {

--- a/packages/app-core/test/app/onboarding-steps.test.tsx
+++ b/packages/app-core/test/app/onboarding-steps.test.tsx
@@ -67,6 +67,7 @@ vi.mock("../../src/components/onboarding/onboarding-step-chrome", async () => {
 import { ActivateStep } from "../../src/components/onboarding/ActivateStep";
 import { ConnectionStep } from "../../src/components/onboarding/ConnectionStep";
 import { IdentityStep } from "../../src/components/onboarding/IdentityStep";
+import { onboardingHeaderBlockClass } from "../../src/components/onboarding/onboarding-step-chrome";
 
 // ── Helpers ───────────────────────────────────────────────────────────
 
@@ -492,6 +493,13 @@ describe("ConnectionStep", () => {
     expect(text).toContain("onboarding.back");
 
     const buttons = findButtons(tree?.root as TestRenderer.ReactTestInstance);
+    const headerBlock = (tree?.root as TestRenderer.ReactTestInstance).findAll(
+      (node) =>
+        node.type === "div" &&
+        String(node.props.className ?? "").includes(onboardingHeaderBlockClass),
+    )[0];
+    expect(headerBlock).toBeDefined();
+
     const remoteButton = buttons.find((button) =>
       collectText(button).includes("onboarding.hostingRemote"),
     );

--- a/packages/app-core/test/app/onboarding-steps.test.tsx
+++ b/packages/app-core/test/app/onboarding-steps.test.tsx
@@ -495,7 +495,7 @@ describe("ConnectionStep", () => {
     const buttons = findButtons(tree?.root as TestRenderer.ReactTestInstance);
     const headerBlock = (tree?.root as TestRenderer.ReactTestInstance).findAll(
       (node) =>
-        node.type === "div" &&
+        node.type === "header" &&
         String(node.props.className ?? "").includes(onboardingHeaderBlockClass),
     )[0];
     expect(headerBlock).toBeDefined();


### PR DESCRIPTION
## Summary
- reset onboarding panel and card surfaces back to restrained neutral glass instead of tinting or deepening them
- move readability ownership into shared onboarding text primitives with a dual-tone fill plus edge/shadow treatment
- propagate the shared foreground contract through hosting, provider detail, cloud login, identity, and rpc onboarding screens

## Verification
- /Users/mac/.bun/bin/bunx vitest run packages/app-core/src/components/onboarding/onboarding-step-chrome.test.tsx packages/app-core/src/components/onboarding/CloudLoginStep.test.tsx packages/app-core/src/components/onboarding/OnboardingPanel.test.tsx packages/app-core/src/components/onboarding/connection/ConnectionProviderDetailScreen.test.tsx packages/app-core/test/app/onboarding-steps.test.tsx packages/app-core/src/styles/brand-gold.test.ts
- git diff --check

## Notes
- draft on purpose: visual balance questions remain and the browser pass is still open