### PR TITLE
fix: dedupe ci workspace bootstrap

### DIFF
--- a/.github/actions/setup-bun-workspace/action.yml
+++ b/.github/actions/setup-bun-workspace/action.yml
@@ -1,0 +1,75 @@
+name: "Setup Bun Workspace"
+description: "Install Bun workspace dependencies and optional postinstall patches for CI jobs."
+
+inputs:
+  bun-version:
+    description: "Bun version to install"
+    required: false
+    default: "1.3.10"
+  python-version:
+    description: "Python version for node-gyp fallbacks"
+    required: false
+    default: "3.12"
+  install-command:
+    description: "Dependency install command"
+    required: false
+    default: "bun install --ignore-scripts"
+  install-native-deps:
+    description: "Whether to install native apt dependencies"
+    required: false
+    default: "true"
+  run-postinstall:
+    description: "Whether to run the repo postinstall step explicitly"
+    required: false
+    default: "true"
+  skip-avatar-clone:
+    description: "Set SKIP_AVATAR_CLONE=1 for postinstall"
+    required: false
+    default: "false"
+  no-vision-deps:
+    description: "Set MILADY_NO_VISION_DEPS=1 for postinstall"
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install setuptools for distutils (Python 3.12+)
+      shell: bash
+      run: pip install setuptools
+
+    - name: Install native dependencies
+      if: ${{ inputs.install-native-deps == 'true' }}
+      shell: bash
+      run: sudo apt-get update && sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev libpixman-1-dev librsvg2-dev
+
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: ${{ inputs.bun-version }}
+
+    - name: Cache Bun install
+      uses: actions/cache@v4
+      with:
+        path: ~/.bun/install/cache
+        key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+        restore-keys: bun-${{ runner.os }}-
+
+    - name: Install dependencies
+      shell: bash
+      run: ${{ inputs.install-command }}
+      env:
+        npm_config_python: ${{ env.pythonLocation }}/bin/python3
+
+    - name: Run repository postinstall patches
+      if: ${{ inputs.run-postinstall == 'true' }}
+      shell: bash
+      run: bun run postinstall
+      env:
+        SKIP_AVATAR_CLONE: ${{ inputs.skip-avatar-clone == 'true' && '1' || '' }}
+        MILADY_NO_VISION_DEPS: ${{ inputs.no-vision-deps == 'true' && '1' || '' }}

--- a/.github/workflows/ci-fork.yml
+++ b/.github/workflows/ci-fork.yml
@@ -3,8 +3,6 @@ name: CI (Fork)
 on:
   pull_request:
     branches: [main, develop]
-  push:
-    branches: [main, develop, "codex/**"]
   workflow_dispatch:
 
 concurrency:
@@ -17,6 +15,7 @@ env:
 jobs:
   lint:
     name: Lint & Format
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -26,36 +25,11 @@ jobs:
         with:
           node-version: 22
 
-      - name: Setup Python (for node-gyp when native prebuilds missing)
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install setuptools for distutils (Python 3.12+)
-        run: pip install setuptools
-
-      - name: Install native dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev libpixman-1-dev librsvg2-dev
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
         with:
           bun-version: ${{ env.BUN_VERSION }}
-
-      - name: Cache Bun install
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-${{ runner.os }}-
-
-      - name: Install dependencies
-        run: bun install --ignore-scripts
-        env:
-          npm_config_python: ${{ env.pythonLocation }}/bin/python3
-
-      - name: Run repository postinstall patches
-        run: bun run postinstall
+          install-command: bun install --ignore-scripts
 
       - name: Biome lint
         run: bun run lint
@@ -65,6 +39,7 @@ jobs:
 
   typecheck:
     name: Type Check
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -74,42 +49,18 @@ jobs:
         with:
           node-version: 22
 
-      - name: Setup Python (for node-gyp when native prebuilds missing)
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install setuptools for distutils (Python 3.12+)
-        run: pip install setuptools
-
-      - name: Install native dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev libpixman-1-dev librsvg2-dev
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
         with:
           bun-version: ${{ env.BUN_VERSION }}
-
-      - name: Cache Bun install
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-${{ runner.os }}-
-
-      - name: Install dependencies
-        run: bun install --ignore-scripts
-        env:
-          npm_config_python: ${{ env.pythonLocation }}/bin/python3
-
-      - name: Run repository postinstall patches
-        run: bun run postinstall
+          install-command: bun install --ignore-scripts
 
       - name: Run type checker
         run: bun run typecheck
 
   test:
     name: Targeted Tests
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -119,42 +70,18 @@ jobs:
         with:
           node-version: 22
 
-      - name: Setup Python (for node-gyp when native prebuilds missing)
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install setuptools for distutils (Python 3.12+)
-        run: pip install setuptools
-
-      - name: Install native dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev libpixman-1-dev librsvg2-dev
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
         with:
           bun-version: ${{ env.BUN_VERSION }}
-
-      - name: Cache Bun install
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-${{ runner.os }}-
-
-      - name: Install dependencies
-        run: bun install --ignore-scripts
-        env:
-          npm_config_python: ${{ env.pythonLocation }}/bin/python3
-
-      - name: Run repository postinstall patches
-        run: bun run postinstall
+          install-command: bun install --ignore-scripts
 
       - name: Run onboarding voice regression tests
         run: bunx vitest run packages/app-core/src/components/onboarding/identity-preview-tts.test.ts
 
   build:
     name: Build
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -164,36 +91,11 @@ jobs:
         with:
           node-version: 22
 
-      - name: Setup Python (for node-gyp when native prebuilds missing)
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install setuptools for distutils (Python 3.12+)
-        run: pip install setuptools
-
-      - name: Install native dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev libpixman-1-dev librsvg2-dev
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
         with:
           bun-version: ${{ env.BUN_VERSION }}
-
-      - name: Cache Bun install
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-${{ runner.os }}-
-
-      - name: Install dependencies
-        run: bun install --ignore-scripts
-        env:
-          npm_config_python: ${{ env.pythonLocation }}/bin/python3
-
-      - name: Run repository postinstall patches
-        run: bun run postinstall
+          install-command: bun install --ignore-scripts
 
       - name: Build project
         run: bun run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,39 +28,13 @@ jobs:
         with:
           node-version: 22
 
-      - name: Setup Python (for node-gyp when native prebuilds missing)
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install setuptools for distutils (Python 3.12+)
-        run: pip install setuptools
-
-      - name: Install native dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev libpixman-1-dev librsvg2-dev
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
         with:
           bun-version: ${{ env.BUN_VERSION }}
-
-      - name: Cache Bun install
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-${{ runner.os }}-
-
-      - name: Install dependencies
-        run: bun install --ignore-scripts
-        env:
-          npm_config_python: ${{ env.pythonLocation }}/bin/python3
-
-      - name: Run repository postinstall patches
-        run: bun run postinstall
-        env:
-          SKIP_AVATAR_CLONE: "1"
-          MILADY_NO_VISION_DEPS: "1"
+          install-command: bun install --ignore-scripts
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
 
       - name: Fetch upstream develop for pre-review base
         run: |
@@ -83,36 +57,11 @@ jobs:
         with:
           node-version: 22
 
-      - name: Setup Python (for node-gyp when native prebuilds missing)
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install setuptools for distutils (Python 3.12+)
-        run: pip install setuptools
-
-      - name: Install native dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev libpixman-1-dev librsvg2-dev
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
         with:
           bun-version: ${{ env.BUN_VERSION }}
-
-      - name: Cache Bun install
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-${{ runner.os }}-
-
-      - name: Install dependencies
-        run: bun install --ignore-scripts
-        env:
-          npm_config_python: ${{ env.pythonLocation }}/bin/python3
-
-      - name: Run repository postinstall patches
-        run: bun run postinstall
+          install-command: bun install --ignore-scripts
 
       - name: Biome lint
         run: bun run lint
@@ -131,36 +80,11 @@ jobs:
         with:
           node-version: 22
 
-      - name: Setup Python (for node-gyp when native prebuilds missing)
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install setuptools for distutils (Python 3.12+)
-        run: pip install setuptools
-
-      - name: Install native dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev libpixman-1-dev librsvg2-dev
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
         with:
           bun-version: ${{ env.BUN_VERSION }}
-
-      - name: Cache Bun install
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-${{ runner.os }}-
-
-      - name: Install dependencies
-        run: bun install --ignore-scripts
-        env:
-          npm_config_python: ${{ env.pythonLocation }}/bin/python3
-
-      - name: Run repository postinstall patches
-        run: bun run postinstall
+          install-command: bun install --ignore-scripts
 
       - name: Run type checker
         run: bun run typecheck
@@ -176,36 +100,11 @@ jobs:
         with:
           node-version: 22
 
-      - name: Setup Python (for node-gyp when native prebuilds missing)
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install setuptools for distutils (Python 3.12+)
-        run: pip install setuptools
-
-      - name: Install native dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev libpixman-1-dev librsvg2-dev
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
         with:
           bun-version: ${{ env.BUN_VERSION }}
-
-      - name: Cache Bun install
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-${{ runner.os }}-
-
-      - name: Install dependencies
-        run: bun install --ignore-scripts
-        env:
-          npm_config_python: ${{ env.pythonLocation }}/bin/python3
-
-      - name: Run repository postinstall patches
-        run: bun run postinstall
+          install-command: bun install --ignore-scripts
 
       - name: Run unit tests
         run: bunx vitest run --config vitest.unit.config.ts
@@ -221,36 +120,11 @@ jobs:
         with:
           node-version: 22
 
-      - name: Setup Python (for node-gyp when native prebuilds missing)
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install setuptools for distutils (Python 3.12+)
-        run: pip install setuptools
-
-      - name: Install native dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev libpixman-1-dev librsvg2-dev
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
         with:
           bun-version: ${{ env.BUN_VERSION }}
-
-      - name: Cache Bun install
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-${{ runner.os }}-
-
-      - name: Install dependencies
-        run: bun install --ignore-scripts
-        env:
-          npm_config_python: ${{ env.pythonLocation }}/bin/python3
-
-      - name: Run repository postinstall patches
-        run: bun run postinstall
+          install-command: bun install --ignore-scripts
 
       - name: Build project
         run: bun run build
@@ -259,4 +133,3 @@ jobs:
         run: bun run build:homepage
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,39 +31,13 @@ jobs:
         with:
           node-version: 22
 
-      - name: Setup Python (for node-gyp when native prebuilds missing)
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install setuptools for distutils (Python 3.12+)
-        run: pip install setuptools
-
-      - name: Install native dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev libpixman-1-dev librsvg2-dev
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
         with:
           bun-version: ${{ env.BUN_VERSION }}
-
-      - name: Cache Bun install
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-${{ runner.os }}-
-
-      - name: Install dependencies
-        run: bun install --ignore-scripts
-        env:
-          npm_config_python: ${{ env.pythonLocation }}/bin/python3
-
-      - name: Run repository postinstall patches
-        run: bun run postinstall
-        env:
-          SKIP_AVATAR_CLONE: "1"
-          MILADY_NO_VISION_DEPS: "1"
+          install-command: bun install --ignore-scripts
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
 
       - name: Run unit tests with coverage
         run: bun run test:coverage
@@ -88,39 +62,13 @@ jobs:
         with:
           node-version: 22
 
-      - name: Setup Python (for node-gyp when native prebuilds missing)
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install setuptools for distutils (Python 3.12+)
-        run: pip install setuptools
-
-      - name: Install canvas native dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev libpixman-1-dev librsvg2-dev
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
         with:
           bun-version: ${{ env.BUN_VERSION }}
-
-      - name: Cache Bun install
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-${{ runner.os }}-
-
-      - name: Install dependencies
-        run: bun install --ignore-scripts
-        env:
-          npm_config_python: ${{ env.pythonLocation }}/bin/python3
-
-      - name: Run repository postinstall patches
-        run: bun run postinstall
-        env:
-          SKIP_AVATAR_CLONE: "1"
-          MILADY_NO_VISION_DEPS: "1"
+          install-command: bun install --ignore-scripts
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
 
       - name: Run database security and query-guard tests
         run: bun run db:check
@@ -138,33 +86,12 @@ jobs:
         with:
           node-version: 22
 
-      - name: Setup Python (for node-gyp when native prebuilds missing)
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install setuptools for distutils (Python 3.12+)
-        run: pip install setuptools
-
-      - name: Install canvas native dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev libpixman-1-dev librsvg2-dev
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
         with:
           bun-version: ${{ env.BUN_VERSION }}
-
-      - name: Cache Bun install
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-${{ runner.os }}-
-
-      - name: Install dependencies
-        run: bun install
-        env:
-          npm_config_python: ${{ env.pythonLocation }}/bin/python3
+          install-command: bun install
+          run-postinstall: "false"
 
       - name: Build
         run: bun run build
@@ -183,42 +110,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install canvas native dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev libpixman-1-dev librsvg2-dev
-
       # WHY useblacksmith: colocated cache avoids nodejs.org download timeouts on Blacksmith runners.
       - name: Setup Node.js
         uses: useblacksmith/setup-node@v5
         with:
           node-version: 22
 
-      - name: Setup Python (for node-gyp)
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install setuptools for distutils (Python 3.12+)
-        run: pip install setuptools
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
         with:
           bun-version: ${{ env.BUN_VERSION }}
-
-      - name: Cache Bun install
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-${{ runner.os }}-
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile --ignore-scripts
-        env:
-          npm_config_python: ${{ env.pythonLocation }}/bin/python3
-
-      - name: Run repository postinstall patches
-        run: bun run postinstall
+          install-command: bun install --frozen-lockfile --ignore-scripts
 
       - name: Run app startup/onboarding tests
         run: >
@@ -254,36 +156,17 @@ jobs:
         if: steps.cloud.outputs.enabled == 'true'
         uses: actions/checkout@v4
 
-      - name: Install canvas native dependencies
+      - name: Setup workspace dependencies
         if: steps.cloud.outputs.enabled == 'true'
-        run: sudo apt-get update && sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev libpixman-1-dev librsvg2-dev
-
-      - name: Setup Bun
-        if: steps.cloud.outputs.enabled == 'true'
-        uses: oven-sh/setup-bun@v2
+        uses: ./.github/actions/setup-bun-workspace
         with:
           bun-version: ${{ env.BUN_VERSION }}
-
-      - name: Cache Bun install
-        if: steps.cloud.outputs.enabled == 'true'
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-${{ runner.os }}-
-
-      - name: Install dependencies
-        if: steps.cloud.outputs.enabled == 'true'
-        run: |
-          for i in 1 2 3 4 5; do
-            bun install --frozen-lockfile --ignore-scripts && break
-            echo "Attempt $i failed, retrying in $((i * 15))s..."
-            sleep $((i * 15))
-          done
-
-      - name: Run repository postinstall patches
-        if: steps.cloud.outputs.enabled == 'true'
-        run: bun run postinstall
+          install-command: |
+            for i in 1 2 3 4 5; do
+              bun install --frozen-lockfile --ignore-scripts && break
+              echo "Attempt $i failed, retrying in $((i * 15))s..."
+              sleep $((i * 15))
+            done
 
       - name: Run cloud live test
         if: steps.cloud.outputs.enabled == 'true'
@@ -303,26 +186,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install canvas native dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev libpixman-1-dev librsvg2-dev
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
         with:
           bun-version: ${{ env.BUN_VERSION }}
-
-      - name: Cache Bun install
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-${{ runner.os }}-
-
-      - name: Install dependencies
-        run: bun install --ignore-scripts
-
-      - name: Run repository postinstall patches
-        run: bun run postinstall
+          install-command: bun install --ignore-scripts
 
       - name: Build
         run: bun run build

--- a/scripts/ci-workflow-drift.test.ts
+++ b/scripts/ci-workflow-drift.test.ts
@@ -37,24 +37,34 @@ describe("CI workflow drift", () => {
 
     expect(workflow).not.toContain("push:");
     expect(countOccurrences(workflow, forkGate)).toBe(4);
-    expect(countOccurrences(workflow, "uses: ./.github/actions/setup-bun-workspace")).toBe(4);
+    expect(
+      countOccurrences(workflow, "uses: ./.github/actions/setup-bun-workspace"),
+    ).toBe(4);
   });
 
   it("routes core CI jobs through the shared setup action", () => {
     const workflow = read(CI_WORKFLOW_PATH);
 
-    expect(countOccurrences(workflow, "uses: ./.github/actions/setup-bun-workspace")).toBe(5);
+    expect(
+      countOccurrences(workflow, "uses: ./.github/actions/setup-bun-workspace"),
+    ).toBe(5);
     expect(workflow).toContain('skip-avatar-clone: "true"');
     expect(workflow).toContain('no-vision-deps: "true"');
-    expect(workflow).not.toContain("Run repository postinstall patches\n        run: bun run postinstall");
+    expect(workflow).not.toContain(
+      "Run repository postinstall patches\n        run: bun run postinstall",
+    );
   });
 
   it("uses the shared setup action in test jobs without reintroducing double postinstall", () => {
     const workflow = read(TEST_WORKFLOW_PATH);
 
-    expect(countOccurrences(workflow, "uses: ./.github/actions/setup-bun-workspace")).toBe(6);
+    expect(
+      countOccurrences(workflow, "uses: ./.github/actions/setup-bun-workspace"),
+    ).toBe(6);
     expect(workflow).toContain('run-postinstall: "false"');
     expect(workflow).toContain("install-command: bun install");
-    expect(workflow).toContain('install-command: bun install --frozen-lockfile --ignore-scripts');
+    expect(workflow).toContain(
+      "install-command: bun install --frozen-lockfile --ignore-scripts",
+    );
   });
 });

--- a/scripts/ci-workflow-drift.test.ts
+++ b/scripts/ci-workflow-drift.test.ts
@@ -1,0 +1,60 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = path.resolve(import.meta.dirname, "..");
+const SETUP_ACTION_PATH = path.join(
+  ROOT,
+  ".github/actions/setup-bun-workspace/action.yml",
+);
+const CI_WORKFLOW_PATH = path.join(ROOT, ".github/workflows/ci.yml");
+const CI_FORK_WORKFLOW_PATH = path.join(ROOT, ".github/workflows/ci-fork.yml");
+const TEST_WORKFLOW_PATH = path.join(ROOT, ".github/workflows/test.yml");
+
+function read(filePath: string): string {
+  return fs.readFileSync(filePath, "utf8");
+}
+
+function countOccurrences(text: string, needle: string): number {
+  return text.split(needle).length - 1;
+}
+
+describe("CI workflow drift", () => {
+  it("defines a shared workspace setup action for Bun-based jobs", () => {
+    const action = read(SETUP_ACTION_PATH);
+
+    expect(action).toContain('name: "Setup Bun Workspace"');
+    expect(action).toContain("uses: actions/setup-python@v5");
+    expect(action).toContain("uses: oven-sh/setup-bun@v2");
+    expect(action).toContain("uses: actions/cache@v4");
+    expect(action).toContain("run: bun run postinstall");
+  });
+
+  it("keeps same-repo PRs and pushes out of the fork workflow", () => {
+    const workflow = read(CI_FORK_WORKFLOW_PATH);
+    const forkGate =
+      "if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)";
+
+    expect(workflow).not.toContain("push:");
+    expect(countOccurrences(workflow, forkGate)).toBe(4);
+    expect(countOccurrences(workflow, "uses: ./.github/actions/setup-bun-workspace")).toBe(4);
+  });
+
+  it("routes core CI jobs through the shared setup action", () => {
+    const workflow = read(CI_WORKFLOW_PATH);
+
+    expect(countOccurrences(workflow, "uses: ./.github/actions/setup-bun-workspace")).toBe(5);
+    expect(workflow).toContain('skip-avatar-clone: "true"');
+    expect(workflow).toContain('no-vision-deps: "true"');
+    expect(workflow).not.toContain("Run repository postinstall patches\n        run: bun run postinstall");
+  });
+
+  it("uses the shared setup action in test jobs without reintroducing double postinstall", () => {
+    const workflow = read(TEST_WORKFLOW_PATH);
+
+    expect(countOccurrences(workflow, "uses: ./.github/actions/setup-bun-workspace")).toBe(6);
+    expect(workflow).toContain('run-postinstall: "false"');
+    expect(workflow).toContain("install-command: bun install");
+    expect(workflow).toContain('install-command: bun install --frozen-lockfile --ignore-scripts');
+  });
+});

--- a/scripts/electrobun-test-workflow-drift.test.ts
+++ b/scripts/electrobun-test-workflow-drift.test.ts
@@ -18,14 +18,12 @@ describe("Electrobun test workflow drift", () => {
     const workflow = fs.readFileSync(WORKFLOW_PATH, "utf8");
 
     expect(workflow).toContain(
-      "name: Install dependencies\n        run: bun install",
+      "name: Setup workspace dependencies\n        uses: ./.github/actions/setup-bun-workspace",
     );
+    expect(workflow).toContain("install-command: bun install");
+    expect(workflow).toContain('run-postinstall: "false"');
     expect(workflow).not.toContain(
-      "name: Install dependencies\n        run: bun install\n        env:\n          npm_config_python: $" +
-        "{{ env.pythonLocation }}/bin/python3\n\n      - name: Run repository postinstall patches",
-    );
-    expect(workflow).not.toContain(
-      "name: Install dependencies\n        run: bun install\n\n      - name: Run repository postinstall patches",
+      'install-command: bun install\n          run-postinstall: "true"',
     );
   });
 
@@ -33,7 +31,7 @@ describe("Electrobun test workflow drift", () => {
     const workflow = fs.readFileSync(WORKFLOW_PATH, "utf8");
 
     expect(workflow).toContain(
-      'name: Run repository postinstall patches\n        run: bun run postinstall\n        env:\n          SKIP_AVATAR_CLONE: "1"\n          MILADY_NO_VISION_DEPS: "1"',
+      'skip-avatar-clone: "true"\n          no-vision-deps: "true"',
     );
   });
 


### PR DESCRIPTION
## Summary
- add a shared CI setup action for Bun/Python/native dependency bootstrap and reuse it across core CI and test workflows
- stop the fork-only workflow from running on normal pushes and same-repo pull requests
- add a drift test that locks the fork gating and shared setup usage so the duplication does not regress

## Testing
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "OK #{f}" }' .github/actions/setup-bun-workspace/action.yml .github/workflows/ci.yml .github/workflows/ci-fork.yml .github/workflows/test.yml
- bunx vitest run scripts/ci-workflow-drift.test.ts
- bun run typecheck
- MILADY_PRE_REVIEW_BASE=origin/develop bun run pre-review:local