### PR TITLE
[codex] fix deferred websocket auth regression

### DIFF
--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -6908,7 +6908,7 @@ export function resolveWebSocketUpgradeRejection(
   }
 
   const handshakeToken = extractWebSocketHandshakeToken(req, wsUrl);
-  if (!handshakeToken || !tokenMatches(expected, handshakeToken)) {
+  if (handshakeToken && !tokenMatches(expected, handshakeToken)) {
     return { status: 401, reason: "Unauthorized" };
   }
 

--- a/packages/agent/test/api-auth.e2e.test.ts
+++ b/packages/agent/test/api-auth.e2e.test.ts
@@ -387,12 +387,9 @@ describe("Token auth gate (ELIZA_API_TOKEN set)", () => {
     expect(status).toBe(200);
   });
 
-  it("rejects WebSocket upgrade without token", async () => {
+  it("allows WebSocket upgrade without token so clients can auth on the first message", async () => {
     const result = await connectWs(`ws://127.0.0.1:${port}/ws`);
-    expect(result.kind).toBe("rejected");
-    if (result.kind === "rejected") {
-      expect(result.status).toBe(401);
-    }
+    expect(result.kind).toBe("open");
   });
 
   it("rejects WebSocket query-token auth by default", async () => {

--- a/packages/agent/test/api/websocket-auth.test.ts
+++ b/packages/agent/test/api/websocket-auth.test.ts
@@ -18,7 +18,7 @@ describe("resolveWebSocketUpgradeRejection", () => {
     process.env = { ...originalEnv };
   });
 
-  it("rejects websocket upgrades when an API token is configured", () => {
+  it("allows websocket upgrades without a handshake token so clients can auth on the first message", () => {
     process.env.ELIZA_API_TOKEN = "local-token";
 
     const request = { headers: {} } as http.IncomingMessage;
@@ -27,18 +27,32 @@ describe("resolveWebSocketUpgradeRejection", () => {
       new URL("ws://127.0.0.1/ws"),
     );
 
-    expect(result).toEqual({ status: 401, reason: "Unauthorized" });
+    expect(result).toBeNull();
   });
 
-  it("does not bypass websocket auth for steward-managed cloud containers", () => {
+  it("rejects websocket upgrades when a provided handshake token is invalid", () => {
     process.env.MILADY_CLOUD_PROVISIONED = "1";
     process.env.STEWARD_AGENT_TOKEN = "steward-token";
     process.env.ELIZA_API_TOKEN = "cloud-token";
 
-    const request = { headers: {} } as http.IncomingMessage;
+    const request = {
+      headers: { authorization: "Bearer wrong-token" },
+    } as http.IncomingMessage;
     const result = resolveWebSocketUpgradeRejection(
       request,
       new URL("ws://127.0.0.1/ws"),
+    );
+
+    expect(result).toEqual({ status: 401, reason: "Unauthorized" });
+  });
+
+  it("rejects websocket query-string tokens unless explicitly enabled", () => {
+    process.env.ELIZA_API_TOKEN = "local-token";
+
+    const request = { headers: {} } as http.IncomingMessage;
+    const result = resolveWebSocketUpgradeRejection(
+      request,
+      new URL("ws://127.0.0.1/ws?token=local-token"),
     );
 
     expect(result).toEqual({ status: 401, reason: "Unauthorized" });

--- a/packages/app-core/src/api/server.websocket-auth.test.ts
+++ b/packages/app-core/src/api/server.websocket-auth.test.ts
@@ -52,13 +52,13 @@ describe("resolveWebSocketUpgradeRejection", () => {
     expect(rejection).toEqual({ status: 403, reason: "Origin not allowed" });
   });
 
-  it("rejects unauthenticated upgrades when API token is enabled", () => {
+  it("allows tokenless upgrades so clients can authenticate on the first message", () => {
     process.env.ELIZA_API_TOKEN = "test-token";
     const rejection = resolveWebSocketUpgradeRejection(
       mockReq() as http.IncomingMessage,
       new URL("ws://localhost/ws"),
     );
-    expect(rejection).toEqual({ status: 401, reason: "Unauthorized" });
+    expect(rejection).toBeNull();
   });
 
   it("accepts valid bearer token", () => {
@@ -175,13 +175,13 @@ describe("resolveWebSocketUpgradeRejection", () => {
     expect(rejection).toBeNull();
   });
 
-  it("rejects whitespace-only bearer token", () => {
+  it("treats whitespace-only bearer tokens as missing and falls back to deferred auth", () => {
     process.env.ELIZA_API_TOKEN = "test-token";
     const rejection = resolveWebSocketUpgradeRejection(
       mockReq({ authorization: "Bearer   " }) as http.IncomingMessage,
       new URL("ws://localhost/ws"),
     );
-    expect(rejection).toEqual({ status: 401, reason: "Unauthorized" });
+    expect(rejection).toBeNull();
   });
 
   it("accepts query token via apiKey param when enabled", () => {


### PR DESCRIPTION
## What changed
- allow `/ws` upgrades to proceed without a handshake token when an API token is configured
- keep rejecting invalid provided handshake tokens during the HTTP upgrade
- add focused regression coverage for deferred auth, invalid header tokens, and blocked query-string tokens

## Why it changed
- commit `eeebd7ddb0043bf6e74a82077c7bdc68747e01f5` tightened `resolveWebSocketUpgradeRejection()` so it rejected upgrades with no handshake token
- the server still supports deferred WebSocket auth via a first socket message `{"type":"auth","token":"..."}`, so the stricter upgrade gate broke that existing flow

## Impact
- restores compatibility for clients that authenticate immediately after the socket opens instead of during the HTTP upgrade
- preserves the hardening for invalid handshake credentials and query-token blocking

## Validation
- `bunx vitest run packages/agent/test/api/websocket-auth.test.ts`
- `git push -u origin codex/fix-websocket-upgrade-auth` (pre-review gate: `APPROVE`)
