### PR TITLE
fix(installer): canonical windows exe + explicit shortcut icon

### DIFF
--- a/.github/workflows/release-electrobun.yml
+++ b/.github/workflows/release-electrobun.yml
@@ -975,6 +975,10 @@ jobs:
 
           $exeFiles = Get-ChildItem -Path $artifactsDir -File -Filter "*.exe" -ErrorAction SilentlyContinue
           foreach ($exe in $exeFiles) {
+            if ($exe.FullName -eq $canonicalInstaller.FullName) {
+              Write-Host "Keeping canonical Windows installer uncompressed for single-extract downloads: $($exe.Name)"
+              continue
+            }
             $zipPath = $exe.FullName + ".zip"
             Write-Host "Compressing $($exe.Name) -> $($exe.Name).zip"
             Compress-Archive -Path $exe.FullName -DestinationPath $zipPath -CompressionLevel Optimal
@@ -993,29 +997,41 @@ jobs:
           Remove-Item $publicCanaryDir -Recurse -Force -ErrorAction SilentlyContinue
           New-Item -ItemType Directory -Force -Path $publicCanaryDir | Out-Null
 
-          $canonicalInstallerZips = Get-ChildItem -Path $artifactsDir -File -Filter "Milady-Setup-*.exe.zip" -ErrorAction SilentlyContinue |
+          $canonicalInstallers = Get-ChildItem -Path $artifactsDir -File -Filter "Milady-Setup-*.exe" -ErrorAction SilentlyContinue |
             Sort-Object LastWriteTime -Descending
-          if (-not $canonicalInstallerZips) {
-            Write-Error "No canonical Windows installer zip found for canary artifact publishing."
-            exit 1
-          }
-          if ($canonicalInstallerZips.Count -gt 1) {
-            Write-Error "Multiple canonical Windows installer zips found for canary artifact publishing."
-            $canonicalInstallerZips | ForEach-Object { Write-Host "  - $($_.FullName)" }
-            exit 1
-          }
+          if ($canonicalInstallers) {
+            if ($canonicalInstallers.Count -gt 1) {
+              Write-Error "Multiple canonical Windows installers found for canary artifact publishing."
+              $canonicalInstallers | ForEach-Object { Write-Host "  - $($_.FullName)" }
+              exit 1
+            }
+            $canonicalInstaller = $canonicalInstallers | Select-Object -First 1
+            Copy-Item $canonicalInstaller.FullName -Destination $publicCanaryDir -Force
+          } else {
+            $canonicalInstallerZips = Get-ChildItem -Path $artifactsDir -File -Filter "Milady-Setup-*.exe.zip" -ErrorAction SilentlyContinue |
+              Sort-Object LastWriteTime -Descending
+            if (-not $canonicalInstallerZips) {
+              Write-Error "No canonical Windows installer (or zip fallback) found for canary artifact publishing."
+              exit 1
+            }
+            if ($canonicalInstallerZips.Count -gt 1) {
+              Write-Error "Multiple canonical Windows installer zips found for canary artifact publishing."
+              $canonicalInstallerZips | ForEach-Object { Write-Host "  - $($_.FullName)" }
+              exit 1
+            }
 
-          $canonicalInstallerZip = $canonicalInstallerZips | Select-Object -First 1
-          Expand-Archive -Path $canonicalInstallerZip.FullName -DestinationPath $publicCanaryDir -Force
+            $canonicalInstallerZip = $canonicalInstallerZips | Select-Object -First 1
+            Expand-Archive -Path $canonicalInstallerZip.FullName -DestinationPath $publicCanaryDir -Force
+          }
 
           $publicInstallers = Get-ChildItem -Path $publicCanaryDir -File -Filter "Milady-Setup-*.exe" -ErrorAction SilentlyContinue |
             Sort-Object LastWriteTime -Descending
           if (-not $publicInstallers) {
-            Write-Error "Failed to expand a public Windows installer from $($canonicalInstallerZip.FullName)"
+            Write-Error "Failed to stage a public Windows installer under $publicCanaryDir"
             exit 1
           }
           if ($publicInstallers.Count -gt 1) {
-            Write-Error "Expanded canary installer artifact contains multiple public installers."
+            Write-Error "Canary installer artifact contains multiple public installers."
             $publicInstallers | ForEach-Object { Write-Host "  - $($_.FullName)" }
             exit 1
           }
@@ -1090,6 +1106,7 @@ jobs:
           # installer, not the raw Electrobun bootstrap stub.
           find release-artifacts -type f \( \
             -name "*.dmg" -o \
+            -name "Milady-Setup-*.exe" -o \
             -name "Milady-Setup-*.exe.zip" -o \
             -name "*Setup*.tar.gz" -o \
             -name "*.msix" \

--- a/packaging/inno/Milady.iss
+++ b/packaging/inno/Milady.iss
@@ -9,6 +9,7 @@
 #define MyOutputBaseFilename "__OUTPUT_BASE_FILENAME__"
 #define MySourceDir "__SOURCE_DIR__"
 #define MySetupIconFile "__ICON_FILE__"
+#define MyAppIconFile "Milady.ico"
 
 [Setup]
 AppId={#MyAppId}
@@ -24,7 +25,7 @@ DisableProgramGroupPage=yes
 OutputDir={#MyOutputDir}
 OutputBaseFilename={#MyOutputBaseFilename}
 SetupIconFile={#MySetupIconFile}
-UninstallDisplayIcon={app}\{#MyAppExeName}
+UninstallDisplayIcon={app}\{#MyAppIconFile}
 Compression=lzma2/ultra64
 SolidCompression=yes
 ArchitecturesAllowed=x64compatible
@@ -44,8 +45,9 @@ Name: "desktopicon"; Description: "Create a desktop shortcut"; GroupDescription:
 
 [Files]
 Source: "{#MySourceDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#MySetupIconFile}"; DestDir: "{app}"; DestName: "{#MyAppIconFile}"; Flags: ignoreversion
 
 [Icons]
-Name: "{autoprograms}\{#MyDefaultGroupName}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
+Name: "{autoprograms}\{#MyDefaultGroupName}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; IconFilename: "{app}\{#MyAppIconFile}"
 Name: "{autoprograms}\{#MyDefaultGroupName}\Uninstall {#MyAppName}"; Filename: "{uninstallexe}"
-Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
+Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon; IconFilename: "{app}\{#MyAppIconFile}"

--- a/scripts/electrobun-release-workflow-drift.test.ts
+++ b/scripts/electrobun-release-workflow-drift.test.ts
@@ -333,6 +333,7 @@ describe("Electrobun release workflow drift", () => {
 
     expect(workflow).toContain("name: Collect public release files");
     expect(workflow).toContain(' -name "*.dmg" -o \\');
+    expect(workflow).toContain(' -name "Milady-Setup-*.exe" -o \\');
     expect(workflow).toContain(' -name "Milady-Setup-*.exe.zip" -o \\');
     expect(workflow).toContain(' -name "*Setup*.tar.gz" -o \\');
     expect(workflow).toContain(' -name "*.msix" \\');
@@ -427,12 +428,16 @@ describe("Electrobun release workflow drift", () => {
     const template = fs.readFileSync(INNO_TEMPLATE_PATH, "utf8");
 
     expect(template).toContain('#define MyAppExeName "bin\\launcher.exe"');
-    expect(template).toContain("UninstallDisplayIcon={app}\\{#MyAppExeName}");
+    expect(template).toContain('#define MyAppIconFile "Milady.ico"');
     expect(template).toContain(
-      'Name: "{autoprograms}\\{#MyDefaultGroupName}\\{#MyAppName}"; Filename: "{app}\\{#MyAppExeName}"',
+      'Source: "{#MySetupIconFile}"; DestDir: "{app}"; DestName: "{#MyAppIconFile}"; Flags: ignoreversion',
+    );
+    expect(template).toContain("UninstallDisplayIcon={app}\\{#MyAppIconFile}");
+    expect(template).toContain(
+      'Name: "{autoprograms}\\{#MyDefaultGroupName}\\{#MyAppName}"; Filename: "{app}\\{#MyAppExeName}"; IconFilename: "{app}\\{#MyAppIconFile}"',
     );
     expect(template).toContain(
-      'Name: "{autodesktop}\\{#MyAppName}"; Filename: "{app}\\{#MyAppExeName}"; Tasks: desktopicon',
+      'Name: "{autodesktop}\\{#MyAppName}"; Filename: "{app}\\{#MyAppExeName}"; Tasks: desktopicon; IconFilename: "{app}\\{#MyAppIconFile}"',
     );
     expect(template).not.toContain('#define MyAppExeName "launcher.exe"');
   });
@@ -730,10 +735,16 @@ describe("Electrobun release workflow drift", () => {
       "if: matrix.platform.os == 'windows' && needs.prepare.outputs.env == 'canary'",
     );
     expect(workflow).toContain(
+      '$canonicalInstallers = Get-ChildItem -Path $artifactsDir -File -Filter "Milady-Setup-*.exe"',
+    );
+    expect(workflow).toContain(
+      "Copy-Item $canonicalInstaller.FullName -Destination $publicCanaryDir -Force",
+    );
+    expect(workflow).toContain(
       '$canonicalInstallerZips = Get-ChildItem -Path $artifactsDir -File -Filter "Milady-Setup-*.exe.zip"',
     );
     expect(workflow).toContain(
-      "Expand-Archive -Path $canonicalInstallerZip.FullName -DestinationPath $publicCanaryDir -Force",
+      "No canonical Windows installer (or zip fallback) found for canary artifact publishing.",
     );
     expect(workflow).toContain(
       '$publicInstallers = Get-ChildItem -Path $publicCanaryDir -File -Filter "Milady-Setup-*.exe"',

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -82,12 +82,16 @@ const requiredWorkflowSnippets = [
   "name: Prepare public canary Windows installer artifact",
   "needs.prepare.outputs.env == 'canary'",
   '$publicCanaryDir = Join-Path $artifactsDir "public-canary-installer"',
-  "Expand-Archive -Path $canonicalInstallerZip.FullName -DestinationPath $publicCanaryDir -Force",
+  '$canonicalInstallers = Get-ChildItem -Path $artifactsDir -File -Filter "Milady-Setup-*.exe"',
+  "Copy-Item $canonicalInstaller.FullName -Destination $publicCanaryDir -Force",
+  '$canonicalInstallerZips = Get-ChildItem -Path $artifactsDir -File -Filter "Milady-Setup-*.exe.zip"',
+  "No canonical Windows installer (or zip fallback) found for canary artifact publishing.",
   "Prepared public canary installer artifact:",
   "name: Upload public canary installer artifact",
   "name: electrobun-$" + "{{ matrix.platform.artifact-name }}-public-installer",
   "path: apps/app/electrobun/artifacts/public-canary-installer/Milady-Setup-*.exe",
   "name: Collect public release files",
+  '-name "Milady-Setup-*.exe" -o \\',
   '-name "Milady-Setup-*.exe.zip" -o \\',
   '-name "*Setup*.tar.gz" -o \\',
   "name: Collect update channel files",
@@ -826,9 +830,11 @@ function assertInnoTemplateTargetsBundledLauncher() {
   const template = readFileSync("packaging/inno/Milady.iss", "utf8");
   const requiredSnippets = [
     '#define MyAppExeName "bin\\launcher.exe"',
-    "UninstallDisplayIcon={app}\\{#MyAppExeName}",
-    'Name: "{autoprograms}\\{#MyDefaultGroupName}\\{#MyAppName}"; Filename: "{app}\\{#MyAppExeName}"',
-    'Name: "{autodesktop}\\{#MyAppName}"; Filename: "{app}\\{#MyAppExeName}"; Tasks: desktopicon',
+    '#define MyAppIconFile "Milady.ico"',
+    'Source: "{#MySetupIconFile}"; DestDir: "{app}"; DestName: "{#MyAppIconFile}"; Flags: ignoreversion',
+    "UninstallDisplayIcon={app}\\{#MyAppIconFile}",
+    'Name: "{autoprograms}\\{#MyDefaultGroupName}\\{#MyAppName}"; Filename: "{app}\\{#MyAppExeName}"; IconFilename: "{app}\\{#MyAppIconFile}"',
+    'Name: "{autodesktop}\\{#MyAppName}"; Filename: "{app}\\{#MyAppExeName}"; Tasks: desktopicon; IconFilename: "{app}\\{#MyAppIconFile}"',
   ];
   const missingSnippets = requiredSnippets.filter(
     (snippet) => !template.includes(snippet),


### PR DESCRIPTION
## What this fixes
- keeps the canonical `Milady-Setup-*.exe` uncompressed in Windows build artifacts to avoid nested zip downloads
- keeps zip fallback support for canary artifact prep when only `.exe.zip` exists
- includes plain `Milady-Setup-*.exe` in release file collection (still supports `.exe.zip`)
- updates Inno installer template so Start Menu/Desktop/ARP icon uses a shipped `.ico` explicitly

## Why
- installers were requiring an extra extraction step in artifact flows due to inner `.exe.zip`
- installed shortcuts could show missing/default icons when launcher resource icon was unreliable

## Implementation
- `.github/workflows/release-electrobun.yml`
- `packaging/inno/Milady.iss`
- contract updates in `scripts/electrobun-release-workflow-drift.test.ts` and `scripts/release-check.ts`

## Validation
- `bun run lint`
- `bunx vitest run scripts/electrobun-release-workflow-drift.test.ts scripts/release-check.test.ts`
- `bun run release:check`