### PR TITLE
Fix Windows installer asset guardrails + Release Center resilience

### DIFF
--- a/apps/app/electrobun/scripts/smoke-test-windows.ps1
+++ b/apps/app/electrobun/scripts/smoke-test-windows.ps1
@@ -84,6 +84,118 @@ function Stop-MiladyProcesses() {
     Stop-Process -Force
 }
 
+function Get-TarCommand() {
+  if (Test-Path "C:\\Windows\\System32\\tar.exe") {
+    return "C:\\Windows\\System32\\tar.exe"
+  }
+  return "tar"
+}
+
+function Assert-PackagedAssetVariants(
+  [string]$Description,
+  [int]$MinSizeBytes,
+  [string[]]$Candidates
+) {
+  foreach ($candidate in $Candidates) {
+    if (-not (Test-Path $candidate)) {
+      continue
+    }
+    $length = (Get-Item $candidate).Length
+    if ($length -ge $MinSizeBytes) {
+      return
+    }
+  }
+
+  throw "Missing packaged $Description. Checked: $($Candidates -join ', ')"
+}
+
+function Assert-PackagedArchiveAssetVariants(
+  [string]$ArchivePath,
+  [string]$Description,
+  [int]$MinSizeBytes,
+  [string[]]$Suffixes
+) {
+  $tarCommand = Get-TarCommand
+  $archiveList = & $tarCommand -tf $ArchivePath 2>$null
+
+  foreach ($suffix in $Suffixes) {
+    $normalizedSuffix = $suffix.Replace("\", "/")
+    $member = $archiveList |
+      Where-Object { ($_ -replace "\\", "/") -like "*$normalizedSuffix" } |
+      Select-Object -First 1
+
+    if (-not $member) {
+      continue
+    }
+
+    $extractDir = Join-Path $env:RUNNER_TEMP ("milady-archive-asset-check-" + [Guid]::NewGuid().ToString("N"))
+    New-Item -ItemType Directory -Force -Path $extractDir | Out-Null
+    try {
+      & $tarCommand -xf $ArchivePath -C $extractDir $member 2>$null | Out-Null
+      $memberPath = Join-Path $extractDir ($member -replace "/", "\")
+      if (-not (Test-Path $memberPath)) {
+        continue
+      }
+      $length = (Get-Item $memberPath).Length
+      if ($length -ge $MinSizeBytes) {
+        return
+      }
+    } finally {
+      Remove-Item $extractDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+  }
+
+  throw "Missing packaged $Description in runtime archive. Checked suffixes: $($Suffixes -join ', ')"
+}
+
+function Verify-PackagedRendererAssets([string]$LauncherPath) {
+  $launcherDir = Split-Path -Parent $LauncherPath
+  $appRoot = Split-Path -Parent $launcherDir
+  $rendererDir = Join-Path $appRoot "resources\\app\\renderer"
+
+  if (Test-Path $rendererDir) {
+    Assert-PackagedAssetVariants -Description "renderer entrypoint" -MinSizeBytes 256 -Candidates @(
+      (Join-Path $rendererDir "index.html")
+    )
+    Assert-PackagedAssetVariants -Description "default avatar VRM" -MinSizeBytes 1024 -Candidates @(
+      (Join-Path $rendererDir "vrms\\milady-1.vrm.gz"),
+      (Join-Path $rendererDir "vrms\\milady-1.vrm")
+    )
+    Assert-PackagedAssetVariants -Description "default avatar preview" -MinSizeBytes 1024 -Candidates @(
+      (Join-Path $rendererDir "vrms\\previews\\milady-1.png")
+    )
+    Assert-PackagedAssetVariants -Description "default avatar background" -MinSizeBytes 1024 -Candidates @(
+      (Join-Path $rendererDir "vrms\\backgrounds\\milady-1.png")
+    )
+    Write-Host "Packaged renderer asset check PASSED (direct app bundle)."
+    return
+  }
+
+  $resourcesDir = Join-Path $appRoot "resources"
+  $runtimeArchive = Get-ChildItem -Path $resourcesDir -File -Filter "*.tar.zst" -ErrorAction SilentlyContinue |
+    Sort-Object LastWriteTime -Descending |
+    Select-Object -First 1
+
+  if (-not $runtimeArchive) {
+    throw "Packaged renderer directory missing and no runtime archive found under $resourcesDir"
+  }
+
+  Assert-PackagedArchiveAssetVariants -ArchivePath $runtimeArchive.FullName -Description "renderer entrypoint" -MinSizeBytes 256 -Suffixes @(
+    "renderer/index.html"
+  )
+  Assert-PackagedArchiveAssetVariants -ArchivePath $runtimeArchive.FullName -Description "default avatar VRM" -MinSizeBytes 1024 -Suffixes @(
+    "renderer/vrms/milady-1.vrm.gz",
+    "renderer/vrms/milady-1.vrm"
+  )
+  Assert-PackagedArchiveAssetVariants -ArchivePath $runtimeArchive.FullName -Description "default avatar preview" -MinSizeBytes 1024 -Suffixes @(
+    "renderer/vrms/previews/milady-1.png"
+  )
+  Assert-PackagedArchiveAssetVariants -ArchivePath $runtimeArchive.FullName -Description "default avatar background" -MinSizeBytes 1024 -Suffixes @(
+    "renderer/vrms/backgrounds/milady-1.png"
+  )
+  Write-Host "Packaged renderer asset check PASSED (runtime archive)."
+}
+
 function Get-ObservedBackendPorts([int]$DefaultPort) {
   $ports = [System.Collections.Generic.List[int]]::new()
   $ports.Add($DefaultPort)
@@ -241,6 +353,7 @@ if (-not $launcher) {
 
 $launcher = Write-ReusableLauncherPath -Launcher $launcher -TemporaryRoot $tempExtractDir
 Write-Host "Using $launcherSource launcher: $($launcher.FullName)"
+Verify-PackagedRendererAssets -LauncherPath $launcher.FullName
 $launcherDir = Split-Path -Parent $launcher.FullName
 $launcherProcess = Start-Process -FilePath $launcher.FullName -WorkingDirectory $launcherDir -PassThru
 $launcherStarted = $true

--- a/packages/app-core/src/components/ReleaseCenterView.test.tsx
+++ b/packages/app-core/src/components/ReleaseCenterView.test.tsx
@@ -166,4 +166,58 @@ describe("ReleaseCenterView", () => {
       }),
     );
   });
+
+  it("stays interactive when one desktop bridge request rejects", async () => {
+    invokeDesktopBridgeRequestMock.mockImplementation(
+      async ({ rpcMethod }: { rpcMethod: string }) => {
+        if (rpcMethod === "desktopGetBuildInfo") {
+          throw new Error("desktop build info unavailable");
+        }
+        if (rpcMethod === "desktopGetUpdaterState") {
+          return {
+            currentVersion: "1.0.0",
+            updateAvailable: false,
+            updateReady: false,
+            latestVersion: null,
+            baseUrl: "https://milady.ai/releases/",
+            lastStatus: null,
+          };
+        }
+        if (rpcMethod === "desktopGetDockIconVisibility") {
+          return { visible: true };
+        }
+        if (rpcMethod === "desktopGetWebGpuBrowserStatus") {
+          return {
+            available: false,
+            reason: "Renderer WebGPU unavailable in test.",
+            renderer: "native",
+            chromeBetaPath: null,
+            downloadUrl: null,
+          };
+        }
+        if (rpcMethod === "desktopGetSessionSnapshot") {
+          return {
+            partition: "persist:default",
+            persistent: true,
+            cookieCount: 0,
+            cookies: [],
+          };
+        }
+        return null;
+      },
+    );
+
+    let renderer: TestRenderer.ReactTestRenderer | undefined;
+    await act(async () => {
+      renderer = TestRenderer.create(React.createElement(ReleaseCenterView));
+    });
+
+    if (!renderer) {
+      throw new Error("ReleaseCenterView did not render");
+    }
+
+    const root = renderer.root;
+    expect(() => findButtonByText(root, "Refresh")).not.toThrow();
+    expect(() => findButtonByText(root, "Open Detached Release Center")).not.toThrow();
+  });
 });

--- a/packages/app-core/src/components/ReleaseCenterView.tsx
+++ b/packages/app-core/src/components/ReleaseCenterView.tsx
@@ -69,8 +69,8 @@ export function ReleaseCenterView() {
       return;
     }
 
-    const [updater, build, dock, gpuStatus, ...sessionResults] =
-      await Promise.all([
+    const [updaterResult, buildResult, dockResult, gpuStatusResult, ...sessionResults] =
+      await Promise.allSettled([
         invokeDesktopBridgeRequest<DesktopUpdaterSnapshot>({
           rpcMethod: "desktopGetUpdaterState",
           ipcChannel: "desktop:getUpdaterState",
@@ -96,6 +96,13 @@ export function ReleaseCenterView() {
         ),
       ]);
 
+    const updater =
+      updaterResult.status === "fulfilled" ? updaterResult.value : null;
+    const build = buildResult.status === "fulfilled" ? buildResult.value : null;
+    const dock = dockResult.status === "fulfilled" ? dockResult.value : null;
+    const gpuStatus =
+      gpuStatusResult.status === "fulfilled" ? gpuStatusResult.value : null;
+
     setNativeUpdater(updater);
     setBuildInfo(build);
     _setDockVisible(dock?.visible ?? true);
@@ -104,7 +111,9 @@ export function ReleaseCenterView() {
       Object.fromEntries(
         SESSION_PARTITIONS.map((entry, index) => [
           entry.partition,
-          sessionResults[index] ?? undefined,
+          sessionResults[index]?.status === "fulfilled"
+            ? (sessionResults[index].value ?? undefined)
+            : undefined,
         ]),
       ),
     );
@@ -113,6 +122,18 @@ export function ReleaseCenterView() {
         ? current
         : normalizeReleaseNotesUrl(updater?.baseUrl ?? current),
     );
+
+    if (
+      updaterResult.status === "rejected" ||
+      buildResult.status === "rejected" ||
+      dockResult.status === "rejected" ||
+      gpuStatusResult.status === "rejected" ||
+      sessionResults.some((result) => result.status === "rejected")
+    ) {
+      console.warn(
+        "[ReleaseCenter] One or more desktop runtime requests failed during refresh.",
+      );
+    }
   }, [desktopRuntime, releaseNotesUrlDirty]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- harden `ReleaseCenterView` desktop state refresh so one failing desktop bridge call no longer breaks the page
- add a regression test proving Release Center stays interactive when a desktop bridge request rejects
- add Windows packaged renderer asset verification in `smoke-test-windows.ps1`, including required `vrms/previews/milady-1.png`

## Why
- users reported Chen preview missing in packaged Windows installs
- users also reported About/Release Center failing to load reliably when desktop bridge calls fail

## Validation
- `bunx vitest run packages/app-core/src/components/ReleaseCenterView.test.tsx`