### PR TITLE
fix(desktop): immediate language sync + Windows Milady menu actions

### DIFF
--- a/apps/app/electrobun/src/__tests__/application-menu.test.ts
+++ b/apps/app/electrobun/src/__tests__/application-menu.test.ts
@@ -21,9 +21,10 @@ function getMenu(
     title: string;
     singleton: boolean;
   }> = [],
+  isMac = true,
 ) {
   const menu = buildApplicationMenu({
-    isMac: true,
+    isMac,
     browserEnabled,
     heartbeatSnapshot: EMPTY_HEARTBEAT_MENU_SNAPSHOT,
     detachedWindows,
@@ -356,5 +357,14 @@ describe("buildApplicationMenu", () => {
       .filter((i): i is { action: string } => typeof i.action === "string")
       .map((i) => i.action);
     expect(actions).toContain("reset-milady");
+  });
+
+  it("uses explicit About/Quit actions on Windows", () => {
+    const milady = getMenu("Milady", false, [], false);
+    const actions = (milady?.submenu ?? [])
+      .filter((i): i is { action: string } => typeof i.action === "string")
+      .map((i) => i.action);
+    expect(actions).toContain("open-about");
+    expect(actions).toContain("quit");
   });
 });

--- a/apps/app/electrobun/src/application-menu.ts
+++ b/apps/app/electrobun/src/application-menu.ts
@@ -255,7 +255,9 @@ export function buildApplicationMenu({
     {
       label: "Milady",
       submenu: [
-        { role: "about" },
+        ...(isMac
+          ? ([{ role: "about" }] as ApplicationMenuItem[])
+          : ([{ label: "About Milady", action: "open-about" }] as ApplicationMenuItem[])),
         { label: "Check for Updates", action: "check-for-updates" },
         { type: "separator" },
         {
@@ -265,7 +267,7 @@ export function buildApplicationMenu({
         },
         { label: "Restart Agent", action: "restart-agent" },
         { label: "Relaunch Milady", action: "relaunch" },
-        { label: "Reset Milady…", action: "reset-milady" },
+        { label: "Reset Milady...", action: "reset-milady" },
         { type: "separator" },
         ...(isMac
           ? [
@@ -277,7 +279,9 @@ export function buildApplicationMenu({
               { type: "separator" as const },
             ]
           : []),
-        { role: "quit" },
+        ...(isMac
+          ? ([{ role: "quit" }] as ApplicationMenuItem[])
+          : ([{ label: "Quit", action: "quit" }] as ApplicationMenuItem[])),
       ] as ApplicationMenuItem[],
     },
     {

--- a/apps/app/electrobun/src/application-menu.ts
+++ b/apps/app/electrobun/src/application-menu.ts
@@ -257,7 +257,9 @@ export function buildApplicationMenu({
       submenu: [
         ...(isMac
           ? ([{ role: "about" }] as ApplicationMenuItem[])
-          : ([{ label: "About Milady", action: "open-about" }] as ApplicationMenuItem[])),
+          : ([
+              { label: "About Milady", action: "open-about" },
+            ] as ApplicationMenuItem[])),
         { label: "Check for Updates", action: "check-for-updates" },
         { type: "separator" },
         {

--- a/apps/app/electrobun/src/index.ts
+++ b/apps/app/electrobun/src/index.ts
@@ -1162,6 +1162,12 @@ async function setupUpdater(): Promise<void> {
             "[Updater] Skipping auto-update check:",
             updaterState.autoUpdateDisabledReason,
           );
+          if (notifyOnNoUpdate) {
+            Utils.showNotification({
+              title: "Updates Unavailable",
+              body: updaterState.autoUpdateDisabledReason,
+            });
+          }
         }
         return;
       }
@@ -1213,6 +1219,10 @@ async function setupUpdater(): Promise<void> {
     });
 
     const triggerManualUpdateCheck = () => {
+      Utils.showNotification({
+        title: "Checking for Updates",
+        body: "Milady is checking for a newer release.",
+      });
       void runUpdateCheck(true);
     };
 
@@ -1227,6 +1237,14 @@ async function setupUpdater(): Promise<void> {
         }
         if (action === "check-for-updates") {
           triggerManualUpdateCheck();
+        } else if (action === "open-about") {
+          const updaterState = await getDesktopManager().getUpdaterState();
+          const version = updaterState.currentVersion || "unknown";
+          Utils.showNotification({
+            title: "About Milady",
+            body: `Version ${version} (${process.platform}/${process.arch})`,
+          });
+          void createSettingsWindow("updates");
         } else if (action === "export-config") {
           void exportConfigFromMenu();
         } else if (action === "import-config") {
@@ -1275,6 +1293,8 @@ async function setupUpdater(): Promise<void> {
             .catch((err: unknown) => {
               console.error("[Main] Agent restart failed:", err);
             });
+        } else if (action === "quit") {
+          Utils.quit();
         } else if (action === "show") {
           void getDesktopManager().showWindow();
         } else if (action?.startsWith("navigate-")) {

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -2647,6 +2647,38 @@ interface ChatGenerateOptions {
   onSnapshot?: (text: string) => void;
   isAborted?: () => boolean;
   resolveNoResponseText?: () => string;
+  preferredLanguage?: string;
+}
+
+const CHAT_LANGUAGE_INSTRUCTION: Record<string, string> = {
+  en: "Reply in natural English unless the user explicitly requests another language.",
+  "zh-CN":
+    "Reply in natural Simplified Chinese unless the user explicitly requests another language.",
+  ko: "Reply in natural Korean unless the user explicitly requests another language.",
+  es: "Reply in natural Spanish unless the user explicitly requests another language.",
+  pt: "Reply in natural Brazilian Portuguese unless the user explicitly requests another language.",
+  vi: "Reply in natural Vietnamese unless the user explicitly requests another language.",
+  tl: "Reply in natural Tagalog unless the user explicitly requests another language.",
+};
+
+function maybeAugmentChatMessageWithLanguage(
+  message: ReturnType<typeof createMessageMemory>,
+  preferredLanguage?: string,
+): ReturnType<typeof createMessageMemory> {
+  if (!preferredLanguage) return message;
+  const instruction =
+    CHAT_LANGUAGE_INSTRUCTION[normalizeCharacterLanguage(preferredLanguage)];
+  if (!instruction) return message;
+  const originalText = extractCompatTextContent(message.content);
+  if (!originalText) return message;
+
+  return {
+    ...message,
+    content: {
+      ...(message.content as Content),
+      text: `${originalText}\n\n[Language instruction: ${instruction}]`,
+    },
+  };
 }
 
 const PROVIDER_ISSUE_CHAT_REPLY = "Sorry, I'm having a provider issue";
@@ -3438,9 +3470,13 @@ async function generateChatResponse(
         responseMessages: [],
       };
     } else {
+      const languageAugmentedMessage = maybeAugmentChatMessageWithLanguage(
+        message,
+        opts?.preferredLanguage,
+      );
       const walletAugmentedMessage = maybeAugmentChatMessageWithWalletContext(
         runtime,
-        message,
+        languageAugmentedMessage,
       );
       const generationMessage = await maybeAugmentChatMessageWithKnowledge(
         runtime,
@@ -4106,12 +4142,14 @@ async function readChatRequestPayload(
   channelType: ChannelType;
   images?: ChatImageAttachment[];
   conversationMode?: "simple" | "power";
+  preferredLanguage?: string;
 } | null> {
   const body = await helpers.readJsonBody<{
     text?: string;
     channelType?: string;
     images?: ChatImageAttachment[];
     conversationMode?: string;
+    language?: string;
   }>(req, res, { maxBytes });
   if (!body) return null;
   const normalizedPrompt = normalizeIncomingChatPrompt(body.text, body.images);
@@ -4143,11 +4181,19 @@ async function readChatRequestPayload(
         mimeType: img.mimeType.toLowerCase(),
       }))
     : undefined;
+  const rawPreferredLanguage =
+    (typeof body.language === "string" && body.language.trim()
+      ? body.language
+      : undefined) ?? readUiLanguageHeader(req);
+  const preferredLanguage = rawPreferredLanguage
+    ? normalizeCharacterLanguage(rawPreferredLanguage)
+    : undefined;
   return {
     prompt: normalizedPrompt,
     channelType,
     images,
     ...(conversationMode ? { conversationMode } : {}),
+    ...(preferredLanguage ? { preferredLanguage } : {}),
   };
 }
 
@@ -15252,7 +15298,8 @@ async function handleRequest(
       error,
     });
     if (!chatPayload) return;
-    const { prompt, channelType, images, conversationMode } = chatPayload;
+    const { prompt, channelType, images, conversationMode, preferredLanguage } =
+      chatPayload;
 
     const runtime = state.runtime;
     if (!runtime) {
@@ -15366,6 +15413,7 @@ async function handleRequest(
           },
           resolveNoResponseText: () =>
             resolveNoResponseFallback(state.logBuffer, runtime),
+          preferredLanguage,
         },
       );
 
@@ -15434,7 +15482,8 @@ async function handleRequest(
       error,
     });
     if (!chatPayload) return;
-    const { prompt, channelType, images, conversationMode } = chatPayload;
+    const { prompt, channelType, images, conversationMode, preferredLanguage } =
+      chatPayload;
     const runtime = state.runtime;
     if (!runtime) {
       error(res, "Agent is not running", 503);
@@ -15500,6 +15549,7 @@ async function handleRequest(
         {
           resolveNoResponseText: () =>
             resolveNoResponseFallback(state.logBuffer, runtime),
+          preferredLanguage,
         },
       );
 
@@ -15704,7 +15754,8 @@ async function handleRequest(
       MAX_BODY_BYTES,
     );
     if (!chatPayload) return;
-    const { prompt, channelType, conversationMode } = chatPayload;
+    const { prompt, channelType, conversationMode, preferredLanguage } =
+      chatPayload;
 
     // Cloud proxy path
 
@@ -15784,6 +15835,7 @@ async function handleRequest(
           },
           resolveNoResponseText: () =>
             resolveNoResponseFallback(state.logBuffer, runtime),
+          preferredLanguage,
         },
       );
 
@@ -15831,7 +15883,8 @@ async function handleRequest(
       MAX_BODY_BYTES,
     );
     if (!chatPayload) return;
-    const { prompt, channelType, conversationMode } = chatPayload;
+    const { prompt, channelType, conversationMode, preferredLanguage } =
+      chatPayload;
 
     if (!state.runtime) {
       error(res, "Agent is not running", 503);
@@ -15886,6 +15939,7 @@ async function handleRequest(
         {
           resolveNoResponseText: () =>
             resolveNoResponseFallback(state.logBuffer, runtime),
+          preferredLanguage,
         },
       );
 

--- a/packages/app-core/src/state/TranslationContext.tsx
+++ b/packages/app-core/src/state/TranslationContext.tsx
@@ -50,6 +50,12 @@ export function TranslationProvider({
     (language: UiLanguage) => {
       const next = normalizeLanguage(language);
       setUiLanguageRaw(next);
+      if (
+        "setUiLanguage" in client &&
+        typeof client.setUiLanguage === "function"
+      ) {
+        (client.setUiLanguage as (lang: string) => void)(next);
+      }
       void client.updateConfig({ ui: { language: next } }).catch(() => {
         onLanguageSyncError?.(next);
       });


### PR DESCRIPTION
## Summary
- apply UI language immediately to request headers and chat generation language handling
- enforce preferred language per chat request in agent API (streaming + non-streaming paths)
- improve Windows Milady menu behavior: explicit About/Quit actions, update-check feedback, and cleaned Reset label
- add menu test coverage for Windows About/Quit action wiring

## Validation
- pnpm -C apps/app/electrobun test -- src/__tests__/application-menu.test.ts src/__tests__/kitchen-sink.test.ts
- pnpm exec vitest run packages/app-core/test/app/chat-language-header.test.ts
- pnpm -C packages/agent exec tsc --noEmit
- bun run lint