### PR TITLE
fix: voice locale sticking + reset verification hardening

### DIFF
--- a/apps/app/electrobun/src/__tests__/menu-reset-from-main.test.ts
+++ b/apps/app/electrobun/src/__tests__/menu-reset-from-main.test.ts
@@ -236,4 +236,76 @@ describe("runMainMenuResetAfterApiBaseResolved", () => {
       }),
     ).rejects.toThrow(/Reset API failed \(403\)/);
   });
+
+  it("retries reset once when onboarding is still complete after restart", async () => {
+    const fetchImpl = vi.fn(async (input: string) => {
+      if (input.endsWith("/api/agent/reset")) return mockResponse(true);
+      if (input.endsWith("/api/onboarding/status")) {
+        if (
+          fetchImpl.mock.calls.filter((call) =>
+            String(call[0]).endsWith("/api/onboarding/status"),
+          ).length === 1
+        ) {
+          return mockResponse(true, { complete: true });
+        }
+        return mockResponse(true, { complete: false });
+      }
+      if (input.endsWith("/api/status")) {
+        return mockResponse(true, { state: "running", agentName: "Milady" });
+      }
+      return mockResponse(true, {});
+    });
+
+    const restartEmbeddedClearingLocalDb = vi
+      .fn()
+      .mockResolvedValue({ port: 42_000 });
+
+    await runMainMenuResetAfterApiBaseResolved({
+      apiBase: "http://127.0.0.1:1",
+      fetchImpl,
+      buildHeaders: () => ({}),
+      useEmbeddedRestart: true,
+      restartEmbeddedClearingLocalDb,
+      pushEmbeddedApiBaseToRenderer: vi.fn(),
+      getLocalApiAuthToken: () => "tok",
+      postExternalAgentRestart: vi.fn(),
+      resolveApiBaseForStatusPoll: () => "http://127.0.0.1:1",
+      sendMenuResetAppliedToRenderer: vi.fn(),
+    });
+
+    expect(restartEmbeddedClearingLocalDb).toHaveBeenCalledTimes(2);
+    expect(
+      fetchImpl.mock.calls.filter((call) =>
+        String(call[0]).endsWith("/api/agent/reset"),
+      ).length,
+    ).toBe(2);
+  });
+
+  it("throws when onboarding remains complete after retry", async () => {
+    const fetchImpl = vi.fn(async (input: string) => {
+      if (input.endsWith("/api/agent/reset")) return mockResponse(true);
+      if (input.endsWith("/api/onboarding/status")) {
+        return mockResponse(true, { complete: true });
+      }
+      if (input.endsWith("/api/status")) {
+        return mockResponse(true, { state: "running", agentName: "Milady" });
+      }
+      return mockResponse(true, {});
+    });
+
+    await expect(
+      runMainMenuResetAfterApiBaseResolved({
+        apiBase: "http://127.0.0.1:1",
+        fetchImpl,
+        buildHeaders: () => ({}),
+        useEmbeddedRestart: false,
+        restartEmbeddedClearingLocalDb: vi.fn(),
+        pushEmbeddedApiBaseToRenderer: vi.fn(),
+        getLocalApiAuthToken: () => "",
+        postExternalAgentRestart: vi.fn(),
+        resolveApiBaseForStatusPoll: () => "http://127.0.0.1:1",
+        sendMenuResetAppliedToRenderer: vi.fn(),
+      }),
+    ).rejects.toThrow(/onboarding still marked complete/);
+  });
 });

--- a/apps/app/electrobun/src/menu-reset-from-main.ts
+++ b/apps/app/electrobun/src/menu-reset-from-main.ts
@@ -20,6 +20,7 @@ export type FetchLike = (
 export const MAIN_RESET_API_PROBE_TIMEOUT_MS = 4000;
 export const MENU_RESET_STATUS_POLL_MS = 1000;
 export const MENU_RESET_STATUS_MAX_MS = 120_000;
+export const MENU_RESET_VERIFY_RETRIES = 1;
 
 export function buildMainMenuResetApiCandidates(options: {
   embeddedPort: number | null | undefined;
@@ -133,30 +134,66 @@ export type MainMenuResetPostConfirmDeps = {
 export async function runMainMenuResetAfterApiBaseResolved(
   d: MainMenuResetPostConfirmDeps,
 ): Promise<void> {
-  const resetRes = await d.fetchImpl(`${d.apiBase}/api/agent/reset`, {
-    method: "POST",
-    headers: d.buildHeaders(),
-  });
-  if (!resetRes.ok) {
-    throw new Error(`Reset API failed (${resetRes.status})`);
-  }
-
-  if (d.useEmbeddedRestart) {
-    const status = await d.restartEmbeddedClearingLocalDb();
-    const apiToken = d.getLocalApiAuthToken();
-    if (status.port) {
-      d.pushEmbeddedApiBaseToRenderer(status.port, apiToken);
+  const executeResetAndRestart = async (): Promise<Record<string, unknown>> => {
+    const resetRes = await d.fetchImpl(`${d.apiBase}/api/agent/reset`, {
+      method: "POST",
+      headers: d.buildHeaders(),
+    });
+    if (!resetRes.ok) {
+      throw new Error(`Reset API failed (${resetRes.status})`);
     }
-  } else {
-    await d.postExternalAgentRestart();
+
+    if (d.useEmbeddedRestart) {
+      const status = await d.restartEmbeddedClearingLocalDb();
+      const apiToken = d.getLocalApiAuthToken();
+      if (status.port) {
+        d.pushEmbeddedApiBaseToRenderer(status.port, apiToken);
+      }
+    } else {
+      await d.postExternalAgentRestart();
+    }
+
+    const pollBase = d.resolveApiBaseForStatusPoll();
+    return pollMenuResetAgentStatusJson({
+      apiBase: pollBase,
+      fetchImpl: d.fetchImpl,
+      buildHeaders: d.buildHeaders,
+    });
+  };
+
+  const readOnboardingComplete = async (): Promise<boolean | null> => {
+    try {
+      const res = await d.fetchImpl(`${d.apiBase}/api/onboarding/status`, {
+        method: "GET",
+        headers: d.buildHeaders(),
+      });
+      if (!res.ok) {
+        return null;
+      }
+      const payload = (await res.json()) as { complete?: unknown };
+      return typeof payload.complete === "boolean" ? payload.complete : null;
+    } catch {
+      return null;
+    }
+  };
+
+  let statusPayload = await executeResetAndRestart();
+  let onboardingComplete = await readOnboardingComplete();
+
+  for (
+    let attempt = 0;
+    onboardingComplete === true && attempt < MENU_RESET_VERIFY_RETRIES;
+    attempt += 1
+  ) {
+    statusPayload = await executeResetAndRestart();
+    onboardingComplete = await readOnboardingComplete();
   }
 
-  const pollBase = d.resolveApiBaseForStatusPoll();
-  const statusPayload = await pollMenuResetAgentStatusJson({
-    apiBase: pollBase,
-    fetchImpl: d.fetchImpl,
-    buildHeaders: d.buildHeaders,
-  });
+  if (onboardingComplete === true) {
+    throw new Error(
+      "Reset verification failed: onboarding still marked complete",
+    );
+  }
 
   d.sendMenuResetAppliedToRenderer({
     itemId: "menu-reset-milady-applied",

--- a/packages/app-core/src/components/ChatView.tsx
+++ b/packages/app-core/src/components/ChatView.tsx
@@ -51,6 +51,25 @@ function nowMs(): number {
   return typeof performance !== "undefined" ? performance.now() : Date.now();
 }
 
+function mapUiLanguageToSpeechLocale(uiLanguage: string): string {
+  switch (uiLanguage) {
+    case "zh-CN":
+      return "zh-CN";
+    case "ko":
+      return "ko-KR";
+    case "es":
+      return "es-ES";
+    case "pt":
+      return "pt-BR";
+    case "vi":
+      return "vi-VN";
+    case "tl":
+      return "fil-PH";
+    default:
+      return "en-US";
+  }
+}
+
 const CHAT_INPUT_MIN_HEIGHT_PX = 46;
 const CHAT_INPUT_MAX_HEIGHT_PX = 200;
 const COMPANION_VISIBLE_MESSAGE_LIMIT = 2;
@@ -329,7 +348,7 @@ function useChatVoiceController(options: {
   const voice = useVoiceChat({
     cloudConnected: cloudVoiceAvailable,
     interruptOnSpeech: isGameModal,
-    lang: uiLanguage === "zh-CN" ? "zh-CN" : "en-US",
+    lang: mapUiLanguageToSpeechLocale(uiLanguage),
     onPlaybackStart: handleVoicePlaybackStart,
     onTranscript: handleVoiceTranscript,
     onTranscriptPreview: handleVoiceTranscriptPreview,

--- a/packages/app-core/src/hooks/useVoiceChat.ts
+++ b/packages/app-core/src/hooks/useVoiceChat.ts
@@ -680,6 +680,26 @@ function webSpeechVoiceDebugFields(
   };
 }
 
+function normalizeSpeechLocale(input: string | undefined): string {
+  const trimmed = input?.trim();
+  return trimmed || "en-US";
+}
+
+function localePrefix(locale: string): string {
+  return locale.toLowerCase().split("-")[0] || "en";
+}
+
+function matchesVoiceLocale(
+  voice: SpeechSynthesisVoice,
+  targetLocale: string,
+): boolean {
+  const target = targetLocale.toLowerCase();
+  const voiceLang = voice.lang.toLowerCase();
+  if (voiceLang === target) return true;
+  const base = localePrefix(targetLocale);
+  return voiceLang.startsWith(`${base}-`) || voiceLang === base;
+}
+
 // ── Hook ──────────────────────────────────────────────────────────────
 
 export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
@@ -1509,6 +1529,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
     (text: string, task: SpeakTask, generation: number) => {
       const config = voiceConfigRef.current;
       const synth = synthRef.current;
+      const requestedLocale = normalizeSpeechLocale(options.lang);
       const words = text.trim().split(/\s+/).length;
       const estimatedMs = Math.max(1200, (words / 3) * 1000);
       const useTalkModeTts = !synth && Boolean(getElectrobunRendererRpc());
@@ -1590,6 +1611,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
         }
 
         const utterance = new SpeechSynthesisUtterance(text.trim());
+        utterance.lang = requestedLocale;
         utteranceRef.current = utterance;
 
         let selectedVoice: SpeechSynthesisVoice | undefined;
@@ -1607,7 +1629,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
                 edgeVoiceName.toLowerCase().includes("guy") ||
                 edgeVoiceName.toLowerCase().includes("male");
               selectedVoice = voices.find((v) => {
-                if (!v.lang.startsWith("en")) return false;
+                if (!matchesVoiceLocale(v, requestedLocale)) return false;
                 const nameLower = v.name.toLowerCase();
                 if (isMale) {
                   return (
@@ -1630,6 +1652,22 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
           }
 
           if (!selectedVoice) {
+            if (localePrefix(requestedLocale) === "en") {
+              selectedVoice =
+                voices.find(
+                  (v) =>
+                    matchesVoiceLocale(v, requestedLocale) &&
+                    !v.name.toLowerCase().includes("alex") &&
+                    !v.name.toLowerCase().includes("david"),
+                ) || voices.find((v) => matchesVoiceLocale(v, requestedLocale));
+            } else {
+              selectedVoice = voices.find((v) =>
+                matchesVoiceLocale(v, requestedLocale),
+              );
+            }
+          }
+
+          if (!selectedVoice) {
             selectedVoice =
               voices.find(
                 (v) =>
@@ -1641,6 +1679,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
 
           if (selectedVoice) {
             utterance.voice = selectedVoice;
+            utterance.lang = selectedVoice.lang || requestedLocale;
           }
         }
 
@@ -1652,6 +1691,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
           append: task.append,
           textChars: text.trim().length,
           preview: miladyTtsDebugTextPreview(text),
+          requestedLocale,
           engine: "speechSynthesis",
           ...webSpeechVoiceDebugFields(selectedVoice),
         });
@@ -1665,6 +1705,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
             append: task.append,
             textChars: text.trim().length,
             preview: miladyTtsDebugTextPreview(text),
+            requestedLocale,
             engine: "speechSynthesis-utterance-onstart",
             ...webSpeechVoiceDebugFields(selectedVoice),
           });
@@ -1694,6 +1735,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
             segment: task.segment,
             synthesisError: errEv.error ?? "unknown",
             preview: miladyTtsDebugTextPreview(text),
+            requestedLocale,
             ...webSpeechVoiceDebugFields(selectedVoice),
           });
           endBrowserUtterance();
@@ -1703,7 +1745,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
         speechTimeoutRef.current = setTimeout(finish, estimatedMs + 5000);
       });
     },
-    [clearSpeechTimers],
+    [clearSpeechTimers, options.lang],
   );
 
   const processQueue = useCallback(() => {

--- a/packages/app-core/test/app/chat-view.test.tsx
+++ b/packages/app-core/test/app/chat-view.test.tsx
@@ -35,7 +35,7 @@ interface ChatViewContextStub {
           prev: Array<{ data: string; mimeType: string; name: string }>,
         ) => Array<{ data: string; mimeType: string; name: string }>),
   ) => void;
-  uiLanguage: "en" | "zh-CN";
+  uiLanguage: "en" | "zh-CN" | "ko" | "es" | "pt" | "vi" | "tl";
   chatMode: "simple" | "power";
   chatAgentVoiceMuted: boolean;
   elizaCloudConnected: boolean;
@@ -227,6 +227,22 @@ describe("ChatView", () => {
       (node) => node.type === "span" && text(node) === "stream me",
     );
     expect(userTextNodes.length).toBe(1);
+  });
+
+  it("maps ui language to matching voice locale", async () => {
+    mockUseApp.mockReturnValue(
+      createContext({
+        uiLanguage: "es",
+      }),
+    );
+
+    await act(async () => {
+      TestRenderer.create(React.createElement(ChatView));
+    });
+
+    expect(mockUseVoiceChat).toHaveBeenCalledWith(
+      expect.objectContaining({ lang: "es-ES" }),
+    );
   });
 
   it("does not auto-play assistant speech while stream is active in default chat", async () => {


### PR DESCRIPTION
## Summary
- fix voice language sticking by mapping UI language to speech locale in ChatView
- update Web Speech/TTS fallback voice selection to honor requested locale instead of defaulting to English
- harden desktop menu reset by verifying /api/onboarding/status after reset/restart and retrying reset once if onboarding remains complete

## Why
- #1429 already merged, but these two follow-up edge-case fixes were pushed afterward and are not in develop
- prevents mixed reset state where onboarding remains complete and cloud state appears stale

## Validation
- pnpm exec vitest run packages/app-core/test/app/chat-view.test.tsx packages/app-core/test/app/chat-language-header.test.ts
- pnpm -C apps/app/electrobun test -- src/__tests__/menu-reset-from-main.test.ts