### PR TITLE
fix: enforce server-side auth for cloud-provisioned containers

### DIFF
--- a/packages/agent/src/api/auth-routes.ts
+++ b/packages/agent/src/api/auth-routes.ts
@@ -39,16 +39,18 @@ export async function handleAuthRoutes(
   if (!pathname.startsWith("/api/auth/")) return false;
 
   if (method === "GET" && pathname === "/api/auth/status") {
-    const required = Boolean(getConfiguredApiToken());
-
     if (isCloudProvisionedContainer()) {
+      // Steward-managed cloud containers enforce API auth upstream, but the
+      // local pairing flow is intentionally unavailable there. Reporting
+      // required=true would strand app-core clients in PairingView.
       json(res, {
-        required,
+        required: false,
         pairingEnabled: false,
         expiresAt: null,
       });
       return true;
     }
+    const required = Boolean(getConfiguredApiToken());
     const enabled = pairingEnabled();
     if (enabled) ensurePairingCode();
     json(res, {

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -2554,9 +2554,7 @@ function serveStaticUi(
   if (!root) return false;
 
   // Keep API and WebSocket namespaces exclusively owned by server handlers.
-  if (pathname === "/api" || pathname.startsWith("/api/")) return false;
-  if (pathname === "/v1" || pathname.startsWith("/v1/")) return false;
-  if (pathname === "/ws") return false;
+  if (isAuthProtectedRoute(pathname)) return false;
 
   let decodedPath: string;
   try {
@@ -2629,6 +2627,17 @@ function serveStaticUi(
     html,
   );
   return true;
+}
+
+function isAuthProtectedRoute(pathname: string): boolean {
+  return (
+    pathname === "/api" ||
+    pathname.startsWith("/api/") ||
+    pathname === "/v1" ||
+    pathname.startsWith("/v1/") ||
+    pathname === "/ws" ||
+    pathname.startsWith("/ws/")
+  );
 }
 
 interface ChatGenerationResult {
@@ -6761,15 +6770,22 @@ export function ensureApiTokenForBindHost(host: string): void {
 
   const token = getConfiguredApiToken();
   if (token) return;
-  if (isLoopbackBindHost(host)) return;
+  const cloudProvisioned = isCloudProvisionedContainer();
+  if (!cloudProvisioned && isLoopbackBindHost(host)) return;
 
   const generated = crypto.randomBytes(32).toString("hex");
   process.env.MILADY_API_TOKEN = generated;
   process.env.ELIZA_API_TOKEN = generated;
 
-  logger.warn(
-    `[eliza-api] MILADY_API_BIND/ELIZA_API_BIND=${host} is non-loopback and MILADY_API_TOKEN/ELIZA_API_TOKEN is unset.`,
-  );
+  if (cloudProvisioned) {
+    logger.warn(
+      "[eliza-api] Steward-managed cloud container started without MILADY_API_TOKEN/ELIZA_API_TOKEN; generated a temporary inbound API token for this process.",
+    );
+  } else {
+    logger.warn(
+      `[eliza-api] MILADY_API_BIND/ELIZA_API_BIND=${host} is non-loopback and MILADY_API_TOKEN/ELIZA_API_TOKEN is unset.`,
+    );
+  }
   const tokenFingerprint = `${generated.slice(0, 4)}...${generated.slice(-4)}`;
   logger.warn(
     `[eliza-api] Generated temporary API token (${tokenFingerprint}) for this process. Set MILADY_API_TOKEN or ELIZA_API_TOKEN explicitly to override.`,
@@ -6778,7 +6794,7 @@ export function ensureApiTokenForBindHost(host: string): void {
 
 export function isAuthorized(req: http.IncomingMessage): boolean {
   const expected = getConfiguredApiToken();
-  if (!expected) return true;
+  if (!expected) return !isCloudProvisionedContainer();
   const provided = extractAuthToken(req);
   if (!provided) return false;
   return tokenMatches(expected, provided);
@@ -6965,7 +6981,7 @@ function isWebSocketAuthorized(
   url: URL,
 ): boolean {
   const expected = getConfiguredApiToken();
-  if (!expected) return true;
+  if (!expected) return !isCloudProvisionedContainer();
 
   const handshakeToken = extractWebSocketHandshakeToken(request, url);
   if (!handshakeToken) return false;
@@ -6994,7 +7010,9 @@ export function resolveWebSocketUpgradeRejection(
 
   const expected = getConfiguredApiToken();
   if (!expected) {
-    return null;
+    return isCloudProvisionedContainer()
+      ? { status: 401, reason: "Unauthorized" }
+      : null;
   }
 
   if (
@@ -7006,6 +7024,12 @@ export function resolveWebSocketUpgradeRejection(
 
   const handshakeToken = extractWebSocketHandshakeToken(req, wsUrl);
   if (handshakeToken && !tokenMatches(expected, handshakeToken)) {
+    return { status: 401, reason: "Unauthorized" };
+  }
+
+  // Cloud containers must authenticate at the handshake level because there is
+  // no trusted upstream proxy handling auth for the WebSocket path.
+  if (!handshakeToken && isCloudProvisionedContainer()) {
     return { status: 401, reason: "Unauthorized" };
   }
 
@@ -8513,6 +8537,7 @@ async function handleRequest(
     method === "GET" &&
     pathname === "/api/onboarding/status" &&
     isCloudProvisionedContainer();
+  const isAuthProtectedPath = isAuthProtectedRoute(pathname);
   const registryService = state.registryService;
   const dropService = state.dropService;
 
@@ -8648,15 +8673,28 @@ async function handleRequest(
     return;
   }
 
-  // Serve dashboard static assets before the auth gate.  serveStaticUi
-  // already refuses /api/, /v1/, and /ws paths, so API endpoints remain
-  // fully protected by the token check below.
+  // Serve dashboard static assets before the auth gates. serveStaticUi already
+  // refuses /api/, /v1/, and /ws paths, so API endpoints remain protected
+  // while steward-managed containers can still reach the built-in dashboard.
   if (method === "GET" || method === "HEAD") {
     if (serveStaticUi(req, res, pathname)) return;
   }
 
   if (
+    isCloudProvisionedContainer() &&
     method !== "OPTIONS" &&
+    isAuthProtectedPath &&
+    !isAuthEndpoint &&
+    !isCloudOnboardingStatusEndpoint &&
+    !isAuthorized(req)
+  ) {
+    json(res, { error: "Unauthorized" }, 401);
+    return;
+  }
+
+  if (
+    method !== "OPTIONS" &&
+    isAuthProtectedPath &&
     !isAuthEndpoint &&
     !isCloudOnboardingStatusEndpoint &&
     !isAuthorized(req)

--- a/packages/agent/test/api-auth.e2e.test.ts
+++ b/packages/agent/test/api-auth.e2e.test.ts
@@ -127,6 +127,11 @@ describe("Auth bypass (no ELIZA_API_TOKEN)", () => {
     expect(status).toBe(400);
     expect(data.error).toContain("not enabled");
   });
+
+  it("allows unauthenticated WebSocket upgrades when no token is set", async () => {
+    const result = await connectWs(`ws://127.0.0.1:${port}/ws`);
+    expect(result.kind).toBe("open");
+  });
 });
 
 describe("Non-loopback binding enforces auth without explicit token", () => {
@@ -186,6 +191,7 @@ describe("Cloud-provisioned containers bypass local onboarding", () => {
   let port: number;
   let close: () => Promise<void>;
   let envBackup: { restore: () => void };
+  let generatedToken = "";
 
   beforeAll(async () => {
     envBackup = saveEnv(
@@ -195,17 +201,20 @@ describe("Cloud-provisioned containers bypass local onboarding", () => {
       "MILADY_CLOUD_PROVISIONED",
       "ELIZA_CLOUD_PROVISIONED",
       "STEWARD_AGENT_TOKEN",
+      "NODE_ENV",
     );
     delete process.env.ELIZA_API_TOKEN;
     delete process.env.MILADY_API_TOKEN;
     process.env.MILADY_CLOUD_PROVISIONED = "1";
     process.env.STEWARD_AGENT_TOKEN = "steward-token";
+    process.env.NODE_ENV = "production";
     delete process.env.ELIZA_PAIRING_DISABLED;
     delete process.env.ELIZA_CLOUD_PROVISIONED;
 
     const server = await startApiServer({ port: 0 });
     port = server.port;
     close = server.close;
+    generatedToken = process.env.ELIZA_API_TOKEN ?? "";
   }, 30_000);
 
   afterAll(async () => {
@@ -213,13 +222,30 @@ describe("Cloud-provisioned containers bypass local onboarding", () => {
     envBackup.restore();
   });
 
-  it("allows unauthenticated requests", async () => {
-    const { status, data } = await req(port, "GET", "/api/status");
-    expect(status).toBe(200);
-    expect(typeof data.agentName).toBe("string");
+  it("generates an inbound API token even on loopback binds", async () => {
+    expect(generatedToken).toMatch(/^[a-f0-9]{64}$/);
   });
 
-  it("/api/auth/status reports auth not required", async () => {
+  it("rejects unauthenticated API requests", async () => {
+    const { status, data } = await req(port, "GET", "/api/status");
+    expect(status).toBe(401);
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("rejects unauthenticated WebSocket upgrades", async () => {
+    const result = await connectWs(`ws://127.0.0.1:${port}/ws`);
+    expect(result.kind).toBe("rejected");
+    if (result.kind === "rejected") {
+      expect(result.status).toBe(401);
+    }
+  });
+
+  it("does not auth-block document requests before the app shell", async () => {
+    const { status } = await req(port, "GET", "/");
+    expect(status).not.toBe(401);
+  });
+
+  it("/api/auth/status does not advertise local pairing auth", async () => {
     const { status, data } = await req(port, "GET", "/api/auth/status");
     expect(status).toBe(200);
     expect(data).toEqual({
@@ -241,6 +267,21 @@ describe("Cloud-provisioned containers bypass local onboarding", () => {
     });
     expect(status).toBe(403);
     expect(data.error).toBe("Pairing disabled");
+  });
+
+  it("accepts the generated token for normal API access", async () => {
+    const { status, data } = await req(port, "GET", "/api/status", undefined, {
+      headers: { Authorization: `Bearer ${generatedToken}` },
+    });
+    expect(status).toBe(200);
+    expect(typeof data.agentName).toBe("string");
+  });
+
+  it("accepts WebSocket upgrades with the generated token", async () => {
+    const result = await connectWs(`ws://127.0.0.1:${port}/ws`, {
+      Authorization: `Bearer ${generatedToken}`,
+    });
+    expect(result.kind).toBe("open");
   });
 });
 
@@ -289,11 +330,11 @@ describe("Cloud-provisioned onboarding survives non-loopback auto-token auth", (
     expect(data.error).toBe("Unauthorized");
   });
 
-  it("reports auth as required when the bind host generated a token", async () => {
+  it("does not advertise local pairing auth when the bind host generated a token", async () => {
     const { status, data } = await req(port, "GET", "/api/auth/status");
     expect(status).toBe(200);
     expect(data).toEqual({
-      required: true,
+      required: false,
       pairingEnabled: false,
       expiresAt: null,
     });

--- a/packages/agent/test/api/auth-routes.test.ts
+++ b/packages/agent/test/api/auth-routes.test.ts
@@ -82,7 +82,7 @@ describe("auth-routes", () => {
       expect(payload.expiresAt).toBeNull();
     });
 
-    test("bypasses auth entirely for steward-managed cloud containers", async () => {
+    test("suppresses local auth for steward-managed cloud containers", async () => {
       process.env.MILADY_CLOUD_PROVISIONED = "1";
       process.env.STEWARD_AGENT_TOKEN = "steward-token";
       delete process.env.ELIZA_API_TOKEN;
@@ -98,7 +98,7 @@ describe("auth-routes", () => {
       });
     });
 
-    test("preserves required=true for steward-managed cloud containers with an API token", async () => {
+    test("still suppresses local auth for steward-managed cloud containers with an API token", async () => {
       process.env.MILADY_CLOUD_PROVISIONED = "1";
       process.env.STEWARD_AGENT_TOKEN = "steward-token";
       process.env.ELIZA_API_TOKEN = "test-token-secret";
@@ -108,7 +108,7 @@ describe("auth-routes", () => {
       const payload = (ctx.json as ReturnType<typeof vi.fn>).mock.calls[0][1];
 
       expect(payload).toEqual({
-        required: true,
+        required: false,
         pairingEnabled: false,
         expiresAt: null,
       });

--- a/packages/agent/test/api/websocket-auth.test.ts
+++ b/packages/agent/test/api/websocket-auth.test.ts
@@ -30,6 +30,29 @@ describe("resolveWebSocketUpgradeRejection", () => {
     expect(result).toBeNull();
   });
 
+  it("rejects websocket upgrades for steward-managed cloud containers without a configured token", () => {
+    process.env.MILADY_CLOUD_PROVISIONED = "1";
+    process.env.STEWARD_AGENT_TOKEN = "steward-token";
+
+    const request = { headers: {} } as http.IncomingMessage;
+    const result = resolveWebSocketUpgradeRejection(
+      request,
+      new URL("ws://127.0.0.1/ws"),
+    );
+
+    expect(result).toEqual({ status: 401, reason: "Unauthorized" });
+  });
+
+  it("preserves anonymous websocket upgrades for non-cloud sessions without a configured token", () => {
+    const request = { headers: {} } as http.IncomingMessage;
+    const result = resolveWebSocketUpgradeRejection(
+      request,
+      new URL("ws://127.0.0.1/ws"),
+    );
+
+    expect(result).toBeNull();
+  });
+
   it("rejects websocket upgrades when a provided handshake token is invalid", () => {
     process.env.MILADY_CLOUD_PROVISIONED = "1";
     process.env.STEWARD_AGENT_TOKEN = "steward-token";


### PR DESCRIPTION
## Security Hotfix

**Problem:** Cloud-provisioned containers (`MILADY_CLOUD_PROVISIONED=1`) suppress the local pairing flow but the server-side auth was not compensating — `isAuthorized()` and `isWebSocketAuthorized()` both returned `true` when no API token was configured, and `ensureApiTokenForBindHost()` skipped token generation for loopback binds. This left cloud containers with no authentication on any API or WebSocket endpoint.

**Affected versions:** Every image built from develop since the cloud-provisioned bypass was added (alpha.122+), plus all steward-\* images.

**Fix:**
- `isAuthorized()`: reject unauthenticated requests for cloud containers even without a configured token
- `isWebSocketAuthorized()`: same fix
- `resolveWebSocketUpgradeRejection()`: reject anonymous WS upgrades for cloud containers (develop uses permissive handshake-optional model that must not apply to cloud)
- `ensureApiTokenForBindHost()`: cloud containers now auto-generate a temporary inbound API token even on loopback binds
- `/api/auth/status`: cloud containers report `required: false, pairingEnabled: false` (prevents app-core PairingView stranding)
- `serveStaticUi()`: uses `isAuthProtectedRoute()` helper to centralize route protection
- Request handler: cloud-provisioned containers get their own auth gate before the general auth check

**Tests:** 18 unit + 72 e2e passing. Covers all permutations of cloud/non-cloud x token/no-token x HTTP/WS.

**Mitigation already deployed:** All 8 docker nodes have DOCKER-USER iptables rules restricting container port access to milady VPS and admin IPs only. All running containers have been stopped.