### PR TITLE
fix: exempt /api/health from cloud auth gate

### DIFF
--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -9305,6 +9305,8 @@ async function handleRequest(
   }
   const pathname = url.pathname;
   const isAuthEndpoint = pathname.startsWith("/api/auth/");
+  const isHealthEndpoint =
+    method === "GET" && pathname === "/api/health";
   const isCloudOnboardingStatusEndpoint =
     method === "GET" &&
     pathname === "/api/onboarding/status" &&
@@ -9457,6 +9459,7 @@ async function handleRequest(
     method !== "OPTIONS" &&
     isAuthProtectedPath &&
     !isAuthEndpoint &&
+    !isHealthEndpoint &&
     !isCloudOnboardingStatusEndpoint &&
     !isAuthorized(req)
   ) {
@@ -9468,6 +9471,7 @@ async function handleRequest(
     method !== "OPTIONS" &&
     isAuthProtectedPath &&
     !isAuthEndpoint &&
+    !isHealthEndpoint &&
     !isCloudOnboardingStatusEndpoint &&
     !isAuthorized(req)
   ) {

--- a/packages/agent/test/api-auth.e2e.test.ts
+++ b/packages/agent/test/api-auth.e2e.test.ts
@@ -325,6 +325,11 @@ describe("Cloud-provisioned containers bypass local onboarding", () => {
     });
     expect(result.kind).toBe("open");
   });
+
+  it("allows unauthenticated GET /api/health for readiness probes", async () => {
+    const { status } = await req(port, "GET", "/api/health");
+    expect(status).not.toBe(401);
+  });
 });
 
 describe("Cloud-provisioned onboarding survives non-loopback auto-token auth", () => {

--- a/packages/app-core/src/components/onboarding/onboarding-form-primitives.tsx
+++ b/packages/app-core/src/components/onboarding/onboarding-form-primitives.tsx
@@ -64,9 +64,9 @@ export function getOnboardingChoiceCardClassName({
       ? `${onboardingRecommendedSurfaceClassName} ${onboardingRecommendedSurfaceHoverClassName}`
       : `${onboardingCardSurfaceClassName} ${onboardingCardSurfaceHoverClassName}`,
     selected &&
-    "border-[rgba(240,185,11,0.32)] bg-[rgba(240,185,11,0.12)] shadow-[0_0_0_1px_rgba(240,185,11,0.18)]",
+      "border-[rgba(240,185,11,0.32)] bg-[rgba(240,185,11,0.12)] shadow-[0_0_0_1px_rgba(240,185,11,0.18)]",
     detected &&
-    "border-[rgba(34,197,94,0.4)] bg-[rgba(34,197,94,0.1)] hover:border-[rgba(34,197,94,0.5)] hover:bg-[rgba(34,197,94,0.15)]",
+      "border-[rgba(34,197,94,0.4)] bg-[rgba(34,197,94,0.1)] hover:border-[rgba(34,197,94,0.5)] hover:bg-[rgba(34,197,94,0.15)]",
   );
 }
 


### PR DESCRIPTION
Follow-up to #1434. The cloud auth gate blocks `/api/health` because it falls under `/api/*`. This breaks the provisioning worker's readiness check — containers start fine but the health probe gets 401, causing permanent provisioning failure after 3 timeout rounds.

**Fix:** Add `isHealthEndpoint` exemption to both auth gates (cloud-specific and general), matching the existing pattern for `/api/auth/*` and `/api/onboarding/status`.

**Note:** The Dockerfile HEALTHCHECK already tolerates 401 (`[ "$code" = "200" -o "$code" = "401" ]`), so Docker's own health monitoring was unaffected. This fix is specifically for the cloud provisioning worker which expects 200.

Tests: 18 unit + 73 e2e passing.