### PR TITLE
fix(ui): align onboarding language selector with app header

### DIFF
--- a/packages/app-core/src/components/Header.test.tsx
+++ b/packages/app-core/src/components/Header.test.tsx
@@ -28,6 +28,8 @@ vi.mock("@miladyai/app-core/navigation", () => ({
 }));
 
 vi.mock("@miladyai/app-core/components", () => ({
+  LANGUAGE_DROPDOWN_TRIGGER_CLASSNAME:
+    "!h-11 !min-h-[44px] !min-w-[44px] !rounded-xl !px-3.5 sm:!px-3.5 leading-none",
   LanguageDropdown: () => React.createElement("div", null, "LanguageDropdown"),
   ThemeToggle: () => React.createElement("div", null, "ThemeToggle"),
 }));

--- a/packages/app-core/src/components/LanguageDropdown.tsx
+++ b/packages/app-core/src/components/LanguageDropdown.tsx
@@ -48,6 +48,9 @@ export interface LanguageDropdownProps {
   menuPlacement?: "bottom-end" | "top-end";
 }
 
+export const LANGUAGE_DROPDOWN_TRIGGER_CLASSNAME =
+  "!h-11 !min-h-[44px] !min-w-[44px] !rounded-xl !px-3.5 sm:!px-3.5 leading-none";
+
 export function LanguageDropdown({
   uiLanguage,
   setUiLanguage,

--- a/packages/app-core/src/components/OnboardingWizard.test.tsx
+++ b/packages/app-core/src/components/OnboardingWizard.test.tsx
@@ -4,10 +4,19 @@ import React from "react";
 import type { ReactTestRenderer } from "react-test-renderer";
 import TestRenderer, { act } from "react-test-renderer";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { LanguageDropdownProps } from "./LanguageDropdown";
+import { LANGUAGE_DROPDOWN_TRIGGER_CLASSNAME } from "./LanguageDropdown";
 
-const { mockUseApp, mockVrmStage } = vi.hoisted(() => ({
+const { mockUseApp, mockVrmStage, mockLanguageDropdown } = vi.hoisted(() => ({
   mockUseApp: vi.fn(),
   mockVrmStage: vi.fn(() => React.createElement("div", null, "VrmStage")),
+  mockLanguageDropdown: vi.fn((props: LanguageDropdownProps) =>
+    React.createElement("div", {
+      "data-testid": "language-dropdown-stub",
+      "data-trigger-class": props.triggerClassName,
+      "data-variant": props.variant,
+    }),
+  ),
 }));
 
 vi.mock("@miladyai/app-core/state", () => ({
@@ -25,7 +34,9 @@ vi.mock("@miladyai/app-core/state", () => ({
 }));
 
 vi.mock("@miladyai/app-core/components", () => ({
-  LanguageDropdown: () => React.createElement("div", null, "LanguageDropdown"),
+  LANGUAGE_DROPDOWN_TRIGGER_CLASSNAME,
+  LanguageDropdown: (props: LanguageDropdownProps) =>
+    mockLanguageDropdown(props),
 }));
 
 vi.mock("@miladyai/app-core/utils", () => ({
@@ -82,6 +93,7 @@ describe("OnboardingWizard", () => {
   beforeEach(() => {
     mockUseApp.mockReset();
     mockVrmStage.mockClear();
+    mockLanguageDropdown.mockClear();
   });
 
   it("keeps the day scene and light tokens when the UI theme is light", async () => {
@@ -163,6 +175,37 @@ describe("OnboardingWizard", () => {
 
     const svgs = tree?.root.findAll((node) => node.type === "svg");
     expect(svgs?.length ?? 0).toBe(0);
+  });
+
+  it("uses the shared header language trigger class in onboarding", async () => {
+    mockUseApp.mockReturnValue({
+      onboardingStep: "hosting",
+      selectedVrmIndex: 1,
+      customVrmUrl: "",
+      uiLanguage: "en",
+      uiTheme: "light",
+      setState: vi.fn(),
+      t: (key: string) => key,
+      onboardingUiRevealNonce: 0,
+      companionVrmPowerMode: "balanced",
+      companionHalfFramerateMode: "when_saving_power",
+      companionAnimateWhenHidden: false,
+    });
+
+    let tree: ReactTestRenderer | undefined;
+    await act(async () => {
+      tree = TestRenderer.create(<OnboardingWizard />);
+    });
+
+    const dropdown = tree?.root.findByProps({
+      "data-testid": "language-dropdown-stub",
+    });
+
+    expect(mockLanguageDropdown).toHaveBeenCalled();
+    expect(dropdown?.props["data-variant"]).toBe("companion");
+    expect(dropdown?.props["data-trigger-class"]).toBe(
+      LANGUAGE_DROPDOWN_TRIGGER_CLASSNAME,
+    );
   });
 
   describe("onboarding overlay reveal fallback", () => {

--- a/packages/app-core/src/components/OnboardingWizard.tsx
+++ b/packages/app-core/src/components/OnboardingWizard.tsx
@@ -1,4 +1,7 @@
-import { LanguageDropdown } from "@miladyai/app-core/components";
+import {
+  LANGUAGE_DROPDOWN_TRIGGER_CLASSNAME,
+  LanguageDropdown,
+} from "@miladyai/app-core/components";
 import type { UiLanguage } from "@miladyai/app-core/i18n";
 import { normalizeLanguage } from "@miladyai/app-core/i18n";
 import {
@@ -215,7 +218,7 @@ export function OnboardingWizard() {
             setUiLanguage={setUiLanguage}
             t={t}
             variant="companion"
-            triggerClassName="!h-9 !min-h-[36px] !rounded-[8px] !border !border-[var(--onboarding-card-border)] !bg-[var(--onboarding-card-bg)] !text-[var(--onboarding-text-primary)] !shadow-[0_2px_4px_rgba(0,0,0,0.04)] !ring-0 hover:!border-[var(--onboarding-field-focus-border)] transition-colors"
+            triggerClassName={LANGUAGE_DROPDOWN_TRIGGER_CLASSNAME}
           />
         </div>
 

--- a/packages/app-core/src/components/companion/ShellHeaderControls.test.tsx
+++ b/packages/app-core/src/components/companion/ShellHeaderControls.test.tsx
@@ -14,6 +14,8 @@ vi.mock("@miladyai/app-core/hooks", () => ({
 }));
 
 vi.mock("@miladyai/app-core/components", () => ({
+  LANGUAGE_DROPDOWN_TRIGGER_CLASSNAME:
+    "!h-11 !min-h-[44px] !min-w-[44px] !rounded-xl !px-3.5 sm:!px-3.5 leading-none",
   LanguageDropdown: () =>
     React.createElement("div", { "data-testid": "language-dropdown-stub" }),
   ThemeToggle: () =>

--- a/packages/app-core/src/components/companion/ShellHeaderControls.tsx
+++ b/packages/app-core/src/components/companion/ShellHeaderControls.tsx
@@ -1,4 +1,8 @@
-import { LanguageDropdown, ThemeToggle } from "@miladyai/app-core/components";
+import {
+  LANGUAGE_DROPDOWN_TRIGGER_CLASSNAME,
+  LanguageDropdown,
+  ThemeToggle,
+} from "@miladyai/app-core/components";
 import { useMediaQuery } from "@miladyai/app-core/hooks";
 import type { UiLanguage } from "@miladyai/app-core/i18n";
 import type { ShellView, UiTheme } from "@miladyai/app-core/state";
@@ -340,7 +344,7 @@ export function ShellHeaderControls({
             setUiLanguage={setUiLanguage}
             t={t}
             variant={controlsVariant}
-            triggerClassName="!h-11 !min-h-[44px] !min-w-[44px] !rounded-xl !px-3.5 sm:!px-3.5 leading-none"
+            triggerClassName={LANGUAGE_DROPDOWN_TRIGGER_CLASSNAME}
           />
         </div>
         <div


### PR DESCRIPTION
## Summary
- remove the onboarding-specific language trigger override that shrank and re-skinned the selector
- reuse one shared language trigger class for both onboarding and the in-app header
- tighten onboarding test coverage so the dropdown props are asserted instead of hidden behind a dumb stub

## Testing
- /Users/mac/.bun/bin/bunx vitest run packages/app-core/src/components/OnboardingWizard.test.tsx packages/app-core/src/components/Header.test.tsx packages/app-core/src/components/companion/ShellHeaderControls.test.tsx
- git diff --check

## Notes
- scope is limited to selector parity only
- no language-switch behavior, menu behavior, or i18n logic changed