### PR TITLE
[codex] preserve onboarded startup state

### DIFF
--- a/packages/app-core/src/state/AppContext.tsx
+++ b/packages/app-core/src/state/AppContext.tsx
@@ -165,6 +165,7 @@ import {
   loadCompanionVrmPowerMode,
   loadLastNativeTab,
   loadPersistedConnectionMode,
+  loadPersistedOnboardingComplete,
   loadPersistedOnboardingStep,
   loadUiTheme,
   mergeStreamingText,
@@ -201,6 +202,7 @@ import { NavigationEventHub } from "./navigation-events";
 import {
   deriveDetectedProviderPrefill,
   detectExistingOnboardingConnection,
+  resolveStartupWithoutRestoredConnection,
 } from "./onboarding-bootstrap";
 import {
   deriveUiShellModeForTab,
@@ -6698,6 +6700,8 @@ function AppProviderInner({
         pairingEnabled: false,
         expiresAt: null,
       };
+      const hadPersistedOnboardingCompletion =
+        loadPersistedOnboardingComplete();
       setStartupError(null);
       setStartupPhase("starting-backend");
       setAuthRequired(false);
@@ -6739,6 +6743,17 @@ function AppProviderInner({
       );
 
       if (!restoredConnection) {
+        const startupWithoutConnection = resolveStartupWithoutRestoredConnection(
+          {
+            hadPersistedOnboardingCompletion,
+          },
+        );
+        if (startupWithoutConnection.kind === "startup-error") {
+          setOnboardingComplete(true);
+          setStartupError(startupWithoutConnection.error);
+          setOnboardingLoading(false);
+          return;
+        }
         // No reusable backend/config was found yet. Show static onboarding
         // immediately so first-run users are not blocked on server startup.
         setOnboardingOptions({

--- a/packages/app-core/src/state/AppContext.tsx
+++ b/packages/app-core/src/state/AppContext.tsx
@@ -6743,11 +6743,10 @@ function AppProviderInner({
       );
 
       if (!restoredConnection) {
-        const startupWithoutConnection = resolveStartupWithoutRestoredConnection(
-          {
+        const startupWithoutConnection =
+          resolveStartupWithoutRestoredConnection({
             hadPersistedOnboardingCompletion,
-          },
-        );
+          });
         if (startupWithoutConnection.kind === "startup-error") {
           setOnboardingComplete(true);
           setStartupError(startupWithoutConnection.error);

--- a/packages/app-core/src/state/onboarding-bootstrap.test.ts
+++ b/packages/app-core/src/state/onboarding-bootstrap.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   deriveDetectedProviderPrefill,
   detectExistingOnboardingConnection,
+  resolveStartupWithoutRestoredConnection,
 } from "./onboarding-bootstrap";
 
 describe("detectExistingOnboardingConnection", () => {
@@ -128,5 +129,33 @@ describe("deriveDetectedProviderPrefill", () => {
         { id: "openrouter", apiKey: "   " },
       ]),
     ).toBeNull();
+  });
+});
+
+describe("resolveStartupWithoutRestoredConnection", () => {
+  it("keeps fresh installs on onboarding when no reusable connection exists", () => {
+    expect(
+      resolveStartupWithoutRestoredConnection({
+        hadPersistedOnboardingCompletion: false,
+      }),
+    ).toEqual({ kind: "onboarding" });
+  });
+
+  it("surfaces a recoverable startup error for previously onboarded users", () => {
+    expect(
+      resolveStartupWithoutRestoredConnection({
+        hadPersistedOnboardingCompletion: true,
+      }),
+    ).toEqual({
+      kind: "startup-error",
+      error: {
+        reason: "backend-unreachable",
+        phase: "starting-backend",
+        message:
+          "No reusable backend connection was found for this previously onboarded app.",
+        detail:
+          "Local onboarding state is preserved so setup does not restart unexpectedly. Retry after the backend is reachable again.",
+      },
+    });
   });
 });

--- a/packages/app-core/src/state/onboarding-bootstrap.ts
+++ b/packages/app-core/src/state/onboarding-bootstrap.ts
@@ -1,6 +1,7 @@
 import { asRecord, readString } from "./config-readers";
 import { deriveOnboardingResumeConnection } from "./onboarding-resume";
 import type { PersistedConnectionMode } from "./persistence";
+import type { StartupErrorState } from "./types";
 
 export interface ExistingOnboardingProbeClient {
   apiAvailable: boolean;
@@ -17,6 +18,10 @@ export interface DetectedProviderCandidate {
   id: string;
   apiKey?: string;
 }
+
+export type StartupWithoutConnectionResolution =
+  | { kind: "onboarding" }
+  | { kind: "startup-error"; error: StartupErrorState };
 
 const LOCAL_CONNECTION: PersistedConnectionMode = { runMode: "local" };
 
@@ -95,6 +100,26 @@ export async function detectExistingOnboardingConnection(args: {
   }
 
   return result === timeoutToken ? null : result;
+}
+
+export function resolveStartupWithoutRestoredConnection(args: {
+  hadPersistedOnboardingCompletion: boolean;
+}): StartupWithoutConnectionResolution {
+  if (!args.hadPersistedOnboardingCompletion) {
+    return { kind: "onboarding" };
+  }
+
+  return {
+    kind: "startup-error",
+    error: {
+      reason: "backend-unreachable",
+      phase: "starting-backend",
+      message:
+        "No reusable backend connection was found for this previously onboarded app.",
+      detail:
+        "Local onboarding state is preserved so setup does not restart unexpectedly. Retry after the backend is reachable again.",
+    },
+  };
 }
 
 export function deriveDetectedProviderPrefill(


### PR DESCRIPTION
## Summary
- preserve previously onboarded users when startup cannot recover a reusable backend connection
- route that case to a recoverable startup error instead of the first-run onboarding fallback
- add pure startup-bootstrap coverage for fresh-install vs returning-user behavior

## Root cause
Startup treated `!restoredConnection` as a fresh install unconditionally. During testing, if backend state dropped out and no reusable connection/config could be recovered, already-onboarded users were sent back to onboarding.

## Impact
Returning users now keep their onboarded state and see a retryable startup failure instead of unexpectedly re-entering onboarding. Fresh installs still go straight to onboarding.

## Validation
- `bun node_modules/vitest/vitest.mjs run packages/app-core/src/state/onboarding-bootstrap.test.ts packages/app-core/test/app/connection-mode-persistence.test.ts`
- `bun node_modules/vitest/vitest.mjs run --config vitest.e2e.config.ts packages/app-core/test/app/startup-backend-missing.e2e.test.ts`