### PR TITLE
test: align develop ci expectations

### DIFF
--- a/packages/agent/test/api-server.e2e.test.ts
+++ b/packages/agent/test/api-server.e2e.test.ts
@@ -3520,6 +3520,9 @@ describe("API Server E2E (no runtime)", () => {
   });
 
   describe("provider issue fallback", () => {
+    const CLOUD_CREDITS_DEPLETED_REPLY =
+      "Eliza Cloud credits are depleted. Top up the cloud balance and try again.";
+
     it("POST /api/chat replaces '(no response)' with the provider issue message", async () => {
       const runtime = createRuntimeForCreditNoResponseTests();
       const streamServer = await startApiServer({ port: 0, runtime });
@@ -3534,7 +3537,7 @@ describe("API Server E2E (no runtime)", () => {
           },
         );
         expect(status).toBe(200);
-        expect(String(data.text)).toBe("Sorry, I'm having a provider issue");
+        expect(String(data.text)).toBe(CLOUD_CREDITS_DEPLETED_REPLY);
         expect(String(data.text)).not.toBe("(no response)");
       } finally {
         await streamServer.close();
@@ -3554,7 +3557,7 @@ describe("API Server E2E (no runtime)", () => {
         const doneEvent = events.find((event) => event.type === "done");
         expect(doneEvent).toBeDefined();
         expect(String(doneEvent?.fullText ?? "")).toBe(
-          "Sorry, I'm having a provider issue",
+          CLOUD_CREDITS_DEPLETED_REPLY,
         );
       } finally {
         await streamServer.close();
@@ -3595,7 +3598,7 @@ describe("API Server E2E (no runtime)", () => {
           },
         );
         expect(status).toBe(200);
-        expect(String(data.text)).toBe("Sorry, I'm having a provider issue");
+        expect(String(data.text)).toBe(CLOUD_CREDITS_DEPLETED_REPLY);
       } finally {
         await streamServer.close();
       }
@@ -3615,7 +3618,7 @@ describe("API Server E2E (no runtime)", () => {
           },
         );
         expect(status).toBe(200);
-        expect(String(data.text)).toBe("Sorry, I'm having a provider issue");
+        expect(String(data.text)).toBe(CLOUD_CREDITS_DEPLETED_REPLY);
         expect(String(data.text)).not.toBe("(no response)");
       } finally {
         await streamServer.close();

--- a/packages/app-core/src/components/ChatModalView.test.tsx
+++ b/packages/app-core/src/components/ChatModalView.test.tsx
@@ -37,6 +37,7 @@ vi.mock("@miladyai/ui", async () => {
 
 vi.mock("@miladyai/app-core/state", () => ({
   useApp: vi.fn(),
+  useTranslation: vi.fn(() => ({ t: (key: string) => key })),
 }));
 
 vi.mock("@miladyai/ui", async () => {

--- a/packages/app-core/src/components/onboarding/connection/ConnectionProviderDetailScreen.test.tsx
+++ b/packages/app-core/src/components/onboarding/connection/ConnectionProviderDetailScreen.test.tsx
@@ -44,7 +44,13 @@ function t(key: string): string {
     "onboarding.back": "Back",
     "onboarding.connected": "Connected",
     "onboarding.confirm": "Confirm",
+    "onboarding.connectAccount": "Connect account",
+    "onboarding.connecting": "Connecting",
     "onboarding.login": "Login",
+    "onboarding.openLoginPageInBrowser": "Open login page in browser",
+    "onboarding.openLoginPageInBrowserDesc":
+      "Open the login page in your browser to continue.",
+    "onboarding.reportIssue": "Report issue",
     "onboarding.useExistingKey": "Use an existing key.",
     "onboarding.getOneHere": "Get one here",
     "onboarding.freeCredits": "Free credits included.",
@@ -152,9 +158,7 @@ describe("ConnectionProviderDetailScreen", () => {
       <ConnectionProviderDetailScreen dispatch={vi.fn()} />,
     );
 
-    const reportIssueButton = getByRole("button", {
-      name: (content) => content.includes("onboarding.reportIssue"),
-    });
+    const reportIssueButton = getByRole("button", { name: "Report issue" });
 
     expect(reportIssueButton).toBeDefined();
 

--- a/packages/app-core/test/app/knowledge-ui.e2e.test.ts
+++ b/packages/app-core/test/app/knowledge-ui.e2e.test.ts
@@ -465,7 +465,7 @@ describe("KnowledgeView UI", () => {
     expect(tree).not.toBeNull();
   });
 
-  it("displays document count in stats", async () => {
+  it("renders the loaded knowledge documents in the rail", async () => {
     let tree: TestRenderer.ReactTestRenderer | null = null;
 
     await act(async () => {
@@ -473,7 +473,7 @@ describe("KnowledgeView UI", () => {
     });
 
     const allText = JSON.stringify(tree?.toJSON());
-    expect(allText).toContain("Documents");
+    expect(allText).toContain("README.md");
   });
 
   it("loads fragment details when opening a document", async () => {
@@ -585,19 +585,12 @@ describe("KnowledgeView UI", () => {
         flattenText(node.props.children) === "knowledge.ui.search" &&
         typeof node.props.className === "string",
     );
-    const refreshButton = buttons.find(
-      (node) =>
-        flattenText(node.props.children) === "Refresh" &&
-        typeof node.props.className === "string",
-    );
-
     expect(allText).not.toContain("knowledgeview.ChooseFolder");
     expect(allText).not.toContain("knowledgeview.ChooseFiles");
     expect(allText).toContain("knowledge.ui.search");
     expect(searchForm?.props.className).toContain("max-w-[500px]");
     expect(searchButton?.props.className).toContain("h-10");
     expect(searchButton?.props.className).toContain("text-txt");
-    expect(refreshButton?.props.className).toContain("shadow-sm");
   });
 
   it("shows loading state when knowledgeLoading is true", async () => {

--- a/packages/app-core/test/app/startup-chat.e2e.test.ts
+++ b/packages/app-core/test/app/startup-chat.e2e.test.ts
@@ -324,8 +324,10 @@ describe("app startup routing (e2e)", () => {
 
     const root = tree?.root;
     const buttons = root.findAllByType("button");
-    const chatDrawerButton = buttons.find((node) =>
-      buttonText(node).includes("Chats"),
+    const chatDrawerButton = buttons.find(
+      (node) =>
+        node.props["aria-label"] === "aria.openChatsPanel" ||
+        buttonText(node).includes("conversations.chats"),
     );
     expect(chatDrawerButton).toBeDefined();
 


### PR DESCRIPTION
## Summary
- align stale API fallback assertions with the new Eliza Cloud credit-depleted reply
- update onboarding/chat modal tests for the current translation and drawer labels
- refresh knowledge and startup UI assertions to match the latest develop UI

## Validation
- bunx vitest run packages/app-core/src/components/ChatModalView.test.tsx packages/app-core/src/components/onboarding/connection/ConnectionProviderDetailScreen.test.tsx
- bunx vitest run --config vitest.e2e.config.ts packages/agent/test/api-server.e2e.test.ts -t "provider issue fallback" packages/app-core/test/app/knowledge-ui.e2e.test.ts packages/app-core/test/app/startup-chat.e2e.test.ts
- bun run lint
- bun run test:startup:contract
- bun run test:startup:e2e
- bun run build
- bun run release:check

## Notes
- the broad local Vitest worker paths were noisy on this macOS host, so GitHub Actions is the source of truth for the full matrix.