### PR TITLE
fix(ui): improve contrast and move plugin validation below config form

### DIFF
--- a/packages/app-core/src/components/CloudStatusBadge.tsx
+++ b/packages/app-core/src/components/CloudStatusBadge.tsx
@@ -138,7 +138,7 @@ function resolveCloudStatusToneStyle(
       backgroundColor: "var(--accent)",
       backgroundImage:
         "linear-gradient(180deg, color-mix(in srgb, var(--accent) 86%, white 14%), color-mix(in srgb, var(--accent) 94%, black 6%))",
-      color: "var(--accent-foreground)",
+      color: "#0f0f12",
       boxShadow:
         "inset 0 1px 0 rgba(255,255,255,0.22), 0 12px 28px rgba(3,5,10,0.16)",
     };

--- a/packages/app-core/src/components/InventoryView.tsx
+++ b/packages/app-core/src/components/InventoryView.tsx
@@ -432,9 +432,9 @@ export function InventoryView() {
               {t("wallet.noOnchainWalletHint")}
             </p>
             <Button
-              variant="default"
+              variant="outline"
               size="sm"
-              className="mt-5 rounded-full px-5"
+              className="mt-5 rounded-full border-accent/40 bg-accent/15 px-5 font-semibold text-accent hover:bg-accent/25 hover:border-accent/55"
               onClick={() => setTab("settings")}
             >
               {t("nav.settings")}

--- a/packages/app-core/src/components/PluginsView.tsx
+++ b/packages/app-core/src/components/PluginsView.tsx
@@ -2585,7 +2585,10 @@ function PluginListView({ label, mode = "all", inModal }: PluginListViewProps) {
                                     <div
                                       key={`${plugin.id}:${error.field}:${error.message}`}
                                     >
-                                      <span className="font-medium text-warn">{error.field}</span>: {error.message}
+                                      <span className="font-medium text-warn">
+                                        {error.field}
+                                      </span>
+                                      : {error.message}
                                     </div>
                                   ))}
                                 </div>

--- a/packages/app-core/src/components/PluginsView.tsx
+++ b/packages/app-core/src/components/PluginsView.tsx
@@ -2496,32 +2496,6 @@ function PluginListView({ label, mode = "all", inModal }: PluginListViewProps) {
 
                         {isExpanded && (
                           <div className="border-t border-border/40 bg-bg/18 px-4 py-4 sm:px-5">
-                            {plugin.validationErrors &&
-                              plugin.validationErrors.length > 0 && (
-                                <div className="mb-4 rounded-2xl border border-danger/30 bg-danger/10 px-4 py-3 text-sm text-danger">
-                                  {plugin.validationErrors.map((error) => (
-                                    <div
-                                      key={`${plugin.id}:${error.field}:${error.message}`}
-                                    >
-                                      {error.field}: {error.message}
-                                    </div>
-                                  ))}
-                                </div>
-                              )}
-
-                            {plugin.validationWarnings &&
-                              plugin.validationWarnings.length > 0 && (
-                                <div className="mb-4 rounded-2xl border border-warn/30 bg-warn/10 px-4 py-3 text-sm text-warn">
-                                  {plugin.validationWarnings.map((warning) => (
-                                    <div
-                                      key={`${plugin.id}:${warning.field}:${warning.message}`}
-                                    >
-                                      {warning.message}
-                                    </div>
-                                  ))}
-                                </div>
-                              )}
-
                             {pluginLinks.length > 0 && (
                               <div className="mb-4 flex flex-wrap gap-2">
                                 {pluginLinks.map((link) => (
@@ -2603,6 +2577,32 @@ function PluginListView({ label, mode = "all", inModal }: PluginListViewProps) {
                                 No configuration needed.
                               </div>
                             )}
+
+                            {plugin.validationErrors &&
+                              plugin.validationErrors.length > 0 && (
+                                <div className="mt-3 rounded-xl border border-border/40 bg-card/30 px-4 py-3 text-xs text-muted">
+                                  {plugin.validationErrors.map((error) => (
+                                    <div
+                                      key={`${plugin.id}:${error.field}:${error.message}`}
+                                    >
+                                      <span className="font-medium text-warn">{error.field}</span>: {error.message}
+                                    </div>
+                                  ))}
+                                </div>
+                              )}
+
+                            {plugin.validationWarnings &&
+                              plugin.validationWarnings.length > 0 && (
+                                <div className="mt-3 rounded-xl border border-border/40 bg-card/30 px-4 py-3 text-xs text-muted">
+                                  {plugin.validationWarnings.map((warning) => (
+                                    <div
+                                      key={`${plugin.id}:${warning.field}:${warning.message}`}
+                                    >
+                                      {warning.message}
+                                    </div>
+                                  ))}
+                                </div>
+                              )}
 
                             <div className="mt-4 flex flex-wrap items-center gap-2">
                               {plugin.isActive && (


### PR DESCRIPTION
## Summary

- **Wallet empty state**: Settings button now has visible gold outline + text instead of near-invisible default variant on dark background
- **Cloud credits badge**: Dollar amount text uses solid dark color (#0f0f12) for readable contrast on gold pill
- **Plugin config**: Validation errors moved below the config form instead of a big red banner at the top. Users see fields first, errors after — less alarming. Restyled from harsh red to subtle inline notice with warn-colored field names.

## Test plan

- [x] Visual — wallet empty state button is clearly visible
- [x] Visual — credits badge amount is readable
- [x] Visual — plugin validation errors appear below form, not above

🤖 Generated with [Claude Code](https://claude.com/claude-code)