### PR TITLE
docs: fix stale versions, broken links, and incorrect instructions ac…

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Grab from **[Releases](https://github.com/milady-ai/milady/releases/latest)**:
 | macOS (Apple Silicon) | [`Milady-arm64.dmg`](https://github.com/milady-ai/milady/releases/latest) | for your overpriced rectangle |
 | macOS (Intel) | [`Milady-x64.dmg`](https://github.com/milady-ai/milady/releases/latest) | boomer mac (why separate arm64/x64: [Build & release](docs/build-and-release.md#macos-why-two-dmgs-arm64-and-x64)) |
 | Windows | [`Milady-Setup.exe`](https://github.com/milady-ai/milady/releases/latest) | for the gamer anons |
-| iOS | [App Store](https://apps.apple.com/app/milady-private-ai-assistant/id0000000000) | for the privacy-pilled |
+| iOS | App Store (coming soon) | for the privacy-pilled |
 | Android | [Google Play](https://play.google.com/store/apps/details?id=ai.milady.app) / [APK](https://github.com/milady-ai/milady/releases/latest) | for the degen on the go |
 | Linux | [`.AppImage`](https://github.com/milady-ai/milady/releases/latest) / [`.deb`](https://github.com/milady-ai/milady/releases/latest) / [Snap](#snap) / [Flatpak](#flatpak) / [APT repo](#debian--ubuntu-apt) | I use arch btw |
 

--- a/docs/apps/chrome-extension.md
+++ b/docs/apps/chrome-extension.md
@@ -5,12 +5,12 @@ description: Release-status and architecture notes for the Milady Browser Relay 
 ---
 
 <Warning>
-Release `v2.0.0-alpha.125` does not ship an in-repo Chrome extension app, and the Browser Relay extension is not part of the shipped release surface for this repository checkout.
+Release `the current release` does not ship an in-repo Chrome extension app, and the Browser Relay extension is not part of the shipped release surface for this repository checkout.
 </Warning>
 
 ## Release status
 
-The **Milady Browser Relay** remains a planned or separately distributed extension. This repository does not contain the extension source, an unpacked extension directory, or a supported in-repo installation path for release `v2.0.0-alpha.125`.
+The **Milady Browser Relay** remains a planned or separately distributed extension. This repository does not contain the extension source, an unpacked extension directory, or a supported in-repo installation path for release `the current release`.
 
 Use this page as the single source of truth for that status:
 
@@ -28,7 +28,7 @@ The Browser Relay concept is still useful context because other runtime surfaces
 
 ## Current recommendation
 
-For release `v2.0.0-alpha.125`, treat browser control as one of these:
+For release `the current release`, treat browser control as one of these:
 
 1. A separately distributed Browser Relay package with its own source and install instructions.
 2. A browser-capable runtime plugin such as `@elizaos/plugin-browser`.

--- a/docs/apps/dashboard.md
+++ b/docs/apps/dashboard.md
@@ -174,7 +174,7 @@ The `PermissionsSection` component manages system permission grants for native p
 
 - **Relay server status** -- shows whether the WebSocket relay at `ws://127.0.0.1:{port}/extension` is reachable, with a green/red indicator.
 - **Check Connection** button to re-test relay status.
-- **Release status** -- links to the Browser Relay status page, which explains that the extension is not shipped in release `v2.0.0-alpha.125` and must be sourced separately if needed.
+- **Release status** -- links to the Browser Relay status page, which explains that the extension is not shipped in the current release and must be sourced separately if needed.
 - **Extension path** display when available.
 
 #### 9. Agent Export / Import

--- a/docs/apps/mobile.md
+++ b/docs/apps/mobile.md
@@ -15,7 +15,7 @@ The Milady mobile app brings the full dashboard experience to iOS and Android de
 
 **App ID:** `com.miladyai.milady`
 **Package name:** `@miladyai/app`
-**Current version:** `2.0.0-alpha.87`
+**Current version:** See root `package.json` for the latest version.
 
 ## Prerequisites
 

--- a/docs/apps/overview.md
+++ b/docs/apps/overview.md
@@ -1,10 +1,10 @@
 ---
 title: Apps Overview
 sidebarTitle: Overview
-description: Milady ships as a cross-platform suite for desktop, mobile, and web dashboard workflows in release v2.0.0-alpha.125.
+description: Milady ships as a cross-platform suite for desktop, mobile, and web dashboard workflows.
 ---
 
-Milady is available across the primary shipped platforms in release `v2.0.0-alpha.125`. Each app connects to the same agent runtime, giving you a consistent experience whether you're at your desk or on your phone.
+Milady is available across the primary shipped platforms. Each app connects to the same agent runtime, giving you a consistent experience whether you're at your desk or on your phone.
 
 ## Available Apps
 

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -549,7 +549,7 @@ You can now download and run AI models locally for fully offline inference. Five
 
 ## Chrome extension for browser control
 
-The Browser Relay extension remains documented as a separate or planned distribution. It is not part of the shipped `v2.0.0-alpha.125` repository surface, and its documentation now serves only as a release-status page plus architecture notes.
+The Browser Relay extension remains documented as a separate or planned distribution. It is not part of the shipped repository surface, and its documentation now serves only as a release-status page plus architecture notes.
 
 ## Mobile app (iOS and Android)
 

--- a/docs/es/guides/tutorial-telegram-bot.md
+++ b/docs/es/guides/tutorial-telegram-bot.md
@@ -11,7 +11,7 @@ description: "Aprende a crear y configurar un bot de Telegram con Milady en solo
 Comienza con la integración del bot de Telegram de Milady. Este tutorial te guía a través de la creación de tu primer bot, su configuración y las pruebas de extremo a extremo.
 
 <Info>
-  Este tutorial asume que tienes Milady instalado. Si aún no lo has hecho, consulta la [Guía de instalación](../getting-started/installation.md).
+  Este tutorial asume que tienes Milady instalado. Si aún no lo has hecho, consulta la [Guía de instalación](/installation).
 </Info>
 
 <div id="prerequisites">

--- a/docs/fr/guides/tutorial-telegram-bot.md
+++ b/docs/fr/guides/tutorial-telegram-bot.md
@@ -11,7 +11,7 @@ description: "Apprenez à créer et configurer un bot Telegram avec Milady en qu
 Démarrez avec l'intégration du bot Telegram de Milady. Ce tutoriel vous guide à travers la création de votre premier bot, sa configuration et ses tests de bout en bout.
 
 <Info>
-  Ce tutoriel suppose que vous avez installé Milady. Si ce n'est pas encore fait, consultez le [Guide d'installation](../getting-started/installation.md).
+  Ce tutoriel suppose que vous avez installé Milady. Si ce n'est pas encore fait, consultez le [Guide d'installation](/installation).
 </Info>
 
 <div id="prerequisites">

--- a/docs/guides/tutorial-discord-bot.md
+++ b/docs/guides/tutorial-discord-bot.md
@@ -50,18 +50,15 @@ If your token is ever exposed, regenerate it immediately by clicking **Regenerat
 </Step>
 
 <Step title="Configure milady.json">
-1. Open your Milady installation directory and locate or create `milady.json` in the root folder
-2. Add the Discord plugin configuration:
+1. Open `~/.milady/milady.json` (create it if it doesn't exist)
+2. Add the Discord connector configuration:
 
 ```json5
 {
   // ... existing config ...
-  "plugins": {
+  "connectors": {
     "discord": {
-      "enabled": true,
-      "token": "YOUR_BOT_TOKEN_HERE",
-      "intents": ["GUILDS", "GUILD_MESSAGES", "DIRECT_MESSAGES", "MESSAGE_CONTENT"],
-      "prefix": "!"
+      "botToken": "YOUR_BOT_TOKEN_HERE"
     }
   }
 }
@@ -71,21 +68,20 @@ If your token is ever exposed, regenerate it immediately by clicking **Regenerat
 4. Save the file
 
 <Info>
-The `intents` field tells Discord which events your bot should receive. `MESSAGE_CONTENT` is required to read message text.
+The Discord connector auto-enables when it detects a `botToken` in your connector config. No additional plugin installation is needed.
 </Info>
 
 </Step>
 
-<Step title="Enable the Discord Plugin">
-1. Open your terminal and navigate to your Milady installation directory
+<Step title="Verify the Discord Plugin">
+1. Open your terminal
 2. Run the following command to verify the plugin is recognized:
 
 ```bash
-bun run milady --plugins
+milady plugins installed
 ```
 
-3. Confirm that `discord` appears in the list of available plugins
-4. Check `milady.json` to ensure `"enabled": true` is set for the Discord plugin
+3. Start or restart Milady — the Discord connector loads automatically when `botToken` is configured
 
 </Step>
 

--- a/docs/guides/tutorial-telegram-bot.md
+++ b/docs/guides/tutorial-telegram-bot.md
@@ -9,7 +9,7 @@ description: "Learn how to create and configure a Telegram bot with Milady in ju
 Get started with Milady's Telegram bot integration. This tutorial walks you through creating your first bot, configuring it, and testing it end-to-end.
 
 <Info>
-  This tutorial assumes you have Milady installed. If you haven't already, check out the [Installation Guide](../getting-started/installation.md).
+  This tutorial assumes you have Milady installed. If you haven't already, check out the [Installation Guide](/installation).
 </Info>
 
 ## Prerequisites

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -96,15 +96,27 @@ milady plugins list
 
 ### Enable/Disable
 
-```bash
-milady plugins enable plugin-name
-milady plugins disable plugin-name
+Toggle plugins via the config file or `milady plugins config`:
+
+```json
+// milady.json
+{
+  "plugins": {
+    "entries": {
+      "plugin-name": { "enabled": false }
+    }
+  }
+}
 ```
+
+Or use the Dashboard Settings UI to toggle plugins on/off.
 
 ### Eject (Copy to Local)
 
+Eject a plugin to a local editable copy via the REST API or Dashboard:
+
 ```bash
-milady plugins eject plugin-name
+curl -X POST http://localhost:2138/api/plugins/plugin-name/eject
 ```
 
 See [Plugin Eject](/plugins/plugin-eject) for details on customizing ejected plugins.

--- a/docs/plugins/plugin-eject.md
+++ b/docs/plugins/plugin-eject.md
@@ -17,7 +17,7 @@ The eject system lets you clone an upstream plugin's source code locally, modify
 7. [The .upstream.json Format](#the-upstreamjson-format)
 8. [Syncing with Upstream](#syncing-with-upstream)
 9. [Contributing Back](#contributing-back)
-10. [CLI Commands](#cli-commands)
+10. [Usage](#usage)
 11. [Troubleshooting](#troubleshooting)
 
 ---
@@ -322,9 +322,9 @@ gh pr create --repo elizaos-plugins/plugin-telegram --base 1.x
 
 ---
 
-## CLI Commands
+## Usage
 
-### List Ejected Plugins
+### REST API
 
 ```
 GET /api/plugins/ejected
@@ -332,7 +332,7 @@ GET /api/plugins/ejected
 
 Returns all ejected plugins with their `.upstream.json` metadata.
 
-### Via Agent Chat
+### Agent Chat Commands
 
 - `"eject the telegram plugin"` -- triggers `EJECT_PLUGIN`
 - `"sync the ejected telegram plugin"` -- triggers `SYNC_PLUGIN`

--- a/docs/zh/guides/tutorial-telegram-bot.md
+++ b/docs/zh/guides/tutorial-telegram-bot.md
@@ -11,7 +11,7 @@ description: "了解如何在几分钟内使用 Milady 创建和配置 Telegram 
 开始使用 Milady 的 Telegram 机器人集成。本教程将引导你完成创建第一个机器人、配置以及端到端测试的全过程。
 
 <Info>
-  本教程假设你已经安装了 Milady。如果还没有，请查看[安装指南](../getting-started/installation.md)。
+  本教程假设你已经安装了 Milady。如果还没有，请查看[安装指南](/installation)。
 </Info>
 
 <div id="prerequisites">


### PR DESCRIPTION
…ross docs

Remove hardcoded alpha.125 version refs (now version-agnostic), replace placeholder iOS App Store link, fix Discord tutorial wrong config keys (plugins.discord → connectors.discord), fix broken installation links in telegram tutorial (all i18n), correct nonexistent CLI commands in plugin overview and plugin-eject docs.

https://claude.ai/code/session_01YGhT26pVLAHJ1GChPGVLND

This PR will be reviewed by an AI agent. Provide clear context to help it assess your changes.

Aesthetic/UI changes that don't improve agent capability are out of scope and will be rejected.

## Category
- [ ] Bug fix
- [ ] Security fix
- [ ] Performance improvement
- [ ] New feature
- [ ] Documentation
- [ ] Test coverage
- [ ] Other

## What
(brief description)

## Why
(motivation)

## How
(implementation approach)

## Testing
(what was tested, how to verify)
