### PR TITLE
fix docs: correct Discord config field, gateway port, deployment comm…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ All `@elizaos/*` packages use the `alpha` dist-tag. When developing locally, `bu
 |---------|----------|--------------|
 | API + WebSocket | 31337 | `MILADY_API_PORT` |
 | Dashboard UI | 2138 | `MILADY_PORT` |
-| Gateway | 19001 | `MILADY_GATEWAY_PORT` |
+| Gateway | 18789 | `MILADY_GATEWAY_PORT` |
 | Home Dashboard | 2142 | `MILADY_HOME_PORT` |
 | WeChat Webhook | 18790 | `MILADY_WECHAT_WEBHOOK_PORT` |
 

--- a/deploy/docker-setup.sh
+++ b/deploy/docker-setup.sh
@@ -186,7 +186,7 @@ echo "  - Gateway token: $MILADY_GATEWAY_TOKEN"
 echo "  - Tailscale exposure: Off"
 echo "  - Install Gateway daemon: No"
 echo ""
-docker compose "${COMPOSE_ARGS[@]}" run --rm milady-cli onboard --no-install-daemon
+docker compose "${COMPOSE_ARGS[@]}" run --rm milady-cli setup
 
 echo ""
 echo "==> Provider setup (optional)"

--- a/docs/connectors/blooio.md
+++ b/docs/connectors/blooio.md
@@ -20,7 +20,7 @@ The Blooio connector is an external elizaOS plugin that bridges your agent to iM
 
 ## Minimal Configuration
 
-In your character file:
+In `~/.milady/milady.json`:
 
 ```json
 {
@@ -49,7 +49,7 @@ To explicitly disable the connector even when an API key is present:
 
 ## Auto-Enable Mechanism
 
-The `plugin-auto-enable.ts` module checks `connectors.blooio` in your character config. If the `apiKey` field is truthy (and `enabled` is not explicitly `false`), the runtime automatically loads `@elizaos/plugin-blooio`.
+The `plugin-auto-enable.ts` module checks `connectors.blooio` in your config. If the `apiKey` field is truthy (and `enabled` is not explicitly `false`), the runtime automatically loads `@elizaos/plugin-blooio`.
 
 No environment variable is required to trigger auto-enable — it is driven entirely by the connector config object.
 
@@ -68,7 +68,7 @@ No environment variable is required to trigger auto-enable — it is driven enti
 
 ## Full Configuration Reference
 
-All fields are defined under `connectors.blooio` in your character file.
+All fields are defined under `connectors.blooio` in `milady.json`.
 
 ### Core Fields
 

--- a/docs/connectors/bluebubbles.md
+++ b/docs/connectors/bluebubbles.md
@@ -20,7 +20,7 @@ The BlueBubbles connector is an external elizaOS plugin that bridges your agent 
 
 ## Minimal Configuration
 
-In your character file:
+In `~/.milady/milady.json`:
 
 ```json
 {
@@ -51,13 +51,13 @@ To explicitly disable the connector even when credentials are present:
 
 ## Auto-Enable Mechanism
 
-The `plugin-auto-enable.ts` module checks `connectors.bluebubbles` in your character config. If both `serverUrl` and `password` are truthy (and `enabled` is not explicitly `false`), the runtime automatically loads `@elizaos/plugin-bluebubbles`.
+The `plugin-auto-enable.ts` module checks `connectors.bluebubbles` in your config. If both `serverUrl` and `password` are truthy (and `enabled` is not explicitly `false`), the runtime automatically loads `@elizaos/plugin-bluebubbles`.
 
 No environment variable is required to trigger auto-enable — it is driven entirely by the connector config object.
 
 ## Full Configuration Reference
 
-All fields are defined under `connectors.bluebubbles` in your character file.
+All fields are defined under `connectors.bluebubbles` in `milady.json`.
 
 ### Core Fields
 

--- a/docs/connectors/discord.md
+++ b/docs/connectors/discord.md
@@ -16,21 +16,25 @@ The Discord connector is an external elizaOS plugin that bridges your agent to D
 |-------|-------|
 | Package | `@elizaos/plugin-discord` |
 | Config key | `connectors.discord` |
-| Auto-enable trigger | `botToken`, `token`, or `apiKey` is truthy in connector config |
+| Auto-enable trigger | `token`, `botToken`, or `apiKey` is truthy in connector config |
 
 ## Minimal Configuration
 
-In your character file:
+In `~/.milady/milady.json`:
 
 ```json
 {
   "connectors": {
     "discord": {
-      "botToken": "your-discord-bot-token"
+      "token": "your-discord-bot-token"
     }
   }
 }
 ```
+
+<Warning>
+Use the `token` field — the Discord config schema uses strict validation and `botToken` is not a recognized schema field. While `botToken` triggers auto-enable detection, only `token` passes schema validation.
+</Warning>
 
 ## Disabling the Connector
 
@@ -40,7 +44,7 @@ To explicitly disable the connector even when a token is present:
 {
   "connectors": {
     "discord": {
-      "botToken": "your-discord-bot-token",
+      "token": "your-discord-bot-token",
       "enabled": false
     }
   }
@@ -49,9 +53,9 @@ To explicitly disable the connector even when a token is present:
 
 ## Auto-Enable Mechanism
 
-The `plugin-auto-enable.ts` module checks `connectors.discord` in your character config. If any of the fields `botToken`, `token`, or `apiKey` is truthy (and `enabled` is not explicitly `false`), the runtime automatically loads `@elizaos/plugin-discord`.
+The `plugin-auto-enable.ts` module checks `connectors.discord` in your config. If `token` (or `botToken` / `apiKey`) is truthy and `enabled` is not explicitly `false`, the runtime automatically loads `@elizaos/plugin-discord`.
 
-No environment variable is required to trigger auto-enable -- it is driven entirely by the connector config object.
+No environment variable is required to trigger auto-enable — it is driven entirely by the connector config object.
 
 ## Environment Variables
 
@@ -59,15 +63,15 @@ When loaded, secrets are pushed to `process.env` for the plugin to consume:
 
 | Variable | Source | Description |
 |----------|--------|-------------|
-| `DISCORD_API_TOKEN` | `botToken` or `token` | Primary bot token (always set) |
-| `DISCORD_BOT_TOKEN` | `botToken` or `token` | Mirror of `DISCORD_API_TOKEN` (both always set) |
+| `DISCORD_API_TOKEN` | `token` | Primary bot token (always set) |
+| `DISCORD_BOT_TOKEN` | `token` | Mirror of `DISCORD_API_TOKEN` (both always set) |
 | `DISCORD_APPLICATION_ID` | `applicationId` | Application ID. Auto-resolved via Discord OAuth2 API if not set |
 
 Note: If `DISCORD_APPLICATION_ID` is not configured, the runtime automatically resolves it by calling `https://discord.com/api/v10/oauth2/applications/@me` with the bot token.
 
 ## Full Configuration Reference
 
-All fields are set under `connectors.discord` in the character config.
+All fields are set under `connectors.discord` in `milady.json`.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|

--- a/docs/connectors/farcaster.md
+++ b/docs/connectors/farcaster.md
@@ -20,7 +20,7 @@ The Farcaster connector is an external elizaOS plugin that bridges your agent to
 
 ## Minimal Configuration
 
-In your character file:
+In `~/.milady/milady.json`:
 
 ```json
 {
@@ -53,13 +53,13 @@ To explicitly disable the connector even when an API key is present:
 
 ## Auto-Enable Mechanism
 
-The `plugin-auto-enable.ts` module checks `connectors.farcaster` in your character config. If the `apiKey` field is truthy (and `enabled` is not explicitly `false`), the runtime automatically loads `@elizaos/plugin-farcaster`.
+The `plugin-auto-enable.ts` module checks `connectors.farcaster` in your config. If the `apiKey` field is truthy (and `enabled` is not explicitly `false`), the runtime automatically loads `@elizaos/plugin-farcaster`.
 
 No environment variable is required to trigger auto-enable — it is driven entirely by the connector config object.
 
 ## Full Configuration Reference
 
-All fields are defined under `connectors.farcaster` in your character file.
+All fields are defined under `connectors.farcaster` in `milady.json`.
 
 ### Core Fields
 

--- a/docs/connectors/googlechat.md
+++ b/docs/connectors/googlechat.md
@@ -73,13 +73,13 @@ To explicitly disable the connector even when credentials are present:
 
 ## Auto-Enable Mechanism
 
-The `plugin-auto-enable.ts` module checks `connectors.googlechat` in your character config. If any of the fields `botToken`, `token`, or `apiKey` is truthy (and `enabled` is not explicitly `false`), the runtime automatically loads `@elizaos/plugin-google-chat`.
+The `plugin-auto-enable.ts` module checks `connectors.googlechat` in your config. If any of the fields `botToken`, `token`, or `apiKey` is truthy (and `enabled` is not explicitly `false`), the runtime automatically loads `@elizaos/plugin-google-chat`.
 
 No environment variable is required to trigger auto-enable — it is driven entirely by the connector config object.
 
 ## Full Configuration Reference
 
-All fields are defined under `connectors.googlechat` in your character file.
+All fields are defined under `connectors.googlechat` in `milady.json`.
 
 ### Core Fields
 

--- a/docs/connectors/imessage.md
+++ b/docs/connectors/imessage.md
@@ -26,7 +26,7 @@ The iMessage connector is an external elizaOS plugin that bridges your agent to 
 
 ## Minimal Configuration
 
-In your character file:
+In `~/.milady/milady.json`:
 
 ```json
 {
@@ -57,13 +57,13 @@ To explicitly disable the connector even when a CLI path is present:
 
 ## Auto-Enable Mechanism
 
-The `plugin-auto-enable.ts` module checks `connectors.imessage` in your character config. If the `cliPath` field is truthy (and `enabled` is not explicitly `false`), the runtime automatically loads `@elizaos/plugin-imessage`.
+The `plugin-auto-enable.ts` module checks `connectors.imessage` in your config. If the `cliPath` field is truthy (and `enabled` is not explicitly `false`), the runtime automatically loads `@elizaos/plugin-imessage`.
 
 No environment variable is required to trigger auto-enable — it is driven entirely by the connector config object.
 
 ## Full Configuration Reference
 
-All fields are defined under `connectors.imessage` in your character file.
+All fields are defined under `connectors.imessage` in `milady.json`.
 
 ### Core Fields
 

--- a/docs/connectors/mattermost.md
+++ b/docs/connectors/mattermost.md
@@ -20,7 +20,7 @@ The Mattermost connector is an external elizaOS plugin that bridges your agent t
 
 ## Minimal Configuration
 
-In your character file:
+In `~/.milady/milady.json`:
 
 ```json
 {
@@ -51,7 +51,7 @@ To explicitly disable the connector even when a token is present:
 
 ## Auto-Enable Mechanism
 
-The `plugin-auto-enable.ts` module checks `connectors.mattermost` in your character config. If the `botToken` field is truthy (and `enabled` is not explicitly `false`), the runtime automatically loads `@elizaos/plugin-mattermost`.
+The `plugin-auto-enable.ts` module checks `connectors.mattermost` in your config. If the `botToken` field is truthy (and `enabled` is not explicitly `false`), the runtime automatically loads `@elizaos/plugin-mattermost`.
 
 No environment variable is required to trigger auto-enable — it is driven entirely by the connector config object.
 
@@ -66,7 +66,7 @@ When the connector is loaded, the runtime pushes the following secrets from your
 
 ## Full Configuration Reference
 
-All fields are defined under `connectors.mattermost` in your character file.
+All fields are defined under `connectors.mattermost` in `milady.json`.
 
 ### Core Fields
 

--- a/docs/connectors/msteams.md
+++ b/docs/connectors/msteams.md
@@ -71,7 +71,7 @@ To explicitly disable the connector even when credentials are present:
 
 ## Auto-Enable Mechanism
 
-The `plugin-auto-enable.ts` module checks `connectors.msteams` in your character config. If any of the fields `botToken`, `token`, or `apiKey` is truthy (and `enabled` is not explicitly `false`), the runtime automatically loads `@elizaos/plugin-msteams`.
+The `plugin-auto-enable.ts` module checks `connectors.msteams` in your config. If any of the fields `botToken`, `token`, or `apiKey` is truthy (and `enabled` is not explicitly `false`), the runtime automatically loads `@elizaos/plugin-msteams`.
 
 No environment variable is required to trigger auto-enable — it is driven entirely by the connector config object.
 
@@ -87,7 +87,7 @@ When the connector is loaded, the runtime can consume the following secrets from
 
 ## Full Configuration Reference
 
-All fields are defined under `connectors.msteams` in your character file.
+All fields are defined under `connectors.msteams` in `milady.json`.
 
 ### Core Fields
 

--- a/docs/connectors/signal.md
+++ b/docs/connectors/signal.md
@@ -20,7 +20,7 @@ The Signal connector is an external elizaOS plugin that bridges your agent to Si
 
 ## Minimal Configuration
 
-In your character file:
+In `~/.milady/milady.json`:
 
 ```json
 {
@@ -53,7 +53,7 @@ signal-cli -a +1234567890 daemon --http localhost:8080
 
 ### 3. Configure Milady
 
-Add the `connectors.signal` block to your character file as shown in the minimal configuration above.
+Add the `connectors.signal` block to `milady.json` as shown in the minimal configuration above.
 
 ## Disabling
 
@@ -73,7 +73,7 @@ To explicitly disable the connector even when an account is configured:
 
 ## Auto-Enable Mechanism
 
-The `plugin-auto-enable.ts` module checks `connectors.signal` in your character config. The plugin auto-enables when any of the following conditions are met (and `enabled` is not explicitly `false`):
+The `plugin-auto-enable.ts` module checks `connectors.signal` in your config. The plugin auto-enables when any of the following conditions are met (and `enabled` is not explicitly `false`):
 
 - `account` is set together with `httpUrl`
 - `cliPath` is set (signal-cli binary path for auto-start)
@@ -83,7 +83,7 @@ No environment variable is required to trigger auto-enable — it is driven enti
 
 ## Full Configuration Reference
 
-All fields are defined under `connectors.signal` in your character file.
+All fields are defined under `connectors.signal` in `milady.json`.
 
 ### Core Fields
 

--- a/docs/connectors/slack.md
+++ b/docs/connectors/slack.md
@@ -18,7 +18,7 @@ The Slack connector is an external elizaOS plugin that bridges your agent to Sla
 
 ## Minimal Configuration
 
-In your character file:
+In `~/.milady/milady.json`:
 
 ```json
 {
@@ -47,7 +47,7 @@ To explicitly disable the connector even when a token is present:
 
 ## Auto-Enable Mechanism
 
-The `plugin-auto-enable.ts` module checks `connectors.slack` in your character config. If any of the fields `botToken`, `token`, or `apiKey` is truthy (and `enabled` is not explicitly `false`), the runtime automatically loads `@elizaos/plugin-slack`.
+The `plugin-auto-enable.ts` module checks `connectors.slack` in your config. If any of the fields `botToken`, `token`, or `apiKey` is truthy (and `enabled` is not explicitly `false`), the runtime automatically loads `@elizaos/plugin-slack`.
 
 No environment variable is required to trigger auto-enable — it is driven entirely by the connector config object.
 

--- a/docs/connectors/telegram.md
+++ b/docs/connectors/telegram.md
@@ -20,7 +20,7 @@ The Telegram connector is an external elizaOS plugin that bridges your agent to 
 
 ## Minimal Configuration
 
-In your character file:
+In `~/.milady/milady.json`:
 
 ```json
 {
@@ -49,7 +49,7 @@ To explicitly disable the connector even when a token is present:
 
 ## Auto-Enable Mechanism
 
-The `plugin-auto-enable.ts` module checks `connectors.telegram` in your character config. If any of the fields `botToken`, `token`, or `apiKey` is truthy (and `enabled` is not explicitly `false`), the runtime automatically loads `@elizaos/plugin-telegram`.
+The `plugin-auto-enable.ts` module checks `connectors.telegram` in your config. If any of the fields `botToken`, `token`, or `apiKey` is truthy (and `enabled` is not explicitly `false`), the runtime automatically loads `@elizaos/plugin-telegram`.
 
 No environment variable is required to trigger auto-enable — it is driven entirely by the connector config object.
 
@@ -63,7 +63,7 @@ When the connector is loaded, the runtime pushes the following secret from your 
 
 ## Full Configuration Reference
 
-All fields are defined under `connectors.telegram` in your character file.
+All fields are defined under `connectors.telegram` in `milady.json`.
 
 ### Core Fields
 

--- a/docs/connectors/twitch.md
+++ b/docs/connectors/twitch.md
@@ -20,7 +20,7 @@ The Twitch connector is an external elizaOS plugin that bridges your agent to Tw
 
 ## Minimal Configuration
 
-In your character file:
+In `~/.milady/milady.json`:
 
 ```json
 {
@@ -51,7 +51,7 @@ To explicitly disable the connector even when credentials are present:
 
 ## Auto-Enable Mechanism
 
-The `plugin-auto-enable.ts` module checks `connectors.twitch` in your character config. If any of the fields `accessToken` or `clientId` is truthy, or `enabled` is explicitly `true` (and `enabled` is not explicitly `false`), the runtime automatically loads `@elizaos/plugin-twitch`.
+The `plugin-auto-enable.ts` module checks `connectors.twitch` in your config. If any of the fields `accessToken` or `clientId` is truthy, or `enabled` is explicitly `true` (and `enabled` is not explicitly `false`), the runtime automatically loads `@elizaos/plugin-twitch`.
 
 No environment variable is required to trigger auto-enable — it is driven entirely by the connector config object.
 
@@ -71,7 +71,7 @@ No environment variable is required to trigger auto-enable — it is driven enti
 
 ## Full Configuration Reference
 
-All fields are defined under `connectors.twitch` in your character file.
+All fields are defined under `connectors.twitch` in `milady.json`.
 
 ### Core Fields
 

--- a/docs/connectors/twitter.md
+++ b/docs/connectors/twitter.md
@@ -20,7 +20,7 @@ The Twitter connector is an external elizaOS plugin that bridges your agent to T
 
 ## Minimal Configuration
 
-In your character file:
+In `~/.milady/milady.json`:
 
 ```json
 {
@@ -49,7 +49,7 @@ To explicitly disable the connector even when a token is present:
 
 ## Auto-Enable Mechanism
 
-The `plugin-auto-enable.ts` module checks `connectors.twitter` in your character config. If any of the fields `botToken`, `token`, or `apiKey` is truthy (and `enabled` is not explicitly `false`), the runtime automatically loads `@elizaos/plugin-twitter`.
+The `plugin-auto-enable.ts` module checks `connectors.twitter` in your config. If any of the fields `botToken`, `token`, or `apiKey` is truthy (and `enabled` is not explicitly `false`), the runtime automatically loads `@elizaos/plugin-twitter`.
 
 No environment variable is required to trigger auto-enable — it is driven entirely by the connector config object.
 
@@ -59,7 +59,7 @@ Unlike Discord, Telegram, and Slack, the Twitter connector does **not** inject s
 
 ## Full Configuration Reference
 
-All fields are nested under `connectors.twitter` in your character file.
+All fields are nested under `connectors.twitter` in `milady.json`.
 
 Note: Twitter does **not** support multi-account configuration or the `accounts` array pattern used by some other connectors. Only a single Twitter account can be configured per agent.
 

--- a/docs/connectors/wechat.md
+++ b/docs/connectors/wechat.md
@@ -24,7 +24,7 @@ The WeChat connector sends your API key and message payloads through the configu
 
 ## Minimal Configuration
 
-In your character file:
+In `~/.milady/milady.json`:
 
 ```json
 {
@@ -55,7 +55,7 @@ To explicitly disable the connector even when an API key is present:
 
 ## Auto-Enable Mechanism
 
-The `plugin-auto-enable.ts` module checks `connectors.wechat` in your character config. The plugin auto-enables when:
+The `plugin-auto-enable.ts` module checks `connectors.wechat` in your config. The plugin auto-enables when:
 
 - A top-level `apiKey` is truthy, OR
 - An `accounts` map contains at least one enabled account with a truthy `apiKey`
@@ -70,7 +70,7 @@ Setting `enabled: false` at the connector or account level disables auto-enable.
 
 ## Full Configuration Reference
 
-All fields are defined under `connectors.wechat` in your character file.
+All fields are defined under `connectors.wechat` in `milady.json`.
 
 ### Core Fields
 

--- a/docs/connectors/whatsapp.md
+++ b/docs/connectors/whatsapp.md
@@ -20,7 +20,7 @@ The WhatsApp connector is an external elizaOS plugin that bridges your agent to 
 
 ## Minimal Configuration
 
-In your character file (Baileys / QR code):
+In `~/.milady/milady.json` (Baileys / QR code):
 
 ```json
 {
@@ -66,7 +66,7 @@ To explicitly disable the connector even when auth config is present:
 
 ## Auto-Enable Mechanism
 
-The `plugin-auto-enable.ts` module checks `connectors.whatsapp` in your character config. The plugin is loaded when any of the following is truthy (and `enabled` is not explicitly `false`):
+The `plugin-auto-enable.ts` module checks `connectors.whatsapp` in your config. The plugin is loaded when any of the following is truthy (and `enabled` is not explicitly `false`):
 
 - `authDir` is set at the top level
 - `authState` is set at the top level
@@ -106,7 +106,7 @@ These can also be placed in the `env` section of your config file. Baileys mode 
 
 ## Full Configuration Reference
 
-All fields are defined under `connectors.whatsapp` in your character file.
+All fields are defined under `connectors.whatsapp` in `milady.json`.
 
 ### Core Fields
 

--- a/docs/deployment.mdx
+++ b/docs/deployment.mdx
@@ -20,7 +20,7 @@ The setup script performs the following steps:
 1. Builds the Docker image (`milady:local` by default)
 2. Generates a random gateway token (via `openssl rand -hex 32`, or Python `secrets.token_hex(32)` as fallback)
 3. Writes environment variables to `deploy/.env`
-4. Runs interactive onboarding (`milady-cli onboard --no-install-daemon`)
+4. Runs interactive setup (`milady-cli setup`)
 5. Starts the gateway service in detached mode
 
 <Warning>


### PR DESCRIPTION
…and, and connector terminology

- Discord connector: use `token` instead of `botToken` (schema is strict, rejects unknown fields)
- CLAUDE.md: fix gateway port 19001 → 18789 (matches actual default in code)
- deployment.mdx + docker-setup.sh: fix non-existent `milady-cli onboard` → `milady-cli setup`
- All 14 connector docs: replace "character file/config" with "milady.json"/"your config"

https://claude.ai/code/session_0112oAGbC2DGnEQvJhgmD62P

This PR will be reviewed by an AI agent. Provide clear context to help it assess your changes.

Aesthetic/UI changes that don't improve agent capability are out of scope and will be rejected.

## Category
- [ ] Bug fix
- [ ] Security fix
- [ ] Performance improvement
- [ ] New feature
- [ ] Documentation
- [ ] Test coverage
- [ ] Other

## What
(brief description)

## Why
(motivation)

## How
(implementation approach)

## Testing
(what was tested, how to verify)
