### PR TITLE
fix(ui): polish knowledge view sidebar and search

### DIFF
--- a/apps/homepage/src/components/dashboard/AgentDetail.tsx
+++ b/apps/homepage/src/components/dashboard/AgentDetail.tsx
@@ -12,7 +12,16 @@ import { PolicyControls } from "./PolicyControls";
 import { TransactionHistory } from "./TransactionHistory";
 import { WalletsPanel } from "./WalletsPanel";
 
-const TABS = ["Overview", "Wallets", "Policies", "Transactions", "Approvals", "Metrics", "Logs", "Snapshots"] as const;
+const TABS = [
+  "Overview",
+  "Wallets",
+  "Policies",
+  "Transactions",
+  "Approvals",
+  "Metrics",
+  "Logs",
+  "Snapshots",
+] as const;
 type Tab = (typeof TABS)[number];
 
 interface AgentDetailProps {

--- a/apps/homepage/src/components/dashboard/TransactionHistory.tsx
+++ b/apps/homepage/src/components/dashboard/TransactionHistory.tsx
@@ -1,5 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { CloudApiClient, StewardTxRecord, StewardTxStatus } from "../../lib/cloud-api";
+import type {
+  CloudApiClient,
+  StewardTxRecord,
+  StewardTxStatus,
+} from "../../lib/cloud-api";
 
 const STATUS_FILTERS: Array<{ value: string; label: string }> = [
   { value: "", label: "ALL" },
@@ -90,12 +94,34 @@ function CopyButton({ text }: { text: string }) {
       className="ml-1 text-text-subtle hover:text-text-light transition-colors"
     >
       {copied ? (
-        <svg aria-hidden="true" className="w-3 h-3 text-emerald-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-          <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+        <svg
+          aria-hidden="true"
+          className="w-3 h-3 text-emerald-400"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M5 13l4 4L19 7"
+          />
         </svg>
       ) : (
-        <svg aria-hidden="true" className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-          <path strokeLinecap="round" strokeLinejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+        <svg
+          aria-hidden="true"
+          className="w-3 h-3"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+          />
         </svg>
       )}
     </button>
@@ -138,9 +164,12 @@ export function TransactionHistory({ client }: TransactionHistoryProps) {
         setOffset(newOffset);
       } catch (err) {
         if (!mountedRef.current) return;
-        const msg = err instanceof Error ? err.message : "Failed to load transactions";
+        const msg =
+          err instanceof Error ? err.message : "Failed to load transactions";
         if (msg.includes("503") || msg.includes("not configured")) {
-          setError("Steward is not configured for this agent. Transaction history requires a connected Steward instance.");
+          setError(
+            "Steward is not configured for this agent. Transaction history requires a connected Steward instance.",
+          );
         } else {
           setError(msg);
         }
@@ -234,11 +263,24 @@ export function TransactionHistory({ client }: TransactionHistoryProps) {
         {!loading && !error && records.length === 0 && (
           <div className="p-8 text-center">
             <div className="w-10 h-10 mx-auto mb-3 bg-surface-elevated border border-border flex items-center justify-center">
-              <svg aria-hidden="true" className="w-5 h-5 text-text-subtle" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
+              <svg
+                aria-hidden="true"
+                className="w-5 h-5 text-text-subtle"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={1.5}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z"
+                />
               </svg>
             </div>
-            <p className="font-mono text-sm text-text-light mb-1">NO TRANSACTIONS</p>
+            <p className="font-mono text-sm text-text-light mb-1">
+              NO TRANSACTIONS
+            </p>
             <p className="font-mono text-xs text-text-muted">
               {statusFilter
                 ? `No transactions with status "${statusFilter}"`
@@ -283,7 +325,9 @@ export function TransactionHistory({ client }: TransactionHistoryProps) {
                       <CopyButton text={toAddr} />
                     </span>
                   ) : (
-                    <span className="font-mono text-[11px] text-text-muted">—</span>
+                    <span className="font-mono text-[11px] text-text-muted">
+                      —
+                    </span>
                   )}
                 </div>
 
@@ -341,7 +385,9 @@ export function TransactionHistory({ client }: TransactionHistoryProps) {
                       </svg>
                     </a>
                   ) : (
-                    <span className="font-mono text-[11px] text-text-muted">—</span>
+                    <span className="font-mono text-[11px] text-text-muted">
+                      —
+                    </span>
                   )}
                 </div>
               </div>

--- a/packages/app-core/src/api/client.ts
+++ b/packages/app-core/src/api/client.ts
@@ -3595,7 +3595,12 @@ export class MiladyClient {
     status?: string;
     limit?: number;
     offset?: number;
-  }): Promise<{ records: StewardHistoryResponse; total: number; offset: number; limit: number }> {
+  }): Promise<{
+    records: StewardHistoryResponse;
+    total: number;
+    offset: number;
+    limit: number;
+  }> {
     const params = new URLSearchParams();
     if (opts?.status) params.set("status", opts.status);
     if (opts?.limit) params.set("limit", String(opts.limit));
@@ -3615,14 +3620,19 @@ export class MiladyClient {
     });
   }
 
-  async rejectStewardTx(txId: string, reason?: string): Promise<StewardApprovalActionResponse> {
+  async rejectStewardTx(
+    txId: string,
+    reason?: string,
+  ): Promise<StewardApprovalActionResponse> {
     return this.fetch("/api/wallet/steward-deny-tx", {
       method: "POST",
       body: JSON.stringify({ txId, reason }),
     });
   }
 
-  async signViaSteward(request: StewardSignRequest): Promise<StewardSignResponse> {
+  async signViaSteward(
+    request: StewardSignRequest,
+  ): Promise<StewardSignResponse> {
     return this.fetch("/api/wallet/steward-sign", {
       method: "POST",
       body: JSON.stringify(request),

--- a/packages/app-core/src/api/steward-bridge.ts
+++ b/packages/app-core/src/api/steward-bridge.ts
@@ -478,7 +478,9 @@ export async function getStewardTokenBalances(
  * Build auth headers for direct steward API calls.
  * Used for endpoints not yet exposed in the SDK (pending, approve, deny).
  */
-export function buildStewardHeaders(env: NodeJS.ProcessEnv = process.env): Headers {
+export function buildStewardHeaders(
+  env: NodeJS.ProcessEnv = process.env,
+): Headers {
   const headers = new Headers();
   headers.set("Content-Type", "application/json");
   headers.set("Accept", "application/json");
@@ -1047,7 +1049,6 @@ async function doEnsureStewardAgent(
     } catch {
       console.warn("[steward] Token generation failed (non-fatal)");
     }
-
 
     const result: EnsureStewardAgentResult = {
       agentId,

--- a/packages/app-core/src/components/ConfigPageView.tsx
+++ b/packages/app-core/src/components/ConfigPageView.tsx
@@ -314,32 +314,48 @@ type CloudServiceKey = "inference" | "rpc" | "media" | "tts" | "embeddings";
 const CLOUD_SERVICE_DEFS: {
   key: CloudServiceKey;
   labelKey: string;
+  labelDefault: string;
   descriptionKey: string;
+  descriptionDefault: string;
 }[] = [
   {
     key: "inference",
     labelKey: "configpageview.ServiceInferenceLabel",
+    labelDefault: "Inference",
     descriptionKey: "configpageview.ServiceInferenceDesc",
+    descriptionDefault:
+      "Use cloud-hosted models for chat and completions. Disable to use your own API keys.",
   },
   {
     key: "rpc",
     labelKey: "configpageview.ServiceRpcLabel",
+    labelDefault: "RPC",
     descriptionKey: "configpageview.ServiceRpcDesc",
+    descriptionDefault:
+      "Remote procedure calls for agent coordination and messaging.",
   },
   {
     key: "media",
     labelKey: "configpageview.ServiceMediaLabel",
+    labelDefault: "Media",
     descriptionKey: "configpageview.ServiceMediaDesc",
+    descriptionDefault:
+      "Cloud media processing for images, video, and file conversion.",
   },
   {
     key: "tts",
     labelKey: "configpageview.ServiceTtsLabel",
+    labelDefault: "Text-to-Speech",
     descriptionKey: "configpageview.ServiceTtsDesc",
+    descriptionDefault: "Cloud-hosted voice synthesis for agent speech output.",
   },
   {
     key: "embeddings",
     labelKey: "configpageview.ServiceEmbeddingsLabel",
+    labelDefault: "Embeddings",
     descriptionKey: "configpageview.ServiceEmbeddingsDesc",
+    descriptionDefault:
+      "Cloud-hosted embedding models for knowledge search and memory.",
   },
 ];
 
@@ -432,32 +448,40 @@ function CloudServicesSection() {
         })}
       </p>
       <div className="flex flex-col gap-2">
-        {CLOUD_SERVICE_DEFS.map(({ key, labelKey, descriptionKey }) => (
-          <div
-            key={key}
-            className={`flex items-center justify-between p-3 border border-border rounded-lg transition-colors ${
-              services[key] ? "bg-accent/5" : ""
-            }`}
-          >
-            <div className="flex-1 min-w-0 mr-4">
-              <div
-                id={`cloud-service-${key}`}
-                className="text-[13px] font-medium text-txt"
-              >
-                {t(labelKey)}
+        {CLOUD_SERVICE_DEFS.map(
+          ({
+            key,
+            labelKey,
+            labelDefault,
+            descriptionKey,
+            descriptionDefault,
+          }) => (
+            <div
+              key={key}
+              className={`flex items-center justify-between p-3 border border-border rounded-lg transition-colors ${
+                services[key] ? "bg-accent/5" : ""
+              }`}
+            >
+              <div className="flex-1 min-w-0 mr-4">
+                <div
+                  id={`cloud-service-${key}`}
+                  className="text-[13px] font-medium text-txt"
+                >
+                  {t(labelKey, { defaultValue: labelDefault })}
+                </div>
+                <div className="text-[11px] text-muted mt-0.5">
+                  {t(descriptionKey, { defaultValue: descriptionDefault })}
+                </div>
               </div>
-              <div className="text-[11px] text-muted mt-0.5">
-                {t(descriptionKey)}
-              </div>
+              <Switch
+                checked={services[key]}
+                disabled={saving}
+                onCheckedChange={() => void handleToggle(key)}
+                aria-labelledby={`cloud-service-${key}`}
+              />
             </div>
-            <Switch
-              checked={services[key]}
-              disabled={saving}
-              onCheckedChange={() => void handleToggle(key)}
-              aria-labelledby={`cloud-service-${key}`}
-            />
-          </div>
-        ))}
+          ),
+        )}
       </div>
     </div>
   );

--- a/packages/app-core/src/components/InventoryView.tsx
+++ b/packages/app-core/src/components/InventoryView.tsx
@@ -264,14 +264,12 @@ export function InventoryView() {
   const tradeReady =
     singleChainFocus === "bsc" ? bnbBalance >= BSC_GAS_READY_THRESHOLD : true;
   // When steward is connected, use steward addresses for copy buttons
-  const stewardEvmAddr =
-    stewardStatus?.connected
-      ? stewardStatus.walletAddresses?.evm ?? stewardStatus.evmAddress ?? null
-      : null;
-  const stewardSolAddr =
-    stewardStatus?.connected
-      ? stewardStatus.walletAddresses?.solana ?? null
-      : null;
+  const stewardEvmAddr = stewardStatus?.connected
+    ? (stewardStatus.walletAddresses?.evm ?? stewardStatus.evmAddress ?? null)
+    : null;
+  const stewardSolAddr = stewardStatus?.connected
+    ? (stewardStatus.walletAddresses?.solana ?? null)
+    : null;
   const displayEvmAddr = stewardEvmAddr ?? evmAddr;
   const displaySolAddr = stewardSolAddr ?? solAddr;
   const addresses = [
@@ -443,7 +441,9 @@ export function InventoryView() {
     );
   }
 
-  const stewardHasAddresses = stewardStatus?.connected && (stewardStatus.walletAddresses?.evm || stewardStatus.evmAddress);
+  const stewardHasAddresses =
+    stewardStatus?.connected &&
+    (stewardStatus.walletAddresses?.evm || stewardStatus.evmAddress);
   if (!evmAddr && !solAddr && !stewardHasAddresses) {
     return (
       <DesktopPageFrame>

--- a/packages/app-core/src/components/KnowledgeView.tsx
+++ b/packages/app-core/src/components/KnowledgeView.tsx
@@ -22,9 +22,7 @@ import {
   formatShortDate,
 } from "@miladyai/app-core/components";
 import { useApp } from "@miladyai/app-core/state";
-import { confirmDesktopAction } from "@miladyai/app-core/utils";
-import { Button, Checkbox, Input } from "@miladyai/ui";
-import { RefreshCw } from "lucide-react";
+import { Button, Input } from "@miladyai/ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   DESKTOP_INSET_EMPTY_PANEL_CLASSNAME,
@@ -36,61 +34,25 @@ import {
   DesktopPageFrame,
 } from "./desktop-surface-primitives";
 import {
-  isKnowledgeImageFile,
-  MAX_KNOWLEDGE_IMAGE_PROCESSING_BYTES,
-  maybeCompressKnowledgeUploadImage,
-} from "./knowledge-upload-image";
-import {
   APP_PANEL_SHELL_CLASSNAME,
   APP_SIDEBAR_CARD_ACTIVE_CLASSNAME,
   APP_SIDEBAR_CARD_BASE_CLASSNAME,
   APP_SIDEBAR_CARD_INACTIVE_CLASSNAME,
   APP_SIDEBAR_INNER_CLASSNAME,
-  APP_SIDEBAR_KICKER_CLASSNAME,
-  APP_SIDEBAR_PILL_CLASSNAME,
   APP_SIDEBAR_RAIL_CLASSNAME,
 } from "./sidebar-shell-styles";
 
-const MAX_UPLOAD_REQUEST_BYTES = 32 * 1_048_576; // Must match server knowledge route limit
-const BULK_UPLOAD_TARGET_BYTES = 24 * 1_048_576;
-const MAX_BULK_REQUEST_DOCUMENTS = 100;
-const LARGE_FILE_WARNING_BYTES = 8 * 1_048_576;
-const SUPPORTED_UPLOAD_EXTENSIONS = new Set([
-  ".txt",
-  ".md",
-  ".mdx",
-  ".pdf",
-  ".docx",
-  ".json",
-  ".csv",
-  ".xml",
-  ".html",
-  ".png",
-  ".jpg",
-  ".jpeg",
-  ".webp",
-  ".gif",
-]);
-
 const KNOWLEDGE_SHELL_CLASS = APP_PANEL_SHELL_CLASSNAME;
 const KNOWLEDGE_SIDEBAR_CLASS = `lg:w-[22rem] lg:max-w-[360px] ${APP_SIDEBAR_RAIL_CLASSNAME}`;
-const KNOWLEDGE_KICKER_CLASS = APP_SIDEBAR_KICKER_CLASSNAME;
-const KNOWLEDGE_SECTION_LABEL_CLASS =
-  "px-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-muted/60";
 const KNOWLEDGE_PANEL_CLASS = DESKTOP_SURFACE_PANEL_CLASSNAME;
 const KNOWLEDGE_INSET_PANEL_CLASS = DESKTOP_INSET_PANEL_CLASSNAME;
 const KNOWLEDGE_SIDEBAR_ITEM_BASE_CLASS = APP_SIDEBAR_CARD_BASE_CLASSNAME;
 const KNOWLEDGE_SIDEBAR_ITEM_ACTIVE_CLASS = APP_SIDEBAR_CARD_ACTIVE_CLASSNAME;
 const KNOWLEDGE_SIDEBAR_ITEM_INACTIVE_CLASS =
   APP_SIDEBAR_CARD_INACTIVE_CLASSNAME;
-const KNOWLEDGE_META_PILL_CLASS = `${APP_SIDEBAR_PILL_CLASSNAME} text-[10px] font-semibold uppercase tracking-[0.14em] text-txt-strong`;
 
 export type KnowledgeUploadFile = File & {
   webkitRelativePath?: string;
-};
-
-type KnowledgeUploadOptions = {
-  includeImageDescriptions: boolean;
 };
 
 export function getKnowledgeUploadFilename(file: KnowledgeUploadFile): string {
@@ -116,14 +78,6 @@ export function shouldReadKnowledgeFileAsText(
   );
 }
 
-function isSupportedKnowledgeFile(file: Pick<File, "name">): boolean {
-  const lowerName = file.name.toLowerCase();
-  for (const extension of SUPPORTED_UPLOAD_EXTENSIONS) {
-    if (lowerName.endsWith(extension)) return true;
-  }
-  return false;
-}
-
 function getKnowledgeTypeLabel(contentType?: string): string {
   return contentType?.split("/").pop()?.toUpperCase() || "DOC";
 }
@@ -139,212 +93,6 @@ function getKnowledgeSourceLabel(
     return t("knowledgeview.FromUrl", { defaultValue: "From URL" });
   }
   return t("knowledgeview.Upload", { defaultValue: "Upload" });
-}
-
-function getKnowledgeDocumentSummary(
-  doc: KnowledgeDocument,
-  t: (key: string, options?: Record<string, unknown>) => string,
-): string {
-  const fragmentLabel =
-    doc.fragmentCount === 1
-      ? t("knowledgeview.FragmentCountOne", {
-          defaultValue: "1 fragment",
-        })
-      : t("knowledgeview.FragmentCountMany", {
-          defaultValue: "{{count}} fragments",
-          count: doc.fragmentCount,
-        });
-  return `${getKnowledgeSourceLabel(doc.source, t)} • ${fragmentLabel} • ${formatByteSize(doc.fileSize)}`;
-}
-
-/* ── Upload Zone ────────────────────────────────────────────────────── */
-
-function UploadZone({
-  onFilesUpload,
-  onUrlUpload,
-  uploading,
-  uploadStatus,
-}: {
-  onFilesUpload: (
-    files: KnowledgeUploadFile[],
-    options: KnowledgeUploadOptions,
-  ) => void;
-  onUrlUpload: (url: string, options: KnowledgeUploadOptions) => void;
-  uploading: boolean;
-  uploadStatus: { current: number; total: number; filename: string } | null;
-}) {
-  const { t } = useApp();
-  const [dragOver, setDragOver] = useState(false);
-  const [urlInput, setUrlInput] = useState("");
-  const [showUrlInput, setShowUrlInput] = useState(false);
-  const [includeImageDescriptions, setIncludeImageDescriptions] =
-    useState(true);
-  const fileInputRef = useRef<HTMLInputElement>(null);
-
-  const handleDrop = useCallback(
-    (e: React.DragEvent) => {
-      e.preventDefault();
-      setDragOver(false);
-      const files = Array.from(e.dataTransfer.files) as KnowledgeUploadFile[];
-      if (files.length > 0 && !uploading) {
-        onFilesUpload(files, { includeImageDescriptions });
-      }
-    },
-    [includeImageDescriptions, onFilesUpload, uploading],
-  );
-
-  const handleFileSelect = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const files = e.target.files;
-      if (files && files.length > 0 && !uploading) {
-        onFilesUpload(Array.from(files) as KnowledgeUploadFile[], {
-          includeImageDescriptions,
-        });
-      }
-      e.target.value = "";
-    },
-    [includeImageDescriptions, onFilesUpload, uploading],
-  );
-
-  const handleUrlSubmit = useCallback(() => {
-    const url = urlInput.trim();
-    if (url && !uploading) {
-      onUrlUpload(url, { includeImageDescriptions });
-      setUrlInput("");
-      setShowUrlInput(false);
-    }
-  }, [includeImageDescriptions, urlInput, uploading, onUrlUpload]);
-
-  return (
-    <fieldset
-      className="w-full"
-      onDragOver={(e) => {
-        e.preventDefault();
-        setDragOver(true);
-      }}
-      onDragLeave={() => setDragOver(false)}
-      onDrop={handleDrop}
-      aria-label={t("aria.knowledgeUpload")}
-    >
-      <input
-        ref={fileInputRef}
-        type="file"
-        className="hidden"
-        multiple
-        accept=".txt,.md,.mdx,.pdf,.docx,.json,.csv,.xml,.html,.png,.jpg,.jpeg,.webp,.gif"
-        onChange={handleFileSelect}
-      />
-      <div className="flex items-start justify-between gap-3 px-1">
-        <div className={KNOWLEDGE_META_PILL_CLASS}>
-          {t("knowledgeview.FormatsCount", {
-            defaultValue: "{{count}} formats",
-            count: SUPPORTED_UPLOAD_EXTENSIONS.size,
-          })}
-        </div>
-      </div>
-
-      <div className="mt-3 grid grid-cols-2 gap-2">
-        <Button
-          variant="default"
-          size="sm"
-          className="h-10 px-4 text-[11px] font-semibold text-txt-strong shadow-sm hover:text-txt-strong"
-          onClick={() => fileInputRef.current?.click()}
-          disabled={uploading}
-        >
-          {t("knowledgeview.ChooseFiles")}
-        </Button>
-        <Button
-          variant="outline"
-          size="sm"
-          className="h-10 px-4 text-[11px] font-semibold text-txt shadow-sm hover:text-txt"
-          onClick={() => setShowUrlInput(!showUrlInput)}
-          disabled={uploading}
-        >
-          {t("knowledgeview.AddFromURL")}
-        </Button>
-      </div>
-      {/* biome-ignore lint/a11y/noLabelWithoutControl: form control is associated programmatically */}
-      <label className="mt-2 inline-flex min-h-11 w-full cursor-pointer items-center gap-2 rounded-xl border border-border/35 bg-bg/18 px-3 text-[11px] leading-relaxed text-muted-strong transition-colors hover:border-border/55 hover:bg-bg/28 hover:text-txt">
-        <Checkbox
-          checked={includeImageDescriptions}
-          onCheckedChange={(checked) => setIncludeImageDescriptions(!!checked)}
-          disabled={uploading}
-        />
-        <span className="min-w-0">{t("knowledgeview.IncludeAIImageDes")}</span>
-      </label>
-      <div
-        className={`mt-3 rounded-2xl border px-3 py-3 transition-colors ${
-          dragOver
-            ? "border-accent/50 bg-accent/8 shadow-sm"
-            : "border-dashed border-border/35 bg-card/62"
-        } ${uploading ? "opacity-60" : ""}`}
-      >
-        {(dragOver || uploading) && (
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-muted/80">
-            <span className="font-medium text-txt/80">
-              {uploadStatus
-                ? t("knowledgeview.UploadingProgress", {
-                    defaultValue: "Uploading {{current}}/{{total}}{{filename}}",
-                    current: uploadStatus.current,
-                    total: uploadStatus.total,
-                    filename: uploadStatus.filename
-                      ? `: ${uploadStatus.filename}`
-                      : "",
-                  })
-                : t("knowledgeview.DropFilesOrFoldersToUpload", {
-                    defaultValue: "Drop files or folders to upload",
-                  })}
-            </span>
-          </div>
-        )}
-
-        {!dragOver && !uploading && !showUrlInput && (
-          <div className="space-y-1 py-1 text-center">
-            <div className="text-[11px] font-medium text-muted-strong">
-              {t("knowledgeview.DropFilesHereToUpload", {
-                defaultValue: "Drop files here to upload",
-              })}
-            </div>
-            <div className="text-[10px] text-muted">
-              {t("knowledgeview.UploadSupportedTypes", {
-                defaultValue: "Docs, PDFs, JSON, CSV, and supported images.",
-              })}
-            </div>
-          </div>
-        )}
-
-        {showUrlInput && (
-          <div
-            className={`${dragOver || uploading ? "mt-2" : ""} animate-in fade-in slide-in-from-top-2 duration-300`}
-          >
-            <div className="mb-2 text-[11px] font-medium leading-relaxed text-muted">
-              {t("knowledgeview.PasteAURLToImpor")}
-            </div>
-            <div className="flex flex-col gap-2 sm:flex-row">
-              <Input
-                type="url"
-                placeholder={t("knowledgeview.httpsExampleCom")}
-                value={urlInput}
-                onChange={(e) => setUrlInput(e.target.value)}
-                onKeyDown={(e) => e.key === "Enter" && handleUrlSubmit()}
-                disabled={uploading}
-                className="h-10 flex-1 border-border/55 bg-bg/72 text-xs shadow-none"
-              />
-              <Button
-                variant="default"
-                size="sm"
-                className="h-10 px-4 text-[11px] font-semibold"
-                onClick={handleUrlSubmit}
-                disabled={!urlInput.trim() || uploading}
-              >
-                {t("settings.import")}
-              </Button>
-            </div>
-          </div>
-        )}
-      </div>
-    </fieldset>
-  );
 }
 
 /* ── Search Result Item ─────────────────────────────────────────────── */
@@ -417,32 +165,25 @@ function DocumentListItem({
 }) {
   const { t } = useApp();
   return (
-    <div
+    <button
+      type="button"
       className={`${KNOWLEDGE_SIDEBAR_ITEM_BASE_CLASS} relative cursor-pointer ${
         active
           ? KNOWLEDGE_SIDEBAR_ITEM_ACTIVE_CLASS
           : KNOWLEDGE_SIDEBAR_ITEM_INACTIVE_CLASS
       }`}
       onClick={() => onSelect(doc.id)}
-      role="button"
-      tabIndex={0}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          onSelect(doc.id);
-        }
-      }}
       aria-label={t("knowledgeview.OpenDocument", {
         defaultValue: "Open {{filename}}",
         filename: doc.filename,
       })}
       aria-current={active ? "page" : undefined}
     >
-      <div className="min-w-0 flex-1">
-        <div className="truncate text-sm font-semibold leading-snug text-txt">
+      <span className="min-w-0 flex-1 text-left">
+        <span className="block truncate text-sm font-semibold leading-snug text-txt">
           {doc.filename}
-        </div>
-        <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+        </span>
+        <span className="mt-1.5 flex flex-wrap items-center gap-1.5">
           <span
             className={`inline-flex items-center rounded-md border px-1.5 py-0.5 text-[9px] font-bold uppercase leading-none tracking-wider ${
               active
@@ -458,9 +199,10 @@ function DocumentListItem({
           <span className="text-[10px] text-muted/50 opacity-0 transition-opacity group-hover:opacity-100">
             {formatShortDate(doc.createdAt, { fallback: "—" })}
           </span>
-        </div>
-      </div>
-      <div
+        </span>
+      </span>
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents lint/a11y/noStaticElementInteractions: stopPropagation wrapper for nested interactive */}
+      <span
         className="absolute right-2 top-2 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100"
         onClick={(e) => e.stopPropagation()}
       >
@@ -472,8 +214,8 @@ function DocumentListItem({
           busyLabel="..."
           onConfirm={() => onDelete(doc.id)}
         />
-      </div>
-    </div>
+      </span>
+    </button>
   );
 }
 
@@ -530,7 +272,7 @@ function DocumentViewer({ documentId }: { documentId: string | null }) {
     return () => {
       cancelled = true;
     };
-  }, [documentId]);
+  }, [documentId, t]);
 
   const previewText = doc?.content?.text?.trim();
 
@@ -723,12 +465,6 @@ export function KnowledgeView({ inModal }: { inModal?: boolean } = {}) {
     KnowledgeSearchResult[] | null
   >(null);
   const [loading, setLoading] = useState(true);
-  const [uploading, setUploading] = useState(false);
-  const [uploadStatus, setUploadStatus] = useState<{
-    current: number;
-    total: number;
-    filename: string;
-  } | null>(null);
   const [searching, setSearching] = useState(false);
   const [deleting, setDeleting] = useState<string | null>(null);
   const [selectedDocId, setSelectedDocId] = useState<string | null>(null);
@@ -762,7 +498,7 @@ export function KnowledgeView({ inModal }: { inModal?: boolean } = {}) {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [t]);
 
   useEffect(() => {
     loadData().catch((err) => {
@@ -792,387 +528,7 @@ export function KnowledgeView({ inModal }: { inModal?: boolean } = {}) {
       loadData();
     }, delayMs);
     return () => clearTimeout(timer);
-  }, [isServiceLoading, loadData]);
-
-  const readKnowledgeFile = useCallback(async (file: KnowledgeUploadFile) => {
-    const reader = new FileReader();
-    return new Promise<string>((resolve, reject) => {
-      reader.onload = () => {
-        const result = reader.result;
-        if (typeof result === "string") {
-          resolve(result);
-          return;
-        }
-
-        if (result instanceof ArrayBuffer) {
-          const bytes = new Uint8Array(result);
-          let binary = "";
-          for (let i = 0; i < bytes.byteLength; i++) {
-            binary += String.fromCharCode(bytes[i]);
-          }
-          resolve(btoa(binary));
-          return;
-        }
-
-        reject(
-          new Error(
-            t("knowledgeview.FailedToReadFile", {
-              defaultValue: "Failed to read file",
-            }),
-          ),
-        );
-      };
-
-      reader.onerror = () => reject(reader.error);
-
-      if (shouldReadKnowledgeFileAsText(file)) {
-        reader.readAsText(file);
-      } else {
-        reader.readAsArrayBuffer(file);
-      }
-    });
-  }, []);
-
-  const buildKnowledgeUploadRequest = useCallback(
-    async (file: KnowledgeUploadFile, options: KnowledgeUploadOptions) => {
-      const optimizedImage = await maybeCompressKnowledgeUploadImage(file);
-      const uploadFile = optimizedImage.file as KnowledgeUploadFile;
-      if (
-        isKnowledgeImageFile(uploadFile) &&
-        uploadFile.size > MAX_KNOWLEDGE_IMAGE_PROCESSING_BYTES
-      ) {
-        throw new Error(
-          t("knowledgeview.ImageCouldNotBeCompressed", {
-            defaultValue:
-              "Image could not be compressed below {{limit}} for processing.",
-            limit: formatByteSize(MAX_KNOWLEDGE_IMAGE_PROCESSING_BYTES),
-          }),
-        );
-      }
-
-      const uploadFilename = getKnowledgeUploadFilename(uploadFile);
-      const content = await readKnowledgeFile(uploadFile);
-
-      const request = {
-        content,
-        filename: uploadFilename,
-        contentType: uploadFile.type || "application/octet-stream",
-        metadata: {
-          includeImageDescriptions: options.includeImageDescriptions,
-          relativePath: uploadFile.webkitRelativePath || undefined,
-        },
-      };
-      const requestBytes = new TextEncoder().encode(
-        JSON.stringify(request),
-      ).length;
-      if (requestBytes > MAX_UPLOAD_REQUEST_BYTES) {
-        throw new Error(
-          t("knowledgeview.UploadPayloadExceedsLimit", {
-            defaultValue:
-              "Upload payload is {{size}}, which exceeds the current limit ({{limit}}).",
-            size: formatByteSize(requestBytes),
-            limit: formatByteSize(MAX_UPLOAD_REQUEST_BYTES),
-          }),
-        );
-      }
-
-      return {
-        filename: uploadFilename,
-        request,
-        requestBytes,
-      };
-    },
-    [readKnowledgeFile],
-  );
-
-  const handleFilesUpload = useCallback(
-    async (files: KnowledgeUploadFile[], options: KnowledgeUploadOptions) => {
-      const unsupportedFiles = files.filter(
-        (file) => !isSupportedKnowledgeFile(file),
-      );
-      const uploadQueue = files.filter(
-        (file) => file.size > 0 && isSupportedKnowledgeFile(file),
-      );
-      if (uploadQueue.length === 0) {
-        setActionNotice(
-          unsupportedFiles.length > 0
-            ? t("knowledgeview.NoSupportedNonEmptyFiles", {
-                defaultValue: "No supported non-empty files were selected.",
-              })
-            : t("knowledgeview.NoNonEmptyFiles", {
-                defaultValue: "No non-empty files were selected.",
-              }),
-          "info",
-          3000,
-        );
-        return;
-      }
-
-      const largeFiles = uploadQueue.filter(
-        (file) => file.size >= LARGE_FILE_WARNING_BYTES,
-      );
-      if (largeFiles.length > 0) {
-        const shouldContinue =
-          typeof window === "undefined"
-            ? true
-            : await confirmDesktopAction({
-                title: t("knowledgeview.UploadLargeFiles", {
-                  defaultValue: "Upload Large Files",
-                }),
-                message: t("knowledgeview.LargeFilesDetected", {
-                  defaultValue: "{{count}} large file(s) detected.",
-                  count: largeFiles.length,
-                }),
-                detail: t("knowledgeview.UploadLargeFilesDetail", {
-                  defaultValue:
-                    "Uploading can take longer and may increase embedding or vision costs.",
-                }),
-                confirmLabel: t("onboarding.savedMyKeys", {
-                  defaultValue: "Continue",
-                }),
-                cancelLabel: t("common.cancel", {
-                  defaultValue: "Cancel",
-                }),
-                type: "warning",
-              });
-        if (!shouldContinue) return;
-      }
-
-      const failures: string[] = [];
-      const warnings: string[] = [];
-      let successful = 0;
-
-      const normalizeUploadError = (err: unknown): string => {
-        const message =
-          err instanceof Error
-            ? err.message
-            : t("knowledgeview.UnknownUploadError", {
-                defaultValue: "Unknown upload error",
-              });
-        const status = (err as Error & { status?: number })?.status;
-        return status === 413 || /maximum size|payload is/i.test(message)
-          ? t("knowledgeview.UploadTooLarge", {
-              defaultValue: "Upload too large. Try splitting this file.",
-            })
-          : message;
-      };
-
-      setUploading(true);
-      setUploadStatus({
-        current: 0,
-        total: uploadQueue.length,
-        filename: t("knowledgeview.Preparing", {
-          defaultValue: "Preparing...",
-        }),
-      });
-
-      try {
-        type PreparedUpload = {
-          filename: string;
-          request: {
-            content: string;
-            filename: string;
-            contentType: string;
-            metadata: {
-              includeImageDescriptions: boolean;
-              relativePath: string | undefined;
-            };
-          };
-          requestBytes: number;
-        };
-
-        let currentBatch: PreparedUpload[] = [];
-        let currentBatchBytes = 0;
-
-        const flushBatch = async () => {
-          if (currentBatch.length === 0) return;
-
-          const batchToUpload = currentBatch;
-          currentBatch = [];
-          currentBatchBytes = 0;
-
-          const batchLabel =
-            batchToUpload[0]?.filename ||
-            t("knowledgeview.Batch", { defaultValue: "batch" });
-          setUploadStatus({
-            current: successful + failures.length,
-            total: uploadQueue.length,
-            filename: t("knowledgeview.UploadingBatchStartingWith", {
-              defaultValue: "Uploading batch starting with {{label}}",
-              label: batchLabel,
-            }),
-          });
-
-          try {
-            const result = await client.uploadKnowledgeDocumentsBulk({
-              documents: batchToUpload.map((item) => item.request),
-            });
-
-            for (const item of result.results) {
-              const batchItem = batchToUpload[item.index];
-              const filename =
-                item.filename ||
-                batchItem?.filename ||
-                t("knowledgeview.Document", {
-                  defaultValue: "document",
-                });
-              if (item.ok) {
-                successful += 1;
-                if (item.warnings?.[0]) {
-                  warnings.push(`${filename}: ${item.warnings[0]}`);
-                }
-              } else {
-                failures.push(
-                  `${filename}: ${
-                    item.error ||
-                    t("knowledgeview.UploadFailed", {
-                      defaultValue: "Upload failed",
-                    })
-                  }`,
-                );
-              }
-            }
-          } catch (err) {
-            const message = normalizeUploadError(err);
-            for (const batchItem of batchToUpload) {
-              failures.push(`${batchItem.filename}: ${message}`);
-            }
-          }
-        };
-
-        for (const [index, file] of uploadQueue.entries()) {
-          const uploadFilename = getKnowledgeUploadFilename(file);
-          setUploadStatus({
-            current: index + 1,
-            total: uploadQueue.length,
-            filename: t("knowledgeview.PreparingFile", {
-              defaultValue: "Preparing: {{filename}}",
-              filename: uploadFilename,
-            }),
-          });
-
-          try {
-            const prepared = await buildKnowledgeUploadRequest(file, options);
-            if (
-              currentBatch.length > 0 &&
-              (currentBatchBytes + prepared.requestBytes >
-                BULK_UPLOAD_TARGET_BYTES ||
-                currentBatch.length >= MAX_BULK_REQUEST_DOCUMENTS)
-            ) {
-              await flushBatch();
-            }
-            currentBatch.push(prepared);
-            currentBatchBytes += prepared.requestBytes;
-          } catch (err) {
-            failures.push(`${uploadFilename}: ${normalizeUploadError(err)}`);
-          }
-        }
-
-        await flushBatch();
-
-        let refreshFailed = false;
-        try {
-          await loadData();
-        } catch (err) {
-          refreshFailed = true;
-          console.error("[KnowledgeView] Failed to refresh after upload:", err);
-        }
-
-        const skippedSummary =
-          unsupportedFiles.length > 0
-            ? ` Skipped ${unsupportedFiles.length} unsupported file(s).`
-            : "";
-        const refreshSummary = refreshFailed
-          ? " Uploaded, but failed to refresh document list."
-          : "";
-
-        if (
-          uploadQueue.length === 1 &&
-          successful === 1 &&
-          failures.length === 0
-        ) {
-          const onlyFile = getKnowledgeUploadFilename(uploadQueue[0]);
-          const baseMessage = `Uploaded "${onlyFile}"`;
-          if (warnings.length > 0) {
-            setActionNotice(`${baseMessage}. ${warnings[0]}`, "info", 6000);
-          } else if (refreshFailed) {
-            setActionNotice(
-              `${baseMessage}. Uploaded, but failed to refresh document list.`,
-              "info",
-              6000,
-            );
-          } else {
-            setActionNotice(baseMessage, "success", 3000);
-          }
-          return;
-        }
-
-        if (failures.length === 0) {
-          setActionNotice(
-            `Uploaded ${successful}/${uploadQueue.length} files.${warnings.length > 0 ? ` ${warnings[0]}` : ""}${skippedSummary}${refreshSummary}`,
-            warnings.length > 0 || refreshFailed || unsupportedFiles.length > 0
-              ? "info"
-              : "success",
-            7000,
-          );
-          return;
-        }
-
-        setActionNotice(
-          `Uploaded ${successful}/${uploadQueue.length} files. ${failures.length} failed.${failures.length > 0 ? ` ${failures[0]}` : ""}${skippedSummary}${refreshSummary}`,
-          successful > 0 ? "info" : "error",
-          7000,
-        );
-      } finally {
-        setUploading(false);
-        setUploadStatus(null);
-      }
-    },
-    [buildKnowledgeUploadRequest, loadData, setActionNotice],
-  );
-
-  const handleUrlUpload = useCallback(
-    async (url: string, options: KnowledgeUploadOptions) => {
-      setUploading(true);
-      try {
-        const result = await client.uploadKnowledgeFromUrl(url, {
-          includeImageDescriptions: options.includeImageDescriptions,
-        });
-
-        const baseMessage = result.isYouTubeTranscript
-          ? `Imported YouTube transcript (${result.fragmentCount} fragments)`
-          : `Imported "${result.filename}" (${result.fragmentCount} fragments)`;
-        if (result.warnings && result.warnings.length > 0) {
-          setActionNotice(
-            `${baseMessage}. ${result.warnings[0]}`,
-            "info",
-            6000,
-          );
-        } else {
-          setActionNotice(baseMessage, "success", 3000);
-        }
-        loadData();
-      } catch (err) {
-        const message =
-          err instanceof Error
-            ? err.message
-            : t("knowledgeview.UnknownImportError", {
-                defaultValue: "Unknown import error",
-              });
-        setActionNotice(
-          t("knowledgeview.FailedToImportFromUrl", {
-            defaultValue: "Failed to import from URL: {{message}}",
-            message,
-          }),
-          "error",
-          5000,
-        );
-      } finally {
-        setUploading(false);
-      }
-    },
-    [loadData, setActionNotice],
-  );
+  }, [isServiceLoading, loadData, t]);
 
   const handleSearch = useCallback(
     async (query: string) => {
@@ -1203,7 +559,7 @@ export function KnowledgeView({ inModal }: { inModal?: boolean } = {}) {
         setSearching(false);
       }
     },
-    [setActionNotice],
+    [setActionNotice, t],
   );
 
   const handleDelete = useCallback(
@@ -1251,7 +607,7 @@ export function KnowledgeView({ inModal }: { inModal?: boolean } = {}) {
         setDeleting(null);
       }
     },
-    [loadData, setActionNotice],
+    [loadData, setActionNotice, t],
   );
 
   const handleSearchSubmit = useCallback(
@@ -1264,13 +620,19 @@ export function KnowledgeView({ inModal }: { inModal?: boolean } = {}) {
     [handleSearch, searchQuery],
   );
 
-  const totalFragments = useMemo(
-    () => documents.reduce((sum, d) => sum + (d.fragmentCount || 0), 0),
-    [documents],
-  );
-  const selectedDoc = documents.find((doc) => doc.id === selectedDocId) || null;
   const isShowingSearchResults = searchResults !== null;
   const visibleSearchResults = searchResults ?? [];
+
+  // Local filename filter — filters document list as user types (before submitting semantic search)
+  const filteredDocuments = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    if (!q || isShowingSearchResults) return documents;
+    return documents.filter(
+      (doc) =>
+        doc.filename.toLowerCase().includes(q) ||
+        doc.contentType?.toLowerCase().includes(q),
+    );
+  }, [documents, searchQuery, isShowingSearchResults]);
 
   useEffect(() => {
     if (documents.length === 0) {
@@ -1299,14 +661,47 @@ export function KnowledgeView({ inModal }: { inModal?: boolean } = {}) {
                 onSubmit={handleSearchSubmit}
               >
                 <div className="flex items-stretch gap-2">
-                  <Input
-                    type="text"
-                    placeholder={t("knowledge.ui.searchPlaceholder")}
-                    value={searchQuery}
-                    onChange={(e) => setSearchQuery(e.target.value)}
-                    disabled={searching}
-                    className="h-10 border-border/55 bg-bg/82 text-sm shadow-sm focus-visible:ring-1 focus-visible:ring-accent"
-                  />
+                  <div className="relative flex-1">
+                    <Input
+                      type="text"
+                      placeholder={t("knowledge.ui.searchPlaceholder")}
+                      value={searchQuery}
+                      onChange={(e) => {
+                        setSearchQuery(e.target.value);
+                        // Clear semantic results when user edits the query — fall back to local filter
+                        if (isShowingSearchResults) setSearchResults(null);
+                      }}
+                      disabled={searching}
+                      className="h-10 border-border/55 bg-bg/82 pr-8 text-sm shadow-sm focus-visible:ring-1 focus-visible:ring-accent"
+                    />
+                    {searchQuery && (
+                      <button
+                        type="button"
+                        className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full p-0.5 text-muted/60 transition-colors hover:text-txt"
+                        onClick={() => {
+                          setSearchQuery("");
+                          setSearchResults(null);
+                        }}
+                        aria-label={t("common.clear", {
+                          defaultValue: "Clear",
+                        })}
+                      >
+                        <svg
+                          width="14"
+                          height="14"
+                          viewBox="0 0 14 14"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="1.5"
+                          strokeLinecap="round"
+                          aria-hidden="true"
+                        >
+                          <title>Clear</title>
+                          <path d="M3.5 3.5l7 7M10.5 3.5l-7 7" />
+                        </svg>
+                      </button>
+                    )}
+                  </div>
                   <Button
                     type="submit"
                     variant="default"
@@ -1326,9 +721,14 @@ export function KnowledgeView({ inModal }: { inModal?: boolean } = {}) {
                     variant="ghost"
                     size="sm"
                     className="h-8 rounded-lg border border-border/35 px-3 text-[11px] font-semibold text-muted hover:border-border/60 hover:bg-bg/35 hover:text-txt"
-                    onClick={() => setSearchResults(null)}
+                    onClick={() => {
+                      setSearchResults(null);
+                      setSearchQuery("");
+                    }}
                   >
-                    {t("common.clear", { defaultValue: "Clear" })}
+                    {t("knowledgeview.ClearSearch", {
+                      defaultValue: "Clear search",
+                    })}
                   </Button>
                 )}
               </div>
@@ -1350,6 +750,22 @@ export function KnowledgeView({ inModal }: { inModal?: boolean } = {}) {
                     className="min-h-[12rem] px-4 py-8"
                     description={t("knowledgeview.UploadFilesOrImpo")}
                     title={t("knowledgeview.NoDocumentsYet")}
+                  />
+                )}
+
+              {!loading &&
+                !isShowingSearchResults &&
+                documents.length > 0 &&
+                filteredDocuments.length === 0 && (
+                  <DesktopEmptyStatePanel
+                    className="min-h-[12rem] px-4 py-8"
+                    description={t("knowledgeview.SearchTips", {
+                      defaultValue:
+                        "Try a filename, topic, or phrase from the document body.",
+                    })}
+                    title={t("knowledgeview.NoMatchingDocuments", {
+                      defaultValue: "No matching documents",
+                    })}
                   />
                 )}
 
@@ -1375,7 +791,7 @@ export function KnowledgeView({ inModal }: { inModal?: boolean } = {}) {
                       onSelect={setSelectedDocId}
                     />
                   ))
-                : documents.map((doc) => (
+                : filteredDocuments.map((doc) => (
                     <DocumentListItem
                       key={doc.id}
                       doc={doc}

--- a/packages/app-core/src/components/SettingsView.tsx
+++ b/packages/app-core/src/components/SettingsView.tsx
@@ -20,7 +20,14 @@ import {
   SelectValue,
   Spinner,
 } from "@miladyai/ui";
-import { AlertTriangle, ChevronDown, Copy, Download, Shield, Upload } from "lucide-react";
+import {
+  AlertTriangle,
+  ChevronDown,
+  Copy,
+  Download,
+  Shield,
+  Upload,
+} from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { client } from "../api";
 import { useApp } from "../state";

--- a/packages/app-core/src/components/__tests__/PolicyControlsView.test.tsx
+++ b/packages/app-core/src/components/__tests__/PolicyControlsView.test.tsx
@@ -1,7 +1,14 @@
 /**
  * @vitest-environment jsdom
  */
-import { cleanup, fireEvent, render, screen, act, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  act,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock the client module before importing the component
@@ -29,22 +36,39 @@ vi.mock("lucide-react", () => ({
 // Mock @miladyai/ui components as simple HTML elements
 vi.mock("@miladyai/ui", () => ({
   Button: ({ children, onClick, disabled, ...props }: any) => (
-    <button onClick={onClick} disabled={disabled} {...props}>{children}</button>
+    <button onClick={onClick} disabled={disabled} {...props}>
+      {children}
+    </button>
   ),
-  ConfirmDialog: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  ConfirmDialog: ({ children, ...props }: any) => (
+    <div {...props}>{children}</div>
+  ),
   Input: ({ value, onChange, ...props }: any) => (
     <input value={value} onChange={onChange} {...props} />
   ),
   Label: ({ children, ...props }: any) => <label {...props}>{children}</label>,
   SectionCard: ({ children, title, ...props }: any) => (
-    <div {...props}><h3>{title}</h3>{children}</div>
+    <div {...props}>
+      <h3>{title}</h3>
+      {children}
+    </div>
   ),
   Slider: ({ value, onValueChange, ...props }: any) => (
-    <input type="range" value={value?.[0]} onChange={(e) => onValueChange?.([Number(e.target.value)])} {...props} />
+    <input
+      type="range"
+      value={value?.[0]}
+      onChange={(e) => onValueChange?.([Number(e.target.value)])}
+      {...props}
+    />
   ),
   Spinner: () => <div data-testid="spinner" />,
   Switch: ({ checked, onCheckedChange, ...props }: any) => (
-    <input type="checkbox" checked={checked} onChange={() => onCheckedChange?.(!checked)} {...props} />
+    <input
+      type="checkbox"
+      checked={checked}
+      onChange={() => onCheckedChange?.(!checked)}
+      {...props}
+    />
   ),
 }));
 
@@ -94,9 +118,9 @@ describe("PolicyControlsView", () => {
       // Should indicate steward isn't connected/configured
       expect(
         text.toLowerCase().includes("not connected") ||
-        text.toLowerCase().includes("not configured") ||
-        text.toLowerCase().includes("connect") ||
-        text.toLowerCase().includes("steward"),
+          text.toLowerCase().includes("not configured") ||
+          text.toLowerCase().includes("connect") ||
+          text.toLowerCase().includes("steward"),
       ).toBe(true);
     });
   });
@@ -136,8 +160,8 @@ describe("PolicyControlsView", () => {
       // Should display spending limit policy
       expect(
         text.toLowerCase().includes("spending") ||
-        text.toLowerCase().includes("limit") ||
-        text.toLowerCase().includes("0.1"),
+          text.toLowerCase().includes("limit") ||
+          text.toLowerCase().includes("0.1"),
       ).toBe(true);
     });
   });
@@ -151,7 +175,9 @@ describe("PolicyControlsView", () => {
       connected: true,
       agentId: "test-agent",
     });
-    (client.getStewardPolicies as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    (client.getStewardPolicies as ReturnType<typeof vi.fn>).mockResolvedValue(
+      [],
+    );
 
     const mod = await import("../PolicyControlsView");
     render(<mod.PolicyControlsView />);
@@ -161,8 +187,8 @@ describe("PolicyControlsView", () => {
       // Should show some indication of no policies or ability to add
       expect(
         text.toLowerCase().includes("no polic") ||
-        text.toLowerCase().includes("add") ||
-        text.toLowerCase().includes("create"),
+          text.toLowerCase().includes("add") ||
+          text.toLowerCase().includes("create"),
       ).toBe(true);
     });
   });
@@ -199,7 +225,7 @@ describe("PolicyControlsView", () => {
       const text = document.body.textContent ?? "";
       expect(
         text.toLowerCase().includes("spending") ||
-        text.toLowerCase().includes("limit"),
+          text.toLowerCase().includes("limit"),
       ).toBe(true);
     });
 
@@ -210,8 +236,7 @@ describe("PolicyControlsView", () => {
 
       // Look for save button
       const saveButton = Array.from(document.querySelectorAll("button")).find(
-        (btn) =>
-          (btn.textContent ?? "").toLowerCase().includes("save"),
+        (btn) => (btn.textContent ?? "").toLowerCase().includes("save"),
       );
       if (saveButton) {
         fireEvent.click(saveButton);
@@ -244,8 +269,8 @@ describe("PolicyControlsView", () => {
       // Should show an error message
       expect(
         text.toLowerCase().includes("error") ||
-        text.toLowerCase().includes("failed") ||
-        text.toLowerCase().includes("retry"),
+          text.toLowerCase().includes("failed") ||
+          text.toLowerCase().includes("retry"),
       ).toBe(true);
     });
   });

--- a/packages/app-core/src/components/onboarding/connection/ConnectionProviderDetailScreen.tsx
+++ b/packages/app-core/src/components/onboarding/connection/ConnectionProviderDetailScreen.tsx
@@ -292,6 +292,8 @@ export function ConnectionProviderDetailScreen({
       const { authUrl } = await client.startAnthropicLogin();
       if (authUrl) {
         await openExternalUrl(authUrl);
+        // Always transition to the code-paste screen — even if the popup was
+        // blocked the URL is logged to console and the user can open it manually.
         setAnthropicOAuthStarted(true);
         return;
       }

--- a/packages/app-core/src/state/AppContext.tsx
+++ b/packages/app-core/src/state/AppContext.tsx
@@ -2100,7 +2100,8 @@ function AppProviderInner({
   );
 
   const rejectStewardTx = useCallback(
-    async (txId: string, reason?: string) => client.rejectStewardTx(txId, reason),
+    async (txId: string, reason?: string) =>
+      client.rejectStewardTx(txId, reason),
     [],
   );
 

--- a/packages/app-core/src/state/types.ts
+++ b/packages/app-core/src/state/types.ts
@@ -740,10 +740,18 @@ export interface AppActions {
     status?: string;
     limit?: number;
     offset?: number;
-  }) => Promise<{ records: StewardHistoryResponse; total: number; offset: number; limit: number }>;
+  }) => Promise<{
+    records: StewardHistoryResponse;
+    total: number;
+    offset: number;
+    limit: number;
+  }>;
   getStewardPending: () => Promise<StewardPendingResponse>;
   approveStewardTx: (txId: string) => Promise<StewardApprovalActionResponse>;
-  rejectStewardTx: (txId: string, reason?: string) => Promise<StewardApprovalActionResponse>;
+  rejectStewardTx: (
+    txId: string,
+    reason?: string,
+  ) => Promise<StewardApprovalActionResponse>;
   loadWalletTradingProfile: (
     window?: WalletTradingProfileWindow,
     source?: WalletTradingProfileSourceFilter,

--- a/packages/app-core/src/utils/openExternalUrl.ts
+++ b/packages/app-core/src/utils/openExternalUrl.ts
@@ -23,13 +23,17 @@ export async function openExternalUrl(url: string): Promise<void> {
     return;
   }
 
-  // Non-desktop (web browser) fallback
+  // Non-desktop (web browser) fallback — never throw on popup block.
+  // OAuth flows call this after async gaps which lose user-gesture context,
+  // so popup blocking is expected. Callers handle the fallback (e.g. showing
+  // the URL for manual copy-paste) and continue polling.
   if (typeof window === "undefined" || typeof window.open !== "function") {
-    throw new Error("Popup blocked. Allow popups and try again.");
+    console.warn("[openExternalUrl] window.open unavailable — URL:", url);
+    return;
   }
 
   const popup = window.open(url, "_blank", "noopener,noreferrer");
   if (!popup) {
-    throw new Error("Popup blocked. Allow popups and try again.");
+    console.warn("[openExternalUrl] popup blocked — URL:", url);
   }
 }

--- a/packages/app-core/test/app/knowledge-inventory-polish.test.tsx
+++ b/packages/app-core/test/app/knowledge-inventory-polish.test.tsx
@@ -189,6 +189,36 @@ vi.mock("../../src/components/inventory/useInventoryData", () => ({
 import { InventoryView } from "../../src/components/InventoryView";
 import { KnowledgeView } from "../../src/components/KnowledgeView";
 
+function translate(key: string, options?: Record<string, unknown>): string {
+  const template =
+    typeof options?.defaultValue === "string" ? options.defaultValue : key;
+  return template.replace(/\{\{(\w+)\}\}/g, (_, token: string) =>
+    String(options?.[token] ?? `{{${token}}}`),
+  );
+}
+
+function flattenText(value: React.ReactNode): string {
+  if (typeof value === "string" || typeof value === "number") {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map(flattenText).join("");
+  }
+  if (React.isValidElement(value)) {
+    return flattenText(value.props.children);
+  }
+  return "";
+}
+
+function findKnowledgeDocumentButtons(tree: TestRenderer.ReactTestRenderer) {
+  return tree.root.findAll(
+    (node) =>
+      node.type === "button" &&
+      typeof node.props["aria-label"] === "string" &&
+      node.props["aria-label"].startsWith("Open "),
+  );
+}
+
 describe("Knowledge and inventory polish", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -251,6 +281,84 @@ describe("Knowledge and inventory polish", () => {
     expect(sidebars.length).toBeGreaterThan(0);
   });
 
+  it("filters documents locally before semantic search and clears back to the full list", async () => {
+    mockListKnowledgeDocuments.mockResolvedValue({
+      documents: [
+        {
+          id: "doc-1",
+          filename: "README.md",
+          contentType: "text/markdown",
+          fileSize: 1024,
+          createdAt: Date.now(),
+          fragmentCount: 4,
+          source: "upload",
+        },
+        {
+          id: "doc-2",
+          filename: "roadmap.txt",
+          contentType: "text/plain",
+          fileSize: 2048,
+          createdAt: Date.now(),
+          fragmentCount: 2,
+          source: "upload",
+        },
+      ],
+    });
+    mockUseApp.mockReturnValue({
+      t: translate,
+      setActionNotice: vi.fn(),
+    });
+
+    let tree!: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      tree = TestRenderer.create(React.createElement(KnowledgeView));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(findKnowledgeDocumentButtons(tree)).toHaveLength(2);
+
+    const searchInput = tree.root.find(
+      (node) => node.type === "input" && node.props.type === "text",
+    );
+
+    await act(async () => {
+      searchInput.props.onChange({
+        target: { value: "road" },
+      });
+    });
+
+    const filteredButtons = findKnowledgeDocumentButtons(tree);
+    expect(filteredButtons).toHaveLength(1);
+    expect(flattenText(filteredButtons[0].props.children)).toContain(
+      "roadmap.txt",
+    );
+    expect(mockSearchKnowledge).not.toHaveBeenCalled();
+
+    await act(async () => {
+      searchInput.props.onChange({
+        target: { value: "zzz" },
+      });
+    });
+
+    expect(findKnowledgeDocumentButtons(tree)).toHaveLength(0);
+    expect(JSON.stringify(tree.toJSON())).toContain("No matching documents");
+
+    const clearButton = tree.root.find(
+      (node) => node.type === "button" && node.props["aria-label"] === "Clear",
+    );
+
+    await act(async () => {
+      clearButton.props.onClick();
+    });
+
+    const resetButtons = findKnowledgeDocumentButtons(tree);
+    expect(resetButtons).toHaveLength(2);
+    expect(JSON.stringify(tree.toJSON())).not.toContain(
+      "No matching documents",
+    );
+  });
+
   it("renders the steward badge with token-driven accent styling", async () => {
     mockUseApp.mockReturnValue({
       walletConfig: {
@@ -307,7 +415,9 @@ describe("Knowledge and inventory polish", () => {
 
     expect(stewardBadge.props.className).toContain("bg-accent/10");
     expect(stewardBadge.props.className).toContain("text-accent-fg");
-    expect(String(sidebar.props.className)).toContain("border-b border-border/34");
+    expect(String(sidebar.props.className)).toContain(
+      "border-b border-border/34",
+    );
     expect(String(sidebar.props.className)).toContain("backdrop-blur-md");
   });
 });

--- a/packages/app-core/test/app/knowledge-ui.e2e.test.ts
+++ b/packages/app-core/test/app/knowledge-ui.e2e.test.ts
@@ -408,6 +408,24 @@ type KnowledgeState = {
   }>;
 };
 
+function translate(
+  key: string,
+  vars?: {
+    defaultValue?: string;
+    [key: string]: unknown;
+  },
+): string {
+  if (typeof vars?.defaultValue === "string") {
+    let value = vars.defaultValue;
+    for (const [token, raw] of Object.entries(vars)) {
+      if (token === "defaultValue") continue;
+      value = value.replace(`{{${token}}}`, String(raw));
+    }
+    return value;
+  }
+  return key;
+}
+
 function createKnowledgeUIState(): KnowledgeState {
   return {
     knowledgeStats: { documentCount: 5, fragmentCount: 42 },
@@ -438,36 +456,31 @@ function createKnowledgeUIState(): KnowledgeState {
 
 describe("KnowledgeView UI", () => {
   let state: KnowledgeState;
+  let appActions: {
+    loadKnowledgeStats: ReturnType<typeof vi.fn>;
+    loadKnowledgeDocuments: ReturnType<typeof vi.fn>;
+    uploadKnowledgeDocument: ReturnType<typeof vi.fn>;
+    searchKnowledge: ReturnType<typeof vi.fn>;
+    deleteKnowledgeDocument: ReturnType<typeof vi.fn>;
+    setActionNotice: ReturnType<typeof vi.fn>;
+  };
 
   beforeEach(() => {
     state = createKnowledgeUIState();
-
-    mockUseApp.mockReset();
-    mockUseApp.mockImplementation(() => ({
-      t: (
-        k: string,
-        vars?: {
-          defaultValue?: string;
-          [key: string]: unknown;
-        },
-      ) => {
-        if (typeof vars?.defaultValue === "string") {
-          let value = vars.defaultValue;
-          for (const [key, raw] of Object.entries(vars)) {
-            if (key === "defaultValue") continue;
-            value = value.replace(`{{${key}}}`, String(raw));
-          }
-          return value;
-        }
-        return k;
-      },
-      ...state,
+    appActions = {
       loadKnowledgeStats: vi.fn(),
       loadKnowledgeDocuments: vi.fn(),
       uploadKnowledgeDocument: vi.fn(),
       searchKnowledge: vi.fn(),
       deleteKnowledgeDocument: vi.fn(),
       setActionNotice: vi.fn(),
+    };
+
+    mockUseApp.mockReset();
+    mockUseApp.mockImplementation(() => ({
+      t: translate,
+      ...state,
+      ...appActions,
     }));
   });
 

--- a/scripts/browser-mocks.test.ts
+++ b/scripts/browser-mocks.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+import {
+  installCanvasMocks,
+  suppressReactTestConsoleErrors,
+} from "../test/helpers/browser-mocks";
+
+describe("browser-mocks", () => {
+  it("suppresses React test console errors without wrapping console.error repeatedly", () => {
+    const original = console.error;
+
+    suppressReactTestConsoleErrors();
+    const firstPatched = console.error;
+    suppressReactTestConsoleErrors();
+    const secondPatched = console.error;
+
+    expect(firstPatched).toBe(original);
+    expect(secondPatched).toBe(firstPatched);
+  });
+
+  it("installs canvas mocks only once per environment", () => {
+    installCanvasMocks();
+    const firstGetContext = HTMLCanvasElement.prototype.getContext;
+    const firstToDataURL = HTMLCanvasElement.prototype.toDataURL;
+
+    installCanvasMocks();
+
+    expect(HTMLCanvasElement.prototype.getContext).toBe(firstGetContext);
+    expect(HTMLCanvasElement.prototype.toDataURL).toBe(firstToDataURL);
+  });
+});

--- a/scripts/live-e2e-script-drift.test.ts
+++ b/scripts/live-e2e-script-drift.test.ts
@@ -39,9 +39,7 @@ describe("live E2E script contract", () => {
     expect(liveScript).toContain(
       "bunx vitest run --config vitest.live-e2e.config.ts",
     );
-    expect(liveScript).toContain(
-      "packages/agent/test/wallet-live.e2e.test.ts",
-    );
+    expect(liveScript).toContain("packages/agent/test/wallet-live.e2e.test.ts");
     expect(liveScript).toContain(
       "packages/agent/test/api-auth-live.e2e.test.ts",
     );

--- a/scripts/startup-e2e-script-drift.test.ts
+++ b/scripts/startup-e2e-script-drift.test.ts
@@ -41,6 +41,7 @@ describe("startup E2E script contract", () => {
     expect(config).toContain('pool: "forks"');
     expect(config).not.toContain("poolOptions:");
     expect(config).toContain("maxWorkers: 1");
+    expect(config).toContain('execArgv: ["--max-old-space-size=4096"]');
   });
 
   it("uses Vitest 4 top-level worker options in the shared E2E config", () => {
@@ -50,5 +51,6 @@ describe("startup E2E script contract", () => {
     expect(config).toContain("fileParallelism: false");
     expect(config).not.toContain("poolOptions:");
     expect(config).toContain("maxWorkers: 1");
+    expect(config).toContain('execArgv: ["--max-old-space-size=4096"]');
   });
 });

--- a/test/helpers/browser-mocks.ts
+++ b/test/helpers/browser-mocks.ts
@@ -7,6 +7,9 @@
 
 import { vi } from "vitest";
 
+const CANVAS_PATCH_MARK = Symbol.for("milady.test.canvasMocksInstalled");
+const CONSOLE_PATCH_MARK = Symbol.for("milady.test.consoleErrorPatched");
+
 /**
  * Create an in-memory Storage mock backed by a Map.
  * Wraps methods in vi.fn() so tests can assert on storage calls.
@@ -80,9 +83,10 @@ export function createCanvas2DContext(): CanvasRenderingContext2D {
     createLinearGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
     createRadialGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
     createPattern: vi.fn(() => null),
-    canvas: typeof document !== "undefined"
-      ? document.createElement("canvas")
-      : ({} as HTMLCanvasElement),
+    canvas:
+      typeof document !== "undefined"
+        ? document.createElement("canvas")
+        : ({} as HTMLCanvasElement),
     lineWidth: 1,
     globalAlpha: 1,
     fillStyle: "#000",
@@ -95,8 +99,13 @@ export function createCanvas2DContext(): CanvasRenderingContext2D {
  */
 export function installCanvasMocks(): void {
   if (typeof globalThis.HTMLCanvasElement === "undefined") return;
+  const prototype = globalThis.HTMLCanvasElement
+    .prototype as HTMLCanvasElement["prototype"] & {
+    [CANVAS_PATCH_MARK]?: boolean;
+  };
+  if (prototype[CANVAS_PATCH_MARK]) return;
 
-  Object.defineProperty(globalThis.HTMLCanvasElement.prototype, "getContext", {
+  Object.defineProperty(prototype, "getContext", {
     value: vi.fn((contextType: string) =>
       contextType === "2d" ? createCanvas2DContext() : null,
     ),
@@ -104,19 +113,27 @@ export function installCanvasMocks(): void {
     configurable: true,
   });
 
-  Object.defineProperty(globalThis.HTMLCanvasElement.prototype, "toDataURL", {
+  Object.defineProperty(prototype, "toDataURL", {
     value: vi.fn(() => "data:image/png;base64,dGVzdA=="),
     writable: true,
     configurable: true,
   });
+
+  prototype[CANVAS_PATCH_MARK] = true;
 }
 
 /**
  * Suppress known noisy console.error messages from React test tooling.
  */
 export function suppressReactTestConsoleErrors(): void {
+  const currentConsoleError = console.error as typeof console.error & {
+    [CONSOLE_PATCH_MARK]?: boolean;
+  };
+  if (currentConsoleError[CONSOLE_PATCH_MARK]) {
+    return;
+  }
   const originalConsoleError = console.error.bind(console);
-  console.error = (...args: unknown[]) => {
+  const patchedConsoleError = ((...args: unknown[]) => {
     const first = args[0];
     if (
       typeof first === "string" &&
@@ -128,5 +145,9 @@ export function suppressReactTestConsoleErrors(): void {
       return;
     }
     originalConsoleError(...args);
+  }) as typeof console.error & {
+    [CONSOLE_PATCH_MARK]?: boolean;
   };
+  patchedConsoleError[CONSOLE_PATCH_MARK] = true;
+  console.error = patchedConsoleError;
 }

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -7,6 +7,17 @@ import {
   suppressReactTestConsoleErrors,
 } from "./helpers/browser-mocks";
 
+const REACT_RESOLVE_PATCH_MARK = Symbol.for("milady.test.reactResolvePatched");
+const ANCHOR_CLICK_PATCH_MARK = Symbol.for("milady.test.anchorClickPatched");
+const JSDOM_EMIT_PATCH_MARK = Symbol.for("milady.test.jsdomEmitPatched");
+
+type ResolveFilename = (
+  request: string,
+  parent: unknown,
+  isMain: boolean,
+  options: unknown,
+) => string;
+
 // ── React deduplication ──────────────────────────────────────────────
 // bun hoists react-test-renderer's peer react into a separate .bun/ path,
 // creating two React instances that break hooks.  Intercept Node's CJS
@@ -18,10 +29,15 @@ try {
     _require.resolve("react/package.json"),
   );
 
-  const origResolve = (Module as unknown as { _resolveFilename: Function })
-    ._resolveFilename;
-  (Module as unknown as { _resolveFilename: Function })._resolveFilename =
-    function patchedResolve(
+  const moduleInternals = Module as unknown as {
+    _resolveFilename: ResolveFilename & {
+      [REACT_RESOLVE_PATCH_MARK]?: boolean;
+    };
+  };
+  if (!moduleInternals._resolveFilename[REACT_RESOLVE_PATCH_MARK]) {
+    const origResolve = moduleInternals._resolveFilename;
+    const patchedResolve = function patchedResolve(
+      this: unknown,
       request: string,
       parent: unknown,
       isMain: boolean,
@@ -52,7 +68,10 @@ try {
         }
       }
       return resolved;
-    };
+    } as typeof moduleInternals._resolveFilename;
+    patchedResolve[REACT_RESOLVE_PATCH_MARK] = true;
+    moduleInternals._resolveFilename = patchedResolve;
+  }
 } catch {
   // React not available — skip deduplication patch (e.g. CI without react)
 }
@@ -117,10 +136,15 @@ if (typeof globalThis.window !== "undefined") {
   const anchorPrototype = globalThis.HTMLAnchorElement?.prototype as
     | ({
         click?: () => void;
+        [ANCHOR_CLICK_PATCH_MARK]?: boolean;
       } & Record<string, unknown>)
     | undefined;
   const originalAnchorClick = anchorPrototype?.click;
-  if (anchorPrototype && typeof originalAnchorClick === "function") {
+  if (
+    anchorPrototype &&
+    typeof originalAnchorClick === "function" &&
+    !anchorPrototype[ANCHOR_CLICK_PATCH_MARK]
+  ) {
     Object.defineProperty(anchorPrototype, "click", {
       configurable: true,
       writable: true,
@@ -146,18 +170,25 @@ if (typeof globalThis.window !== "undefined") {
         return originalAnchorClick.call(this);
       },
     });
+    anchorPrototype[ANCHOR_CLICK_PATCH_MARK] = true;
   }
 
   const virtualConsole = (
     globalThis.window as typeof globalThis.window & {
       _virtualConsole?: {
-        emit?: (eventName: string, ...args: unknown[]) => unknown;
+        emit?: ((eventName: string, ...args: unknown[]) => unknown) & {
+          [JSDOM_EMIT_PATCH_MARK]?: boolean;
+        };
       };
     }
   )._virtualConsole;
   const originalEmit = virtualConsole?.emit;
-  if (virtualConsole && typeof originalEmit === "function") {
-    virtualConsole.emit = function patchedEmit(eventName, ...args) {
+  if (
+    virtualConsole &&
+    typeof originalEmit === "function" &&
+    !originalEmit[JSDOM_EMIT_PATCH_MARK]
+  ) {
+    const patchedEmit = function patchedEmit(eventName, ...args) {
       const [firstArg] = args;
       if (
         eventName === "jsdomError" &&
@@ -167,7 +198,9 @@ if (typeof globalThis.window !== "undefined") {
         return;
       }
       return originalEmit.call(this, eventName, ...args);
-    };
+    } as typeof originalEmit;
+    patchedEmit[JSDOM_EMIT_PATCH_MARK] = true;
+    virtualConsole.emit = patchedEmit;
   }
 }
 

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -187,6 +187,9 @@ export default defineConfig({
     fileParallelism: false,
     pool: "forks",
     maxWorkers: 1,
+    // Match the unit test worker heap to avoid late jsdom OOM crashes during
+    // serial E2E runs, where one fork accumulates dozens of suites.
+    execArgv: ["--max-old-space-size=4096"],
     sequence: {
       concurrent: false,
       shuffle: false,

--- a/vitest.startup-e2e.config.ts
+++ b/vitest.startup-e2e.config.ts
@@ -191,6 +191,8 @@ export default defineConfig({
     fileParallelism: false,
     pool: "forks",
     maxWorkers: 1,
+    // Startup E2E also runs serial jsdom suites in a single fork.
+    execArgv: ["--max-old-space-size=4096"],
     sequence: {
       concurrent: false,
       shuffle: false,


### PR DESCRIPTION
## Summary
- Fix document type/source badge clipping at top of rounded panel
- Redesign sidebar items: filename-first with small inline tags, hover-to-reveal date and delete
- Add live filename filtering in the search box (semantic search still on Enter)
- Add inline clear button on search input, auto-clear semantic results on query edit
- Remove ~580 lines of dead code (unused UploadZone, upload handlers, constants, imports)
- Fix all biome lint warnings (exhaustive deps, a11y, optional chaining, formatting)

## Test plan
- [ ] Knowledge page loads with documents listed in sidebar
- [ ] Sidebar items show filename prominently with small type/source tags
- [ ] Date appears on hover, delete button appears on hover (top-right)
- [ ] Typing in search box filters documents by filename in real-time
- [ ] Pressing Enter or clicking Search does semantic vector search
- [ ] Clear (X) button on search input clears query and results
- [ ] Document viewer shows type/source badges without clipping
- [ ] `npx biome check` passes with zero errors