### PR TITLE
feat(ui): owner name prompt and personalized agent entity

### DIFF
--- a/packages/agent/src/api/server.owner-name.test.ts
+++ b/packages/agent/src/api/server.owner-name.test.ts
@@ -1,0 +1,26 @@
+import type { ElizaConfig } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { resolveAppUserName } from "./server";
+
+function buildConfig(ui?: Record<string, unknown>): ElizaConfig {
+  return { ui } as ElizaConfig;
+}
+
+describe("resolveAppUserName", () => {
+  it("falls back to User when ui.ownerName is missing or blank", () => {
+    expect(resolveAppUserName(buildConfig())).toBe("User");
+    expect(resolveAppUserName(buildConfig({ ownerName: "   " }))).toBe("User");
+  });
+
+  it("trims persisted owner names before returning them", () => {
+    expect(resolveAppUserName(buildConfig({ ownerName: "  Ada Lovelace  " }))).toBe(
+      "Ada Lovelace",
+    );
+  });
+
+  it("caps persisted owner names before injecting them into agent context", () => {
+    expect(
+      resolveAppUserName(buildConfig({ ownerName: `  ${"a".repeat(80)}  ` })),
+    ).toBe("a".repeat(60));
+  });
+});

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -8831,7 +8831,7 @@ function wireCoordinatorEventRouting(st: ServerState): boolean {
               entityId: adminId,
               roomId: st.chatRoomId,
               worldId,
-              userName: resolveAppUserName(state.config),
+              userName: resolveAppUserName(st.config),
               source: "client_chat",
               channelId: `${agentName}-web-chat`,
               type: ChannelType.DM,

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -449,6 +449,13 @@ function hasPersistedOnboardingState(config: ElizaConfig): boolean {
   );
 }
 
+/** Resolve the app owner's display name from config, or fall back to "User". */
+function resolveAppUserName(config: ElizaConfig): string {
+  const ownerName = (config.ui as Record<string, unknown> | undefined)
+    ?.ownerName as string | undefined;
+  return ownerName?.trim() || "User";
+}
+
 function resolveConversationGreetingText(
   runtime: AgentRuntime,
   lang: string,
@@ -8824,7 +8831,7 @@ function wireCoordinatorEventRouting(st: ServerState): boolean {
               entityId: adminId,
               roomId: st.chatRoomId,
               worldId,
-              userName: "User",
+              userName: resolveAppUserName(state.config),
               source: "client_chat",
               channelId: `${agentName}-web-chat`,
               type: ChannelType.DM,
@@ -15221,7 +15228,7 @@ async function handleRequest(
       entityId: userId,
       roomId: conv.roomId,
       worldId,
-      userName: "User",
+      userName: resolveAppUserName(state.config),
       source: "client_chat",
       channelId: `web-conv-${conv.id}`,
       type: ChannelType.DM,
@@ -15426,7 +15433,7 @@ async function handleRequest(
             entityId: target.userId,
             roomId: target.roomId,
             worldId: target.worldId,
-            userName: "User",
+            userName: resolveAppUserName(state.config),
             source: "client_chat",
             channelId: `${agentName}-web-chat`,
             type: ChannelType.DM,
@@ -15503,7 +15510,7 @@ async function handleRequest(
       entityId: userId,
       roomId,
       worldId,
-      userName: "User",
+      userName: resolveAppUserName(state.config),
       source: "client_chat",
       channelId: `${channelIdPrefix}-${roomKey}`,
       type: ChannelType.DM,

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -449,11 +449,14 @@ function hasPersistedOnboardingState(config: ElizaConfig): boolean {
   );
 }
 
+const APP_OWNER_NAME_MAX_LENGTH = 60;
+
 /** Resolve the app owner's display name from config, or fall back to "User". */
-function resolveAppUserName(config: ElizaConfig): string {
+export function resolveAppUserName(config: ElizaConfig): string {
   const ownerName = (config.ui as Record<string, unknown> | undefined)
     ?.ownerName as string | undefined;
-  return ownerName?.trim() || "User";
+  const normalized = ownerName?.trim().slice(0, APP_OWNER_NAME_MAX_LENGTH);
+  return normalized || "User";
 }
 
 function resolveConversationGreetingText(

--- a/packages/app-core/src/App.test.ts
+++ b/packages/app-core/src/App.test.ts
@@ -69,6 +69,7 @@ vi.mock("./app-shell-components", () => {
     InventoryView: stub("InventoryView"),
     KnowledgeView: stub("KnowledgeView"),
     OnboardingWizard: stub("OnboardingWizard"),
+    OwnerNamePrompt: stub("OwnerNamePrompt"),
     PairingView: stub("PairingView"),
     SaveCommandModal: stub("SaveCommandModal"),
     SettingsView: stub("SettingsView"),
@@ -126,6 +127,8 @@ describe("App", () => {
       unreadConversations: new Set(),
       activeGameViewerUrl: null,
       gameOverlayEnabled: false,
+      showOwnerNamePrompt: false,
+      handleOwnerNameSubmit: vi.fn(),
     };
     useAppMock.mockImplementation(() => appState);
 

--- a/packages/app-core/src/App.tsx
+++ b/packages/app-core/src/App.tsx
@@ -40,6 +40,7 @@ import {
   InventoryView,
   KnowledgeView,
   OnboardingWizard,
+  OwnerNamePrompt,
   PairingView,
   SaveCommandModal,
   SettingsView,
@@ -316,6 +317,8 @@ export function App() {
     activeGameViewerUrl,
     gameOverlayEnabled,
     retryOnboardingHandoff,
+    showOwnerNamePrompt,
+    handleOwnerNameSubmit,
     t,
   } = useApp();
 
@@ -789,6 +792,10 @@ export function App() {
           setCustomActionsEditorOpen(false);
           setEditingAction(null);
         }}
+      />
+      <OwnerNamePrompt
+        open={showOwnerNamePrompt}
+        onSubmit={handleOwnerNameSubmit}
       />
       <ConnectionFailedBanner />
       <SystemWarningBanner />

--- a/packages/app-core/src/app-shell-components.ts
+++ b/packages/app-core/src/app-shell-components.ts
@@ -18,6 +18,7 @@ export { HeartbeatsView } from "./components/HeartbeatsView";
 export { InventoryView } from "./components/InventoryView";
 export { KnowledgeView } from "./components/KnowledgeView";
 export { OnboardingWizard } from "./components/OnboardingWizard";
+export { OwnerNamePrompt } from "./components/OwnerNamePrompt";
 export { PairingView } from "./components/PairingView";
 export { SaveCommandModal } from "./components/SaveCommandModal";
 export { SettingsView } from "./components/SettingsView";

--- a/packages/app-core/src/components/CharacterEditor.tsx
+++ b/packages/app-core/src/components/CharacterEditor.tsx
@@ -504,10 +504,26 @@ export function CharacterEditor({
     }
   }, [onboardingPresetStyles, uiLanguage]);
 
-  const characterRoster = useMemo(
+  const baseRosterEntries = useMemo(
     () => resolveRosterEntries(rosterStyles),
     [rosterStyles],
   );
+
+  // If the user renamed the selected character, reflect it in the roster
+  const characterRoster = useMemo(() => {
+    const activeId = selectedCharacterId ?? savedCharacterId;
+    const draftName =
+      typeof characterDraft.name === "string" ? characterDraft.name.trim() : "";
+    if (!activeId || !draftName) return baseRosterEntries;
+    return baseRosterEntries.map((entry) =>
+      entry.id === activeId ? { ...entry, name: draftName } : entry,
+    );
+  }, [
+    baseRosterEntries,
+    selectedCharacterId,
+    savedCharacterId,
+    characterDraft.name,
+  ]);
 
   const d = characterDraft;
   const fallbackCharacterName =

--- a/packages/app-core/src/components/OwnerNamePrompt.test.tsx
+++ b/packages/app-core/src/components/OwnerNamePrompt.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OWNER_NAME_MAX_LENGTH } from "../utils/owner-name";
+import { OwnerNamePrompt } from "./OwnerNamePrompt";
+
+describe("OwnerNamePrompt", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("does not render when closed", () => {
+    render(<OwnerNamePrompt open={false} onSubmit={vi.fn()} />);
+
+    expect(screen.queryByRole("textbox")).toBeNull();
+  });
+
+  it("caps submitted names at 60 characters and keeps blank submissions disabled", () => {
+    const onSubmit = vi.fn();
+
+    render(<OwnerNamePrompt open={true} onSubmit={onSubmit} />);
+
+    const input = screen.getByRole("textbox");
+    const submit = screen.getByRole("button", { name: /that's me/i });
+
+    expect(input.getAttribute("maxlength")).toBe(
+      String(OWNER_NAME_MAX_LENGTH),
+    );
+    expect((submit as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.change(input, { target: { value: "   " } });
+    expect((submit as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.change(input, { target: { value: `  ${"a".repeat(80)}  ` } });
+    expect((submit as HTMLButtonElement).disabled).toBe(false);
+
+    fireEvent.click(submit);
+
+    expect(onSubmit).toHaveBeenCalledWith("a".repeat(OWNER_NAME_MAX_LENGTH));
+  });
+});

--- a/packages/app-core/src/components/OwnerNamePrompt.test.tsx
+++ b/packages/app-core/src/components/OwnerNamePrompt.test.tsx
@@ -30,9 +30,7 @@ describe("OwnerNamePrompt", () => {
     const input = screen.getByRole("textbox");
     const submit = screen.getByRole("button", { name: /that's me/i });
 
-    expect(input.getAttribute("maxlength")).toBe(
-      String(OWNER_NAME_MAX_LENGTH),
-    );
+    expect(input.getAttribute("maxlength")).toBe(String(OWNER_NAME_MAX_LENGTH));
     expect((submit as HTMLButtonElement).disabled).toBe(true);
 
     fireEvent.change(input, { target: { value: "   " } });

--- a/packages/app-core/src/components/OwnerNamePrompt.tsx
+++ b/packages/app-core/src/components/OwnerNamePrompt.tsx
@@ -9,10 +9,7 @@
 
 import { Button, Input } from "@miladyai/ui";
 import { useCallback, useEffect, useRef, useState } from "react";
-import {
-  normalizeOwnerName,
-  OWNER_NAME_MAX_LENGTH,
-} from "../utils/owner-name";
+import { normalizeOwnerName, OWNER_NAME_MAX_LENGTH } from "../utils/owner-name";
 
 const PROMPT_TEXT = "Sorry, I didn't get your name! What should I call you?";
 

--- a/packages/app-core/src/components/OwnerNamePrompt.tsx
+++ b/packages/app-core/src/components/OwnerNamePrompt.tsx
@@ -1,0 +1,123 @@
+/**
+ * One-time modal that asks the user for their name when it's not set.
+ * Shown the first time the user navigates to native/desktop UI.
+ * Dismissed forever once a name is entered and persisted to config.
+ *
+ * Attempts to speak the prompt using the character's cloud TTS voice.
+ * Silently skips TTS if cloud is not connected.
+ */
+
+import { Button, Input } from "@miladyai/ui";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const PROMPT_TEXT = "Sorry, I didn't get your name! What should I call you?";
+
+/** Best-effort TTS using the character's configured voice via cloud proxy. */
+async function speakPrompt(): Promise<void> {
+  let voiceId: string | undefined;
+  let modelId: string | undefined;
+  try {
+    const cfgRes = await fetch("/api/config");
+    if (cfgRes.ok) {
+      const cfg = (await cfgRes.json()) as Record<string, unknown>;
+      const tts = (cfg.messages as Record<string, unknown> | undefined)?.tts as
+        | Record<string, unknown>
+        | undefined;
+      const el = tts?.elevenlabs as Record<string, unknown> | undefined;
+      if (typeof el?.voiceId === "string") voiceId = el.voiceId;
+      if (typeof el?.modelId === "string") modelId = el.modelId;
+    }
+  } catch {
+    return;
+  }
+
+  try {
+    const res = await fetch("/api/tts/cloud", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        text: PROMPT_TEXT,
+        ...(voiceId ? { voiceId } : {}),
+        ...(modelId ? { modelId } : {}),
+      }),
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) return;
+    const blob = await res.blob();
+    if (blob.size < 100) return;
+    const url = URL.createObjectURL(blob);
+    const audio = new Audio(url);
+    audio.onended = () => URL.revokeObjectURL(url);
+    await audio.play();
+  } catch {
+    // TTS is best-effort — modal still works without it
+  }
+}
+
+interface OwnerNamePromptProps {
+  open: boolean;
+  onSubmit: (name: string) => void;
+}
+
+export function OwnerNamePrompt({ open, onSubmit }: OwnerNamePromptProps) {
+  const [name, setName] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const spokeRef = useRef(false);
+
+  useEffect(() => {
+    if (!open) return;
+    const timer = setTimeout(() => inputRef.current?.focus(), 200);
+    if (!spokeRef.current) {
+      spokeRef.current = true;
+      void speakPrompt();
+    }
+    return () => clearTimeout(timer);
+  }, [open]);
+
+  const handleSubmit = useCallback(() => {
+    const trimmed = name.trim();
+    if (trimmed) onSubmit(trimmed);
+  }, [name, onSubmit]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/60 backdrop-blur-sm animate-in fade-in duration-300">
+      <div className="mx-4 w-full max-w-sm rounded-3xl border border-border/40 bg-card/95 px-6 py-8 shadow-2xl backdrop-blur-xl animate-in slide-in-from-bottom-4 duration-500">
+        <div className="text-center">
+          <p className="text-lg font-semibold text-txt-strong">
+            Hey! What should I call you?
+          </p>
+          <p className="mt-2 text-sm leading-relaxed text-muted">
+            I&apos;d love to know your name so I can greet you properly.
+          </p>
+        </div>
+        <form
+          className="mt-6"
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleSubmit();
+          }}
+        >
+          <Input
+            ref={inputRef}
+            type="text"
+            placeholder="Your name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="h-12 border-border/55 bg-bg/82 text-center text-base"
+            autoComplete="given-name"
+          />
+          <Button
+            type="submit"
+            variant="default"
+            className="mt-4 h-11 w-full text-sm font-semibold"
+            disabled={!name.trim()}
+          >
+            That&apos;s me!
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/packages/app-core/src/components/OwnerNamePrompt.tsx
+++ b/packages/app-core/src/components/OwnerNamePrompt.tsx
@@ -9,6 +9,10 @@
 
 import { Button, Input } from "@miladyai/ui";
 import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  normalizeOwnerName,
+  OWNER_NAME_MAX_LENGTH,
+} from "../utils/owner-name";
 
 const PROMPT_TEXT = "Sorry, I didn't get your name! What should I call you?";
 
@@ -75,8 +79,8 @@ export function OwnerNamePrompt({ open, onSubmit }: OwnerNamePromptProps) {
   }, [open]);
 
   const handleSubmit = useCallback(() => {
-    const trimmed = name.trim();
-    if (trimmed) onSubmit(trimmed);
+    const normalized = normalizeOwnerName(name);
+    if (normalized) onSubmit(normalized);
   }, [name, onSubmit]);
 
   if (!open) return null;
@@ -107,12 +111,13 @@ export function OwnerNamePrompt({ open, onSubmit }: OwnerNamePromptProps) {
             onChange={(e) => setName(e.target.value)}
             className="h-12 border-border/55 bg-bg/82 text-center text-base"
             autoComplete="given-name"
+            maxLength={OWNER_NAME_MAX_LENGTH}
           />
           <Button
             type="submit"
             variant="default"
             className="mt-4 h-11 w-full text-sm font-semibold"
-            disabled={!name.trim()}
+            disabled={!normalizeOwnerName(name)}
           >
             That&apos;s me!
           </Button>

--- a/packages/app-core/src/components/index.ts
+++ b/packages/app-core/src/components/index.ts
@@ -86,6 +86,7 @@ export * from "./MediaGalleryView";
 export * from "./MediaSettingsSection";
 export * from "./MessageContent";
 export * from "./OnboardingWizard";
+export * from "./OwnerNamePrompt";
 export * from "./PairingView";
 export * from "./PermissionsSection";
 export * from "./PolicyControlsView";

--- a/packages/app-core/src/state/AppContext.tsx
+++ b/packages/app-core/src/state/AppContext.tsx
@@ -1573,11 +1573,7 @@ function AppProviderInner({
     (view: ShellView) => {
       const nextTab = getTabForShellView(view, lastNativeTab);
       // Gate: prompt for owner name the first time user enters desktop/native view
-      if (
-        view === "desktop" &&
-        !ownerName &&
-        !showOwnerNamePrompt
-      ) {
+      if (view === "desktop" && !ownerName && !showOwnerNamePrompt) {
         setShowOwnerNamePrompt(true);
       }
       console.log(

--- a/packages/app-core/src/state/AppContext.tsx
+++ b/packages/app-core/src/state/AppContext.tsx
@@ -1588,13 +1588,7 @@ function AppProviderInner({
       );
       setTab(nextTab);
     },
-    [
-      lastNativeTab,
-      ownerName,
-      ownerNameHydrated,
-      showOwnerNamePrompt,
-      setTab,
-    ],
+    [lastNativeTab, ownerName, ownerNameHydrated, showOwnerNamePrompt, setTab],
   );
 
   const navigationHubRef = useRef(new NavigationEventHub());

--- a/packages/app-core/src/state/AppContext.tsx
+++ b/packages/app-core/src/state/AppContext.tsx
@@ -133,6 +133,7 @@ import {
   yieldMiladyHttpAfterNativeMessageBox,
 } from "../utils";
 import { isMiladyTtsDebugEnabled } from "../utils/milady-tts-debug";
+import { normalizeOwnerName } from "../utils/owner-name";
 import { PREMADE_VOICES } from "../voice/types";
 import {
   computeAgentDeadlineExtensions,
@@ -1028,6 +1029,8 @@ function AppProviderInner({
     useState("/cloud/billing");
   const [elizaCloudUserId, setElizaCloudUserId] = useState<string | null>(null);
   const [ownerName, setOwnerNameState] = useState<string | null>(null);
+  const [ownerNameHydrated, setOwnerNameHydrated] = useState(false);
+  const [pendingOwnerNamePrompt, setPendingOwnerNamePrompt] = useState(false);
   const [showOwnerNamePrompt, setShowOwnerNamePrompt] = useState(false);
   const [elizaCloudStatusReason, setElizaCloudStatusReason] = useState<
     string | null
@@ -1574,14 +1577,24 @@ function AppProviderInner({
       const nextTab = getTabForShellView(view, lastNativeTab);
       // Gate: prompt for owner name the first time user enters desktop/native view
       if (view === "desktop" && !ownerName && !showOwnerNamePrompt) {
-        setShowOwnerNamePrompt(true);
+        if (ownerNameHydrated) {
+          setShowOwnerNamePrompt(true);
+        } else {
+          setPendingOwnerNamePrompt(true);
+        }
       }
       console.log(
         `[shell] switchShellView: ${view} → tab=${nextTab}, lastNativeTab=${lastNativeTab}`,
       );
       setTab(nextTab);
     },
-    [lastNativeTab, ownerName, showOwnerNamePrompt, setTab],
+    [
+      lastNativeTab,
+      ownerName,
+      ownerNameHydrated,
+      showOwnerNamePrompt,
+      setTab,
+    ],
   );
 
   const navigationHubRef = useRef(new NavigationEventHub());
@@ -2175,24 +2188,68 @@ function AppProviderInner({
 
   // Hydrate ownerName from config on startup
   useEffect(() => {
+    let cancelled = false;
     void client
       .getConfig()
       .then((cfg) => {
+        if (cancelled) {
+          return;
+        }
+
         const name = (cfg as Record<string, unknown>).ui as
           | Record<string, unknown>
           | undefined;
-        const persisted = name?.ownerName;
-        if (typeof persisted === "string" && persisted.trim()) {
-          setOwnerNameState(persisted.trim());
+        const persisted = normalizeOwnerName(name?.ownerName as string);
+        if (persisted) {
+          setOwnerNameState(persisted);
         }
       })
-      .catch(() => {});
+      .catch(() => {})
+      .finally(() => {
+        if (!cancelled) {
+          setOwnerNameHydrated(true);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
+  useEffect(() => {
+    if (!ownerNameHydrated) {
+      return;
+    }
+
+    if (ownerName || showOwnerNamePrompt) {
+      if (pendingOwnerNamePrompt) {
+        setPendingOwnerNamePrompt(false);
+      }
+      return;
+    }
+
+    if (pendingOwnerNamePrompt && uiShellMode === "native") {
+      setShowOwnerNamePrompt(true);
+      setPendingOwnerNamePrompt(false);
+    }
+  }, [
+    ownerName,
+    ownerNameHydrated,
+    pendingOwnerNamePrompt,
+    showOwnerNamePrompt,
+    uiShellMode,
+  ]);
+
   const handleOwnerNameSubmit = useCallback((name: string) => {
-    setOwnerNameState(name);
+    const normalized = normalizeOwnerName(name);
+    if (!normalized) {
+      return;
+    }
+
+    setOwnerNameState(normalized);
     setShowOwnerNamePrompt(false);
-    void client.updateConfig({ ui: { ownerName: name } }).catch(() => {});
+    setPendingOwnerNamePrompt(false);
+    void client.updateConfig({ ui: { ownerName: normalized } }).catch(() => {});
   }, []);
 
   useEffect(() => {

--- a/packages/app-core/src/state/AppContext.tsx
+++ b/packages/app-core/src/state/AppContext.tsx
@@ -1027,6 +1027,8 @@ function AppProviderInner({
   const [elizaCloudTopUpUrl, setElizaCloudTopUpUrl] =
     useState("/cloud/billing");
   const [elizaCloudUserId, setElizaCloudUserId] = useState<string | null>(null);
+  const [ownerName, setOwnerNameState] = useState<string | null>(null);
+  const [showOwnerNamePrompt, setShowOwnerNamePrompt] = useState(false);
   const [elizaCloudStatusReason, setElizaCloudStatusReason] = useState<
     string | null
   >(null);
@@ -1570,12 +1572,20 @@ function AppProviderInner({
   const switchShellView = useCallback(
     (view: ShellView) => {
       const nextTab = getTabForShellView(view, lastNativeTab);
+      // Gate: prompt for owner name the first time user enters desktop/native view
+      if (
+        view === "desktop" &&
+        !ownerName &&
+        !showOwnerNamePrompt
+      ) {
+        setShowOwnerNamePrompt(true);
+      }
       console.log(
         `[shell] switchShellView: ${view} → tab=${nextTab}, lastNativeTab=${lastNativeTab}`,
       );
       setTab(nextTab);
     },
-    [lastNativeTab, setTab],
+    [lastNativeTab, ownerName, showOwnerNamePrompt, setTab],
   );
 
   const navigationHubRef = useRef(new NavigationEventHub());
@@ -2165,6 +2175,28 @@ function AppProviderInner({
       setCharacterDraft({});
     }
     setCharacterLoading(false);
+  }, []);
+
+  // Hydrate ownerName from config on startup
+  useEffect(() => {
+    void client
+      .getConfig()
+      .then((cfg) => {
+        const name = (cfg as Record<string, unknown>).ui as
+          | Record<string, unknown>
+          | undefined;
+        const persisted = name?.ownerName;
+        if (typeof persisted === "string" && persisted.trim()) {
+          setOwnerNameState(persisted.trim());
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  const handleOwnerNameSubmit = useCallback((name: string) => {
+    setOwnerNameState(name);
+    setShowOwnerNamePrompt(false);
+    void client.updateConfig({ ui: { ownerName: name } }).catch(() => {});
   }, []);
 
   useEffect(() => {
@@ -8027,6 +8059,9 @@ function AppProviderInner({
     elizaCloudTopUpUrl,
     elizaCloudUserId,
     elizaCloudStatusReason,
+    ownerName,
+    showOwnerNamePrompt,
+    handleOwnerNameSubmit,
     cloudDashboardView,
     elizaCloudLoginBusy,
     elizaCloudLoginError,

--- a/packages/app-core/src/state/types.ts
+++ b/packages/app-core/src/state/types.ts
@@ -281,6 +281,8 @@ export interface AppState {
   uiShellMode: UiShellMode;
   uiLanguage: UiLanguage;
   uiTheme: UiTheme;
+  ownerName: string | null;
+  showOwnerNamePrompt: boolean;
   /** VRM quality vs GPU use: always full quality, battery-aware (default), or always efficient. */
   companionVrmPowerMode: CompanionVrmPowerMode;
   /**
@@ -795,6 +797,7 @@ export interface AppActions {
   goToOnboardingStep: (step: OnboardingStep) => void;
   handleOnboardingRemoteConnect: () => Promise<void>;
   handleOnboardingUseLocalBackend: () => void;
+  handleOwnerNameSubmit: (name: string) => void;
 
   // Cloud
   handleCloudLogin: () => Promise<void>;

--- a/packages/app-core/src/state/types.ts
+++ b/packages/app-core/src/state/types.ts
@@ -621,10 +621,6 @@ export interface AppState {
   // Config text
   configRaw: Record<string, unknown>;
   configText: string;
-
-  // Owner name
-  ownerName: string | null;
-  showOwnerNamePrompt: boolean;
 }
 
 export type LoadConversationMessagesResult =
@@ -834,9 +830,6 @@ export interface AppActions {
     once?: boolean,
     busy?: boolean,
   ) => void;
-
-  // Owner name
-  handleOwnerNameSubmit: (name: string) => void;
 
   // Generic state setter
   setState: <K extends keyof AppState>(key: K, value: AppState[K]) => void;

--- a/packages/app-core/src/state/types.ts
+++ b/packages/app-core/src/state/types.ts
@@ -621,6 +621,10 @@ export interface AppState {
   // Config text
   configRaw: Record<string, unknown>;
   configText: string;
+
+  // Owner name
+  ownerName: string | null;
+  showOwnerNamePrompt: boolean;
 }
 
 export type LoadConversationMessagesResult =
@@ -830,6 +834,9 @@ export interface AppActions {
     once?: boolean,
     busy?: boolean,
   ) => void;
+
+  // Owner name
+  handleOwnerNameSubmit: (name: string) => void;
 
   // Generic state setter
   setState: <K extends keyof AppState>(key: K, value: AppState[K]) => void;

--- a/packages/app-core/src/utils/owner-name.ts
+++ b/packages/app-core/src/utils/owner-name.ts
@@ -1,0 +1,9 @@
+export const OWNER_NAME_MAX_LENGTH = 60;
+
+export function normalizeOwnerName(value: string | null | undefined): string {
+  if (typeof value !== "string") {
+    return "";
+  }
+
+  return value.trim().slice(0, OWNER_NAME_MAX_LENGTH);
+}

--- a/packages/app-core/test/app/onboarding-full-journey.e2e.test.ts
+++ b/packages/app-core/test/app/onboarding-full-journey.e2e.test.ts
@@ -122,9 +122,8 @@ vi.mock("@miladyai/app-core/state", async () => {
 });
 
 vi.mock("../../src/state", async () => {
-  const actual = await vi.importActual<typeof import("../../src/state")>(
-    "../../src/state",
-  );
+  const actual =
+    await vi.importActual<typeof import("../../src/state")>("../../src/state");
   return {
     ...actual,
     useApp: () => mockUseApp(),
@@ -271,8 +270,7 @@ vi.mock("@miladyai/app-core/components", async () => {
 });
 
 vi.mock("@miladyai/app-core/src/app-shell-components", () => ({
-  AdvancedPageView: () =>
-    React.createElement("div", null, "AdvancedPageView"),
+  AdvancedPageView: () => React.createElement("div", null, "AdvancedPageView"),
   AppsPageView: () => React.createElement("div", null, "AppsPageView"),
   AvatarLoader: () => React.createElement("div", null, "AvatarLoader"),
   BugReportModal: () => React.createElement("div", null, "BugReportModal"),
@@ -383,6 +381,7 @@ vi.mock("@miladyai/app-core/src/app-shell-components", () => ({
       "onboarding.enter",
     );
   },
+  OwnerNamePrompt: () => React.createElement("div", null, "OwnerNamePrompt"),
   PairingView: () => React.createElement("div", null, "PairingView"),
   SaveCommandModal: () => React.createElement("div", null, "SaveCommandModal"),
   SettingsView: () => React.createElement("div", null, "SettingsView"),
@@ -396,8 +395,9 @@ vi.mock("@miladyai/app-core/src/app-shell-components", () => ({
     React.createElement("div", null, "SystemWarningBanner"),
 }));
 
-vi.mock("../../src/app-shell-components", () =>
-  import("@miladyai/app-core/src/app-shell-components"),
+vi.mock(
+  "../../src/app-shell-components",
+  () => import("@miladyai/app-core/src/app-shell-components"),
 );
 
 vi.mock("@miladyai/app-core/src/components/Header", () => ({
@@ -1095,7 +1095,11 @@ describe("agent reset and re-onboarding (e2e)", () => {
 
     for (let cycle = 0; cycle < 3; cycle += 1) {
       // Complete onboarding
-      await driveOnboardingToCompletion(tree, state, mocks.handleOnboardingNext);
+      await driveOnboardingToCompletion(
+        tree,
+        state,
+        mocks.handleOnboardingNext,
+      );
       expect(state.onboardingComplete).toBe(true);
 
       // Reset

--- a/packages/app-core/test/app/owner-name-prompt-gate.test.tsx
+++ b/packages/app-core/test/app/owner-name-prompt-gate.test.tsx
@@ -1,0 +1,341 @@
+// @vitest-environment jsdom
+import React, { useEffect } from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockClient } = vi.hoisted(() => ({
+  mockClient: {
+    hasToken: vi.fn(() => false),
+    getAuthStatus: vi.fn(async () => ({
+      required: false,
+      pairingEnabled: false,
+      expiresAt: null,
+    })),
+    getOnboardingStatus: vi.fn(async () => ({ complete: true })),
+    getOnboardingOptions: vi.fn(async () => ({
+      names: ["Milady"],
+      styles: [],
+      providers: [],
+      cloudProviders: [],
+      models: { small: [], large: [] },
+      sharedStyleRules: "",
+    })),
+    listConversations: vi.fn(async () => ({ conversations: [] })),
+    getConversationMessages: vi.fn(async () => ({ messages: [] })),
+    sendWsMessage: vi.fn(),
+    connectWs: vi.fn(),
+    disconnectWs: vi.fn(),
+    onWsEvent: vi.fn(() => () => {}),
+    getAgentEvents: vi.fn(async () => ({ events: [], latestEventId: null })),
+    getStatus: vi.fn(async () => ({
+      state: "running",
+      agentName: "Milady",
+      model: undefined,
+      startedAt: undefined,
+      uptime: undefined,
+    })),
+    getWalletAddresses: vi.fn(async () => null),
+    getConfig: vi.fn(async () => ({})),
+    getCloudStatus: vi.fn(async () => ({ enabled: false, connected: false })),
+    getCodingAgentStatus: vi.fn(async () => null),
+    getWorkbenchOverview: vi.fn(async () => ({
+      tasks: [],
+      triggers: [],
+      todos: [],
+    })),
+    getBaseUrl: vi.fn(() => "http://localhost:2138"),
+    updateConfig: vi.fn(async () => ({})),
+    saveStreamSettings: vi.fn(async () => ({ ok: true })),
+  },
+}));
+
+vi.mock("@miladyai/app-core/api", () => ({
+  client: mockClient,
+  SkillScanReportSummary: {},
+}));
+
+import type { AppState, ShellView } from "@miladyai/app-core/state";
+import { AppProvider, useApp } from "@miladyai/app-core/state";
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+type ProbeApi = {
+  handleOwnerNameSubmit: (name: string) => void;
+  setState: (key: string, value: unknown) => void;
+  snapshot: () => {
+    ownerName: string | null;
+    showOwnerNamePrompt: boolean;
+    tab: string;
+    uiShellMode: string;
+  };
+  switchShellView: (view: ShellView) => void;
+};
+
+function Probe(props: { onReady: (api: ProbeApi) => void }) {
+  const { onReady } = props;
+  const app = useApp();
+
+  useEffect(() => {
+    onReady({
+      handleOwnerNameSubmit: app.handleOwnerNameSubmit,
+      setState: (key, value) =>
+        app.setState(key as keyof AppState, value as AppState[keyof AppState]),
+      snapshot: () => ({
+        ownerName: app.ownerName,
+        showOwnerNamePrompt: app.showOwnerNamePrompt,
+        tab: app.tab,
+        uiShellMode: app.uiShellMode,
+      }),
+      switchShellView: app.switchShellView,
+    });
+  }, [app, onReady]);
+
+  return null;
+}
+
+async function flushMicrotasks(iterations = 2) {
+  for (let i = 0; i < iterations; i += 1) {
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+}
+
+describe("owner name prompt gate", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    window.history.pushState(null, "", "/chat");
+    Object.assign(window, {
+      setTimeout: globalThis.setTimeout,
+      clearTimeout: globalThis.clearTimeout,
+      setInterval: globalThis.setInterval,
+      clearInterval: globalThis.clearInterval,
+      __MILADY_API_BASE__: "http://localhost:2138",
+    });
+    Object.assign(document.documentElement, { setAttribute: vi.fn() });
+
+    for (const fn of Object.values(mockClient)) {
+      if (typeof fn === "function" && "mockReset" in fn) {
+        (fn as { mockReset: () => void }).mockReset();
+      }
+    }
+
+    mockClient.hasToken.mockReturnValue(false);
+    mockClient.getAuthStatus.mockResolvedValue({
+      required: false,
+      pairingEnabled: false,
+      expiresAt: null,
+    });
+    mockClient.getOnboardingStatus.mockResolvedValue({ complete: true });
+    mockClient.getOnboardingOptions.mockResolvedValue({
+      names: ["Milady"],
+      styles: [],
+      providers: [],
+      cloudProviders: [],
+      models: { small: [], large: [] },
+      sharedStyleRules: "",
+    });
+    mockClient.listConversations.mockResolvedValue({ conversations: [] });
+    mockClient.getConversationMessages.mockResolvedValue({ messages: [] });
+    mockClient.sendWsMessage.mockImplementation(() => {});
+    mockClient.connectWs.mockImplementation(() => {});
+    mockClient.disconnectWs.mockImplementation(() => {});
+    mockClient.onWsEvent.mockReturnValue(() => {});
+    mockClient.getAgentEvents.mockResolvedValue({
+      events: [],
+      latestEventId: null,
+    });
+    mockClient.getStatus.mockResolvedValue({
+      state: "running",
+      agentName: "Milady",
+      model: undefined,
+      startedAt: undefined,
+      uptime: undefined,
+    });
+    mockClient.getWalletAddresses.mockResolvedValue(null);
+    mockClient.getCloudStatus.mockResolvedValue({
+      enabled: false,
+      connected: false,
+    });
+    mockClient.getCodingAgentStatus.mockResolvedValue(null);
+    mockClient.getWorkbenchOverview.mockResolvedValue({
+      tasks: [],
+      triggers: [],
+      todos: [],
+    });
+    mockClient.getBaseUrl.mockReturnValue("http://localhost:2138");
+    mockClient.updateConfig.mockResolvedValue({});
+    mockClient.saveStreamSettings.mockResolvedValue({ ok: true });
+
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it("waits for config hydration before opening the prompt on desktop", async () => {
+    const configDeferred = createDeferred<Record<string, unknown>>();
+    mockClient.getConfig.mockReturnValue(configDeferred.promise);
+
+    let api: ProbeApi | null = null;
+    let tree: TestRenderer.ReactTestRenderer | null = null;
+
+    try {
+      await act(async () => {
+        tree = TestRenderer.create(
+          React.createElement(
+            AppProvider,
+            null,
+            React.createElement(Probe, {
+              onReady: (nextApi) => {
+                api = nextApi;
+              },
+            }),
+          ),
+        );
+      });
+
+      await flushMicrotasks();
+
+      const getApi = () => {
+        if (!api) {
+          throw new Error("Probe API unavailable");
+        }
+        return api;
+      };
+
+      await act(async () => {
+        getApi().switchShellView("desktop");
+      });
+
+      expect(getApi().snapshot()).toMatchObject({
+        ownerName: null,
+        showOwnerNamePrompt: false,
+        uiShellMode: "native",
+      });
+
+      await act(async () => {
+        configDeferred.resolve({});
+        await configDeferred.promise;
+      });
+      await flushMicrotasks();
+
+      expect(getApi().snapshot().showOwnerNamePrompt).toBe(true);
+    } finally {
+      await act(async () => {
+        tree?.unmount();
+      });
+    }
+  });
+
+  it("suppresses the prompt when hydration restores an existing owner name", async () => {
+    const configDeferred = createDeferred<Record<string, unknown>>();
+    mockClient.getConfig.mockReturnValue(configDeferred.promise);
+
+    let api: ProbeApi | null = null;
+    let tree: TestRenderer.ReactTestRenderer | null = null;
+
+    try {
+      await act(async () => {
+        tree = TestRenderer.create(
+          React.createElement(
+            AppProvider,
+            null,
+            React.createElement(Probe, {
+              onReady: (nextApi) => {
+                api = nextApi;
+              },
+            }),
+          ),
+        );
+      });
+
+      await flushMicrotasks();
+
+      const getApi = () => {
+        if (!api) {
+          throw new Error("Probe API unavailable");
+        }
+        return api;
+      };
+
+      await act(async () => {
+        getApi().switchShellView("desktop");
+      });
+
+      await act(async () => {
+        configDeferred.resolve({ ui: { ownerName: "  Ada Lovelace  " } });
+        await configDeferred.promise;
+      });
+      await flushMicrotasks();
+
+      expect(getApi().snapshot()).toMatchObject({
+        ownerName: "Ada Lovelace",
+        showOwnerNamePrompt: false,
+      });
+    } finally {
+      await act(async () => {
+        tree?.unmount();
+      });
+    }
+  });
+
+  it("normalizes and persists submitted owner names", async () => {
+    mockClient.getConfig.mockResolvedValue({});
+
+    let api: ProbeApi | null = null;
+    let tree: TestRenderer.ReactTestRenderer | null = null;
+
+    try {
+      await act(async () => {
+        tree = TestRenderer.create(
+          React.createElement(
+            AppProvider,
+            null,
+            React.createElement(Probe, {
+              onReady: (nextApi) => {
+                api = nextApi;
+              },
+            }),
+          ),
+        );
+      });
+
+      await flushMicrotasks(3);
+
+      const getApi = () => {
+        if (!api) {
+          throw new Error("Probe API unavailable");
+        }
+        return api;
+      };
+
+      await act(async () => {
+        getApi().setState("showOwnerNamePrompt", true);
+        getApi().handleOwnerNameSubmit(`  ${"a".repeat(80)}  `);
+      });
+
+      expect(getApi().snapshot()).toMatchObject({
+        ownerName: "a".repeat(60),
+        showOwnerNamePrompt: false,
+      });
+      expect(mockClient.updateConfig).toHaveBeenCalledWith({
+        ui: { ownerName: "a".repeat(60) },
+      });
+    } finally {
+      await act(async () => {
+        tree?.unmount();
+      });
+    }
+  });
+});

--- a/packages/app-core/test/app/pages-navigation-smoke.e2e.test.ts
+++ b/packages/app-core/test/app/pages-navigation-smoke.e2e.test.ts
@@ -46,9 +46,8 @@ vi.mock("@miladyai/app-core/state", async () => {
 });
 
 vi.mock("../../src/state", async () => {
-  const actual = await vi.importActual<typeof import("../../src/state")>(
-    "../../src/state",
-  );
+  const actual =
+    await vi.importActual<typeof import("../../src/state")>("../../src/state");
   return {
     ...actual,
     useApp: () => mockUseApp(),
@@ -167,11 +166,10 @@ vi.mock("@miladyai/app-core/src/app-shell-components", () => ({
     React.createElement("section", null, "InventoryView Ready"),
   KnowledgeView: () =>
     React.createElement("section", null, "KnowledgeView Ready"),
-  OnboardingWizard: () =>
-    React.createElement("div", null, "OnboardingWizard"),
+  OnboardingWizard: () => React.createElement("div", null, "OnboardingWizard"),
+  OwnerNamePrompt: () => React.createElement("div", null, "OwnerNamePrompt"),
   PairingView: () => React.createElement("div", null, "PairingView"),
-  SaveCommandModal: () =>
-    React.createElement("div", null, "SaveCommandModal"),
+  SaveCommandModal: () => React.createElement("div", null, "SaveCommandModal"),
   SettingsView: () =>
     React.createElement("section", null, "SettingsView Ready"),
   SharedCompanionScene: ({ children }: { children: React.ReactNode }) =>
@@ -216,11 +214,10 @@ vi.mock("../../src/app-shell-components", () => ({
     React.createElement("section", null, "InventoryView Ready"),
   KnowledgeView: () =>
     React.createElement("section", null, "KnowledgeView Ready"),
-  OnboardingWizard: () =>
-    React.createElement("div", null, "OnboardingWizard"),
+  OnboardingWizard: () => React.createElement("div", null, "OnboardingWizard"),
+  OwnerNamePrompt: () => React.createElement("div", null, "OwnerNamePrompt"),
   PairingView: () => React.createElement("div", null, "PairingView"),
-  SaveCommandModal: () =>
-    React.createElement("div", null, "SaveCommandModal"),
+  SaveCommandModal: () => React.createElement("div", null, "SaveCommandModal"),
   SettingsView: () =>
     React.createElement("section", null, "SettingsView Ready"),
   SharedCompanionScene: ({ children }: { children: React.ReactNode }) =>
@@ -383,9 +380,8 @@ vi.mock("@miladyai/app-core/hooks", async () => {
 });
 
 vi.mock("../../src/hooks", async () => {
-  const actual = await vi.importActual<typeof import("../../src/hooks")>(
-    "../../src/hooks",
-  );
+  const actual =
+    await vi.importActual<typeof import("../../src/hooks")>("../../src/hooks");
   return {
     ...actual,
     useContextMenu: () => ({

--- a/packages/app-core/test/app/shell-mode-switching.e2e.test.ts
+++ b/packages/app-core/test/app/shell-mode-switching.e2e.test.ts
@@ -147,10 +147,12 @@ vi.mock("@miladyai/app-core/components", async () => {
 vi.mock("@miladyai/app-core/src/app-shell-components", () => ({
   AdvancedPageView: () =>
     React.createElement("section", null, "AdvancedPageView Ready"),
-  AppsPageView: () => React.createElement("section", null, "AppsPageView Ready"),
+  AppsPageView: () =>
+    React.createElement("section", null, "AppsPageView Ready"),
   AvatarLoader: () => React.createElement("div", null, "AvatarLoader"),
   BugReportModal: () => React.createElement("div", null, "BugReportModal"),
-  CharacterEditor: () => React.createElement("section", null, "CharacterView Ready"),
+  CharacterEditor: () =>
+    React.createElement("section", null, "CharacterView Ready"),
   ChatView: () => React.createElement("section", null, "ChatView Ready"),
   CompanionShell: ({ tab }: { tab: string }) =>
     React.createElement("main", null, `CompanionShell Ready: ${tab}`),
@@ -175,9 +177,11 @@ vi.mock("@miladyai/app-core/src/app-shell-components", () => ({
   KnowledgeView: () =>
     React.createElement("section", null, "KnowledgeView Ready"),
   OnboardingWizard: () => React.createElement("div", null, "OnboardingWizard"),
+  OwnerNamePrompt: () => React.createElement("div", null, "OwnerNamePrompt"),
   PairingView: () => React.createElement("div", null, "PairingView"),
   SaveCommandModal: () => React.createElement("div", null, "SaveCommandModal"),
-  SettingsView: () => React.createElement("section", null, "SettingsView Ready"),
+  SettingsView: () =>
+    React.createElement("section", null, "SettingsView Ready"),
   SharedCompanionScene: ({
     active,
     interactive,

--- a/packages/app-core/test/app/startup-asset-missing.e2e.test.ts
+++ b/packages/app-core/test/app/startup-asset-missing.e2e.test.ts
@@ -29,11 +29,10 @@ vi.mock("../../src/app-shell-components", () => ({
   HeartbeatsView: () => React.createElement("div", null, "HeartbeatsView"),
   InventoryView: () => React.createElement("div", null, "InventoryView"),
   KnowledgeView: () => React.createElement("div", null, "KnowledgeView"),
-  OnboardingWizard: () =>
-    React.createElement("div", null, "OnboardingWizard"),
+  OnboardingWizard: () => React.createElement("div", null, "OnboardingWizard"),
+  OwnerNamePrompt: () => React.createElement("div", null, "OwnerNamePrompt"),
   PairingView: () => React.createElement("div", null, "PairingView"),
-  SaveCommandModal: () =>
-    React.createElement("div", null, "SaveCommandModal"),
+  SaveCommandModal: () => React.createElement("div", null, "SaveCommandModal"),
   SettingsView: () => React.createElement("div", null, "SettingsView"),
   SharedCompanionScene: ({ children }: { children: React.ReactNode }) =>
     React.createElement(React.Fragment, null, children),
@@ -108,7 +107,9 @@ describe("startup failure: bundled assets missing", () => {
 
     const rendered = textOf(tree!.root);
     expect(rendered).toContain("StartupFailureView:asset-missing");
-    expect(rendered).toContain("Required companion assets could not be loaded.");
+    expect(rendered).toContain(
+      "Required companion assets could not be loaded.",
+    );
     expect(rendered).toContain("Bundled avatar ELIZA-01 could not be loaded.");
     expect(rendered).not.toContain("PairingView");
 

--- a/packages/app-core/test/app/startup-backend-missing.e2e.test.ts
+++ b/packages/app-core/test/app/startup-backend-missing.e2e.test.ts
@@ -9,6 +9,7 @@ const { mockClient } = vi.hoisted(() => ({
     hasToken: vi.fn(() => false),
     getCodingAgentStatus: vi.fn(async () => null),
     setToken: vi.fn(),
+    getConfig: vi.fn(async () => ({})),
     getAuthStatus: vi.fn(async () => ({
       required: false,
       pairingEnabled: false,
@@ -67,6 +68,7 @@ describe("startup failure: backend missing", () => {
     );
     mockClient.hasToken.mockReturnValue(false);
     mockClient.disconnectWs.mockImplementation(() => {});
+    mockClient.getConfig.mockResolvedValue({});
     mockClient.getAuthStatus.mockResolvedValue({
       required: false,
       pairingEnabled: false,

--- a/packages/app-core/test/app/startup-chat.e2e.test.ts
+++ b/packages/app-core/test/app/startup-chat.e2e.test.ts
@@ -25,9 +25,8 @@ vi.mock("@miladyai/app-core/state", async () => {
 });
 
 vi.mock("../../src/state", async () => {
-  const actual = await vi.importActual<typeof import("../../src/state")>(
-    "../../src/state",
-  );
+  const actual =
+    await vi.importActual<typeof import("../../src/state")>("../../src/state");
   return {
     ...actual,
     useApp: () => mockUseApp(),
@@ -38,9 +37,8 @@ vi.mock("../../src/state", async () => {
 });
 
 vi.mock("@miladyai/ui", async () => {
-  const actual = await vi.importActual<typeof import("@miladyai/ui")>(
-    "@miladyai/ui",
-  );
+  const actual =
+    await vi.importActual<typeof import("@miladyai/ui")>("@miladyai/ui");
   const React = await vi.importActual<typeof import("react")>("react");
 
   return {
@@ -117,6 +115,7 @@ vi.mock("@miladyai/app-core/components", async () => {
     KnowledgeView: () => React.createElement("div", null, "KnowledgeView"),
     OnboardingWizard: () =>
       React.createElement("div", null, "OnboardingWizard"),
+    OwnerNamePrompt: () => React.createElement("div", null, "OwnerNamePrompt"),
     PairingView: () => React.createElement("div", null, "PairingView"),
     SharedCompanionScene: ({
       children,
@@ -186,8 +185,7 @@ vi.mock("@miladyai/app-core/src/components/CompanionView", () => ({
 }));
 
 vi.mock("../../src/app-shell-components", () => ({
-  AdvancedPageView: () =>
-    React.createElement("div", null, "AdvancedPageView"),
+  AdvancedPageView: () => React.createElement("div", null, "AdvancedPageView"),
   AppsPageView: () => React.createElement("div", null, "AppsPageView"),
   AvatarLoader: () => React.createElement("div", null, "AvatarLoader"),
   BugReportModal: () => React.createElement("div", null, "BugReportModal"),
@@ -212,11 +210,10 @@ vi.mock("../../src/app-shell-components", () => ({
   HeartbeatsView: () => React.createElement("div", null, "HeartbeatsView"),
   InventoryView: () => React.createElement("div", null, "InventoryView"),
   KnowledgeView: () => React.createElement("div", null, "KnowledgeView"),
-  OnboardingWizard: () =>
-    React.createElement("div", null, "OnboardingWizard"),
+  OnboardingWizard: () => React.createElement("div", null, "OnboardingWizard"),
+  OwnerNamePrompt: () => React.createElement("div", null, "OwnerNamePrompt"),
   PairingView: () => React.createElement("div", null, "PairingView"),
-  SaveCommandModal: () =>
-    React.createElement("div", null, "SaveCommandModal"),
+  SaveCommandModal: () => React.createElement("div", null, "SaveCommandModal"),
   SettingsView: () => React.createElement("div", null, "SettingsView"),
   SharedCompanionScene: ({
     children,

--- a/packages/app-core/test/app/startup-onboarding.e2e.test.ts
+++ b/packages/app-core/test/app/startup-onboarding.e2e.test.ts
@@ -396,6 +396,7 @@ vi.mock("@miladyai/app-core/src/app-shell-components", () => ({
       "onboarding.enter",
     );
   },
+  OwnerNamePrompt: () => React.createElement("div", null, "OwnerNamePrompt"),
   PairingView: () => React.createElement("div", null, "PairingView"),
   SaveCommandModal: () => React.createElement("div", null, "SaveCommandModal"),
   SettingsView: () => React.createElement("div", null, "SettingsView"),
@@ -515,6 +516,7 @@ vi.mock("../../src/app-shell-components", () => ({
       "onboarding.enter",
     );
   },
+  OwnerNamePrompt: () => React.createElement("div", null, "OwnerNamePrompt"),
   PairingView: () => React.createElement("div", null, "PairingView"),
   SaveCommandModal: () => React.createElement("div", null, "SaveCommandModal"),
   SettingsView: () => React.createElement("div", null, "SettingsView"),

--- a/packages/app-core/test/app/startup-token-401.e2e.test.ts
+++ b/packages/app-core/test/app/startup-token-401.e2e.test.ts
@@ -29,11 +29,10 @@ vi.mock("../../src/app-shell-components", () => ({
   HeartbeatsView: () => React.createElement("div", null, "HeartbeatsView"),
   InventoryView: () => React.createElement("div", null, "InventoryView"),
   KnowledgeView: () => React.createElement("div", null, "KnowledgeView"),
-  OnboardingWizard: () =>
-    React.createElement("div", null, "OnboardingWizard"),
+  OnboardingWizard: () => React.createElement("div", null, "OnboardingWizard"),
+  OwnerNamePrompt: () => React.createElement("div", null, "OwnerNamePrompt"),
   PairingView: () => React.createElement("div", null, "PairingView"),
-  SaveCommandModal: () =>
-    React.createElement("div", null, "SaveCommandModal"),
+  SaveCommandModal: () => React.createElement("div", null, "SaveCommandModal"),
   SettingsView: () => React.createElement("div", null, "SettingsView"),
   SharedCompanionScene: ({ children }: { children: React.ReactNode }) =>
     React.createElement(React.Fragment, null, children),


### PR DESCRIPTION
Add a one-time modal that asks "What should I call you?" the first time a user navigates to the native/desktop UI. The name is persisted to config.ui.ownerName and used as the entity userName for all app conversations, so the agent knows and can address the user by name.

Changes:
- OwnerNamePrompt: modal with TTS support (cloud ElevenLabs voice)
- AppContext: ownerName state, hydrated from config on startup, prompt gate on switchShellView("desktop"), handleOwnerNameSubmit persists
- server.ts: resolveAppUserName() reads config.ui.ownerName, replaces hardcoded "User" in all 4 ensureConnection call sites
- CharacterEditor: roster entry names update live as user types
- App.test.ts: add OwnerNamePrompt mock + state to prevent test break

This PR will be reviewed by an AI agent. Provide clear context to help it assess your changes.

Aesthetic/UI changes that don't improve agent capability are out of scope and will be rejected.

## Category
- [ ] Bug fix
- [ ] Security fix
- [ ] Performance improvement
- [ ] New feature
- [ ] Documentation
- [ ] Test coverage
- [ ] Other

## What
(brief description)

## Why
(motivation)

## How
(implementation approach)

## Testing
(what was tested, how to verify)
