### PR TITLE
fix(ui): log warnings in CharacterEditor catch blocks instead of swallowing silently

### DIFF
--- a/packages/app-core/src/components/CharacterEditor.tsx
+++ b/packages/app-core/src/components/CharacterEditor.tsx
@@ -659,7 +659,9 @@ export function CharacterEditor({
             setSelectedVoicePresetId(preset?.id ?? null);
           }
         }
-      } catch {}
+      } catch (err) {
+        console.warn("[CharacterEditor] Failed to load voice config:", err);
+      }
       setVoiceLoading(false);
     })();
   }, []);
@@ -1077,7 +1079,9 @@ export function CharacterEditor({
               if (parsed.chat) handleStyleEdit("chat", parsed.chat.join("\n"));
               if (parsed.post) handleStyleEdit("post", parsed.post.join("\n"));
             }
-          } catch {}
+          } catch (err) {
+            console.warn("[CharacterEditor] Failed to parse AI-generated style JSON:", err);
+          }
         } else if (field === "chatExamples") {
           const formatted = normalizeCharacterMessageExamples(
             generated,
@@ -1099,7 +1103,9 @@ export function CharacterEditor({
                 handleCharacterArrayInput("postExamples", parsed.join("\n"));
               }
             }
-          } catch {}
+          } catch (err) {
+            console.warn("[CharacterEditor] Failed to parse AI-generated postExamples JSON:", err);
+          }
         }
       } catch (err) {
         const msg = err instanceof Error ? err.message : "Generation failed";


### PR DESCRIPTION
## LARP Assessment — Finding (4): Error handling that silently swallows failures

> *"Check for error handling that silently swallows failures."*

`CharacterEditor.tsx` had **three empty `catch {}` blocks** that silently discarded errors:

| Location | What fails silently |
|----------|---------------------|
| Voice config load (`useEffect`) | `client.getConfig()` network failure — user sees no voice presets, no idea why |
| Style JSON parse | AI-generated style JSON is malformed — silently dropped, user thinks generation did nothing |
| PostExamples JSON parse | Same — AI output dropped without any feedback |

These aren't resilient error handling — they're **lies about system health**. A developer debugging "why isn't the voice preset loading?" has zero signal.

## Changes

All three `catch {}` blocks now log `console.warn("[CharacterEditor] ...")` with the error, so failures appear in dev tools while still degrading gracefully (no UI crash, no user-facing error for recoverable failures).

## Test plan

- [ ] Open CharacterEditor in dev mode
- [ ] Simulate a voice config load failure (e.g. kill API server) — verify warning appears in console
- [ ] Trigger AI style generation with intentionally bad JSON — verify parse warning appears
- [ ] Verify no UI crash on any of these paths

Shaw hotkey: *"Silence is not resilience — it's a lie about your system's health."*

Made with [Cursor](https://cursor.com)