### PR TITLE
fix(api): distinguish resource 404s from catalog 404s in cloud compat proxy

### DIFF
--- a/packages/agent/src/api/cloud-compat-routes.ts
+++ b/packages/agent/src/api/cloud-compat-routes.ts
@@ -203,21 +203,21 @@ export async function handleCloudCompatRoute(
     }
 
     if (parsed.kind === "json") {
-      // Cloud API may not have all routes deployed yet. Return a friendlier
-      // message instead of a raw 404 so the dashboard can show "coming soon".
-      // TODO: Remove or refine this unconditional 404 intercept when Cloud
-      // goes to production — legitimate 404s (e.g. agent not found) will be
-      // incorrectly masked as "coming soon".
       if (upstreamRes.status === 404) {
-        sendJson(
-          res,
-          {
-            success: false,
-            error: "This Cloud feature is not available yet.",
-            code: "CLOUD_NOT_READY",
-          },
-          404,
-        );
+        const isResourcePath = /\/compat\/api\/v\d+\/\w+\/[^/]+/.test(pathname);
+        if (isResourcePath) {
+          sendJson(res, parsed.body, 404);
+        } else {
+          sendJson(
+            res,
+            {
+              success: false,
+              error: "This Cloud feature is not available yet.",
+              code: "CLOUD_NOT_READY",
+            },
+            404,
+          );
+        }
         return true;
       }
       sendJson(res, parsed.body, upstreamRes.status);


### PR DESCRIPTION
## LARP Assessment — Finding (2): Hardcoded values masquerading as dynamic behavior

> *"Check for hardcoded values masquerading as dynamic behavior."*

`cloud-compat-routes.ts` unconditionally rewrote **ALL** upstream 404 responses to:

```json
{ "success": false, "error": "This Cloud feature is not available yet.", "code": "CLOUD_NOT_READY" }
```

This masked legitimate resource-not-found errors. When a user queries a nonexistent agent (`/compat/api/v1/agents/abc123`), the upstream returns a proper 404 with details — but the proxy replaced it with a hardcoded "coming soon" message.

The code itself acknowledged this was wrong:

> ```
> // TODO: Remove or refine this unconditional 404 intercept when Cloud
> // goes to production — legitimate 404s (e.g. agent not found) will be
> // incorrectly masked as "coming soon".
> ```

## Changes

Resource-specific paths (matching `/compat/api/v{N}/{resource}/{id}`) now **pass through the upstream 404 body**. Catalog-level paths (no resource ID) still show the "not ready" message for undeployed features.

## Test plan

- [ ] `GET /api/cloud/compat/api/v1/agents/nonexistent` → returns upstream 404 body (not "coming soon")
- [ ] `GET /api/cloud/compat/api/v1/catalog` with undeployed endpoint → returns CLOUD_NOT_READY
- [ ] Existing cloud dashboard "coming soon" UI still works for undeployed features

Shaw hotkey: *"A hardcoded answer to a dynamic question is a bug with extra steps."*

Made with [Cursor](https://cursor.com)