### PR TITLE
fix: log warnings in catch blocks that silently return empty arrays

### DIFF
--- a/packages/agent/src/runtime/custom-actions.ts
+++ b/packages/agent/src/runtime/custom-actions.ts
@@ -16,7 +16,7 @@ import {
 import { request as requestHttps } from "node:https";
 import net from "node:net";
 import { Readable } from "node:stream";
-import type { Action, HandlerOptions, IAgentRuntime } from "@elizaos/core";
+import { type Action, type HandlerOptions, type IAgentRuntime, logger } from "@elizaos/core";
 import { loadElizaConfig } from "../config/config";
 import {
   resolveApiToken,
@@ -648,7 +648,8 @@ export function loadCustomActions(): Action[] {
     const config = loadElizaConfig();
     const defs = config.customActions ?? [];
     return defs.filter((d) => d.enabled).map(defToAction);
-  } catch {
+  } catch (err) {
+    logger.warn("[custom-actions] Failed to load custom actions from config:", err);
     return [];
   }
 }

--- a/packages/agent/src/runtime/custom-actions.ts
+++ b/packages/agent/src/runtime/custom-actions.ts
@@ -649,7 +649,7 @@ export function loadCustomActions(): Action[] {
     const defs = config.customActions ?? [];
     return defs.filter((d) => d.enabled).map(defToAction);
   } catch (err) {
-    logger.warn("[custom-actions] Failed to load custom actions from config:", err);
+    logger.warn(`[custom-actions] Failed to load custom actions from config: ${err instanceof Error ? err.message : String(err)}`);
     return [];
   }
 }

--- a/packages/agent/src/services/registry-client.ts
+++ b/packages/agent/src/services/registry-client.ts
@@ -149,7 +149,7 @@ export function getConfiguredEndpoints(): RegistryEndpoint[] {
     const cfg = loadElizaConfig();
     return cfg.plugins?.registryEndpoints ?? [];
   } catch (err) {
-    logger.warn("[registry-client] Failed to load config for custom endpoints:", err);
+    logger.warn(`[registry-client] Failed to load config for custom endpoints: ${err instanceof Error ? err.message : String(err)}`);
     return [];
   }
 }

--- a/packages/agent/src/services/registry-client.ts
+++ b/packages/agent/src/services/registry-client.ts
@@ -148,7 +148,8 @@ export function getConfiguredEndpoints(): RegistryEndpoint[] {
   try {
     const cfg = loadElizaConfig();
     return cfg.plugins?.registryEndpoints ?? [];
-  } catch {
+  } catch (err) {
+    logger.warn("[registry-client] Failed to load config for custom endpoints:", err);
     return [];
   }
 }

--- a/packages/agent/src/services/skill-marketplace.ts
+++ b/packages/agent/src/services/skill-marketplace.ts
@@ -354,7 +354,7 @@ async function readInstallRecords(
     const isNoent =
       err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT";
     if (!isNoent) {
-      logger.warn("[skill-marketplace] Failed to read install records:", err);
+      logger.warn(`[skill-marketplace] Failed to read install records: ${err instanceof Error ? err.message : String(err)}`);
     }
     return {};
   }

--- a/packages/agent/src/services/skill-marketplace.ts
+++ b/packages/agent/src/services/skill-marketplace.ts
@@ -350,7 +350,12 @@ async function readInstallRecords(
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
       return {};
     return parsed;
-  } catch {
+  } catch (err) {
+    const isNoent =
+      err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT";
+    if (!isNoent) {
+      logger.warn("[skill-marketplace] Failed to read install records:", err);
+    }
     return {};
   }
 }

--- a/packages/app-core/src/api/client.ts
+++ b/packages/app-core/src/api/client.ts
@@ -5614,7 +5614,8 @@ export class MiladyClient {
       return await this.fetch<CodingAgentScratchWorkspace[]>(
         "/api/coding-agents/scratch",
       );
-    } catch {
+    } catch (err) {
+      console.warn("[api-client] Failed to list coding agent scratch workspaces:", err);
       return [];
     }
   }


### PR DESCRIPTION
## LARP Assessment — Finding (4): Error handling that silently swallows failures

> *"Check for error handling that silently swallows failures."*

Four services had `catch { return []; }` or `catch { return {}; }` blocks that made real errors **indistinguishable from "no data"**:

| File | Function | Error becomes |
|------|----------|--------------|
| `registry-client.ts` | `getConfiguredEndpoints()` | Config load fails → `[]` (looks like "no custom endpoints") |
| `skill-marketplace.ts` | `readInstallRecords()` | Corrupt JSON → `{}` (looks like "no installs") |
| `custom-actions.ts` | `loadCustomActions()` | Config load fails → `[]` (looks like "no custom actions") |
| `api/client.ts` | `listCodingAgentScratchWorkspaces()` | Network error → `[]` (looks like "no workspaces") |

An operator debugging "why aren't my custom actions loading?" has **zero signal** that the config file is malformed.

## Changes

- All four now `logger.warn()` / `console.warn()` before returning the fallback
- `skill-marketplace` additionally skips the warning for `ENOENT` (file doesn't exist yet is normal on first run)
- Fallback behavior preserved — no throwing, no UI crash

## Test plan

- [ ] `bun run test` passes
- [ ] Introduce a malformed `milady.json` config → verify warning appears in logs for registry-client, custom-actions
- [ ] Delete `installs.json` → verify skill-marketplace does NOT warn (ENOENT is expected)
- [ ] Corrupt `installs.json` → verify skill-marketplace DOES warn

Shaw hotkey: *"`catch {} return []` is gaslighting your future self."*

Made with [Cursor](https://cursor.com)