### PR TITLE
fix: logLevelAction.validate now checks for log-level keywords

### DIFF
--- a/packages/app-core/src/actions/log-level.ts
+++ b/packages/app-core/src/actions/log-level.ts
@@ -18,8 +18,14 @@ export const logLevelAction: Action = {
   ],
   description:
     "Set the log level for the current session (trace, debug, info, warn, error).",
-  validate: async (_runtime: IAgentRuntime, _message: Memory) => {
-    return true;
+  validate: async (_runtime: IAgentRuntime, message: Memory) => {
+    const text = (message.content.text || "").toLowerCase();
+    const levels = ["trace", "debug", "info", "warn", "error"];
+    return (
+      levels.some((l) => text.includes(l)) ||
+      /log\s*level/i.test(text) ||
+      /set\s*(debug|verbose|logging)/i.test(text)
+    );
   },
   handler: async (
     runtime: IAgentRuntime,


### PR DESCRIPTION
## LARP Assessment — Finding (6): Validation that doesn't validate

> *"Check for validation that doesn't validate."*

`logLevelAction.validate` was:

```typescript
validate: async (_runtime: IAgentRuntime, _message: Memory) => {
  return true;
},
```

This accepted **every message** as a valid log-level command. The handler already had keyword matching (`levels.find(l => text.includes(l))`), but the validate gate let everything through before action selection could benefit from filtering.

## Changes

`validate` now checks the message text for:
- Log level keywords: `trace`, `debug`, `info`, `warn`, `error`
- Phrases: `"log level"`, `"set debug"`, `"set verbose"`, `"set logging"`

Only messages mentioning log levels will activate the action, freeing up action slots for the LLM.

## Test plan

- [ ] Send "set log level to debug" → action activates, log level changes
- [ ] Send "hello how are you" → action does NOT activate
- [ ] Send "enable debug mode" → action activates
- [ ] `bun run test` passes

Shaw hotkey: *"A validator that returns true is a mass that returns void."*

Made with [Cursor](https://cursor.com)