### PR TITLE
fix(test): convert swabble WakeWordGate placeholder to it.todo

### DIFF
--- a/apps/app/test/plugins/swabble.test.ts
+++ b/apps/app/test/plugins/swabble.test.ts
@@ -142,7 +142,9 @@ describe("@miladyai/capacitor-swabble", () => {
     // (a) exporting it, or (b) mocking SpeechRecognition so start() succeeds.
     // We document this gap here rather than pretending it's tested.
 
-    it.todo("WakeWordGate.match() — requires exporting the class or mocking SpeechRecognition (triggers, substring match, minCommandLength, postGap)");
+    it.todo(
+      "WakeWordGate.match() — requires exporting the class or mocking SpeechRecognition (triggers, substring match, minCommandLength, postGap)",
+    );
   });
 
   // -- setAudioDevice --

--- a/apps/app/test/plugins/swabble.test.ts
+++ b/apps/app/test/plugins/swabble.test.ts
@@ -142,12 +142,7 @@ describe("@miladyai/capacitor-swabble", () => {
     // (a) exporting it, or (b) mocking SpeechRecognition so start() succeeds.
     // We document this gap here rather than pretending it's tested.
 
-    it("DOCUMENTED GAP: WakeWordGate.match() is pure logic that should be tested but requires either export or SpeechRecognition mock", () => {
-      // The gate normalizes triggers to lowercase, checks substring match,
-      // extracts command text after trigger, enforces minCommandLength,
-      // returns postGap=-1 on web. All untested.
-      expect(true).toBe(true); // placeholder acknowledging the gap
-    });
+    it.todo("WakeWordGate.match() — requires exporting the class or mocking SpeechRecognition (triggers, substring match, minCommandLength, postGap)");
   });
 
   // -- setAudioDevice --


### PR DESCRIPTION
## LARP Assessment — Finding (3): Tests that mock away the actual logic being tested

> *"Check for tests that mock away the actual logic being tested."*

`swabble.test.ts` had a test that **counted as passing while testing nothing**:

```typescript
it("DOCUMENTED GAP: WakeWordGate.match() is pure logic that should be tested but requires either export or SpeechRecognition mock", () => {
  expect(true).toBe(true); // placeholder acknowledging the gap
});
```

The test name is honest about the gap, but wrapping that admission in a green-checkmark test inflates test counts and provides false confidence.

## Changes

Converted to `it.todo()` so Vitest correctly reports it as **pending** rather than **passing**:

```typescript
it.todo("WakeWordGate.match() — requires exporting the class or mocking SpeechRecognition (triggers, substring match, minCommandLength, postGap)");
```

## Test plan

- [ ] `bun run test apps/app/test/plugins/swabble.test.ts` — test suite passes, WakeWordGate shows as "todo" not "pass"

Shaw hotkey: *"A passing test that tests nothing is worse than no test — it's false confidence."*

Made with [Cursor](https://cursor.com)