### PR TITLE
fix: remove dead deprecated stubs with zero importers

### DIFF
--- a/packages/app-core/src/components/policy-controls/helpers.ts
+++ b/packages/app-core/src/components/policy-controls/helpers.ts
@@ -13,11 +13,6 @@ export function parseAmount(value: string): number {
   return Number.isNaN(n) ? 0 : n;
 }
 
-/**
- * @deprecated Use parseAmount instead.
- */
-export const ethToNumber = parseAmount;
-
 export function formatHour(h: number): string {
   if (h === 0) return "12:00 AM";
   if (h === 12) return "12:00 PM";

--- a/packages/app-core/src/state/vrm.ts
+++ b/packages/app-core/src/state/vrm.ts
@@ -97,13 +97,3 @@ export function getVrmTitle(index: number): string {
   const safe = n > 0 ? n : 1;
   return assets[safe - 1]?.title ?? assets[0]?.title ?? "Avatar";
 }
-
-/** @deprecated Stub — always returns false. Retained for API compatibility. */
-export function isOfficialVrmIndex(_index: number): boolean {
-  return false;
-}
-
-/** @deprecated Stub — always returns false. Retained for API compatibility. */
-export function getVrmNeedsFlip(_index: number): boolean {
-  return false;
-}


### PR DESCRIPTION
## LARP Assessment — Finding (1): Stubbed functions that return fake data

> *"Check for stubbed functions that return fake data."*

Three exported functions existed solely as stubs returning hardcoded values, with **zero importers** anywhere in the codebase:

| Function | File | Returns | Importers |
|----------|------|---------|-----------|
| `isOfficialVrmIndex()` | `state/vrm.ts` | `false` always | 0 (only definition site) |
| `getVrmNeedsFlip()` | `state/vrm.ts` | `false` always | 0 (only definition site) |
| `ethToNumber` | `policy-controls/helpers.ts` | alias for `parseAmount` | 0 (only definition site) |

All three were marked `@deprecated` and re-exported via barrel files, but no consumer ever imported them. They inflated the public API surface and misled developers into thinking they served a purpose.

**Verification:** `rg "isOfficialVrmIndex|getVrmNeedsFlip"` and `rg "ethToNumber"` each return only the definition file.

## Changes

All three removed.

## Test plan

- [ ] `bun run build` succeeds (no broken imports)
- [ ] `bun run test` passes
- [ ] `bun run check` passes

Shaw hotkey: *"Dead code isn't legacy — it's noise pretending to be signal."*

Made with [Cursor](https://cursor.com)