### PR TITLE
fix: document intentional always-false in shouldStartAtCharacterSelectOnLaunch

### DIFF
--- a/packages/app-core/src/state/shell-routing.ts
+++ b/packages/app-core/src/state/shell-routing.ts
@@ -25,6 +25,10 @@ export function getTabForShellView(view: ShellView, lastNativeTab: Tab): Tab {
   return lastNativeTab;
 }
 
+/**
+ * Character-select auto-redirect on launch is currently disabled.
+ * The parameter shape is retained so callers stay wired for re-enablement.
+ */
 export function shouldStartAtCharacterSelectOnLaunch(_params: {
   onboardingNeedsOptions: boolean;
   onboardingMode: OnboardingMode;


### PR DESCRIPTION
## LARP Assessment — Finding (7): Code path that hasn't been executed and verified

> *"Check for any code path that hasn't been executed and verified. If something looks functional but isn't proven, flag it."*

`shouldStartAtCharacterSelectOnLaunch()` accepts a full parameter object:

```typescript
export function shouldStartAtCharacterSelectOnLaunch(_params: {
  onboardingNeedsOptions: boolean;
  onboardingMode: OnboardingMode;
  navPath: string;
  urlTab: Tab | null;
}): boolean {
  return false;
}
```

It **ignores all parameters** and returns `false` unconditionally. Without documentation, this looks like an unfinished stub or dead code that a contributor might "fix" by removing the params or the function entirely.

**It IS called** in `AppContext.tsx` and **IS tested** — but the tests only verify it returns `false`. The parameter shape is retained because callers are pre-wired for when the feature is re-enabled.

## Changes

Added JSDoc explaining the intentional behavior and why the parameter shape is retained:

```typescript
/**
 * Character-select auto-redirect on launch is currently disabled.
 * The parameter shape is retained so callers stay wired for re-enablement.
 */
```

## Test plan

- [ ] `bun run test packages/app-core/src/state/shell-routing.test.ts` passes
- [ ] `bun run check` passes

Shaw hotkey: *"Undocumented intent is indistinguishable from a bug."*

Made with [Cursor](https://cursor.com)