### PR TITLE
fix: consolidate post-1488 integration and warning coverage

### DIFF
--- a/apps/app/test/app/character-editor-regressions.test.tsx
+++ b/apps/app/test/app/character-editor-regressions.test.tsx
@@ -328,6 +328,88 @@ describe("CharacterEditor regressions", () => {
     expect(JSON.stringify(tree.toJSON())).toContain("Generation exploded");
   });
 
+  it("logs voice config load failures instead of swallowing them", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    clientMock.getConfig.mockRejectedValueOnce(new Error("config unavailable"));
+
+    let tree: TestRenderer.ReactTestRenderer | null = null;
+    await act(async () => {
+      tree = TestRenderer.create(React.createElement(CharacterEditor));
+    });
+
+    await flushEffects();
+
+    expect(tree).not.toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[CharacterEditor] Failed to load voice config:",
+      expect.objectContaining({ message: "config unavailable" }),
+    );
+  });
+
+  it("logs malformed style JSON instead of failing silently", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    clientMock.generateCharacterField.mockResolvedValue({
+      generated: "{not json",
+    });
+
+    let tree: TestRenderer.ReactTestRenderer | null = null;
+    await act(async () => {
+      tree = TestRenderer.create(React.createElement(CharacterEditor));
+    });
+
+    await flushEffects();
+    expect(tree).not.toBeNull();
+    if (!tree) {
+      throw new Error("expected CharacterEditor to render");
+    }
+
+    const root = tree.root;
+    const customizeBtn = root.find(
+      (node: TestRenderer.ReactTestInstance) =>
+        node.type === "button" &&
+        Array.isArray(node.children) &&
+        node.children.includes("Customize"),
+    );
+    await act(async () => {
+      customizeBtn.props.onClick();
+    });
+    await flushEffects();
+
+    const styleTab = root.find(
+      (node: TestRenderer.ReactTestInstance) =>
+        node.type === "button" &&
+        Array.isArray(node.children) &&
+        node.children.includes("Styles"),
+    );
+    await act(async () => {
+      styleTab.props.onClick();
+    });
+    await flushEffects();
+
+    const regenerateButtons = root.findAll(
+      (node: TestRenderer.ReactTestInstance) =>
+        node.type === "button" &&
+        Array.isArray(node.children) &&
+        (node.children.includes("Regenerate") ||
+          node.children.includes("charactereditor.Regenerate")),
+    );
+    const styleRegenerateButton = regenerateButtons.at(-1);
+    expect(styleRegenerateButton).toBeDefined();
+    if (!styleRegenerateButton) {
+      throw new Error("expected a style regenerate button");
+    }
+
+    await act(async () => {
+      await styleRegenerateButton.props.onClick();
+    });
+    await flushEffects();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[CharacterEditor] Failed to parse AI-generated style JSON:",
+      expect.any(Error),
+    );
+  });
+
   it("uses cached preview audio instead of triggering TTS generation", async () => {
     let createdAudio: {
       currentTime: number;

--- a/apps/app/test/plugins/swabble.test.ts
+++ b/apps/app/test/plugins/swabble.test.ts
@@ -132,21 +132,131 @@ describe("@miladyai/capacitor-swabble", () => {
   // by accessing the private wakeGate after a failed start stores the config.
 
   describe("WakeWordGate (pure logic)", () => {
-    // We need to reach the WakeWordGate. Since start() fails without SpeechRecognition,
-    // but still sets config and wakeGate before the API check, we can test it if we
-    // access the private field. Actually, looking at the source: start() returns early
-    // BEFORE setting wakeGate if SpeechRecognition is unavailable. So we export the
-    // class for testing... but it's not exported.
-    //
-    // The honest answer: WakeWordGate cannot be tested without either:
-    // (a) exporting it, or (b) mocking SpeechRecognition so start() succeeds.
-    // We document this gap here rather than pretending it's tested.
+    it("emits wakeWord events when final speech matches a configured trigger", async () => {
+      const originalSpeechRecognition = (
+        window as Window & { SpeechRecognition?: unknown }
+      ).SpeechRecognition;
+      const originalAudioContext = globalThis.AudioContext;
 
-    it("DOCUMENTED GAP: WakeWordGate.match() is pure logic that should be tested but requires either export or SpeechRecognition mock", () => {
-      // The gate normalizes triggers to lowercase, checks substring match,
-      // extracts command text after trigger, enforces minCommandLength,
-      // returns postGap=-1 on web. All untested.
-      expect(true).toBe(true); // placeholder acknowledging the gap
+      class MockSpeechRecognition extends EventTarget {
+        static instance: MockSpeechRecognition | null = null;
+
+        continuous = false;
+        interimResults = false;
+        lang = "en-US";
+        onstart: (() => void) | null = null;
+        onend: (() => void) | null = null;
+        onerror: ((event: { error: string }) => void) | null = null;
+        onresult:
+          | ((event: {
+              resultIndex: number;
+              results: {
+                length: number;
+                [index: number]: {
+                  isFinal: boolean;
+                  0: { transcript: string; confidence: number };
+                };
+              };
+            }) => void)
+          | null = null;
+
+        constructor() {
+          super();
+          MockSpeechRecognition.instance = this;
+        }
+
+        start() {
+          this.onstart?.();
+        }
+
+        stop() {
+          this.onend?.();
+        }
+
+        abort() {}
+      }
+
+      class MockAudioContext {
+        createAnalyser = vi.fn(() => ({
+          fftSize: 0,
+          frequencyBinCount: 32,
+          getByteFrequencyData: vi.fn((arr: Uint8Array) => arr.fill(0)),
+        }));
+
+        createMediaStreamSource = vi.fn(() => ({
+          connect: vi.fn(),
+        }));
+
+        close = vi.fn(async () => {});
+      }
+
+      Object.defineProperty(window, "SpeechRecognition", {
+        configurable: true,
+        value: MockSpeechRecognition,
+      });
+      Object.defineProperty(globalThis, "AudioContext", {
+        configurable: true,
+        value: MockAudioContext,
+      });
+      vi.spyOn(navigator.mediaDevices, "getUserMedia").mockResolvedValue({
+        getTracks: () => [],
+      } as unknown as MediaStream);
+
+      const notifySpy = vi.spyOn(
+        sw as unknown as {
+          notifyListeners: (eventName: string, payload: unknown) => void;
+        },
+        "notifyListeners",
+      );
+
+      const result = await sw.start({
+        config: {
+          triggers: ["hey milady"],
+          minCommandLength: 3,
+        },
+      });
+
+      expect(result.started).toBe(true);
+      expect(MockSpeechRecognition.instance).not.toBeNull();
+      MockSpeechRecognition.instance?.onresult?.({
+        resultIndex: 0,
+        results: {
+          length: 1,
+          0: {
+            isFinal: true,
+            0: {
+              transcript: "hey milady open settings",
+              confidence: 0.91,
+            },
+          },
+        },
+      });
+
+      expect(notifySpy).toHaveBeenCalledWith(
+        "wakeWord",
+        expect.objectContaining({
+          wakeWord: "hey milady",
+          command: "open settings",
+          postGap: -1,
+          transcript: "hey milady open settings",
+          confidence: 0.91,
+        }),
+      );
+
+      await sw.stop();
+
+      if (originalSpeechRecognition === undefined) {
+        Reflect.deleteProperty(window, "SpeechRecognition");
+      } else {
+        Object.defineProperty(window, "SpeechRecognition", {
+          configurable: true,
+          value: originalSpeechRecognition,
+        });
+      }
+      Object.defineProperty(globalThis, "AudioContext", {
+        configurable: true,
+        value: originalAudioContext,
+      });
     });
   });
 

--- a/packages/agent/src/api/cloud-compat-routes.ts
+++ b/packages/agent/src/api/cloud-compat-routes.ts
@@ -203,21 +203,23 @@ export async function handleCloudCompatRoute(
     }
 
     if (parsed.kind === "json") {
-      // Cloud API may not have all routes deployed yet. Return a friendlier
-      // message instead of a raw 404 so the dashboard can show "coming soon".
-      // TODO: Remove or refine this unconditional 404 intercept when Cloud
-      // goes to production — legitimate 404s (e.g. agent not found) will be
-      // incorrectly masked as "coming soon".
       if (upstreamRes.status === 404) {
-        sendJson(
-          res,
-          {
-            success: false,
-            error: "This Cloud feature is not available yet.",
-            code: "CLOUD_NOT_READY",
-          },
-          404,
-        );
+        const compatSegments = pathname.split("/").filter(Boolean);
+        const isResourcePath = compatSegments.length >= 5;
+
+        if (isResourcePath) {
+          sendJson(res, parsed.body, 404);
+        } else {
+          sendJson(
+            res,
+            {
+              success: false,
+              error: "This Cloud feature is not available yet.",
+              code: "CLOUD_NOT_READY",
+            },
+            404,
+          );
+        }
         return true;
       }
       sendJson(res, parsed.body, upstreamRes.status);

--- a/packages/agent/src/runtime/custom-actions.ts
+++ b/packages/agent/src/runtime/custom-actions.ts
@@ -16,7 +16,7 @@ import {
 import { request as requestHttps } from "node:https";
 import net from "node:net";
 import { Readable } from "node:stream";
-import type { Action, HandlerOptions, IAgentRuntime } from "@elizaos/core";
+import { type Action, type HandlerOptions, type IAgentRuntime, logger } from "@elizaos/core";
 import { loadElizaConfig } from "../config/config";
 import {
   resolveApiToken,
@@ -648,7 +648,12 @@ export function loadCustomActions(): Action[] {
     const config = loadElizaConfig();
     const defs = config.customActions ?? [];
     return defs.filter((d) => d.enabled).map(defToAction);
-  } catch {
+  } catch (err) {
+    logger.warn(
+      `[custom-actions] Failed to load custom actions from config: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
     return [];
   }
 }

--- a/packages/agent/src/services/registry-client.ts
+++ b/packages/agent/src/services/registry-client.ts
@@ -148,7 +148,12 @@ export function getConfiguredEndpoints(): RegistryEndpoint[] {
   try {
     const cfg = loadElizaConfig();
     return cfg.plugins?.registryEndpoints ?? [];
-  } catch {
+  } catch (err) {
+    logger.warn(
+      `[registry-client] Failed to load config for custom endpoints: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
     return [];
   }
 }

--- a/packages/agent/src/services/skill-marketplace.ts
+++ b/packages/agent/src/services/skill-marketplace.ts
@@ -350,7 +350,18 @@ async function readInstallRecords(
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
       return {};
     return parsed;
-  } catch {
+  } catch (err) {
+    const isMissingFile =
+      err instanceof Error &&
+      "code" in err &&
+      (err as NodeJS.ErrnoException).code === "ENOENT";
+    if (!isMissingFile) {
+      logger.warn(
+        `[skill-marketplace] Failed to read install records: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
     return {};
   }
 }

--- a/packages/agent/test/discord-connector.e2e.test.ts
+++ b/packages/agent/test/discord-connector.e2e.test.ts
@@ -192,24 +192,22 @@ describeIfPluginAvailable("Discord Connector - Setup & Authentication", () => {
     });
 
     it(
-      "successfully authenticates with Discord bot token",
+      "initializes the Discord runtime from the live bot token",
       async () => {
         expect(runtime).not.toBeNull();
         expect(process.env.DISCORD_BOT_TOKEN).toBeDefined();
-        // If runtime was created without throwing, authentication was successful
-        expect(true).toBe(true);
+        expect(runtime!.agentId).toBe(stringToUuid("discord-test-agent"));
+        expect(runtime!.character.name).toBe("TestBot");
       },
       TEST_TIMEOUT,
     );
 
     it(
-      "bot goes online after connection",
+      "retains the live test character after startup",
       async () => {
-        // This test validates that the bot successfully connects to Discord gateway
-        // In a real scenario, we would check the bot's online status
-        // For now, we verify that the runtime is initialized
         expect(runtime).not.toBeNull();
-        logger.info("[discord-connector] Bot connection test passed");
+        expect(runtime!.character).toBeDefined();
+        expect(runtime!.character.name).toBe("TestBot");
       },
       TEST_TIMEOUT,
     );
@@ -318,23 +316,18 @@ describe("Discord Connector - Integration", () => {
     expect(CONNECTOR_PLUGINS.discord).toBe("@elizaos/plugin-discord");
   });
 
-  it("Discord uses DISCORD_BOT_TOKEN environment variable", () => {
-    // Discord connector expects DISCORD_BOT_TOKEN env var
-    // This is documented in src/runtime/eliza.ts:135
-    const expectedEnvVar = "DISCORD_BOT_TOKEN";
-    expect(expectedEnvVar).toBe("DISCORD_BOT_TOKEN");
+  it("Discord auto-enable requires a token in config", async () => {
+    const { isConnectorConfigured } = await import(
+      "../src/config/plugin-auto-enable"
+    );
 
-    // Verify env var can be set and read
-    const originalValue = process.env.DISCORD_BOT_TOKEN;
-    process.env.DISCORD_BOT_TOKEN = "test-token-value";
-    expect(process.env.DISCORD_BOT_TOKEN).toBe("test-token-value");
-
-    // Restore original value
-    if (originalValue === undefined) {
-      delete process.env.DISCORD_BOT_TOKEN;
-    } else {
-      process.env.DISCORD_BOT_TOKEN = originalValue;
-    }
+    expect(isConnectorConfigured("discord", { enabled: true })).toBe(false);
+    expect(
+      isConnectorConfigured("discord", {
+        enabled: true,
+        token: "test-token-value",
+      }),
+    ).toBe(true);
   });
 
   it("Discord is included in connector list", async () => {
@@ -345,43 +338,40 @@ describe("Discord Connector - Integration", () => {
     expect(connectors).toContain("discord");
   });
 
-  it("Discord connector can be enabled/disabled via config", () => {
-    const config1 = { connectors: { discord: { enabled: true } } };
-    const config2 = { connectors: { discord: { enabled: false } } };
+  it("Discord connector can be enabled/disabled via config", async () => {
+    const { isConnectorConfigured } = await import(
+      "../src/config/plugin-auto-enable"
+    );
 
-    expect(config1.connectors.discord.enabled).toBe(true);
-    expect(config2.connectors.discord.enabled).toBe(false);
+    expect(
+      isConnectorConfigured("discord", { enabled: true, token: "t" }),
+    ).toBe(true);
+    expect(
+      isConnectorConfigured("discord", { enabled: false, token: "t" }),
+    ).toBe(false);
   });
 
-  it("Discord auto-enables when token is present in config", () => {
-    // Documented in src/config/plugin-auto-enable.ts
-    // Discord auto-enables when connectors.discord.token is set
-    const configWithToken = {
-      connectors: {
-        discord: {
-          enabled: true,
-          token: "test-token-123",
-        },
-      },
-    };
+  it("Discord auto-enables when token is present in config", async () => {
+    const { isConnectorConfigured } = await import(
+      "../src/config/plugin-auto-enable"
+    );
 
-    expect(configWithToken.connectors.discord.token).toBeDefined();
-    expect(configWithToken.connectors.discord.enabled).toBe(true);
+    expect(
+      isConnectorConfigured("discord", { token: "test-token-123" }),
+    ).toBe(true);
   });
 
-  it("Discord respects explicit disable even with token present", () => {
-    // Even if token exists, enabled: false should disable
-    const configDisabled = {
-      connectors: {
-        discord: {
-          enabled: false,
-          token: "test-token-123",
-        },
-      },
-    };
+  it("Discord respects explicit disable even with token present", async () => {
+    const { isConnectorConfigured } = await import(
+      "../src/config/plugin-auto-enable"
+    );
 
-    expect(configDisabled.connectors.discord.token).toBeDefined();
-    expect(configDisabled.connectors.discord.enabled).toBe(false);
+    expect(
+      isConnectorConfigured("discord", {
+        enabled: false,
+        token: "test-token-123",
+      }),
+    ).toBe(false);
   });
 });
 
@@ -390,74 +380,71 @@ describe("Discord Connector - Integration", () => {
 // ---------------------------------------------------------------------------
 
 describe("Discord Connector - Configuration", () => {
-  it("validates Discord configuration schema", async () => {
-    // Test configuration structure from zod-schema.providers-core.ts
-    const validConfig = {
+  it("validates Discord DM config via the real Zod schema", async () => {
+    const { DiscordDmSchema } = await import(
+      "../src/config/zod-schema.providers-core"
+    );
+    const result = DiscordDmSchema.safeParse({
       enabled: true,
-      token: "test-token",
-      dm: {
-        enabled: true,
-        policy: "pairing" as const,
-      },
-      guilds: {},
-      actions: {
-        reactions: true,
-        messages: true,
-      },
-    };
+      policy: "pairing",
+    });
 
-    expect(validConfig.enabled).toBe(true);
-    expect(validConfig.dm.policy).toBe("pairing");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.policy).toBe("pairing");
+    }
   });
 
-  it("supports multi-account configuration", async () => {
-    const multiAccountConfig = {
+  it("rejects invalid DM policy via the real Zod schema", async () => {
+    const { DiscordDmSchema } = await import(
+      "../src/config/zod-schema.providers-core"
+    );
+    const result = DiscordDmSchema.safeParse({
+      policy: "invalid-policy",
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("validates Discord account config via the real Zod schema", async () => {
+    const { DiscordAccountSchema } = await import(
+      "../src/config/zod-schema.providers-core"
+    );
+    const result = DiscordAccountSchema.safeParse({
       token: "main-token",
-      accounts: {
-        "main-bot": {
-          token: "bot-1-token",
-        },
-        "secondary-bot": {
-          token: "bot-2-token",
-        },
-      },
-    };
-
-    expect(multiAccountConfig.accounts).toBeDefined();
-    expect(Object.keys(multiAccountConfig.accounts)).toHaveLength(2);
-  });
-
-  it("validates message chunking configuration", async () => {
-    const chunkConfig = {
       maxLinesPerMessage: 17,
       textChunkLimit: 2000,
-      chunkMode: "length" as const,
-    };
+      chunkMode: "length",
+    });
 
-    expect(chunkConfig.maxLinesPerMessage).toBe(17);
-    expect(chunkConfig.textChunkLimit).toBe(2000);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.textChunkLimit).toBe(2000);
+      expect(result.data.chunkMode).toBe("length");
+    }
   });
 
-  it("validates PluralKit integration config", async () => {
-    const pluralkitConfig = {
-      pluralkit: {
-        enabled: true,
-        token: "pk-token-123",
-      },
-    };
+  it("validates Discord guild config via the real Zod schema", async () => {
+    const { DiscordGuildSchema } = await import(
+      "../src/config/zod-schema.providers-core"
+    );
+    const result = DiscordGuildSchema.safeParse({
+      requireMention: true,
+      reactionNotifications: "own",
+    });
 
-    expect(pluralkitConfig.pluralkit.enabled).toBe(true);
+    expect(result.success).toBe(true);
   });
 
-  it("validates privileged intents configuration", async () => {
-    const intentsConfig = {
-      intents: {
-        presence: true,
-        guildMembers: true,
-      },
-    };
+  it("rejects unknown fields in the strict guild channel schema", async () => {
+    const { DiscordGuildChannelSchema } = await import(
+      "../src/config/zod-schema.providers-core"
+    );
+    const result = DiscordGuildChannelSchema.safeParse({
+      allow: true,
+      bogusField: 123,
+    });
 
-    expect(intentsConfig.intents.presence).toBe(true);
-    expect(intentsConfig.intents.guildMembers).toBe(true);
+    expect(result.success).toBe(false);
   });
 });

--- a/packages/app-core/src/actions/__tests__/log-level.test.ts
+++ b/packages/app-core/src/actions/__tests__/log-level.test.ts
@@ -53,6 +53,22 @@ describe("logLevelAction", () => {
     );
   });
 
+  it("validate accepts explicit log level commands", async () => {
+    mockMessage.content.text = "Set log level to trace";
+
+    await expect(
+      logLevelAction.validate(mockRuntime as never, mockMessage as never),
+    ).resolves.toBe(true);
+  });
+
+  it("validate rejects unrelated messages that merely mention errors", async () => {
+    mockMessage.content.text = "I hit an error while syncing";
+
+    await expect(
+      logLevelAction.validate(mockRuntime as never, mockMessage as never),
+    ).resolves.toBe(false);
+  });
+
   it("should fail gracefully when invalid level provided", async () => {
     mockMessage.content.text = "/logLevel invalid_level";
 
@@ -71,6 +87,21 @@ describe("logLevelAction", () => {
         action: "LOG_LEVEL_FAILED",
       }),
     );
+  });
+
+  it("should not match partial words when extracting levels", async () => {
+    mockMessage.content.text = "Set log level to informational";
+
+    const result = await logLevelAction.handler(
+      mockRuntime,
+      mockMessage,
+      undefined,
+      undefined,
+      mockCallback,
+    );
+
+    expect(result.success).toBe(false);
+    expect(mockRuntime.logLevelOverrides.has("test-room-id")).toBe(false);
   });
 
   it("should fail if runtime does not support overrides (missing map)", async () => {

--- a/packages/app-core/src/actions/actions.test.ts
+++ b/packages/app-core/src/actions/actions.test.ts
@@ -8,8 +8,17 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const { loggerWarnMock } = vi.hoisted(() => ({
+  loggerWarnMock: vi.fn(),
+}));
+
 vi.mock("@elizaos/core", () => ({
-  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+  logger: {
+    info: vi.fn(),
+    warn: loggerWarnMock,
+    debug: vi.fn(),
+    error: vi.fn(),
+  },
 }));
 
 vi.mock("@miladyai/agent/config/config", () => {
@@ -166,6 +175,9 @@ describe("loadCustomActions", () => {
     });
     const actions = loadCustomActions();
     expect(actions).toEqual([]);
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      "[custom-actions] Failed to load custom actions from config: config corrupted",
+    );
   });
 });
 

--- a/packages/app-core/src/actions/log-level.ts
+++ b/packages/app-core/src/actions/log-level.ts
@@ -18,8 +18,19 @@ export const logLevelAction: Action = {
   ],
   description:
     "Set the log level for the current session (trace, debug, info, warn, error).",
-  validate: async (_runtime: IAgentRuntime, _message: Memory) => {
-    return true;
+  validate: async (_runtime: IAgentRuntime, message: Memory) => {
+    const text = (message.content.text || "").toLowerCase();
+    const hasLevel = /\b(trace|debug|info|warn|error)\b/.test(text);
+    if (!hasLevel) {
+      return false;
+    }
+
+    return (
+      /\/loglevel\b/.test(text) ||
+      /\blog(?:ging)?\s+level\b/.test(text) ||
+      (/\b(set|change|switch)\b/.test(text) &&
+        /\b(log(?:ging)?|verbosity)\b/.test(text))
+    );
   },
   handler: async (
     runtime: IAgentRuntime,
@@ -29,10 +40,12 @@ export const logLevelAction: Action = {
     callback?: HandlerCallback,
   ): Promise<import("@elizaos/core").ActionResult> => {
     const text = (message.content.text || "").toLowerCase();
-    const levels = ["trace", "debug", "info", "warn", "error"];
+    const levels = ["trace", "debug", "info", "warn", "error"] as const;
 
     // Extract level from text
-    const level = levels.find((l) => text.includes(l));
+    const level = levels.find((candidate) =>
+      new RegExp(`\\b${candidate}\\b`).test(text),
+    );
 
     if (!level) {
       if (callback) {

--- a/packages/app-core/src/api/__tests__/client-coding-agent-fallback.test.ts
+++ b/packages/app-core/src/api/__tests__/client-coding-agent-fallback.test.ts
@@ -4,8 +4,9 @@
  * the CodingAgentSession format consumed by the UI.
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
+  MiladyClient,
   type RawPtySession,
   mapPtySessionsToCodingAgentSessions,
 } from "../client";
@@ -121,5 +122,27 @@ describe("mapPtySessionsToCodingAgentSessions", () => {
     expect(result[0].originalTask).toBe("");
     expect(result[0].decisionCount).toBe(0);
     expect(result[0].autoResolvedCount).toBe(0);
+  });
+});
+
+describe("MiladyClient.listCodingAgentScratchWorkspaces", () => {
+  it("warns and falls back to an empty list when the request fails", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const client = new MiladyClient("http://127.0.0.1:31337");
+    const fetchSpy = vi.spyOn(
+      client as unknown as {
+        fetch: (path: string, init?: RequestInit) => Promise<unknown>;
+      },
+      "fetch",
+    );
+    fetchSpy.mockRejectedValueOnce(new Error("network down"));
+
+    await expect(client.listCodingAgentScratchWorkspaces()).resolves.toEqual(
+      [],
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[api-client] Failed to list coding agent scratch workspaces:",
+      expect.objectContaining({ message: "network down" }),
+    );
   });
 });

--- a/packages/app-core/src/api/client.ts
+++ b/packages/app-core/src/api/client.ts
@@ -5614,7 +5614,11 @@ export class MiladyClient {
       return await this.fetch<CodingAgentScratchWorkspace[]>(
         "/api/coding-agents/scratch",
       );
-    } catch {
+    } catch (err) {
+      console.warn(
+        "[api-client] Failed to list coding agent scratch workspaces:",
+        err,
+      );
       return [];
     }
   }

--- a/packages/app-core/src/api/cloud-compat-routes.test.ts
+++ b/packages/app-core/src/api/cloud-compat-routes.test.ts
@@ -287,6 +287,30 @@ describe("cloud-compat-routes", () => {
       );
     });
 
+    it("preserves upstream 404 bodies for resource-specific compat routes", async () => {
+      const mockBody = {
+        success: false,
+        error: "Agent not found",
+        code: "AGENT_NOT_FOUND",
+      };
+      const mockResponse = new Response(JSON.stringify(mockBody), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+      vi.mocked(fetch).mockResolvedValue(mockResponse);
+
+      const result = await handleCloudCompatRoute(
+        makeReq({ url: "/api/cloud/compat/agents/abc-123/status" }),
+        makeRes(),
+        "/api/cloud/compat/agents/abc-123/status",
+        "GET",
+        makeState(),
+      );
+
+      expect(result).toBe(true);
+      expect(sendJson).toHaveBeenCalledWith(expect.anything(), mockBody, 404);
+    });
+
     it("retries once on 503 response", async () => {
       const response503 = new Response(
         JSON.stringify({ success: false, error: "Service Unavailable" }),

--- a/packages/app-core/src/components/CharacterEditor.tsx
+++ b/packages/app-core/src/components/CharacterEditor.tsx
@@ -659,7 +659,9 @@ export function CharacterEditor({
             setSelectedVoicePresetId(preset?.id ?? null);
           }
         }
-      } catch {}
+      } catch (err) {
+        console.warn("[CharacterEditor] Failed to load voice config:", err);
+      }
       setVoiceLoading(false);
     })();
   }, []);
@@ -1077,7 +1079,12 @@ export function CharacterEditor({
               if (parsed.chat) handleStyleEdit("chat", parsed.chat.join("\n"));
               if (parsed.post) handleStyleEdit("post", parsed.post.join("\n"));
             }
-          } catch {}
+          } catch (err) {
+            console.warn(
+              "[CharacterEditor] Failed to parse AI-generated style JSON:",
+              err,
+            );
+          }
         } else if (field === "chatExamples") {
           const formatted = normalizeCharacterMessageExamples(
             generated,
@@ -1099,7 +1106,12 @@ export function CharacterEditor({
                 handleCharacterArrayInput("postExamples", parsed.join("\n"));
               }
             }
-          } catch {}
+          } catch (err) {
+            console.warn(
+              "[CharacterEditor] Failed to parse AI-generated postExamples JSON:",
+              err,
+            );
+          }
         }
       } catch (err) {
         const msg = err instanceof Error ? err.message : "Generation failed";

--- a/packages/app-core/src/services/registry-client.config-warning.test.ts
+++ b/packages/app-core/src/services/registry-client.config-warning.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { loadElizaConfigMock, loggerWarnMock } = vi.hoisted(() => ({
+  loadElizaConfigMock: vi.fn(),
+  loggerWarnMock: vi.fn(),
+}));
+
+vi.mock("@miladyai/agent/config/config", () => ({
+  loadElizaConfig: loadElizaConfigMock,
+}));
+
+vi.mock("@elizaos/core", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@elizaos/core")>()),
+  logger: {
+    info: vi.fn(),
+    warn: loggerWarnMock,
+    debug: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { getConfiguredEndpoints } from "@miladyai/agent/services/registry-client";
+
+describe("registry-client config warning", () => {
+  beforeEach(() => {
+    loadElizaConfigMock.mockReset();
+    loggerWarnMock.mockReset();
+  });
+
+  it("warns and falls back to an empty endpoint list when config loading fails", () => {
+    loadElizaConfigMock.mockImplementation(() => {
+      throw new Error("config corrupted");
+    });
+
+    expect(getConfiguredEndpoints()).toEqual([]);
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      "[registry-client] Failed to load config for custom endpoints: config corrupted",
+    );
+  });
+});

--- a/packages/app-core/src/services/skill-marketplace.test.ts
+++ b/packages/app-core/src/services/skill-marketplace.test.ts
@@ -13,6 +13,10 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const { loggerWarnMock } = vi.hoisted(() => ({
+  loggerWarnMock: vi.fn(),
+}));
+
 import {
   type InstalledMarketplaceSkill,
   installMarketplaceSkill,
@@ -26,7 +30,12 @@ import {
 // ---------------------------------------------------------------------------
 
 vi.mock("@elizaos/core", () => ({
-  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+  logger: {
+    info: vi.fn(),
+    warn: loggerWarnMock,
+    debug: vi.fn(),
+    error: vi.fn(),
+  },
 }));
 
 // ---------------------------------------------------------------------------
@@ -99,6 +108,7 @@ beforeEach(async () => {
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "skill-mp-test-"));
   delete process.env.SKILLSMP_API_KEY;
   delete process.env.SKILLS_REGISTRY;
+  loggerWarnMock.mockReset();
 });
 
 afterEach(async () => {
@@ -572,6 +582,7 @@ describe("listInstalledMarketplaceSkills", () => {
     const result = await listInstalledMarketplaceSkills(tmpDir);
 
     expect(result).toEqual([]);
+    expect(loggerWarnMock).not.toHaveBeenCalled();
   });
 
   it("returns skills sorted by installedAt descending", async () => {
@@ -604,6 +615,11 @@ describe("listInstalledMarketplaceSkills", () => {
     const result = await listInstalledMarketplaceSkills(tmpDir);
 
     expect(result).toEqual([]);
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "[skill-marketplace] Failed to read install records:",
+      ),
+    );
   });
 
   it("returns empty array when records file contains an array instead of an object", async () => {


### PR DESCRIPTION
## Summary
- replace vacuous Discord assertions and placeholder Swabble coverage with real runtime/helper checks
- surface previously swallowed failures in CharacterEditor, config loaders, and coding-agent scratch workspace listing
- tighten cloud-compat 404 handling and log-level validation so behavior matches actual Milady routes and action intent

## Why
- several PRs after `#1488` were directionally useful, but they either stayed too shallow, over-matched user input, or skipped the coverage needed to merge cleanly
- consolidating the valid parts into one branch removes duplicate review churn and gives the repo one tested replacement instead of a pile of partially correct PRs

## Validation
- `bunx vitest run packages/agent/test/discord-connector.e2e.test.ts packages/app-core/src/api/cloud-compat-routes.test.ts packages/app-core/src/actions/actions.test.ts packages/app-core/src/actions/__tests__/log-level.test.ts packages/app-core/src/services/skill-marketplace.test.ts packages/app-core/src/api/__tests__/client-coding-agent-fallback.test.ts packages/app-core/src/services/registry-client.config-warning.test.ts`
- `bunx vitest run --config .tmp-vitest-app-tests.config.ts`
- `bun run check`
