### PR TITLE
docs: fix references to non-existent CLI subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,8 @@ milady --debug            # enable debug-level runtime logs
 milady setup              # first-time setup / refresh workspace after update
 milady configure          # interactive config wizard
 milady config get <key>   # read a config value
-milady config set <k> <v> # set a config value
+milady config path        # print resolved config file path
+milady config show        # display all config values grouped by section
 ```
 
 ### Dashboard & UI
@@ -323,8 +324,6 @@ milady dashboard --port 3000  # custom port
 
 ```bash
 milady models             # list configured model providers
-milady models add         # add a new provider
-milady models test        # test if your API keys work
 ```
 
 ### Plugins

--- a/docs/model-providers.mdx
+++ b/docs/model-providers.mdx
@@ -143,8 +143,6 @@ When using the config file approach, your API keys are stored in plaintext in `m
 
 ```bash
 milady models             # list configured model providers and their status
-milady models add         # add a new provider interactively
-milady models test        # test if your API keys are valid
 milady configure          # interactive config wizard (includes provider setup)
 ```
 

--- a/docs/plugin-registry/secrets-manager.md
+++ b/docs/plugin-registry/secrets-manager.md
@@ -26,7 +26,9 @@ Navigate to **Agent → Settings → Secrets** and add key-value pairs.
 ### Via the CLI
 
 ```bash
-milady config set secrets.OPENAI_API_KEY sk-...
+# Open the config file in your editor
+$EDITOR "$(milady config path)"
+# Add the key under the "secrets" section
 ```
 
 ### Via Configuration File

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -108,10 +108,10 @@ Enable or disable a plugin by setting its `enabled` flag in `milady.json`:
 }
 ```
 
-Or use the config command:
+Or edit the config file directly (`milady config path` shows the file location):
 
 ```bash
-milady config set plugins.entries.browser.enabled true
+$EDITOR "$(milady config path)"
 ```
 
 ### Eject (Copy to Local)

--- a/docs/self-updates.mdx
+++ b/docs/self-updates.mdx
@@ -354,8 +354,9 @@ To pin Milady to a specific version and prevent automatic updates:
 # Install a specific version
 npm install -g miladyai@2.0.0-alpha.26
 
-# Disable automatic update checks
-milady config set update.checkOnStart false
+# Disable automatic update checks by editing milady.json
+# Set "update": { "checkOnStart": false } in your config file
+$EDITOR "$(milady config path)"
 ```
 
 For package-manager-specific pinning:
@@ -438,10 +439,11 @@ For fully air-gapped deployments, disable the update check entirely:
 }
 ```
 
-Or set via the CLI:
+Or set via the CLI (open config in your editor):
 
 ```bash
-milady config set update.checkOnStart false
+$EDITOR "$(milady config path)"
+# Set "update": { "checkOnStart": false }
 ```
 
 To perform offline updates, download the package tarball on a connected machine and install it locally:


### PR DESCRIPTION
`milady config set`, `milady models add`, and `milady models test` do not exist in the source. Replace with accurate alternatives (config path/show, editor-based workflows).

https://claude.ai/code/session_01SLgmTop4uZt7vypRr9uCoV

This PR will be reviewed by an AI agent. Provide clear context to help it assess your changes.

Aesthetic/UI changes that don't improve agent capability are out of scope and will be rejected.

## Category
- [ ] Bug fix
- [ ] Security fix
- [ ] Performance improvement
- [ ] New feature
- [ ] Documentation
- [ ] Test coverage
- [ ] Other

## What
(brief description)

## Why
(motivation)

## How
(implementation approach)

## Testing
(what was tested, how to verify)
