### PR TITLE
fix: serialize onboarding restart flow

### DIFF
--- a/packages/app-core/src/state/AppContext.tsx
+++ b/packages/app-core/src/state/AppContext.tsx
@@ -124,6 +124,7 @@ import {
   resolveOnboardingPreviousStep,
 } from "../onboarding/flow";
 import { buildOnboardingConnectionConfig } from "../onboarding-config";
+import { restartAgentAfterOnboarding } from "./onboarding-restart";
 import {
   alertDesktopMessage,
   confirmDesktopAction,
@@ -5540,7 +5541,7 @@ function AppProviderInner({
           }
 
           setOnboardingHandoffPhase("restarting");
-          setAgentStatus(await client.restartAgent());
+          setAgentStatus(await restartAgentAfterOnboarding(client));
           setOnboardingHandoffPhase("bootstrapping");
           await bootstrapConversationAfterAgentReady(
             "onboarding:cloud_fast_track",
@@ -5735,7 +5736,7 @@ function AppProviderInner({
         }
 
         setOnboardingHandoffPhase("restarting");
-        setAgentStatus(await client.restartAgent());
+        setAgentStatus(await restartAgentAfterOnboarding(client));
         setOnboardingHandoffPhase("bootstrapping");
         await bootstrapConversationAfterAgentReady("onboarding:full_finish", {
           forceFreshConversation: true,

--- a/packages/app-core/src/state/onboarding-restart.test.ts
+++ b/packages/app-core/src/state/onboarding-restart.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { restartAgentAfterOnboarding } from "./onboarding-restart";
+
+describe("restartAgentAfterOnboarding", () => {
+  it("uses the waitable restart path with the onboarding timeout", async () => {
+    const status = {
+      state: "running",
+      agentName: "Momo",
+      model: "moonshotai/kimi-k2-0905",
+      startedAt: 123,
+      uptime: 456,
+    } as const;
+    const client = {
+      restartAndWait: vi.fn(async (maxWaitMs: number) => {
+        expect(maxWaitMs).toBe(120_000);
+        return status;
+      }),
+    };
+
+    await expect(restartAgentAfterOnboarding(client)).resolves.toEqual(status);
+    expect(client.restartAndWait).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards a custom timeout when explicitly requested", async () => {
+    const client = {
+      restartAndWait: vi.fn(async () => ({
+        state: "running",
+        agentName: "Momo",
+      })),
+    };
+
+    await restartAgentAfterOnboarding(client, 30_000);
+    expect(client.restartAndWait).toHaveBeenCalledWith(30_000);
+  });
+});

--- a/packages/app-core/src/state/onboarding-restart.ts
+++ b/packages/app-core/src/state/onboarding-restart.ts
@@ -1,0 +1,13 @@
+import type { AgentStatus, MiladyClient } from "../api";
+
+/**
+ * Onboarding can overlap a runtime restart already in flight on slower boots.
+ * Use the waitable restart path so "already restarting" is treated as
+ * recoverable rather than surfacing a setup failure.
+ */
+export async function restartAgentAfterOnboarding(
+  client: Pick<MiladyClient, "restartAndWait">,
+  maxWaitMs = 120_000,
+): Promise<AgentStatus> {
+  return client.restartAndWait(maxWaitMs);
+}


### PR DESCRIPTION
## Summary
- replace onboarding raw restart calls with the waitable restart path
- apply onboarding finish/restart guards to the cloud fast-track path too
- add a regression test for the onboarding restart helper

## Problem
Some Windows users hit a setup failure during onboarding with:

> A restart is already in progress

The onboarding flow could issue a direct /api/agent/restart while another restart was already underway. On slower boots this surfaced as a setup failure instead of waiting for the existing restart to finish.

## Fix
- use estartAndWait(120000) for onboarding restart handoff so an in-flight restart is treated as waitable
- serialize the cloud fast-track onboarding path with the same in-progress guards as the standard onboarding path
- extract the onboarding restart handoff into a small helper with regression coverage

## Validation
- unx tsc --noEmit
- unx vitest run packages/app-core/src/state/onboarding-restart.test.ts packages/app-core/src/api/agent-admin-routes.test.ts
