### PR TITLE
fix(patch-deps): use correct root variable in patchGroqSdkVersion

### DIFF
--- a/scripts/patch-deps.mjs
+++ b/scripts/patch-deps.mjs
@@ -1260,10 +1260,10 @@ patchTestCafeBunCompat();
  *    so the plugin uses the compatible version.
  */
 function patchGroqSdkVersion() {
-  const rootGroq = resolve(ROOT, "node_modules", "@ai-sdk", "groq");
+  const rootGroq = resolve(root, "node_modules", "@ai-sdk", "groq");
   if (!existsSync(rootGroq)) return;
 
-  const bunDir = resolve(ROOT, "node_modules", ".bun");
+  const bunDir = resolve(root, "node_modules", ".bun");
   if (!existsSync(bunDir)) return;
 
   let patched = 0;


### PR DESCRIPTION
## Summary
- `patchGroqSdkVersion()` in `scripts/patch-deps.mjs` referenced `ROOT` (undefined) instead of the file-scoped `root` variable, causing `bun install` to crash with `ReferenceError: ROOT is not defined` during postinstall.

## Test plan
- [x] `bun install` completes successfully after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)