### PR TITLE
test(benchmark): add eval harness, perf budgets, and coverage infrastructure

### DIFF
--- a/.github/workflows/benchmark-tests.yml
+++ b/.github/workflows/benchmark-tests.yml
@@ -8,12 +8,18 @@ on:
   push:
     branches: [main, develop]
     paths:
-      - "src/benchmark/**"
+      - "packages/app-core/src/benchmark/**"
+      - "test/eval/**"
+      - "test/perf-budget.test.ts"
+      - "test/perf-baselines.json"
       - ".github/workflows/benchmark-tests.yml"
   pull_request:
     branches: [main, develop]
     paths:
-      - "src/benchmark/**"
+      - "packages/app-core/src/benchmark/**"
+      - "test/eval/**"
+      - "test/perf-budget.test.ts"
+      - "test/perf-baselines.json"
       - ".github/workflows/benchmark-tests.yml"
   workflow_dispatch:
 
@@ -29,9 +35,13 @@ jobs:
       matrix:
         include:
           - lane: benchmark-tests
-            command: bunx vitest run src/benchmark/*.test.ts
+            command: bunx vitest run packages/app-core/src/benchmark/*.test.ts
+          - lane: benchmark-eval
+            command: MILADY_EVAL_TEST=1 bunx vitest run test/eval/**/*.test.ts
+          - lane: benchmark-perf
+            command: MILADY_PERF_TEST=1 bunx vitest run test/perf-budget.test.ts
           - lane: benchmark-lint
-            command: bunx @biomejs/biome check src/benchmark
+            command: bunx @biomejs/biome check packages/app-core/src/benchmark
 
     steps:
       - name: Checkout repository

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,3 +138,5 @@ All `@elizaos/*` packages use the `alpha` dist-tag. When developing locally, `bu
 | `MILADY_CAPTURE_PROMPTS` | Dump raw prompts to `.tmp/prompt-captures/` (dev-only, contains user messages) | `0` |
 | `MILADY_ACTION_COMPACTION` | Context-aware action param stripping | `1` (enabled) |
 | `MILADY_PROMPT_OPT_MODE` | Prompt optimization mode (`baseline` or `compact`) | `baseline` |
+| `MILADY_EVAL_TEST` | Run benchmark eval harness tests (`test/eval/`). Set to `1` to enable. Also runs in the `benchmark-eval` CI lane. | `0` |
+| `MILADY_PERF_TEST` | Run benchmark performance budget tests (`test/perf-budget.test.ts`). Set to `1` to enable. Also runs in the `benchmark-perf` CI lane. | `0` |

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "test:desktop:playwright:windows": "cd apps/app && bunx playwright test --config playwright.electrobun.packaged.config.ts test/electrobun-packaged/electrobun-windows-startup.e2e.spec.ts",
     "test:e2e": "bunx vitest run --config vitest.e2e.config.ts --exclude packages/agent/test/anvil-contracts.e2e.test.ts --exclude packages/agent/test/apps-e2e.e2e.test.ts",
     "test:e2e:heavy": "bunx vitest run --config vitest.e2e.config.ts packages/agent/test/anvil-contracts.e2e.test.ts packages/agent/test/apps-e2e.e2e.test.ts",
-    "test:e2e:validation": "bunx vitest run --config vitest.e2e.config.ts test/e2e-validation.e2e.test.ts",
+    "test:e2e:validation": "bunx vitest run --config vitest.e2e.config.ts packages/agent/test/e2e-validation.e2e.test.ts",
     "test:e2e:coding-agents": "bunx vitest run --config vitest.e2e.config.ts packages/agent/test/agent-orchestration.e2e.test.ts packages/agent/test/coding-agent-route-readiness.e2e.test.ts packages/agent/test/coding-agent-codex-artifact.e2e.test.ts packages/agent/test/coding-agent-chat-roundtrip.e2e.test.ts",
     "test:force": "node --import tsx test/scripts/test-force.ts",
     "test:live:cloud": "node scripts/run-with-env.mjs MILADY_LIVE_TEST=1 -- bunx vitest run --config vitest.live-e2e.config.ts packages/agent/test/cloud-providers.e2e.test.ts",

--- a/packages/app-core/src/benchmark/README.md
+++ b/packages/app-core/src/benchmark/README.md
@@ -32,7 +32,7 @@ The Python client side can live in a local adapter directory such as `benchmarks
 npm run benchmark:server
 
 # or directly
-node --import tsx src/benchmark/server.ts
+node --import tsx packages/app-core/src/benchmark/server.ts
 ```
 
 The server prints `MILADY_BENCH_READY port=<port>` when ready.
@@ -40,8 +40,8 @@ The server prints `MILADY_BENCH_READY port=<port>` when ready.
 ## Testing
 
 ```bash
-# benchmark-focused unit tests
-bunx vitest run src/benchmark/*.test.ts
+# benchmark-focused unit tests (from repo root)
+bunx vitest run packages/app-core/src/benchmark/*.test.ts
 
 # watch a live benchmark smoke run end-to-end
 bun run benchmark:watch
@@ -50,7 +50,7 @@ bun run benchmark:watch
 CUA_HOST=localhost:8000 OPENAI_API_KEY=sk-... CUA_COMPUTER_USE_MODEL=computer-use-preview bun run benchmark:cua:watch
 
 # see the full benchmark testing/checklist protocol
-cat src/benchmark/TESTING_PROTOCOL.md
+cat packages/app-core/src/benchmark/TESTING_PROTOCOL.md
 ```
 
 ## HTTP API

--- a/packages/app-core/src/benchmark/TESTING_PROTOCOL.md
+++ b/packages/app-core/src/benchmark/TESTING_PROTOCOL.md
@@ -1,6 +1,6 @@
 # Milady Benchmark Testing Protocol
 
-This protocol defines benchmark-focused tests for Milady's benchmark bridge (`src/benchmark/`).
+This protocol defines benchmark-focused tests for Milady's benchmark bridge (`packages/app-core/src/benchmark/`).
 
 ## Scope
 
@@ -16,10 +16,10 @@ Covers:
 From the repository root:
 
 ```bash
-bunx vitest run src/benchmark/*.test.ts
+bunx vitest run packages/app-core/src/benchmark/*.test.ts
 ```
 
-This runs all benchmark unit tests in `src/benchmark/*.test.ts`.
+This runs all benchmark unit tests in `packages/app-core/src/benchmark/*.test.ts`.
 
 For a watchable execution run:
 
@@ -64,7 +64,7 @@ These validate the underlying benchmark action/runner contracts we align Milady 
 Run Milady benchmark server with deterministic mock behavior:
 
 ```bash
-MILADY_BENCH_MOCK=true node --import tsx src/benchmark/server.ts
+MILADY_BENCH_MOCK=true node --import tsx packages/app-core/src/benchmark/server.ts
 ```
 
 Then probe:

--- a/packages/app-core/src/benchmark/compute-streaming-delta.test.ts
+++ b/packages/app-core/src/benchmark/compute-streaming-delta.test.ts
@@ -80,7 +80,9 @@ describe("computeStreamingDelta benchmark coverage", () => {
       };
     });
 
-    console.info("[benchmark] computeStreamingDelta", results);
+    if (process.env.MILADY_PERF_TEST === "1") {
+      console.info("[benchmark] computeStreamingDelta", results);
+    }
 
     for (const result of results) {
       expect(result.legacyMs).toBeGreaterThan(0);

--- a/packages/app-core/src/benchmark/plugin.ts
+++ b/packages/app-core/src/benchmark/plugin.ts
@@ -355,7 +355,7 @@ export function createBenchmarkPlugin(): Plugin {
             }
           }
 
-          console.log("[BENCHMARK_ACTION] params:", JSON.stringify(params));
+          logger.debug("[BENCHMARK_ACTION] params:", JSON.stringify(params));
 
           _capturedAction = {
             command:

--- a/scripts/ci-workflow-audit.test.ts
+++ b/scripts/ci-workflow-audit.test.ts
@@ -98,4 +98,35 @@ describe("CI workflow audit regressions", () => {
     expect(content).toMatch(/trust-scoring\.cjs/);
     expect(content).toMatch(/release-tracker/);
   });
+
+  it("benchmark-tests.yml targets packages/app-core/src/benchmark (not root src/benchmark)", () => {
+    const content = readWorkflow("benchmark-tests.yml");
+    expect(content).toContain("packages/app-core/src/benchmark/");
+    expect(content).toMatch(
+      /bunx vitest run packages\/app-core\/src\/benchmark\/\*\.test\.ts/,
+    );
+    expect(content).toMatch(
+      /bunx @biomejs\/biome check packages\/app-core\/src\/benchmark/,
+    );
+    expect(content).not.toMatch(/paths:\s*\n\s*- "src\/benchmark/);
+  });
+
+  it("benchmark-tests.yml runs eval and perf test lanes with env vars", () => {
+    const content = readWorkflow("benchmark-tests.yml");
+    expect(content).toContain("MILADY_EVAL_TEST=1");
+    expect(content).toMatch(
+      /MILADY_EVAL_TEST=1 bunx vitest run test\/eval\/\*\*\/\*\.test\.ts/,
+    );
+    expect(content).toContain("MILADY_PERF_TEST=1");
+    expect(content).toMatch(
+      /MILADY_PERF_TEST=1 bunx vitest run test\/perf-budget\.test\.ts/,
+    );
+  });
+
+  it("benchmark-tests.yml triggers on test/eval and test/perf changes", () => {
+    const content = readWorkflow("benchmark-tests.yml");
+    expect(content).toContain('"test/eval/**"');
+    expect(content).toContain('"test/perf-budget.test.ts"');
+    expect(content).toContain('"test/perf-baselines.json"');
+  });
 });

--- a/scripts/coverage-policy-drift.test.ts
+++ b/scripts/coverage-policy-drift.test.ts
@@ -3,7 +3,12 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   coverageDocReferences,
+  coverageSurfaceGlobs,
+  coverageSurfaceOverrides,
   coverageThresholds,
+  formatCompactCoverageThresholds,
+  formatCoverageThresholdSentence,
+  getThresholdsForSurface,
 } from "./coverage-policy.mjs";
 
 /**
@@ -86,5 +91,177 @@ describe("MW-01 — coverage policy drift detection", () => {
     expect(packageJson.scripts?.["test:coverage"]).toContain(
       "node scripts/report-coverage-surfaces.mjs",
     );
+  });
+});
+
+describe("coverage policy — getThresholdsForSurface", () => {
+  it("returns surface-specific overrides for packages/agent", () => {
+    const thresholds = getThresholdsForSurface("packages/agent");
+    expect(thresholds.lines).toBe(
+      coverageSurfaceOverrides["packages/agent"].lines,
+    );
+    expect(thresholds.functions).toBe(
+      coverageSurfaceOverrides["packages/agent"].functions,
+    );
+    expect(thresholds.statements).toBe(
+      coverageSurfaceOverrides["packages/agent"].statements,
+    );
+    expect(thresholds.branches).toBe(
+      coverageSurfaceOverrides["packages/agent"].branches,
+    );
+  });
+
+  it("returns surface-specific overrides for packages/app-core", () => {
+    const thresholds = getThresholdsForSurface("packages/app-core");
+    expect(thresholds.lines).toBe(
+      coverageSurfaceOverrides["packages/app-core"].lines,
+    );
+    expect(thresholds.branches).toBe(
+      coverageSurfaceOverrides["packages/app-core"].branches,
+    );
+  });
+
+  it("returns global defaults for surfaces without overrides", () => {
+    const thresholds = getThresholdsForSurface("apps/app/electrobun");
+    expect(thresholds).toBe(coverageThresholds);
+  });
+
+  it("returns global defaults for unknown surface names", () => {
+    const thresholds = getThresholdsForSurface("nonexistent/package");
+    expect(thresholds).toBe(coverageThresholds);
+  });
+
+  it("overrides are strictly higher than global defaults", () => {
+    for (const [surface, override] of Object.entries(
+      coverageSurfaceOverrides,
+    )) {
+      for (const [metric, value] of Object.entries(override)) {
+        const globalValue =
+          coverageThresholds[metric as keyof typeof coverageThresholds];
+        expect(
+          value,
+          `${surface}.${metric} override (${value}) should be >= global (${globalValue})`,
+        ).toBeGreaterThanOrEqual(globalValue);
+      }
+    }
+  });
+
+  it("merged result always contains every metric from global defaults", () => {
+    const globalKeys = Object.keys(coverageThresholds);
+    for (const surface of Object.keys(coverageSurfaceOverrides)) {
+      const merged = getThresholdsForSurface(surface);
+      for (const key of globalKeys) {
+        expect(
+          merged,
+          `Merged thresholds for "${surface}" must contain "${key}"`,
+        ).toHaveProperty(key);
+        expect(typeof (merged as Record<string, unknown>)[key]).toBe("number");
+      }
+    }
+  });
+
+  it("merged result for overridden surface is a new object (not a reference to globals)", () => {
+    for (const surface of Object.keys(coverageSurfaceOverrides)) {
+      const merged = getThresholdsForSurface(surface);
+      expect(merged).not.toBe(coverageThresholds);
+    }
+  });
+});
+
+describe("coverage policy — coverageSurfaceOverrides structure", () => {
+  it("only overrides surfaces that exist in coverageSurfaceGlobs", () => {
+    const validSurfaces = Object.keys(coverageSurfaceGlobs);
+    for (const surface of Object.keys(coverageSurfaceOverrides)) {
+      expect(
+        validSurfaces,
+        `Override surface "${surface}" must exist in coverageSurfaceGlobs`,
+      ).toContain(surface);
+    }
+  });
+
+  it("override keys are a subset of threshold metric keys", () => {
+    const validMetrics = Object.keys(coverageThresholds);
+    for (const [surface, override] of Object.entries(
+      coverageSurfaceOverrides,
+    )) {
+      for (const metric of Object.keys(override)) {
+        expect(
+          validMetrics,
+          `${surface} override metric "${metric}" must be a valid threshold key`,
+        ).toContain(metric);
+      }
+    }
+  });
+
+  it("override values are positive numbers", () => {
+    for (const [surface, override] of Object.entries(
+      coverageSurfaceOverrides,
+    )) {
+      for (const [metric, value] of Object.entries(override)) {
+        expect(typeof value).toBe("number");
+        expect(
+          value,
+          `${surface}.${metric} must be positive`,
+        ).toBeGreaterThan(0);
+        expect(value, `${surface}.${metric} must be <= 100`).toBeLessThanOrEqual(
+          100,
+        );
+      }
+    }
+  });
+});
+
+describe("coverage policy — formatter functions", () => {
+  it("formatCompactCoverageThresholds produces expected format", () => {
+    const result = formatCompactCoverageThresholds();
+    expect(result).toBe(
+      `${coverageThresholds.lines}% lines/functions/statements, ${coverageThresholds.branches}% branches`,
+    );
+  });
+
+  it("formatCoverageThresholdSentence produces expected format", () => {
+    const result = formatCoverageThresholdSentence();
+    expect(result).toBe(
+      `${coverageThresholds.lines}% for lines, functions, and statements, and ${coverageThresholds.branches}% for branches`,
+    );
+  });
+
+  it("formatter output matches doc extraction regex", () => {
+    const compact = formatCompactCoverageThresholds();
+    const match = compact.match(COMPACT_RE);
+    expect(match).not.toBeNull();
+    expect(Number(match![1])).toBe(coverageThresholds.lines);
+    expect(Number(match![2])).toBe(coverageThresholds.branches);
+  });
+});
+
+describe("coverage policy — report-coverage-surfaces.mjs source-level checks", () => {
+  it("report-coverage-surfaces.mjs imports getThresholdsForSurface", () => {
+    const scriptSrc = fs.readFileSync(
+      path.join(ROOT, "scripts/report-coverage-surfaces.mjs"),
+      "utf8",
+    );
+    expect(scriptSrc).toContain("getThresholdsForSurface");
+    expect(scriptSrc).toContain("coverageSurfaceGlobs");
+  });
+
+  it("report-coverage-surfaces.mjs uses per-surface thresholds", () => {
+    const scriptSrc = fs.readFileSync(
+      path.join(ROOT, "scripts/report-coverage-surfaces.mjs"),
+      "utf8",
+    );
+    expect(scriptSrc).toContain("getThresholdsForSurface(surface.surface)");
+    expect(scriptSrc).toContain("surface override");
+  });
+
+  it("coverageSurfaceGlobs entries match existing directories", () => {
+    for (const [surface, globs] of Object.entries(coverageSurfaceGlobs)) {
+      const surfacePath = path.join(ROOT, surface);
+      expect(
+        fs.existsSync(surfacePath),
+        `Surface directory "${surface}" must exist`,
+      ).toBe(true);
+      expect(globs.length).toBeGreaterThan(0);
+    }
   });
 });

--- a/scripts/coverage-policy.mjs
+++ b/scripts/coverage-policy.mjs
@@ -5,6 +5,26 @@ export const coverageThresholds = Object.freeze({
   branches: 15,
 });
 
+/**
+ * Per-surface overrides. Surfaces listed here are held to stricter thresholds
+ * than the global defaults. Any metric key not specified falls back to
+ * `coverageThresholds`.
+ */
+export const coverageSurfaceOverrides = Object.freeze({
+  "packages/agent": Object.freeze({
+    lines: 35,
+    functions: 35,
+    statements: 35,
+    branches: 20,
+  }),
+  "packages/app-core": Object.freeze({
+    lines: 30,
+    functions: 30,
+    statements: 30,
+    branches: 18,
+  }),
+});
+
 export const coverageSummaryReporters = Object.freeze([
   "text",
   "json-summary",
@@ -26,6 +46,16 @@ export const coverageSurfaceGlobs = Object.freeze({
   "apps/app/electrobun": ["apps/app/electrobun/src/**/*.ts"],
   "packages/shared": ["packages/shared/src/**/*.ts"],
 });
+
+/**
+ * Returns the effective thresholds for a given surface, merging any
+ * per-surface overrides on top of the global defaults.
+ */
+export function getThresholdsForSurface(surface) {
+  const override = coverageSurfaceOverrides[surface];
+  if (!override) return coverageThresholds;
+  return { ...coverageThresholds, ...override };
+}
 
 export function formatCompactCoverageThresholds() {
   return `${coverageThresholds.lines}% lines/functions/statements, ${coverageThresholds.branches}% branches`;

--- a/scripts/report-coverage-surfaces.mjs
+++ b/scripts/report-coverage-surfaces.mjs
@@ -4,6 +4,7 @@ import path from "node:path";
 import {
   coverageSurfaceGlobs,
   coverageThresholds,
+  getThresholdsForSurface,
 } from "./coverage-policy.mjs";
 
 const ROOT = path.resolve(import.meta.dirname, "..");
@@ -102,11 +103,12 @@ for (const surface of surfaces) {
 
   console.log(line);
 
-  for (const [metric, threshold] of Object.entries(coverageThresholds)) {
+  const effectiveThresholds = getThresholdsForSurface(surface.surface);
+  for (const [metric, threshold] of Object.entries(effectiveThresholds)) {
     const actual = percentage(surface.metrics[metric]);
     if (actual < threshold) {
       failures.push(
-        `${surface.surface} ${metric} coverage ${actual}% is below ${threshold}%`,
+        `${surface.surface} ${metric} coverage ${actual}% is below ${threshold}% (${effectiveThresholds === coverageThresholds ? "global" : "surface override"})`,
       );
     }
   }

--- a/test/eval/eval-harness.test.ts
+++ b/test/eval/eval-harness.test.ts
@@ -1,0 +1,1380 @@
+/**
+ * Agent benchmark evaluation harness.
+ *
+ * Validates the benchmark bridge contract by running golden prompts through
+ * the plugin + server-utils pipeline and checking structural expectations:
+ *
+ *   - Provider output shape (text contains expected sections, values are correct)
+ *   - Prompt composition (input text + context assembly)
+ *   - Action validation (BENCHMARK_ACTION gate honors context presence)
+ *   - Context normalization (field aliasing, session metadata injection)
+ *   - Params coercion (JSON and XML parsing)
+ *   - Captured action → params conversion
+ *
+ * Uses the deterministic mock plugin for model responses — no LLM API keys needed.
+ * Gated behind MILADY_EVAL_TEST=1.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  BENCHMARK_MESSAGE_TEMPLATE,
+  type BenchmarkContext,
+  clearCapturedAction,
+  createBenchmarkPlugin,
+  getBenchmarkContext,
+  getCapturedAction,
+  setBenchmarkContext,
+} from "../../packages/app-core/src/benchmark/plugin";
+import { mockPlugin } from "../../packages/app-core/src/benchmark/mock-plugin-base";
+import {
+  capturedActionToParams,
+  coerceActions,
+  coerceParams,
+  compactCuaResult,
+  compactCuaStep,
+  composeBenchmarkPrompt,
+  createSession,
+  envFlag,
+  extractBenchmarkName,
+  extractRecord,
+  extractTaskId,
+  formatUnknownError,
+  isRecord,
+  normalizeBenchmarkContext,
+  parseBooleanValue,
+  resolveHost,
+  resolvePort,
+  sessionKey,
+  toPlugin,
+} from "../../packages/app-core/src/benchmark/server-utils";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+interface PromptExpectations {
+  provider_contains?: string[];
+  provider_values?: Record<string, unknown>;
+  provider_empty?: boolean;
+  prompt_contains?: string[];
+  action_validates?: boolean;
+}
+
+interface GoldenPrompt {
+  id: string;
+  benchmark: string;
+  taskId: string;
+  input: string;
+  context: Record<string, unknown>;
+  expectations: PromptExpectations;
+}
+
+interface GoldenPromptsFile {
+  version: number;
+  prompts: GoldenPrompt[];
+}
+
+const promptsPath = path.join(__dirname, "golden-prompts.json");
+const promptsFile: GoldenPromptsFile = JSON.parse(
+  fs.readFileSync(promptsPath, "utf8"),
+);
+
+const enabled = process.env.MILADY_EVAL_TEST === "1";
+
+describe.skipIf(!enabled)("benchmark eval harness", () => {
+  const plugin = createBenchmarkPlugin();
+  const provider = plugin.providers?.find((p) => p.name === "ELIZA_BENCHMARK");
+  const action = plugin.actions?.find((a) => a.name === "BENCHMARK_ACTION");
+
+  if (!provider?.get || !action?.handler || !action.validate) {
+    throw new Error("Benchmark plugin missing required provider or action");
+  }
+
+  afterEach(() => {
+    clearCapturedAction();
+    setBenchmarkContext(null);
+  });
+
+  describe("golden prompt provider contracts", () => {
+    for (const prompt of promptsFile.prompts) {
+      it(`${prompt.id}: provider output matches expectations`, async () => {
+        const ctx: BenchmarkContext = {
+          benchmark: prompt.benchmark,
+          taskId: prompt.taskId,
+          ...prompt.context,
+        };
+
+        if (prompt.expectations.provider_empty) {
+          setBenchmarkContext(null);
+          const result = await provider.get(
+            {} as never,
+            {} as never,
+            {} as never,
+          );
+          expect(result.text).toBe("");
+          expect(result.values).toEqual({});
+          return;
+        }
+
+        setBenchmarkContext(ctx);
+        const result = await provider.get(
+          {} as never,
+          {} as never,
+          {} as never,
+        );
+
+        if (prompt.expectations.provider_contains) {
+          for (const expected of prompt.expectations.provider_contains) {
+            expect(result.text).toContain(expected);
+          }
+        }
+
+        if (prompt.expectations.provider_values) {
+          for (const [key, value] of Object.entries(
+            prompt.expectations.provider_values,
+          )) {
+            expect((result.values as Record<string, unknown>)[key]).toEqual(
+              value,
+            );
+          }
+        }
+
+        expect(result.data).toHaveProperty("benchmarkContext");
+        const returnedCtx = (result.data as { benchmarkContext: unknown })
+          .benchmarkContext as Record<string, unknown>;
+        expect(returnedCtx.benchmark).toBe(prompt.benchmark);
+        expect(returnedCtx.taskId).toBe(prompt.taskId);
+      });
+    }
+  });
+
+  describe("golden prompt composition contracts", () => {
+    for (const prompt of promptsFile.prompts) {
+      it(`${prompt.id}: composed prompt includes input and context`, () => {
+        const composed = composeBenchmarkPrompt({
+          text: prompt.input,
+          context:
+            Object.keys(prompt.context).length > 0
+              ? prompt.context
+              : undefined,
+        });
+
+        if (prompt.expectations.prompt_contains) {
+          for (const expected of prompt.expectations.prompt_contains) {
+            expect(composed).toContain(expected);
+          }
+        }
+
+        expect(composed).toContain(prompt.input);
+
+        if (Object.keys(prompt.context).length > 0) {
+          expect(composed).toContain("BENCHMARK CONTEXT (authoritative):");
+        }
+
+        expect(composed).toContain(
+          "Respond using normal Eliza action output",
+        );
+      });
+    }
+  });
+
+  describe("golden prompt action validation contracts", () => {
+    for (const prompt of promptsFile.prompts) {
+      it(`${prompt.id}: action validates=${prompt.expectations.action_validates}`, async () => {
+        if (prompt.expectations.action_validates) {
+          setBenchmarkContext({
+            benchmark: prompt.benchmark,
+            taskId: prompt.taskId,
+            ...prompt.context,
+          });
+          const valid = await action.validate({} as never);
+          expect(valid).toBe(true);
+        } else {
+          setBenchmarkContext(null);
+          const valid = await action.validate({} as never);
+          expect(valid).toBe(false);
+        }
+      });
+    }
+  });
+
+  describe("context normalization contracts", () => {
+    it("normalizes action_space to actionSpace", () => {
+      const session = createSession("task-1", "agentbench");
+      const context = {
+        action_space: ["search[q]", "click[id]"],
+        goal: "test goal",
+      };
+      const normalized = normalizeBenchmarkContext(session, context);
+      expect(normalized.actionSpace).toEqual(["search[q]", "click[id]"]);
+      expect(normalized.benchmark).toBe("agentbench");
+      expect(normalized.taskId).toBe("task-1");
+    });
+
+    it("preserves existing actionSpace over action_space", () => {
+      const session = createSession("task-2", "tau-bench");
+      const context = {
+        actionSpace: ["existing"],
+        action_space: ["should-not-override"],
+      };
+      const normalized = normalizeBenchmarkContext(session, context);
+      expect(normalized.actionSpace).toEqual(["existing"]);
+    });
+
+    it("injects session metadata into normalized context", () => {
+      const session = createSession("task-3", "mind2web");
+      const context = { goal: "Click checkout" };
+      const normalized = normalizeBenchmarkContext(session, context);
+      expect(normalized.benchmark).toBe("mind2web");
+      expect(normalized.taskId).toBe("task-3");
+      expect(normalized.task_id).toBe("task-3");
+    });
+  });
+
+  describe("session lifecycle contracts", () => {
+    it("createSession produces unique IDs per call", () => {
+      const s1 = createSession("task-1", "agentbench");
+      const s2 = createSession("task-1", "agentbench");
+      expect(s1.roomId).not.toBe(s2.roomId);
+      expect(s1.relayRoomId).not.toBe(s2.relayRoomId);
+      expect(s1.userEntityId).not.toBe(s2.userEntityId);
+    });
+
+    it("sessionKey is deterministic for same benchmark:taskId", () => {
+      const s1 = createSession("task-x", "bench-y");
+      const s2 = createSession("task-x", "bench-y");
+      expect(sessionKey(s1)).toBe(sessionKey(s2));
+      expect(sessionKey(s1)).toBe("bench-y:task-x");
+    });
+
+    it("normalizes empty taskId and benchmark", () => {
+      const session = createSession("", "");
+      expect(session.taskId).toBe("default-task");
+      expect(session.benchmark).toBe("unknown");
+    });
+  });
+
+  describe("params coercion contracts", () => {
+    it("coerces JSON object passthrough", () => {
+      const obj = { command: "search[laptop]" };
+      expect(coerceParams(obj)).toEqual(obj);
+    });
+
+    it("coerces JSON string to object", () => {
+      const result = coerceParams('{"command":"search[laptop]"}');
+      expect(result).toEqual({ command: "search[laptop]" });
+    });
+
+    it("coerces XML string to nested object", () => {
+      const xml = [
+        "<BENCHMARK_ACTION>",
+        "<operation>CLICK</operation>",
+        "<element_id>42</element_id>",
+        "<value></value>",
+        "</BENCHMARK_ACTION>",
+      ].join("\n");
+      const result = coerceParams(xml);
+      expect(result).toHaveProperty("BENCHMARK_ACTION");
+      const inner = result.BENCHMARK_ACTION as Record<string, unknown>;
+      expect(inner.operation).toBe("CLICK");
+      expect(inner.element_id).toBe("42");
+    });
+
+    it("returns empty object for non-parseable string", () => {
+      expect(coerceParams("just plain text")).toEqual({});
+    });
+
+    it("returns empty object for arrays", () => {
+      expect(coerceParams(["a", "b"])).toEqual({});
+    });
+
+    it("returns empty object for null/undefined", () => {
+      expect(coerceParams(null)).toEqual({});
+      expect(coerceParams(undefined)).toEqual({});
+    });
+  });
+
+  describe("action capture → params conversion contracts", () => {
+    it("converts command-style capture", () => {
+      const result = capturedActionToParams({
+        command: "search[laptop under $500]",
+      });
+      expect(result).toEqual({
+        BENCHMARK_ACTION: { command: "search[laptop under $500]" },
+      });
+    });
+
+    it("converts tool-call capture", () => {
+      const result = capturedActionToParams({
+        toolName: "lookup_order",
+        arguments: { order_id: "A-123" },
+      });
+      expect(result).toEqual({
+        BENCHMARK_ACTION: {
+          tool_name: "lookup_order",
+          arguments: { order_id: "A-123" },
+        },
+      });
+    });
+
+    it("converts mind2web capture", () => {
+      const result = capturedActionToParams({
+        operation: "CLICK",
+        elementId: "42",
+        value: "",
+      });
+      // Empty string value is falsy, so capturedActionToParams omits it
+      expect(result).toEqual({
+        BENCHMARK_ACTION: {
+          operation: "CLICK",
+          element_id: "42",
+        },
+      });
+    });
+
+    it("converts mind2web capture with non-empty value", () => {
+      const result = capturedActionToParams({
+        operation: "TYPE",
+        elementId: "input-1",
+        value: "laptop under $500",
+      });
+      expect(result).toEqual({
+        BENCHMARK_ACTION: {
+          operation: "TYPE",
+          element_id: "input-1",
+          value: "laptop under $500",
+        },
+      });
+    });
+
+    it("returns empty for null capture", () => {
+      expect(capturedActionToParams(null)).toEqual({});
+    });
+
+    it("returns empty for capture with no fields set", () => {
+      expect(capturedActionToParams({})).toEqual({});
+    });
+  });
+
+  describe("actions coercion contracts", () => {
+    it("passes through string arrays", () => {
+      expect(coerceActions(["BENCHMARK_ACTION", "REPLY"])).toEqual([
+        "BENCHMARK_ACTION",
+        "REPLY",
+      ]);
+    });
+
+    it("filters non-string entries", () => {
+      expect(coerceActions(["BENCHMARK_ACTION", 42, null, "REPLY"])).toEqual([
+        "BENCHMARK_ACTION",
+        "REPLY",
+      ]);
+    });
+
+    it("returns empty for non-arrays", () => {
+      expect(coerceActions("BENCHMARK_ACTION")).toEqual([]);
+      expect(coerceActions(null)).toEqual([]);
+      expect(coerceActions(undefined)).toEqual([]);
+    });
+  });
+
+  describe("mock plugin deterministic model contract", () => {
+    let callTextLarge: (prompt: unknown) => Promise<string>;
+
+    beforeAll(() => {
+      expect(mockPlugin.models).toBeDefined();
+      expect(mockPlugin.models?.TEXT_LARGE).toBeDefined();
+      expect(typeof mockPlugin.models?.TEXT_LARGE).toBe("function");
+      const handler = mockPlugin.models!.TEXT_LARGE as (
+        runtime: unknown,
+        params: unknown,
+      ) => Promise<string>;
+      callTextLarge = (prompt: unknown) => handler({}, { prompt });
+    });
+
+    it("responds with RESPOND for shouldRespond prompts", async () => {
+      const result = await callTextLarge(
+        "Should you respond? Options: RESPOND | IGNORE | STOP. Pick one.",
+      );
+      expect(result).toContain("RESPOND");
+    });
+
+    it("responds with isFinish for finish-check prompts", async () => {
+      const result = await callTextLarge(
+        "Is this conversation finished? <isFinish>true | false</isFinish>",
+      );
+      expect(result).toContain("isFinish");
+      expect(result).toContain("true");
+    });
+
+    it("responds with BENCHMARK_ACTION XML for benchmark prompts", async () => {
+      const result = await callTextLarge(
+        "Execute the benchmark task. Use BENCHMARK_ACTION.",
+      );
+      expect(result).toContain("<actions>BENCHMARK_ACTION</actions>");
+      expect(result).toContain("<operation>CLICK</operation>");
+      expect(result).toContain("<element_id>10</element_id>");
+      expect(result).toContain("<tool_name>ui.click</tool_name>");
+    });
+
+    it("extracts embedded codes from prompt into response", async () => {
+      const testUuid = "12345678-1234-1234-1234-123456789abc";
+      const result = await callTextLarge(
+        `initial code: ${testUuid}\nmiddle code: ${testUuid}\nend code: ${testUuid}`,
+      );
+      expect(result).toContain(`<one_initial_code>${testUuid}</one_initial_code>`);
+      expect(result).toContain(`<one_middle_code>${testUuid}</one_middle_code>`);
+      expect(result).toContain(`<one_end_code>${testUuid}</one_end_code>`);
+    });
+
+    it("falls back to DEFAULT_CODE when prompt has no matching UUID", async () => {
+      const defaultCode = "00000000-0000-0000-0000-000000000000";
+      const result = await callTextLarge(
+        "Some prompt without any code labels",
+      );
+      expect(result).toContain(
+        `<one_initial_code>${defaultCode}</one_initial_code>`,
+      );
+      expect(result).toContain(
+        `<one_middle_code>${defaultCode}</one_middle_code>`,
+      );
+      expect(result).toContain(
+        `<one_end_code>${defaultCode}</one_end_code>`,
+      );
+    });
+
+    it("handles non-string prompt by stringifying", async () => {
+      const result = await callTextLarge({ nested: "object" });
+      expect(typeof result).toBe("string");
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it("handles null/undefined prompt", async () => {
+      const result = await callTextLarge(undefined);
+      expect(typeof result).toBe("string");
+    });
+
+    it("shouldRespond branch takes priority over benchmark XML", async () => {
+      const result = await callTextLarge(
+        "RESPOND | IGNORE | STOP — also has BENCHMARK_ACTION",
+      );
+      expect(result).toContain("<action>RESPOND</action>");
+      expect(result).not.toContain("<actions>BENCHMARK_ACTION</actions>");
+    });
+  });
+
+  describe("BENCHMARK_ACTION handler contracts", () => {
+    it("captures command-style params and stores via getCapturedAction", async () => {
+      setBenchmarkContext({ benchmark: "agentbench", taskId: "handler-1" });
+      const result = await action.handler(
+        {} as never,
+        {} as never,
+        undefined as never,
+        { parameters: { command: "search[laptop]" } },
+      );
+      const captured = getCapturedAction();
+      expect(captured).not.toBeNull();
+      expect(captured?.command).toBe("search[laptop]");
+      expect(captured?.toolName).toBeUndefined();
+      expect(result).toHaveProperty("text");
+      expect(result).toHaveProperty("success", true);
+      expect(result).toHaveProperty("values");
+      expect((result as { values: { captured: boolean } }).values.captured).toBe(true);
+      expect(result).toHaveProperty("data");
+      expect((result as { data: { action: unknown } }).data.action).toEqual(captured);
+    });
+
+    it("captures tool-call params with valid JSON arguments", async () => {
+      setBenchmarkContext({ benchmark: "tau-bench", taskId: "handler-2" });
+      await action.handler({} as never, {} as never, undefined as never, {
+        parameters: {
+          tool_name: "lookup_order",
+          arguments: '{"order_id":"A-123"}',
+        },
+      });
+      const captured = getCapturedAction();
+      expect(captured?.toolName).toBe("lookup_order");
+      expect(captured?.arguments).toEqual({ order_id: "A-123" });
+    });
+
+    it("captures tool-call with invalid JSON as _raw fallback", async () => {
+      setBenchmarkContext({ benchmark: "tau-bench", taskId: "handler-3" });
+      await action.handler({} as never, {} as never, undefined as never, {
+        parameters: {
+          tool_name: "broken_tool",
+          arguments: "{not valid json}",
+        },
+      });
+      const captured = getCapturedAction();
+      expect(captured?.toolName).toBe("broken_tool");
+      expect(captured?.arguments).toEqual({ _raw: "{not valid json}" });
+    });
+
+    it("captures arguments as object when not a string", async () => {
+      setBenchmarkContext({ benchmark: "tau-bench", taskId: "handler-4" });
+      const argObj = { order_id: "B-456", status: "pending" };
+      await action.handler({} as never, {} as never, undefined as never, {
+        parameters: { tool_name: "check_status", arguments: argObj },
+      });
+      const captured = getCapturedAction();
+      expect(captured?.arguments).toEqual(argObj);
+    });
+
+    it("captures mind2web operation/element_id/value", async () => {
+      setBenchmarkContext({ benchmark: "mind2web", taskId: "handler-5" });
+      await action.handler({} as never, {} as never, undefined as never, {
+        parameters: {
+          operation: "TYPE",
+          element_id: "input-42",
+          value: "hello world",
+        },
+      });
+      const captured = getCapturedAction();
+      expect(captured?.operation).toBe("TYPE");
+      expect(captured?.elementId).toBe("input-42");
+      expect(captured?.value).toBe("hello world");
+    });
+
+    it("handles protobuf Struct-style fields extraction", async () => {
+      setBenchmarkContext({ benchmark: "mind2web", taskId: "handler-6" });
+      await action.handler({} as never, {} as never, undefined as never, {
+        parameters: {
+          fields: {
+            operation: { stringValue: "SELECT" },
+            element_id: { stringValue: "dropdown-1" },
+            value: { stringValue: "Option A" },
+          },
+        },
+      });
+      const captured = getCapturedAction();
+      expect(captured?.operation).toBe("SELECT");
+      expect(captured?.elementId).toBe("dropdown-1");
+      expect(captured?.value).toBe("Option A");
+    });
+
+    it("handles empty/missing options gracefully", async () => {
+      setBenchmarkContext({ benchmark: "agentbench", taskId: "handler-7" });
+      await action.handler(
+        {} as never,
+        {} as never,
+        undefined as never,
+        undefined as never,
+      );
+      const captured = getCapturedAction();
+      expect(captured).not.toBeNull();
+      expect(captured?.command).toBeUndefined();
+      expect(captured?.toolName).toBeUndefined();
+    });
+
+    it("clearCapturedAction resets to null", async () => {
+      setBenchmarkContext({ benchmark: "agentbench", taskId: "handler-8" });
+      await action.handler({} as never, {} as never, undefined as never, {
+        parameters: { command: "test" },
+      });
+      expect(getCapturedAction()).not.toBeNull();
+      clearCapturedAction();
+      expect(getCapturedAction()).toBeNull();
+    });
+  });
+
+  describe("getBenchmarkContext / setBenchmarkContext state contracts", () => {
+    it("returns null when no context is set", () => {
+      setBenchmarkContext(null);
+      expect(getBenchmarkContext()).toBeNull();
+    });
+
+    it("returns the set context object", () => {
+      const ctx: BenchmarkContext = {
+        benchmark: "test",
+        taskId: "state-1",
+        goal: "verify state",
+      };
+      setBenchmarkContext(ctx);
+      expect(getBenchmarkContext()).toBe(ctx);
+    });
+
+    it("overwrites previous context", () => {
+      setBenchmarkContext({ benchmark: "first", taskId: "1" });
+      const second: BenchmarkContext = { benchmark: "second", taskId: "2" };
+      setBenchmarkContext(second);
+      expect(getBenchmarkContext()).toBe(second);
+    });
+  });
+
+  describe("BENCHMARK_MESSAGE_TEMPLATE contract", () => {
+    it("contains required response format sections", () => {
+      expect(BENCHMARK_MESSAGE_TEMPLATE).toContain("BENCHMARK_ACTION");
+      expect(BENCHMARK_MESSAGE_TEMPLATE).toContain("{{agentName}}");
+      expect(BENCHMARK_MESSAGE_TEMPLATE).toContain("{{providers}}");
+      expect(BENCHMARK_MESSAGE_TEMPLATE).toContain("AgentBench");
+      expect(BENCHMARK_MESSAGE_TEMPLATE).toContain("tau-bench");
+      expect(BENCHMARK_MESSAGE_TEMPLATE).toContain("mind2web");
+    });
+
+    it("requires BENCHMARK_ACTION for action benchmarks", () => {
+      expect(BENCHMARK_MESSAGE_TEMPLATE).toContain(
+        "Always use BENCHMARK_ACTION",
+      );
+      expect(BENCHMARK_MESSAGE_TEMPLATE).toContain(
+        "Never use REPLY for benchmarks that need tool/command execution",
+      );
+    });
+  });
+
+  describe("plugin structural contracts", () => {
+    it("plugin has expected name and description", () => {
+      expect(plugin.name).toBe("eliza-benchmark");
+      expect(plugin.description).toContain("Benchmark adapter");
+    });
+
+    it("provider has correct metadata", () => {
+      expect(provider.name).toBe("ELIZA_BENCHMARK");
+      expect(provider.description).toContain("benchmark task context");
+      expect((provider as { dynamic?: boolean }).dynamic).toBe(true);
+      expect((provider as { position?: number }).position).toBe(-10);
+    });
+
+    it("action has similes covering common benchmark verbs", () => {
+      const benchAction = plugin.actions?.find(
+        (a) => a.name === "BENCHMARK_ACTION",
+      );
+      const similes = benchAction?.similes ?? [];
+      expect(similes).toContain("SEARCH");
+      expect(similes).toContain("CLICK");
+      expect(similes).toContain("CALL_TOOL");
+      expect(similes).toContain("SQL");
+      expect(similes).toContain("TYPE");
+      expect(similes).toContain("SELECT");
+    });
+
+    it("action has parameter definitions for all benchmark types", () => {
+      const benchAction = plugin.actions?.find(
+        (a) => a.name === "BENCHMARK_ACTION",
+      );
+      const paramNames = (
+        benchAction?.parameters as Array<{ name: string }>
+      )?.map((p) => p.name);
+      expect(paramNames).toContain("command");
+      expect(paramNames).toContain("tool_name");
+      expect(paramNames).toContain("arguments");
+      expect(paramNames).toContain("operation");
+      expect(paramNames).toContain("element_id");
+      expect(paramNames).toContain("value");
+    });
+  });
+
+  describe("provider formatContextAsText edge cases", () => {
+    it("truncates HTML longer than 3000 characters", async () => {
+      const longHtml = "<div>" + "x".repeat(4000) + "</div>";
+      setBenchmarkContext({
+        benchmark: "mind2web",
+        taskId: "long-html",
+        html: longHtml,
+      });
+      const result = await provider.get({} as never, {} as never, {} as never);
+      expect(result.text).toContain("Page HTML");
+      expect(result.text).toContain("...");
+      expect(result.text).not.toContain(longHtml);
+    });
+
+    it("limits elements to first 15", async () => {
+      const elements = Array.from({ length: 20 }, (_, i) => ({
+        backend_node_id: String(i),
+        tag: "div",
+        text_content: `Element ${i}`,
+      }));
+      setBenchmarkContext({
+        benchmark: "mind2web",
+        taskId: "many-elements",
+        elements,
+      });
+      const result = await provider.get({} as never, {} as never, {} as never);
+      expect(result.text).toContain("Element 14");
+      expect(result.text).not.toContain("Element 15");
+    });
+
+    it("handles elements missing backend_node_id gracefully", async () => {
+      setBenchmarkContext({
+        benchmark: "mind2web",
+        taskId: "no-id",
+        elements: [{ tag: "button", text_content: "Click me" }],
+      });
+      const result = await provider.get({} as never, {} as never, {} as never);
+      expect(result.text).toContain("[?]");
+      expect(result.text).toContain("<button");
+    });
+
+    it("handles tool entries with missing fields", async () => {
+      setBenchmarkContext({
+        benchmark: "tau-bench",
+        taskId: "sparse-tools",
+        tools: [{ name: "minimal_tool" }, {}],
+      });
+      const result = await provider.get({} as never, {} as never, {} as never);
+      expect(result.text).toContain("minimal_tool");
+      expect(result.text).toContain("unknown");
+    });
+
+    it("renders observation as string when it is a string", async () => {
+      setBenchmarkContext({
+        benchmark: "agentbench",
+        taskId: "string-obs",
+        observation: "mysql> SELECT 1;",
+      });
+      const result = await provider.get({} as never, {} as never, {} as never);
+      expect(result.text).toContain("Current Observation");
+      expect(result.text).toContain("mysql> SELECT 1;");
+    });
+
+    it("renders question section for context-bench", async () => {
+      setBenchmarkContext({
+        benchmark: "context-bench",
+        taskId: "question-1",
+        question: "What is the meaning of life?",
+      });
+      const result = await provider.get({} as never, {} as never, {} as never);
+      expect(result.text).toContain("## Question");
+      expect(result.text).toContain("What is the meaning of life?");
+    });
+
+    it("renders empty actionSpace without Available Actions section", async () => {
+      setBenchmarkContext({
+        benchmark: "agentbench",
+        taskId: "empty-actions",
+        actionSpace: [],
+      });
+      const result = await provider.get({} as never, {} as never, {} as never);
+      expect(result.text).not.toContain("Available Actions");
+    });
+
+    it("generates tau-bench instructions when tools are present", async () => {
+      setBenchmarkContext({
+        benchmark: "tau-bench",
+        taskId: "tau-instructions",
+        tools: [{ name: "t1", description: "Tool 1" }],
+      });
+      const result = await provider.get({} as never, {} as never, {} as never);
+      expect(result.text).toContain("customer service agent");
+      expect(result.text).toContain("MUST use the available tools");
+    });
+
+    it("generates generic instructions when no tools are present", async () => {
+      setBenchmarkContext({
+        benchmark: "agentbench",
+        taskId: "generic-instructions",
+        goal: "Do something",
+      });
+      const result = await provider.get({} as never, {} as never, {} as never);
+      expect(result.text).toContain("Analyze the above context");
+      expect(result.text).not.toContain("customer service agent");
+    });
+  });
+
+  describe("integration: normalization → provider pipeline", () => {
+    it("normalized context with action_space renders in provider output", async () => {
+      const session = createSession("integration-1", "agentbench");
+      const rawContext = {
+        goal: "Buy a laptop",
+        action_space: ["search[q]", "click[id]"],
+      };
+      const normalized = normalizeBenchmarkContext(session, rawContext);
+      setBenchmarkContext(normalized);
+      const result = await provider.get({} as never, {} as never, {} as never);
+      expect(result.text).toContain("agentbench");
+      expect(result.text).toContain("integration-1");
+      expect(result.text).toContain("Buy a laptop");
+      expect(result.text).toContain("Available Actions");
+      expect(result.text).toContain("search[q]");
+    });
+
+    it("composed prompt feeds into mock model and produces parseable XML", async () => {
+      const composed = composeBenchmarkPrompt({
+        text: "Find laptop deals",
+        context: { benchmark: "agentbench", taskId: "integration-2" },
+      });
+      const handler = mockPlugin.models!.TEXT_LARGE as (
+        runtime: unknown,
+        params: unknown,
+      ) => Promise<string>;
+      const modelOutput = await handler({}, { prompt: composed });
+      // Mock model wraps in <response>; coerceParams parses outer XML level
+      const parsedParams = coerceParams(modelOutput);
+      expect(parsedParams).toHaveProperty("response");
+      const response = parsedParams.response as Record<string, unknown>;
+      expect(response).toHaveProperty("actions", "BENCHMARK_ACTION");
+      expect(response).toHaveProperty("thought");
+
+      // The inner params contain the BENCHMARK_ACTION nested XML
+      const innerParams = coerceParams(response.params as string);
+      expect(innerParams).toHaveProperty("BENCHMARK_ACTION");
+      const benchAction = innerParams.BENCHMARK_ACTION as Record<
+        string,
+        unknown
+      >;
+      expect(benchAction).toHaveProperty("operation", "CLICK");
+      expect(benchAction).toHaveProperty("element_id", "10");
+    });
+
+    it("handler output feeds into capturedActionToParams correctly", async () => {
+      setBenchmarkContext({ benchmark: "agentbench", taskId: "integration-3" });
+      clearCapturedAction();
+      await action.handler({} as never, {} as never, undefined as never, {
+        parameters: { command: "buy[item-42]" },
+      });
+      const captured = getCapturedAction();
+      const params = capturedActionToParams(captured);
+      expect(params).toEqual({
+        BENCHMARK_ACTION: { command: "buy[item-42]" },
+      });
+    });
+  });
+
+  describe("compactCuaStep contracts", () => {
+    it("wraps non-record input", () => {
+      expect(compactCuaStep("not-an-object", false)).toEqual({
+        step: "not-an-object",
+      });
+      expect(compactCuaStep(42, true)).toEqual({ step: 42 });
+      expect(compactCuaStep(null, false)).toEqual({ step: null });
+    });
+
+    it("strips screenshot when includeScreenshots=false", () => {
+      const step = {
+        action: "click",
+        screenshotAfterBase64: "base64data...",
+      };
+      const result = compactCuaStep(step, false);
+      expect(result).not.toHaveProperty("screenshotAfterBase64");
+      expect(result.hasScreenshot).toBe(true);
+      expect(result.action).toBe("click");
+    });
+
+    it("preserves screenshot when includeScreenshots=true", () => {
+      const step = {
+        action: "type",
+        screenshotAfterBase64: "base64data...",
+      };
+      const result = compactCuaStep(step, true);
+      expect(result.screenshotAfterBase64).toBe("base64data...");
+      expect(result.hasScreenshot).toBe(true);
+    });
+
+    it("sets hasScreenshot=false when no screenshot present", () => {
+      const step = { action: "scroll" };
+      expect(compactCuaStep(step, false).hasScreenshot).toBe(false);
+      expect(compactCuaStep(step, true).hasScreenshot).toBe(false);
+    });
+
+    it("handles non-string screenshotAfterBase64", () => {
+      const step = { action: "click", screenshotAfterBase64: 12345 };
+      const result = compactCuaStep(step, true);
+      expect(result.screenshotAfterBase64).toBeUndefined();
+      expect(result.hasScreenshot).toBe(false);
+    });
+  });
+
+  describe("compactCuaResult contracts", () => {
+    it("wraps non-record input with unknown status", () => {
+      expect(compactCuaResult("bad", false)).toEqual({
+        status: "unknown",
+        raw: "bad",
+      });
+      expect(compactCuaResult(null, true)).toEqual({
+        status: "unknown",
+        raw: null,
+      });
+    });
+
+    it("compacts completed result steps", () => {
+      const result = {
+        status: "completed",
+        steps: [
+          { action: "click", screenshotAfterBase64: "img1" },
+          { action: "type", screenshotAfterBase64: "img2" },
+        ],
+      };
+      const compacted = compactCuaResult(result, false);
+      const steps = compacted.steps as Array<Record<string, unknown>>;
+      expect(steps).toHaveLength(2);
+      expect(steps[0]).not.toHaveProperty("screenshotAfterBase64");
+      expect(steps[0].hasScreenshot).toBe(true);
+      expect(steps[1].action).toBe("type");
+    });
+
+    it("preserves screenshots in completed result when requested", () => {
+      const result = {
+        status: "completed",
+        steps: [{ action: "click", screenshotAfterBase64: "img1" }],
+      };
+      const compacted = compactCuaResult(result, true);
+      const steps = compacted.steps as Array<Record<string, unknown>>;
+      expect(steps[0].screenshotAfterBase64).toBe("img1");
+    });
+
+    it("compacts failed result the same as completed", () => {
+      const result = {
+        status: "failed",
+        error: "timeout",
+        steps: [{ action: "wait", screenshotAfterBase64: "err-img" }],
+      };
+      const compacted = compactCuaResult(result, false);
+      expect(compacted.error).toBe("timeout");
+      const steps = compacted.steps as Array<Record<string, unknown>>;
+      expect(steps[0].hasScreenshot).toBe(true);
+      expect(steps[0]).not.toHaveProperty("screenshotAfterBase64");
+    });
+
+    it("handles completed result with no steps array", () => {
+      const result = { status: "completed" };
+      const compacted = compactCuaResult(result, false);
+      expect(compacted.steps).toEqual([]);
+    });
+
+    it("compacts paused_for_approval with pending screenshots", () => {
+      const result = {
+        status: "paused_for_approval",
+        pending: {
+          screenshotBeforeBase64: "before-img",
+          stepsSoFar: [
+            { action: "navigate", screenshotAfterBase64: "step-img" },
+          ],
+          approvalRequired: true,
+        },
+      };
+      const compacted = compactCuaResult(result, false);
+      const pending = compacted.pending as Record<string, unknown>;
+      expect(pending).not.toHaveProperty("screenshotBeforeBase64");
+      expect(pending.hasScreenshotBefore).toBe(true);
+      expect(pending.approvalRequired).toBe(true);
+      const steps = pending.stepsSoFar as Array<Record<string, unknown>>;
+      expect(steps[0].hasScreenshot).toBe(true);
+      expect(steps[0]).not.toHaveProperty("screenshotAfterBase64");
+    });
+
+    it("preserves pending screenshots when requested", () => {
+      const result = {
+        status: "paused_for_approval",
+        pending: {
+          screenshotBeforeBase64: "before-img",
+          stepsSoFar: [],
+        },
+      };
+      const compacted = compactCuaResult(result, true);
+      const pending = compacted.pending as Record<string, unknown>;
+      expect(pending.screenshotBeforeBase64).toBe("before-img");
+      expect(pending.hasScreenshotBefore).toBe(true);
+    });
+
+    it("handles paused_for_approval with non-record pending", () => {
+      const result = { status: "paused_for_approval", pending: "broken" };
+      const compacted = compactCuaResult(result, false);
+      const pending = compacted.pending as Record<string, unknown>;
+      expect(pending.hasScreenshotBefore).toBe(false);
+      expect(pending.stepsSoFar).toEqual([]);
+    });
+
+    it("passes through unknown status as shallow copy", () => {
+      const result = { status: "running", progress: 50 };
+      const compacted = compactCuaResult(result, false);
+      expect(compacted.status).toBe("running");
+      expect(compacted.progress).toBe(50);
+      expect(compacted).not.toBe(result);
+    });
+
+    it("handles result with no status field", () => {
+      const result = { someField: "value" };
+      const compacted = compactCuaResult(result, false);
+      expect(compacted.someField).toBe("value");
+      expect(compacted).not.toBe(result);
+    });
+  });
+
+  describe("server-utils boundary cases", () => {
+    it("isRecord identifies plain objects", () => {
+      expect(isRecord({})).toBe(true);
+      expect(isRecord({ key: "value" })).toBe(true);
+    });
+
+    it("isRecord rejects non-objects", () => {
+      expect(isRecord(null)).toBe(false);
+      expect(isRecord(undefined)).toBe(false);
+      expect(isRecord(42)).toBe(false);
+      expect(isRecord("string")).toBe(false);
+      expect(isRecord([])).toBe(false);
+      expect(isRecord(true)).toBe(false);
+    });
+
+    it("envFlag reads process.env and returns boolean", () => {
+      const key = "__MILADY_TEST_ENVFLAG__";
+      const saved = process.env[key];
+      try {
+        process.env[key] = "1";
+        expect(envFlag(key)).toBe(true);
+        process.env[key] = "0";
+        expect(envFlag(key)).toBe(false);
+        delete process.env[key];
+        expect(envFlag(key)).toBe(false);
+      } finally {
+        if (saved !== undefined) process.env[key] = saved;
+        else delete process.env[key];
+      }
+    });
+
+    it("parseBooleanValue handles all truthy/falsy variants", () => {
+      for (const val of ["1", "true", "yes", "y", "on", "TRUE", "Yes", "ON"]) {
+        expect(parseBooleanValue(val)).toBe(true);
+      }
+      for (const val of [
+        "0",
+        "false",
+        "no",
+        "n",
+        "off",
+        "FALSE",
+        "No",
+        "OFF",
+      ]) {
+        expect(parseBooleanValue(val)).toBe(false);
+      }
+    });
+
+    it("parseBooleanValue returns default for unrecognized values", () => {
+      expect(parseBooleanValue("maybe")).toBe(false);
+      expect(parseBooleanValue("maybe", true)).toBe(true);
+      expect(parseBooleanValue(undefined)).toBe(false);
+      expect(parseBooleanValue(null)).toBe(false);
+    });
+
+    it("parseBooleanValue handles boolean and number inputs", () => {
+      expect(parseBooleanValue(true)).toBe(true);
+      expect(parseBooleanValue(false)).toBe(false);
+      expect(parseBooleanValue(1)).toBe(true);
+      expect(parseBooleanValue(0)).toBe(false);
+      expect(parseBooleanValue(42)).toBe(true);
+    });
+
+    it("formatUnknownError formats Error instances", () => {
+      expect(formatUnknownError(new Error("test error"))).toBe(
+        "Error: test error",
+      );
+      expect(formatUnknownError(new TypeError("bad type"))).toBe(
+        "TypeError: bad type",
+      );
+    });
+
+    it("formatUnknownError stringifies non-Error values", () => {
+      expect(formatUnknownError("plain string")).toBe("plain string");
+      expect(formatUnknownError(42)).toBe("42");
+      expect(formatUnknownError(null)).toBe("null");
+    });
+
+    it("extractRecord returns object for valid record input", () => {
+      expect(extractRecord({ key: "val" })).toEqual({ key: "val" });
+    });
+
+    it("extractRecord returns undefined for non-objects", () => {
+      expect(extractRecord(null)).toBeUndefined();
+      expect(extractRecord(undefined)).toBeUndefined();
+      expect(extractRecord("string")).toBeUndefined();
+      expect(extractRecord(42)).toBeUndefined();
+      expect(extractRecord([])).toBeUndefined();
+    });
+
+    it("extractTaskId handles snake_case and camelCase", () => {
+      expect(extractTaskId({ task_id: "snake" })).toBe("snake");
+      expect(extractTaskId({ taskId: "camel" })).toBe("camel");
+      expect(extractTaskId({ task_id: "snake", taskId: "camel" })).toBe(
+        "snake",
+      );
+    });
+
+    it("extractTaskId defaults to 'default-task'", () => {
+      expect(extractTaskId(undefined)).toBe("default-task");
+      expect(extractTaskId({})).toBe("default-task");
+      expect(extractTaskId({ task_id: "" })).toBe("default-task");
+      expect(extractTaskId({ task_id: "   " })).toBe("default-task");
+    });
+
+    it("extractBenchmarkName extracts benchmark field", () => {
+      expect(extractBenchmarkName({ benchmark: "agentbench" })).toBe(
+        "agentbench",
+      );
+    });
+
+    it("extractBenchmarkName defaults to 'unknown'", () => {
+      expect(extractBenchmarkName(undefined)).toBe("unknown");
+      expect(extractBenchmarkName({})).toBe("unknown");
+      expect(extractBenchmarkName({ benchmark: "" })).toBe("unknown");
+      expect(extractBenchmarkName({ benchmark: "  " })).toBe("unknown");
+    });
+
+    it("toPlugin accepts valid plugin-like objects", () => {
+      const validPlugin = { name: "test-plugin", description: "A test" };
+      expect(() => toPlugin(validPlugin, "test")).not.toThrow();
+      expect(toPlugin(validPlugin, "test")).toBe(validPlugin);
+    });
+
+    it("toPlugin rejects non-objects", () => {
+      expect(() => toPlugin(null, "test")).toThrow("not an object");
+      expect(() => toPlugin(undefined, "test")).toThrow("not an object");
+      expect(() => toPlugin("string", "test")).toThrow("not an object");
+    });
+
+    it("toPlugin rejects objects without a name", () => {
+      expect(() => toPlugin({}, "test")).toThrow("missing a valid name");
+      expect(() => toPlugin({ name: "" }, "test")).toThrow(
+        "missing a valid name",
+      );
+      expect(() => toPlugin({ name: 42 }, "test")).toThrow(
+        "missing a valid name",
+      );
+    });
+
+    it("resolvePort returns DEFAULT_PORT when env is unset", () => {
+      const saved = process.env.ELIZA_BENCH_PORT;
+      delete process.env.ELIZA_BENCH_PORT;
+      try {
+        expect(resolvePort()).toBe(3939);
+      } finally {
+        if (saved !== undefined) process.env.ELIZA_BENCH_PORT = saved;
+      }
+    });
+
+    it("resolvePort returns parsed value for valid port", () => {
+      const saved = process.env.ELIZA_BENCH_PORT;
+      process.env.ELIZA_BENCH_PORT = "8080";
+      try {
+        expect(resolvePort()).toBe(8080);
+      } finally {
+        if (saved !== undefined) process.env.ELIZA_BENCH_PORT = saved;
+        else delete process.env.ELIZA_BENCH_PORT;
+      }
+    });
+
+    it("resolvePort floors fractional port values", () => {
+      const saved = process.env.ELIZA_BENCH_PORT;
+      process.env.ELIZA_BENCH_PORT = "3000.7";
+      try {
+        expect(resolvePort()).toBe(3000);
+      } finally {
+        if (saved !== undefined) process.env.ELIZA_BENCH_PORT = saved;
+        else delete process.env.ELIZA_BENCH_PORT;
+      }
+    });
+
+    it("resolvePort falls back for port 0", () => {
+      const saved = process.env.ELIZA_BENCH_PORT;
+      process.env.ELIZA_BENCH_PORT = "0";
+      try {
+        expect(resolvePort()).toBe(3939);
+      } finally {
+        if (saved !== undefined) process.env.ELIZA_BENCH_PORT = saved;
+        else delete process.env.ELIZA_BENCH_PORT;
+      }
+    });
+
+    it("resolvePort falls back for negative port", () => {
+      const saved = process.env.ELIZA_BENCH_PORT;
+      process.env.ELIZA_BENCH_PORT = "-1";
+      try {
+        expect(resolvePort()).toBe(3939);
+      } finally {
+        if (saved !== undefined) process.env.ELIZA_BENCH_PORT = saved;
+        else delete process.env.ELIZA_BENCH_PORT;
+      }
+    });
+
+    it("resolvePort falls back for port > 65535", () => {
+      const saved = process.env.ELIZA_BENCH_PORT;
+      process.env.ELIZA_BENCH_PORT = "65536";
+      try {
+        expect(resolvePort()).toBe(3939);
+      } finally {
+        if (saved !== undefined) process.env.ELIZA_BENCH_PORT = saved;
+        else delete process.env.ELIZA_BENCH_PORT;
+      }
+    });
+
+    it("resolvePort falls back for non-numeric string", () => {
+      const saved = process.env.ELIZA_BENCH_PORT;
+      process.env.ELIZA_BENCH_PORT = "not-a-number";
+      try {
+        expect(resolvePort()).toBe(3939);
+      } finally {
+        if (saved !== undefined) process.env.ELIZA_BENCH_PORT = saved;
+        else delete process.env.ELIZA_BENCH_PORT;
+      }
+    });
+
+    it("resolvePort accepts boundary port 1", () => {
+      const saved = process.env.ELIZA_BENCH_PORT;
+      process.env.ELIZA_BENCH_PORT = "1";
+      try {
+        expect(resolvePort()).toBe(1);
+      } finally {
+        if (saved !== undefined) process.env.ELIZA_BENCH_PORT = saved;
+        else delete process.env.ELIZA_BENCH_PORT;
+      }
+    });
+
+    it("resolvePort accepts boundary port 65535", () => {
+      const saved = process.env.ELIZA_BENCH_PORT;
+      process.env.ELIZA_BENCH_PORT = "65535";
+      try {
+        expect(resolvePort()).toBe(65535);
+      } finally {
+        if (saved !== undefined) process.env.ELIZA_BENCH_PORT = saved;
+        else delete process.env.ELIZA_BENCH_PORT;
+      }
+    });
+
+    it("resolveHost returns DEFAULT_HOST when env is unset", () => {
+      const saved = process.env.ELIZA_BENCH_HOST;
+      delete process.env.ELIZA_BENCH_HOST;
+      try {
+        expect(resolveHost()).toBe("127.0.0.1");
+      } finally {
+        if (saved !== undefined) process.env.ELIZA_BENCH_HOST = saved;
+        else delete process.env.ELIZA_BENCH_HOST;
+      }
+    });
+
+    it("resolveHost accepts 127.0.0.1", () => {
+      const saved = process.env.ELIZA_BENCH_HOST;
+      process.env.ELIZA_BENCH_HOST = "127.0.0.1";
+      try {
+        expect(resolveHost()).toBe("127.0.0.1");
+      } finally {
+        if (saved !== undefined) process.env.ELIZA_BENCH_HOST = saved;
+        else delete process.env.ELIZA_BENCH_HOST;
+      }
+    });
+
+    it("resolveHost accepts ::1", () => {
+      const saved = process.env.ELIZA_BENCH_HOST;
+      process.env.ELIZA_BENCH_HOST = "::1";
+      try {
+        expect(resolveHost()).toBe("::1");
+      } finally {
+        if (saved !== undefined) process.env.ELIZA_BENCH_HOST = saved;
+        else delete process.env.ELIZA_BENCH_HOST;
+      }
+    });
+
+    it("resolveHost accepts localhost", () => {
+      const saved = process.env.ELIZA_BENCH_HOST;
+      process.env.ELIZA_BENCH_HOST = "localhost";
+      try {
+        expect(resolveHost()).toBe("localhost");
+      } finally {
+        if (saved !== undefined) process.env.ELIZA_BENCH_HOST = saved;
+        else delete process.env.ELIZA_BENCH_HOST;
+      }
+    });
+
+    it("resolveHost rejects non-loopback addresses", () => {
+      const saved = process.env.ELIZA_BENCH_HOST;
+      process.env.ELIZA_BENCH_HOST = "0.0.0.0";
+      try {
+        expect(resolveHost()).toBe("127.0.0.1");
+      } finally {
+        if (saved !== undefined) process.env.ELIZA_BENCH_HOST = saved;
+        else delete process.env.ELIZA_BENCH_HOST;
+      }
+    });
+
+    it("resolveHost rejects external hostnames", () => {
+      const saved = process.env.ELIZA_BENCH_HOST;
+      process.env.ELIZA_BENCH_HOST = "example.com";
+      try {
+        expect(resolveHost()).toBe("127.0.0.1");
+      } finally {
+        if (saved !== undefined) process.env.ELIZA_BENCH_HOST = saved;
+        else delete process.env.ELIZA_BENCH_HOST;
+      }
+    });
+
+    it("resolveHost trims whitespace", () => {
+      const saved = process.env.ELIZA_BENCH_HOST;
+      process.env.ELIZA_BENCH_HOST = "  localhost  ";
+      try {
+        expect(resolveHost()).toBe("localhost");
+      } finally {
+        if (saved !== undefined) process.env.ELIZA_BENCH_HOST = saved;
+        else delete process.env.ELIZA_BENCH_HOST;
+      }
+    });
+
+    it("resolveHost falls back for empty string", () => {
+      const saved = process.env.ELIZA_BENCH_HOST;
+      process.env.ELIZA_BENCH_HOST = "";
+      try {
+        expect(resolveHost()).toBe("127.0.0.1");
+      } finally {
+        if (saved !== undefined) process.env.ELIZA_BENCH_HOST = saved;
+        else delete process.env.ELIZA_BENCH_HOST;
+      }
+    });
+
+    it("composeBenchmarkPrompt omits context section for empty context", () => {
+      const result = composeBenchmarkPrompt({ text: "Hello" });
+      expect(result).toContain("Hello");
+      expect(result).not.toContain("BENCHMARK CONTEXT");
+      expect(result).toContain("Respond using normal Eliza action output");
+    });
+
+    it("composeBenchmarkPrompt includes image payload when provided", () => {
+      const result = composeBenchmarkPrompt({
+        text: "Describe this",
+        image: { type: "base64", data: "abc123" },
+      });
+      expect(result).toContain("IMAGE PAYLOAD:");
+      expect(result).toContain("abc123");
+    });
+
+    it("coerceParams: JSON string with array value returns empty", () => {
+      expect(coerceParams("[1, 2, 3]")).toEqual({});
+    });
+
+    it("coerceParams: empty string returns empty", () => {
+      expect(coerceParams("")).toEqual({});
+    });
+
+    it("coerceParams: whitespace string returns empty", () => {
+      expect(coerceParams("   ")).toEqual({});
+    });
+
+    it("coerceParams: XML with multiple root tags extracts all", () => {
+      const xml = [
+        "<ACTION_A><field>value_a</field></ACTION_A>",
+        "<ACTION_B><field>value_b</field></ACTION_B>",
+      ].join("\n");
+      const result = coerceParams(xml);
+      expect(result).toHaveProperty("ACTION_A");
+      expect(result).toHaveProperty("ACTION_B");
+      expect(
+        (result.ACTION_A as Record<string, unknown>).field,
+      ).toBe("value_a");
+    });
+
+    it("coerceParams: XML tag with no child tags returns body as string", () => {
+      const result = coerceParams("<SIMPLE>just text</SIMPLE>");
+      expect(result).toEqual({ SIMPLE: "just text" });
+    });
+
+    it("session fields are UUID-shaped strings", () => {
+      const session = createSession("test", "bench");
+      const uuidPattern =
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+      expect(session.roomId).toMatch(uuidPattern);
+      expect(session.relayRoomId).toMatch(uuidPattern);
+      expect(session.userEntityId).toMatch(uuidPattern);
+    });
+
+    it("session with whitespace-only taskId normalizes", () => {
+      const session = createSession("   ", "   ");
+      expect(session.taskId).toBe("default-task");
+      expect(session.benchmark).toBe("unknown");
+    });
+  });
+});

--- a/test/eval/golden-prompts.json
+++ b/test/eval/golden-prompts.json
@@ -1,0 +1,136 @@
+{
+  "version": 1,
+  "description": "Golden prompts for benchmark bridge structural evaluation. Each prompt exercises a specific benchmark type and validates that the plugin + server-utils pipeline produces correctly shaped responses. These do NOT test LLM quality — they test the harness contract using the deterministic mock plugin.",
+  "prompts": [
+    {
+      "id": "agentbench-search",
+      "benchmark": "agentbench",
+      "taskId": "webshop-42",
+      "input": "Find a laptop under $500 with good reviews",
+      "context": {
+        "goal": "Buy a laptop under $500",
+        "observation": { "page": "search results", "items": 25 },
+        "action_space": ["search[query]", "click[id]", "buy[id]"]
+      },
+      "expectations": {
+        "provider_contains": ["# Benchmark Task", "agentbench", "webshop-42", "Buy a laptop", "action_space"],
+        "provider_values": { "hasBenchmark": true, "benchmark": "agentbench", "taskId": "webshop-42" },
+        "prompt_contains": ["Find a laptop under $500", "BENCHMARK CONTEXT"],
+        "action_validates": true
+      }
+    },
+    {
+      "id": "tau-bench-tool-call",
+      "benchmark": "tau-bench",
+      "taskId": "customer-service-1",
+      "input": "I need to check my order status",
+      "context": {
+        "goal": "Find order status for customer",
+        "tools": [
+          {
+            "name": "lookup_order",
+            "description": "Look up a customer order by ID",
+            "parameters": {
+              "type": "object",
+              "properties": {
+                "order_id": { "type": "string", "description": "The order identifier" }
+              },
+              "required": ["order_id"]
+            }
+          },
+          {
+            "name": "cancel_order",
+            "description": "Cancel an existing order",
+            "parameters": {
+              "type": "object",
+              "properties": {
+                "order_id": { "type": "string" },
+                "reason": { "type": "string" }
+              }
+            }
+          }
+        ]
+      },
+      "expectations": {
+        "provider_contains": ["# Benchmark Task", "tau-bench", "Available Tools", "lookup_order", "cancel_order", "BENCHMARK_ACTION"],
+        "provider_values": { "hasBenchmark": true, "benchmark": "tau-bench", "taskId": "customer-service-1" },
+        "prompt_contains": ["I need to check my order status", "BENCHMARK CONTEXT"],
+        "action_validates": true
+      }
+    },
+    {
+      "id": "mind2web-navigation",
+      "benchmark": "mind2web",
+      "taskId": "nav-checkout-1",
+      "input": "Click the checkout button to proceed",
+      "context": {
+        "goal": "Complete the checkout process",
+        "html": "<div id='cart'><button id='checkout-btn' class='primary'>Checkout</button></div>",
+        "elements": [
+          {
+            "backend_node_id": "42",
+            "tag": "button",
+            "attributes": { "id": "checkout-btn", "class": "primary" },
+            "text_content": "Checkout"
+          }
+        ]
+      },
+      "expectations": {
+        "provider_contains": ["# Benchmark Task", "mind2web", "Page HTML", "Available Elements", "checkout-btn", "Checkout"],
+        "provider_values": { "hasBenchmark": true, "benchmark": "mind2web", "taskId": "nav-checkout-1" },
+        "prompt_contains": ["Click the checkout button", "BENCHMARK CONTEXT"],
+        "action_validates": true
+      }
+    },
+    {
+      "id": "context-bench-qa",
+      "benchmark": "context-bench",
+      "taskId": "qa-comprehension-1",
+      "input": "Based on the passages, what is the capital of France?",
+      "context": {
+        "question": "What is the capital of France?",
+        "passages": [
+          "France is a country in Western Europe. Its capital city is Paris, which is known for the Eiffel Tower.",
+          "Paris has been the capital since the 10th century and is the most populous city in France."
+        ]
+      },
+      "expectations": {
+        "provider_contains": ["# Benchmark Task", "context-bench", "Question", "Context Passages", "Passage 1", "Passage 2", "Paris"],
+        "provider_values": { "hasBenchmark": true, "benchmark": "context-bench", "taskId": "qa-comprehension-1" },
+        "prompt_contains": ["Based on the passages", "BENCHMARK CONTEXT"],
+        "action_validates": true
+      }
+    },
+    {
+      "id": "no-context-baseline",
+      "benchmark": "none",
+      "taskId": "baseline-1",
+      "input": "Hello, how are you?",
+      "context": {},
+      "expectations": {
+        "provider_empty": true,
+        "prompt_contains": ["Hello, how are you?"],
+        "action_validates": false
+      }
+    },
+    {
+      "id": "agentbench-with-extra-fields",
+      "benchmark": "agentbench",
+      "taskId": "db-task-7",
+      "input": "List all users in the database",
+      "context": {
+        "goal": "Execute a SQL query to list users",
+        "observation": "mysql> ",
+        "action_space": ["SQL[query]", "EXIT"],
+        "difficulty": "easy",
+        "domain": "database"
+      },
+      "expectations": {
+        "provider_contains": ["# Benchmark Task", "agentbench", "Additional Context", "difficulty", "easy", "domain", "database"],
+        "provider_values": { "hasBenchmark": true, "benchmark": "agentbench", "taskId": "db-task-7" },
+        "prompt_contains": ["List all users", "BENCHMARK CONTEXT"],
+        "action_validates": true
+      }
+    }
+  ]
+}

--- a/test/perf-baselines.json
+++ b/test/perf-baselines.json
@@ -1,0 +1,42 @@
+{
+  "version": 1,
+  "description": "Performance budget baselines for benchmark bridge components. All durations in milliseconds. Thresholds are intentionally generous (3-5x expected p95) to avoid flaky failures across different CI runners while still catching severe regressions.",
+  "baselines": {
+    "session-create": {
+      "p95_ms": 5,
+      "description": "createSession() — UUID generation + session struct allocation"
+    },
+    "context-normalize": {
+      "p95_ms": 5,
+      "description": "normalizeBenchmarkContext() — field normalization for benchmark context"
+    },
+    "prompt-compose": {
+      "p95_ms": 10,
+      "description": "composeBenchmarkPrompt() — text + context + image segment assembly"
+    },
+    "params-coerce-json": {
+      "p95_ms": 5,
+      "description": "coerceParams() — JSON object passthrough"
+    },
+    "params-coerce-xml": {
+      "p95_ms": 20,
+      "description": "coerceParams() — XML string parsing with regex extraction"
+    },
+    "plugin-create": {
+      "p95_ms": 10,
+      "description": "createBenchmarkPlugin() — plugin factory"
+    },
+    "plugin-provider-get": {
+      "p95_ms": 10,
+      "description": "ELIZA_BENCHMARK provider.get() — context formatting"
+    },
+    "plugin-action-handler": {
+      "p95_ms": 10,
+      "description": "BENCHMARK_ACTION handler() — action capture and parameter extraction"
+    },
+    "action-to-params": {
+      "p95_ms": 5,
+      "description": "capturedActionToParams() — captured action to response params conversion"
+    }
+  }
+}

--- a/test/perf-budget.test.ts
+++ b/test/perf-budget.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Performance budget tests for the benchmark bridge.
+ *
+ * Measures critical-path functions against baselines defined in
+ * test/perf-baselines.json. Each operation is run multiple times and
+ * the p95 latency is compared against the budget.
+ *
+ * Gated behind MILADY_PERF_TEST=1 — not part of the default test suite
+ * to avoid flakiness from CI runner variance.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  type BenchmarkContext,
+  clearCapturedAction,
+  createBenchmarkPlugin,
+  getCapturedAction,
+  setBenchmarkContext,
+} from "../packages/app-core/src/benchmark/plugin";
+import {
+  capturedActionToParams,
+  coerceParams,
+  composeBenchmarkPrompt,
+  createSession,
+  normalizeBenchmarkContext,
+} from "../packages/app-core/src/benchmark/server-utils";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+interface Baseline {
+  p95_ms: number;
+  description: string;
+}
+
+interface BaselinesFile {
+  version: number;
+  baselines: Record<string, Baseline>;
+}
+
+const baselinesPath = path.join(__dirname, "perf-baselines.json");
+const baselinesFile: BaselinesFile = JSON.parse(
+  fs.readFileSync(baselinesPath, "utf8"),
+);
+
+const ITERATIONS = 1000;
+const P95_INDEX = Math.floor(ITERATIONS * 0.95);
+
+function measureP95(fn: () => void): number {
+  const timings: number[] = new Array(ITERATIONS);
+
+  // Warmup — run 50 iterations to allow JIT to stabilize
+  for (let i = 0; i < 50; i++) {
+    fn();
+  }
+
+  for (let i = 0; i < ITERATIONS; i++) {
+    const start = performance.now();
+    fn();
+    timings[i] = performance.now() - start;
+  }
+
+  timings.sort((a, b) => a - b);
+  return timings[P95_INDEX];
+}
+
+async function measureP95Async(fn: () => Promise<void>): Promise<number> {
+  const timings: number[] = new Array(ITERATIONS);
+
+  for (let i = 0; i < 50; i++) {
+    await fn();
+  }
+
+  for (let i = 0; i < ITERATIONS; i++) {
+    const start = performance.now();
+    await fn();
+    timings[i] = performance.now() - start;
+  }
+
+  timings.sort((a, b) => a - b);
+  return timings[P95_INDEX];
+}
+
+function getBaseline(name: string): Baseline {
+  const baseline = baselinesFile.baselines[name];
+  if (!baseline) {
+    throw new Error(
+      `Missing baseline "${name}" in perf-baselines.json — add it before writing a perf test for it`,
+    );
+  }
+  return baseline;
+}
+
+const enabled = process.env.MILADY_PERF_TEST === "1";
+
+describe.skipIf(!enabled)("performance budgets", () => {
+  afterEach(() => {
+    clearCapturedAction();
+    setBenchmarkContext(null);
+  });
+
+  it("session-create stays within budget and produces valid sessions", () => {
+    const baseline = getBaseline("session-create");
+    let lastSession: ReturnType<typeof createSession> | undefined;
+    const p95 = measureP95(() => {
+      lastSession = createSession("webshop-42", "agentbench");
+    });
+    expect(p95).toBeLessThanOrEqual(baseline.p95_ms);
+    expect(lastSession).toBeDefined();
+    expect(lastSession!.taskId).toBe("webshop-42");
+    expect(lastSession!.benchmark).toBe("agentbench");
+    expect(lastSession!.roomId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+    expect(lastSession!.relayRoomId).not.toBe(lastSession!.roomId);
+  });
+
+  it("context-normalize stays within budget and produces correct output", () => {
+    const baseline = getBaseline("context-normalize");
+    const session = createSession("task-1", "tau-bench");
+    const context = {
+      goal: "Find order status",
+      action_space: ["lookup_order", "cancel_order"],
+      task_id: "task-1",
+      benchmark: "tau-bench",
+    };
+    let lastResult: ReturnType<typeof normalizeBenchmarkContext> | undefined;
+    const p95 = measureP95(() => {
+      lastResult = normalizeBenchmarkContext(session, context);
+    });
+    expect(p95).toBeLessThanOrEqual(baseline.p95_ms);
+    expect(lastResult).toBeDefined();
+    expect(lastResult!.benchmark).toBe("tau-bench");
+    expect(lastResult!.taskId).toBe("task-1");
+    expect(lastResult!.actionSpace).toEqual(["lookup_order", "cancel_order"]);
+    expect(lastResult!.goal).toBe("Find order status");
+  });
+
+  it("prompt-compose stays within budget and produces correct output", () => {
+    const baseline = getBaseline("prompt-compose");
+    const context = {
+      benchmark: "agentbench",
+      taskId: "webshop-42",
+      goal: "Buy a laptop under $500",
+      observation: { page: "search results", items: 25 },
+      action_space: ["search[query]", "click[id]", "buy[id]", "back", "next"],
+    };
+    let lastResult = "";
+    const p95 = measureP95(() => {
+      lastResult = composeBenchmarkPrompt({
+        text: "Find a laptop under $500 with good reviews",
+        context,
+        image: { type: "url", url: "https://example.com/screenshot.png" },
+      });
+    });
+    expect(p95).toBeLessThanOrEqual(baseline.p95_ms);
+    expect(lastResult).toContain("Find a laptop under $500");
+    expect(lastResult).toContain("BENCHMARK CONTEXT (authoritative):");
+    expect(lastResult).toContain("IMAGE PAYLOAD:");
+    expect(lastResult).toContain("Respond using normal Eliza action output");
+  });
+
+  it("params-coerce-json stays within budget and returns identity", () => {
+    const baseline = getBaseline("params-coerce-json");
+    const params = {
+      BENCHMARK_ACTION: {
+        command: "search[laptop under $500]",
+        tool_name: "search",
+        arguments: { query: "laptop under $500" },
+      },
+    };
+    let lastResult: Record<string, unknown> = {};
+    const p95 = measureP95(() => {
+      lastResult = coerceParams(params);
+    });
+    expect(p95).toBeLessThanOrEqual(baseline.p95_ms);
+    expect(lastResult).toEqual(params);
+  });
+
+  it("params-coerce-xml stays within budget and extracts fields", () => {
+    const baseline = getBaseline("params-coerce-xml");
+    const xml = [
+      "<BENCHMARK_ACTION>",
+      "<operation>CLICK</operation>",
+      "<element_id>btn-submit</element_id>",
+      "<value>confirm purchase</value>",
+      "<command>CLICK(btn-submit)</command>",
+      "<tool_name>ui.click</tool_name>",
+      '<arguments>{"x":100,"y":200}</arguments>',
+      "</BENCHMARK_ACTION>",
+    ].join("\n");
+    let lastResult: Record<string, unknown> = {};
+    const p95 = measureP95(() => {
+      lastResult = coerceParams(xml);
+    });
+    expect(p95).toBeLessThanOrEqual(baseline.p95_ms);
+    expect(lastResult).toHaveProperty("BENCHMARK_ACTION");
+    const inner = lastResult.BENCHMARK_ACTION as Record<string, unknown>;
+    expect(inner.operation).toBe("CLICK");
+    expect(inner.element_id).toBe("btn-submit");
+    expect(inner.value).toBe("confirm purchase");
+  });
+
+  it("plugin-create stays within budget and returns valid plugin", () => {
+    const baseline = getBaseline("plugin-create");
+    let lastPlugin: ReturnType<typeof createBenchmarkPlugin> | undefined;
+    const p95 = measureP95(() => {
+      lastPlugin = createBenchmarkPlugin();
+    });
+    expect(p95).toBeLessThanOrEqual(baseline.p95_ms);
+    expect(lastPlugin).toBeDefined();
+    expect(lastPlugin!.name).toBe("eliza-benchmark");
+    expect(lastPlugin!.providers).toHaveLength(1);
+    expect(lastPlugin!.actions).toHaveLength(1);
+    expect(lastPlugin!.providers![0].name).toBe("ELIZA_BENCHMARK");
+    expect(lastPlugin!.actions![0].name).toBe("BENCHMARK_ACTION");
+  });
+
+  it("plugin-provider-get stays within budget", async () => {
+    const baseline = getBaseline("plugin-provider-get");
+    const plugin = createBenchmarkPlugin();
+    const provider = plugin.providers?.find(
+      (entry) => entry.name === "ELIZA_BENCHMARK",
+    );
+    if (!provider?.get) throw new Error("ELIZA_BENCHMARK provider not found");
+
+    const context: BenchmarkContext = {
+      benchmark: "tau-bench",
+      taskId: "task-perf",
+      goal: "Find order status for customer",
+      tools: [
+        {
+          name: "lookup_order",
+          description: "Look up a customer order by ID",
+          parameters: {
+            type: "object",
+            properties: {
+              order_id: { type: "string", description: "The order identifier" },
+              customer_id: {
+                type: "string",
+                description: "The customer identifier",
+              },
+            },
+            required: ["order_id"],
+          },
+        },
+        {
+          name: "cancel_order",
+          description: "Cancel an existing order",
+          parameters: {
+            type: "object",
+            properties: {
+              order_id: { type: "string" },
+              reason: { type: "string" },
+            },
+          },
+        },
+      ],
+    };
+
+    setBenchmarkContext(context);
+    let lastResult: { text: string; values: Record<string, unknown> } = {
+      text: "",
+      values: {},
+    };
+    const p95 = await measureP95Async(async () => {
+      lastResult = (await provider.get(
+        {} as never,
+        {} as never,
+        {} as never,
+      )) as typeof lastResult;
+    });
+    expect(p95).toBeLessThanOrEqual(baseline.p95_ms);
+    expect(lastResult.text).toContain("# Benchmark Task");
+    expect(lastResult.text).toContain("tau-bench");
+    expect(lastResult.text).toContain("lookup_order");
+    expect(lastResult.values).toMatchObject({
+      hasBenchmark: true,
+      benchmark: "tau-bench",
+      taskId: "task-perf",
+    });
+  });
+
+  it("plugin-action-handler stays within budget and captures action", async () => {
+    const baseline = getBaseline("plugin-action-handler");
+    const plugin = createBenchmarkPlugin();
+    const action = plugin.actions?.find(
+      (entry) => entry.name === "BENCHMARK_ACTION",
+    );
+    if (!action?.handler) throw new Error("BENCHMARK_ACTION not found");
+
+    setBenchmarkContext({ benchmark: "agentbench", taskId: "task-perf" });
+    const p95 = await measureP95Async(async () => {
+      clearCapturedAction();
+      await action.handler({} as never, {} as never, undefined as never, {
+        parameters: {
+          command: "search[laptop under $500]",
+          tool_name: "search",
+          arguments: '{"query":"laptop under $500"}',
+        },
+      });
+    });
+    expect(p95).toBeLessThanOrEqual(baseline.p95_ms);
+    const captured = getCapturedAction();
+    expect(captured).not.toBeNull();
+    expect(captured?.command).toBe("search[laptop under $500]");
+    expect(captured?.toolName).toBe("search");
+    expect(captured?.arguments).toEqual({ query: "laptop under $500" });
+  });
+
+  it("action-to-params stays within budget and produces correct output", () => {
+    const baseline = getBaseline("action-to-params");
+    const captured = {
+      command: "search[laptop under $500]",
+      toolName: "search",
+      arguments: { query: "laptop under $500" },
+      operation: "SEARCH",
+      elementId: "search-bar",
+      value: "laptop under $500",
+    };
+    let lastResult: Record<string, unknown> = {};
+    const p95 = measureP95(() => {
+      lastResult = capturedActionToParams(captured);
+    });
+    expect(p95).toBeLessThanOrEqual(baseline.p95_ms);
+    expect(lastResult).toHaveProperty("BENCHMARK_ACTION");
+    const inner = lastResult.BENCHMARK_ACTION as Record<string, unknown>;
+    expect(inner.command).toBe("search[laptop under $500]");
+    expect(inner.tool_name).toBe("search");
+    expect(inner.operation).toBe("SEARCH");
+    expect(inner.element_id).toBe("search-bar");
+    expect(inner.value).toBe("laptop under $500");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -204,6 +204,8 @@ export default defineConfig({
       "apps/chrome-extension/**/*.test.ts",
       "apps/chrome-extension/**/*.test.tsx",
       "test/format-error.test.ts",
+      "test/perf-budget.test.ts",
+      "test/eval/**/*.test.ts",
     ],
     setupFiles: ["test/setup.ts"],
     exclude: [


### PR DESCRIPTION
## Summary

- **Eval harness** (`test/eval/`): 6 golden prompts exercising agentbench, tau-bench, mind2web, and context-bench through the real plugin + server-utils pipeline with the deterministic mock plugin — no LLM API keys needed. 112 tests covering provider output, prompt composition, action validation, context normalization, params coercion, handler contracts, mock model contract, CUA step/result compaction, resolvePort/resolveHost boundary values, and end-to-end integration pipelines.
- **Performance budgets** (`test/perf-budget.test.ts`): 9 tests measuring p95 latency of critical-path functions (session creation, context normalization, prompt composition, JSON/XML param coercion, plugin factory, provider get, action handler, action-to-params conversion) against baselines in `test/perf-baselines.json`.
- **Per-surface coverage overrides** in `scripts/coverage-policy.mjs`: `packages/agent` and `packages/app-core` can now enforce stricter thresholds than the global 25%/15% defaults.
- **CI fixes**: Corrected benchmark workflow paths from `src/benchmark/` to `packages/app-core/src/benchmark/`. Added `benchmark-eval` and `benchmark-perf` CI lanes so env-gated tests actually execute in CI instead of being silently skipped.
- **Production logging fix**: Replaced `console.log` with `logger.debug` in the BENCHMARK_ACTION handler to prevent params leaking to raw stdout. Gated benchmark timing output behind `MILADY_PERF_TEST`.
- **Documentation**: Added `MILADY_EVAL_TEST` and `MILADY_PERF_TEST` to the env var table in `CLAUDE.md`.

## Test plan

- [x] 262 tests across 9 files pass (`MILADY_EVAL_TEST=1 MILADY_PERF_TEST=1`)
- [x] `bunx @biomejs/biome check packages/app-core/src/benchmark` — 12 files, 0 errors
- [x] No `vi.mock()` or `vi.spyOn()` — all tests exercise real production code
- [x] No hardcoded secrets or credentials in any file
- [x] CI workflow triggers on `test/eval/**`, `test/perf-budget.test.ts`, and `test/perf-baselines.json` changes
- [x] LARP assessment verified: no silent-pass guards, no vacuous assertions, no untested branches


Made with [Cursor](https://cursor.com)