### PR TITLE
fix: stabilize ollama and linux desktop qa regressions

### DIFF
--- a/apps/app/electrobun/src/__tests__/close-to-background.test.ts
+++ b/apps/app/electrobun/src/__tests__/close-to-background.test.ts
@@ -22,6 +22,16 @@ describe("close-to-background behavior", () => {
     expect(fnBody).toContain("showBackgroundRunNoticeOnce");
   });
 
+  it("linux close path quits instead of backgrounding the process", () => {
+    const closeHandler = source.indexOf('win.on("close"');
+    expect(closeHandler).toBeGreaterThan(-1);
+
+    const handlerBody = source.slice(closeHandler, closeHandler + 500);
+    expect(handlerBody).toContain("shouldKeepRunningInBackground");
+    expect(handlerBody).toContain("Utils.quit()");
+    expect(handlerBody).toContain("isQuitting = true");
+  });
+
   it("restoreWindow function exists and creates window when needed", () => {
     const fnStart = source.indexOf("async function restoreWindow");
     expect(fnStart).toBeGreaterThan(-1);

--- a/apps/app/electrobun/src/index.ts
+++ b/apps/app/electrobun/src/index.ts
@@ -550,6 +550,13 @@ let isQuitting = false;
 const cleanupFns: Array<() => void | Promise<void>> = [];
 let lastFocusedWindow: ManagedWindowLike | null = null;
 
+function shouldKeepRunningInBackground(): boolean {
+  // Linux package builds do not provide a reliable quit affordance via app
+  // menus, so closing the last window must terminate the process instead of
+  // leaving the agent and renderer servers bound in the background.
+  return process.platform !== "linux";
+}
+
 function sendToActiveRenderer(message: string, payload?: unknown): void {
   currentSendToWebview?.(message, payload);
   if (!currentSendToWebview) {
@@ -802,6 +809,11 @@ function attachMainWindow(win: BrowserWindow): BrowserWindow {
     }
 
     if (!isQuitting) {
+      if (!shouldKeepRunningInBackground()) {
+        isQuitting = true;
+        Utils.quit();
+        return;
+      }
       void ensureBackgroundWindow();
     }
   });

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -67,6 +67,7 @@ import {
   isMiladySettingsDebugEnabled,
   settingsDebugCloudSummary,
 } from "@miladyai/shared";
+import { inferOnboardingConnectionFromConfig } from "../contracts/onboarding";
 import * as pluginAgentOrchestrator from "@elizaos/plugin-agent-orchestrator";
 import * as pluginAgentSkills from "@elizaos/plugin-agent-skills";
 import * as pluginAnthropic from "@elizaos/plugin-anthropic";
@@ -536,6 +537,109 @@ function isLikelyOpenAiTextModel(value: string | undefined): boolean {
   if (!value) return false;
   const normalized = value.trim().toLowerCase();
   return normalized.startsWith("gpt-") || normalized.startsWith("openai/");
+}
+
+function normalizeOllamaOpenAiBaseUrl(value: string): string | null {
+  try {
+    const url = new URL(value);
+    const pathname = url.pathname.replace(/\/+$/, "");
+    const basePath = pathname.endsWith("/api")
+      ? pathname.slice(0, -"/api".length)
+      : pathname;
+    url.pathname = `${basePath || ""}/v1`.replace(/\/{2,}/g, "/");
+    return url.toString().replace(/\/$/, "");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Normalize Ollama into the OpenAI-compatible runtime path.
+ *
+ * @elizaos/plugin-ollama currently depends on an older AI SDK adapter and
+ * fails under AI SDK 6 with `Unsupported model version v1`. Ollama exposes an
+ * OpenAI-compatible `/v1` endpoint, so for the selected Ollama provider we can
+ * route inference through @elizaos/plugin-openai instead.
+ */
+/** @internal Exported for testing. */
+export function normalizeOllamaProviderConfig(
+  config: ElizaConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const cloudInferenceEnabled =
+    config.cloud?.enabled === true &&
+    (config.cloud?.inferenceMode ?? "cloud") === "cloud" &&
+    config.cloud?.services?.inference !== false;
+  if (cloudInferenceEnabled) {
+    return false;
+  }
+
+  const activeConnection = inferOnboardingConnectionFromConfig(
+    config as unknown as Record<string, unknown>,
+  );
+  if (
+    activeConnection?.kind === "local-provider" &&
+    activeConnection.provider !== "ollama"
+  ) {
+    return false;
+  }
+
+  const ollamaBaseUrl = readEffectiveEnvValue(config, "OLLAMA_BASE_URL", env);
+  if (!ollamaBaseUrl) {
+    return false;
+  }
+
+  const normalizedBaseUrl = normalizeOllamaOpenAiBaseUrl(ollamaBaseUrl);
+  if (!normalizedBaseUrl) {
+    return false;
+  }
+
+  const openaiApiKey = readEffectiveEnvValue(config, "OPENAI_API_KEY", env);
+  const existingOpenAiSmallModel = readEffectiveEnvValue(
+    config,
+    "OPENAI_SMALL_MODEL",
+    env,
+  );
+  const existingOpenAiLargeModel = readEffectiveEnvValue(
+    config,
+    "OPENAI_LARGE_MODEL",
+    env,
+  );
+  const sharedSmallModel = readEffectiveEnvValue(config, "SMALL_MODEL", env);
+  const sharedLargeModel = readEffectiveEnvValue(config, "LARGE_MODEL", env);
+  const selectedModel =
+    activeConnection?.kind === "local-provider" &&
+    activeConnection.provider === "ollama"
+      ? trimEnvString(activeConnection.primaryModel)
+      : undefined;
+
+  const normalizedSmallModel =
+    existingOpenAiSmallModel ?? sharedSmallModel ?? selectedModel;
+  const normalizedLargeModel =
+    existingOpenAiLargeModel ?? sharedLargeModel ?? selectedModel;
+
+  env.OPENAI_BASE_URL = normalizedBaseUrl;
+  env.OPENAI_API_KEY = openaiApiKey ?? "ollama";
+  setConfigEnvValue(config, "OPENAI_BASE_URL", normalizedBaseUrl);
+  setConfigEnvValue(config, "OPENAI_API_KEY", openaiApiKey ?? "ollama");
+
+  if (normalizedSmallModel) {
+    env.OPENAI_SMALL_MODEL = normalizedSmallModel;
+    setConfigEnvValue(config, "OPENAI_SMALL_MODEL", normalizedSmallModel);
+  }
+  if (normalizedLargeModel) {
+    env.OPENAI_LARGE_MODEL = normalizedLargeModel;
+    setConfigEnvValue(config, "OPENAI_LARGE_MODEL", normalizedLargeModel);
+  }
+
+  delete env.OLLAMA_BASE_URL;
+  deleteConfigEnvValue(config, "OLLAMA_BASE_URL");
+
+  logger.warn(
+    "[eliza] Detected Ollama selection; normalizing runtime settings to use Ollama's OpenAI-compatible /v1 endpoint via @elizaos/plugin-openai",
+  );
+
+  return true;
 }
 
 /**
@@ -4114,6 +4218,7 @@ export async function startEliza(
     }
   }
 
+  normalizeOllamaProviderConfig(config);
   normalizeOpenAiCompatibleProviderConfig(config);
 
   // Log active database configuration for debugging persistence issues

--- a/packages/app-core/src/runtime/eliza.test.ts
+++ b/packages/app-core/src/runtime/eliza.test.ts
@@ -76,6 +76,7 @@ import {
   isEnvKeyAllowedForForwarding,
   isRecoverablePgliteInitError,
   mergeDropInPlugins,
+  normalizeOllamaProviderConfig,
   normalizeOpenAiCompatibleProviderConfig,
   repairBrokenInstallRecord,
   resolvePackageEntry,
@@ -2709,6 +2710,113 @@ describe("OpenAI-compatible Groq normalization", () => {
     expect(
       (config.env as { vars?: Record<string, string> }).vars?.GROQ_LARGE_MODEL,
     ).toBe("qwen/qwen3-32b");
+  });
+});
+
+describe("Ollama OpenAI-compatible normalization", () => {
+  const envKeys = [
+    "OLLAMA_BASE_URL",
+    "OPENAI_API_KEY",
+    "OPENAI_BASE_URL",
+    "OPENAI_SMALL_MODEL",
+    "OPENAI_LARGE_MODEL",
+    "SMALL_MODEL",
+    "LARGE_MODEL",
+  ];
+  const snap = envSnapshot(envKeys);
+
+  beforeEach(() => {
+    snap.save();
+    for (const key of envKeys) delete process.env[key];
+  });
+
+  afterEach(() => snap.restore());
+
+  it("rewrites explicit Ollama selection into OpenAI-compatible runtime settings", () => {
+    const config = {
+      connection: {
+        kind: "local-provider",
+        provider: "ollama",
+        primaryModel: "llama3.2:3b",
+      },
+      env: {
+        vars: {
+          OLLAMA_BASE_URL: "http://127.0.0.1:11434",
+        },
+      },
+    } as Partial<ElizaConfig> as ElizaConfig;
+
+    const changed = normalizeOllamaProviderConfig(config);
+
+    expect(changed).toBe(true);
+    expect(process.env.OLLAMA_BASE_URL).toBeUndefined();
+    expect(process.env.OPENAI_API_KEY).toBe("ollama");
+    expect(process.env.OPENAI_BASE_URL).toBe("http://127.0.0.1:11434/v1");
+    expect(process.env.OPENAI_SMALL_MODEL).toBe("llama3.2:3b");
+    expect(process.env.OPENAI_LARGE_MODEL).toBe("llama3.2:3b");
+    expect(
+      (config.env as { vars?: Record<string, string> }).vars?.OLLAMA_BASE_URL,
+    ).toBeUndefined();
+    expect(
+      (config.env as { vars?: Record<string, string> }).vars?.OPENAI_BASE_URL,
+    ).toBe("http://127.0.0.1:11434/v1");
+    expect(
+      (config.env as { vars?: Record<string, string> }).vars
+        ?.OPENAI_SMALL_MODEL,
+    ).toBe("llama3.2:3b");
+    expect(
+      (config.env as { vars?: Record<string, string> }).vars
+        ?.OPENAI_LARGE_MODEL,
+    ).toBe("llama3.2:3b");
+
+    const names = collectPluginNames(config);
+    expect(names.has("@elizaos/plugin-openai")).toBe(true);
+    expect(names.has("@elizaos/plugin-ollama")).toBe(false);
+  });
+
+  it("preserves shared model overrides and strips legacy /api from the base URL", () => {
+    const config = {
+      connection: {
+        kind: "local-provider",
+        provider: "ollama",
+        primaryModel: "llama3.2:3b",
+      },
+      env: {
+        vars: {
+          OLLAMA_BASE_URL: "http://127.0.0.1:11434/api",
+          SMALL_MODEL: "qwen2.5:7b",
+          LARGE_MODEL: "llama3.1:8b",
+        },
+      },
+    } as Partial<ElizaConfig> as ElizaConfig;
+
+    const changed = normalizeOllamaProviderConfig(config);
+
+    expect(changed).toBe(true);
+    expect(process.env.OPENAI_BASE_URL).toBe("http://127.0.0.1:11434/v1");
+    expect(process.env.OPENAI_SMALL_MODEL).toBe("qwen2.5:7b");
+    expect(process.env.OPENAI_LARGE_MODEL).toBe("llama3.1:8b");
+  });
+
+  it("does not hijack non-Ollama explicit selections that happen to keep OLLAMA_BASE_URL around", () => {
+    const config = {
+      connection: {
+        kind: "local-provider",
+        provider: "anthropic",
+        primaryModel: "claude-sonnet-4.5",
+      },
+      env: {
+        vars: {
+          OLLAMA_BASE_URL: "http://127.0.0.1:11434",
+        },
+      },
+    } as Partial<ElizaConfig> as ElizaConfig;
+
+    const changed = normalizeOllamaProviderConfig(config);
+
+    expect(changed).toBe(false);
+    expect(process.env.OPENAI_BASE_URL).toBeUndefined();
+    expect(process.env.OPENAI_API_KEY).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary
- route selected Ollama configs through Ollama's OpenAI-compatible runtime path
- stop loading the incompatible Ollama plugin for text inference on current head
- make Linux window close quit the app instead of leaving background ports bound
- add regression coverage for both paths

## Validation
- previously validated on fork CI at https://github.com/dutchiono/milady/pull/4
- targeted local checks were run in the QA branch before splitting the clean upstream branch