### PR TITLE
fix: harden prompt compaction boundary guard

### DIFF
--- a/packages/agent/src/runtime/__tests__/prompt-optimization-actions.test.ts
+++ b/packages/agent/src/runtime/__tests__/prompt-optimization-actions.test.ts
@@ -611,6 +611,18 @@ Possible response actions: REPLY, START_CODING_TASK
     const prompt = "just a plain prompt with no examples";
     expect(compactCodingExamplesForIntent(prompt)).toBe(prompt);
   });
+
+  it("returns prompt unchanged when boundary header is missing", () => {
+    // If # Available Actions is absent, the regex would match to end-of-string.
+    // The guard should prevent stripping in this case.
+    const malformed = `# Coding Agent Action Call Examples
+Some examples here
+## Single Agent Examples
+More content that should NOT be stripped`;
+    const result = compactCodingExamplesForIntent(malformed);
+    expect(result).toContain("# Coding Agent Action Call Examples");
+    expect(result).toContain("should NOT be stripped");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/agent/src/runtime/prompt-compaction.ts
+++ b/packages/agent/src/runtime/prompt-compaction.ts
@@ -274,6 +274,9 @@ export function compactConversationHistory(prompt: string): string {
  */
 export function compactCodingExamplesForIntent(prompt: string): string {
   if (hasIntent(prompt, CODING_INTENT_RE)) return prompt;
+  // Guard: if the boundary header is missing, don't strip — the regex would
+  // match to end-of-string and remove everything after the examples header.
+  if (!prompt.includes("# Available Actions")) return prompt;
   // Strip everything from the examples header up to (but not including)
   // the "# Available Actions" header. The examples section contains its own
   // <actions> tags as part of the examples, so we can't use <actions> as a


### PR DESCRIPTION
## Summary
If `# Available Actions` header is absent from a malformed prompt, `compactCodingExamplesForIntent` would match to end-of-string and strip everything after the examples header. Added a guard to return the prompt unchanged when the boundary header is missing.

Follow-up from PR #1530 review feedback.

## Test plan
- [x] New test: malformed prompt without boundary header returns unchanged
- [x] 51 total tests pass
- [x] Biome clean, tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)