### PR TITLE
fix: harden windows installer reentry

### DIFF
--- a/.github/workflows/docker-ci-smoke.yml
+++ b/.github/workflows/docker-ci-smoke.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   docker-ci-smoke:
     name: Build production Docker image (+ smoke boot)
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_UBUNTU || (github.repository_owner == 'milady-ai' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-latest') }}
     timeout-minutes: 90
     env:
       BUN_VERSION: "1.3.10"

--- a/.github/workflows/test-electrobun-release.yml
+++ b/.github/workflows/test-electrobun-release.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   validate-release-workflow:
     name: Release Workflow Contract
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_UBUNTU || (github.repository_owner == 'milady-ai' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-latest') }}
     timeout-minutes: 20
     defaults:
       run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   regression-matrix:
     name: Regression Matrix Contract
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_UBUNTU || (github.repository_owner == 'milady-ai' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-latest') }}
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -38,7 +38,7 @@ jobs:
 
   unit-tests:
     name: Unit Tests
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_UBUNTU || (github.repository_owner == 'milady-ai' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-latest') }}
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -70,7 +70,7 @@ jobs:
 
   db-check:
     name: Database Security Check
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_UBUNTU || (github.repository_owner == 'milady-ai' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-latest') }}
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -94,7 +94,7 @@ jobs:
 
   e2e-tests:
     name: E2E Tests (Vitest)
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_UBUNTU || (github.repository_owner == 'milady-ai' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-latest') }}
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -120,7 +120,7 @@ jobs:
 
   app-startup-e2e:
     name: App Startup E2E (Onboarding)
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_UBUNTU || (github.repository_owner == 'milady-ai' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-latest') }}
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -146,7 +146,7 @@ jobs:
 
   desktop-contract:
     name: Electrobun Desktop Contract
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_UBUNTU || (github.repository_owner == 'milady-ai' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-latest') }}
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -202,7 +202,7 @@ jobs:
 
   cloud-live-e2e:
     name: Cloud Live E2E (Eliza Cloud)
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_UBUNTU || (github.repository_owner == 'milady-ai' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-latest') }}
     timeout-minutes: 20
     steps:
       - name: Check cloud secrets
@@ -241,7 +241,7 @@ jobs:
 
   validation-e2e:
     name: End-to-End Validation (Issue #6)
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_UBUNTU || (github.repository_owner == 'milady-ai' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-latest') }}
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -265,7 +265,7 @@ jobs:
     name: All Tests Passed
     if: always()
     needs: [regression-matrix, unit-tests, db-check, e2e-tests, app-startup-e2e, desktop-contract, cloud-live-e2e, validation-e2e]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_UBUNTU || (github.repository_owner == 'milady-ai' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-latest') }}
     steps:
       - name: Check test results
         shell: bash

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   update-tap:
     name: Trigger Homebrew tap update
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_UBUNTU || (github.repository_owner == 'milady-ai' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-latest') }}
     steps:
       - name: Determine version
         id: meta
@@ -44,6 +44,6 @@ jobs:
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          repository: milady-ai/homebrew-tap
+          repository: ${{ vars.HOMEBREW_TAP_REPO || 'milady-ai/homebrew-tap' }}
           event-type: update-homebrew
           client-payload: '{"version": "${{ steps.meta.outputs.version }}"}'

--- a/apps/app/electrobun/scripts/verify-windows-installer-proof.ps1
+++ b/apps/app/electrobun/scripts/verify-windows-installer-proof.ps1
@@ -54,6 +54,7 @@ $summary = [ordered]@{
   uninstallerPath = $null
   checks = [ordered]@{
     installerExecuted = $false
+    reinstallExecuted = $false
     installRootExists = $false
     launcherExists = $false
     shortcutExists = $false
@@ -151,6 +152,23 @@ try {
     throw "Uninstaller executable was not found under $ProofInstallDir"
   }
   $summary.uninstallerPath = $uninstaller.FullName
+
+  Stop-MiladyProcesses
+
+  # Re-run the installer into the same target to catch upgrade/reinstall
+  # regressions where stale runtime directories break file replacement.
+  $reinstallArgs = @(
+    "/VERYSILENT",
+    "/SUPPRESSMSGBOXES",
+    "/NORESTART",
+    "/SP-",
+    "/DIR=$ProofInstallDir"
+  )
+  $reinstallProcess = Start-Process -FilePath $installer.FullName -ArgumentList $reinstallArgs -WorkingDirectory $installer.DirectoryName -PassThru -Wait
+  if ($reinstallProcess.ExitCode -ne 0) {
+    throw "Installer reinstall exited with code $($reinstallProcess.ExitCode)"
+  }
+  $summary.checks.reinstallExecuted = $true
 
   Stop-MiladyProcesses
 

--- a/packaging/inno/Milady.iss
+++ b/packaging/inno/Milady.iss
@@ -33,7 +33,7 @@ ArchitecturesInstallIn64BitMode=x64compatible
 PrivilegesRequired=lowest
 WizardStyle=modern
 SetupLogging=yes
-CloseApplications=no
+CloseApplications=yes
 RestartIfNeededByRun=no
 __SIGN_SETUP_LINES__
 
@@ -42,6 +42,15 @@ Name: "en"; MessagesFile: "compiler:Default.isl"
 
 [Tasks]
 Name: "desktopicon"; Description: "Create a desktop shortcut"; GroupDescription: "Additional shortcuts:"
+
+[InstallDelete]
+; Reinstall/upgrade in place over a stale runtime tree can fail during file
+; replacement (MoveFile code 3) when old runtime directories are partially
+; missing or mismatched. Clear the mutable bundle roots first, then copy the
+; packaged app back in atomically.
+Type: filesandordirs; Name: "{app}\Resources"
+Type: filesandordirs; Name: "{app}\resources"
+Type: filesandordirs; Name: "{app}\bin"
 
 [Files]
 Source: "{#MySourceDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs

--- a/scripts/electrobun-release-workflow-drift.test.ts
+++ b/scripts/electrobun-release-workflow-drift.test.ts
@@ -476,6 +476,14 @@ describe("Electrobun release workflow drift", () => {
     expect(template).toContain(
       'Name: "{autodesktop}\\{#MyAppName}"; Filename: "{app}\\{#MyAppExeName}"; Tasks: desktopicon; IconFilename: "{app}\\{#MyAppIconFile}"',
     );
+    expect(template).toContain("CloseApplications=yes");
+    expect(template).toContain(
+      'Type: filesandordirs; Name: "{app}\\Resources"',
+    );
+    expect(template).toContain(
+      'Type: filesandordirs; Name: "{app}\\resources"',
+    );
+    expect(template).toContain('Type: filesandordirs; Name: "{app}\\bin"');
     expect(template).not.toContain('#define MyAppExeName "launcher.exe"');
   });
 
@@ -772,6 +780,13 @@ describe("Electrobun release workflow drift", () => {
     expect(proofScript).toContain("Start Menu");
     expect(proofScript).toContain("unins*.exe");
     expect(proofScript).toContain("proof-summary.json");
+    expect(proofScript).toContain("reinstallExecuted");
+    expect(proofScript).toContain(
+      "$reinstallProcess = Start-Process -FilePath $installer.FullName",
+    );
+    expect(proofScript).toContain(
+      'throw "Installer reinstall exited with code $($reinstallProcess.ExitCode)"',
+    );
   });
 
   it("normalizes Windows setup upload inputs down to canonical installer naming", () => {

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -793,6 +793,9 @@ function assertWindowsInstallerProofScript() {
     "Start Menu",
     "unins*.exe",
     "proof-summary.json",
+    "reinstallExecuted",
+    "$reinstallProcess = Start-Process -FilePath $installer.FullName",
+    'throw "Installer reinstall exited with code $($reinstallProcess.ExitCode)"',
   ];
   const missingSnippets = requiredSnippets.filter(
     (snippet) => !script.includes(snippet),
@@ -844,6 +847,10 @@ function assertInnoTemplateTargetsBundledLauncher() {
     "UninstallDisplayIcon={app}\\{#MyAppIconFile}",
     'Name: "{autoprograms}\\{#MyDefaultGroupName}\\{#MyAppName}"; Filename: "{app}\\{#MyAppExeName}"; IconFilename: "{app}\\{#MyAppIconFile}"',
     'Name: "{autodesktop}\\{#MyAppName}"; Filename: "{app}\\{#MyAppExeName}"; Tasks: desktopicon; IconFilename: "{app}\\{#MyAppIconFile}"',
+    "CloseApplications=yes",
+    'Type: filesandordirs; Name: "{app}\\Resources"',
+    'Type: filesandordirs; Name: "{app}\\resources"',
+    'Type: filesandordirs; Name: "{app}\\bin"',
   ];
   const missingSnippets = requiredSnippets.filter(
     (snippet) => !template.includes(snippet),

--- a/scripts/release-support-workflows-drift.test.ts
+++ b/scripts/release-support-workflows-drift.test.ts
@@ -158,7 +158,9 @@ describe("release support workflow drift", () => {
   it("dispatches Homebrew updates to the actual tap repository", () => {
     const workflow = fs.readFileSync(UPDATE_HOMEBREW_WORKFLOW, "utf8");
 
-    expect(workflow).toContain("repository: milady-ai/homebrew-tap");
+    expect(workflow).toContain(
+      "repository: ${{ vars.HOMEBREW_TAP_REPO || 'milady-ai/homebrew-tap' }}",
+    );
     expect(workflow).not.toContain("repository: milady-ai/homebrew-milady");
   });
 });


### PR DESCRIPTION
## Summary\n- harden the Windows Inno installer against stale runtime trees during reinstall and upgrade\n- make the Windows installer proof script rerun the installer against the same target before uninstall\n- align release workflow contract checks with fork-safe Homebrew and Ubuntu runner configuration\n\n## Problem\nWindows installs could fail during reinstall or upgrade with MoveFile failed; code 3 when the target runtime tree under %LOCALAPPDATA%\\Milady\\canary was stale or partially broken. The installer proof path also did not exercise that reinstall path.\n\n## Fix\n- enable application closure during install and clear stale runtime bundle roots before copying\n- rerun the installer in the proof script against the same destination before uninstall\n- update workflow drift checks so milady-ai/milady keeps Blacksmith while forks fall back to RUNNER_UBUNTU or ubuntu-latest\n\n## Validation\n- unx vitest run scripts/electrobun-release-workflow-drift.test.ts scripts/release-support-workflows-drift.test.ts\n- fork PR passing: https://github.com/dutchiono/milady/pull/7\n