### PR TITLE
[codex] Fix desktop background window restore on Windows

### DIFF
--- a/apps/app/electrobun/electrobun.config.ts
+++ b/apps/app/electrobun/electrobun.config.ts
@@ -65,10 +65,11 @@ export default {
       // package.json is needed so findOwnPackageRoot() can match on the
       // "milady" package name. dist/package.json only has {"type":"module"}.
       "../../../package.json": "milady-dist/package.json",
-      // Tray icon loaded at runtime via path.join(import.meta.dir, "../assets/appIcon.png").
-      // import.meta.dir resolves to app/bun/ in the packaged bundle, so the
-      // destination "assets/appIcon.png" places it at app/assets/appIcon.png.
+      // Runtime window + tray icons are loaded via path.join(import.meta.dir, "../assets/appIcon.*").
+      // import.meta.dir resolves to app/bun/ in the packaged bundle, so these
+      // destinations place the assets at app/assets/appIcon.*.
       "assets/appIcon.png": "assets/appIcon.png",
+      "assets/appIcon.ico": "assets/appIcon.ico",
       // Optional native blur (run build:native-effects locally). Omit when missing to avoid noisy copy errors in dev.
       ...(process.platform === "darwin" &&
       fs.existsSync(libMacWindowEffectsDylib)

--- a/apps/app/electrobun/src/__tests__/startup-bootstrap.test.ts
+++ b/apps/app/electrobun/src/__tests__/startup-bootstrap.test.ts
@@ -3,6 +3,12 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 const INDEX_PATH = path.resolve(import.meta.dirname, "..", "index.ts");
+const CONFIG_PATH = path.resolve(
+  import.meta.dirname,
+  "..",
+  "..",
+  "electrobun.config.ts",
+);
 const BACKGROUND_NOTICE_PATH = path.resolve(
   import.meta.dirname,
   "..",
@@ -47,11 +53,15 @@ describe("Electrobun startup bootstrap", () => {
 
   it("uses the packaged app icon for the main window and tray", () => {
     const source = fs.readFileSync(INDEX_PATH, "utf8");
+    const configSource = fs.readFileSync(CONFIG_PATH, "utf8");
 
     expect(source).toContain("function resolveDesktopAppIconPath()");
     expect(source).toContain("icon: resolveDesktopAppIconPath(),");
     expect(source).toContain('process.platform === "win32"');
     expect(source).toContain('"../assets/appIcon.ico"');
+    expect(configSource).toContain(
+      '"assets/appIcon.ico": "assets/appIcon.ico"',
+    );
   });
 
   it("resolves the initial renderer API base from desktop runtime mode", () => {

--- a/apps/app/electrobun/src/index.ts
+++ b/apps/app/electrobun/src/index.ts
@@ -1612,10 +1612,12 @@ async function main(): Promise<void> {
   });
 
   // Wire detached window callbacks so menus and RPC can open them.
-  getDesktopManager().setOpenSettingsCallback((tabHint) => {
+  const desktopManager = getDesktopManager();
+  desktopManager.setRestoreMainWindowCallback(() => restoreWindow());
+  desktopManager.setOpenSettingsCallback((tabHint) => {
     void createSettingsWindow(tabHint);
   });
-  getDesktopManager().setOpenSurfaceWindowCallback((surface, browse) => {
+  desktopManager.setOpenSurfaceWindowCallback((surface, browse) => {
     if (!surfaceWindowManager) {
       return;
     }
@@ -1637,7 +1639,7 @@ async function main(): Promise<void> {
   setupDeepLinks();
   setupDockReopen();
 
-  const desktop = getDesktopManager();
+  const desktop = desktopManager;
   try {
     await desktop.createTray({
       icon: resolveDesktopAppIconPath(),

--- a/apps/app/electrobun/src/native/__tests__/desktop.test.ts
+++ b/apps/app/electrobun/src/native/__tests__/desktop.test.ts
@@ -581,7 +581,9 @@ describe("DesktopManager", () => {
 
       const snapshot = await manager.getUpdaterState();
 
-      expect(snapshot.appBundlePath).toBe("/Volumes/Milady/Milady.app");
+      expect(snapshot.appBundlePath?.replaceAll("\\", "/")).toMatch(
+        /\/Volumes\/Milady\/Milady\.app$/,
+      );
       expect(snapshot.canAutoUpdate).toBe(false);
       expect(snapshot.autoUpdateDisabledReason).toContain(
         "Move Milady.app to /Applications",
@@ -857,6 +859,57 @@ describe("DesktopManager", () => {
   });
 
   describe("window restore", () => {
+    it("restores the main window before showing when the app is background-only", async () => {
+      const restoredWindow = {
+        show: vi.fn(),
+        focus: vi.fn(),
+        on: vi.fn(),
+        off: vi.fn(),
+        isMaximized: vi.fn(() => false),
+        isMinimized: vi.fn(() => false),
+      };
+      const restoreWindow = vi.fn(() => {
+        manager.setMainWindow(
+          restoredWindow as Parameters<DesktopManager["setMainWindow"]>[0],
+        );
+      });
+
+      manager.setRestoreMainWindowCallback(restoreWindow);
+      manager.clearMainWindow();
+
+      await manager.showWindow();
+
+      expect(restoreWindow).toHaveBeenCalledTimes(1);
+      expect(restoredWindow.show).toHaveBeenCalledTimes(1);
+      expect(restoredWindow.focus).toHaveBeenCalledTimes(1);
+    });
+
+    it("clears the stale window handle when the attached window closes", () => {
+      const fakeWindow = {
+        on: vi.fn(),
+        off: vi.fn(),
+        isMaximized: vi.fn(() => false),
+        isMinimized: vi.fn(() => false),
+      };
+
+      manager.setMainWindow(
+        fakeWindow as Parameters<DesktopManager["setMainWindow"]>[0],
+      );
+
+      const closeHandler = (
+        fakeWindow.on as ReturnType<typeof vi.fn>
+      ).mock.calls.find(([event]) => event === "close")?.[1] as
+        | (() => void)
+        | undefined;
+
+      expect(closeHandler).toBeTypeOf("function");
+      closeHandler?.();
+
+      expect(
+        (manager as unknown as { getWindow: () => unknown }).getWindow(),
+      ).toBeNull();
+    });
+
     it("restores a minimized macOS window when the app becomes active", async () => {
       vi.useFakeTimers();
       setPlatform("darwin");

--- a/apps/app/electrobun/src/native/__tests__/desktop.test.ts
+++ b/apps/app/electrobun/src/native/__tests__/desktop.test.ts
@@ -52,6 +52,10 @@ vi.mock("../rpc-schema", () => ({}));
 // electrobun/bun must be mocked before module import so PATH_NAME_MAP (which
 // reads Utils.paths.* at module load time) resolves to the mock values.
 vi.mock("electrobun/bun", () => {
+  const electrobunEvents = {
+    on: vi.fn(),
+    off: vi.fn(),
+  };
   const createBrowserWindowInstance = () => ({
     id: 99,
     frame: { width: 1180, height: 860 },
@@ -70,6 +74,15 @@ vi.mock("electrobun/bun", () => {
     remove: vi.fn(),
   });
 
+  const createTrayInstance = () => ({
+    on: vi.fn(),
+    off: vi.fn(),
+    setTitle: vi.fn(),
+    setImage: vi.fn(),
+    setMenu: vi.fn(),
+    remove: vi.fn(),
+  });
+
   // biome-ignore lint/complexity/useArrowFunction: constructor mock requires a regular function
   const MockBrowserWindow = vi.fn(function () {
     return createBrowserWindowInstance();
@@ -80,10 +93,15 @@ vi.mock("electrobun/bun", () => {
   ) {
     return createBrowserViewInstance(options);
   });
+  // biome-ignore lint/complexity/useArrowFunction: constructor mock requires a regular function
+  const MockTray = vi.fn(function () {
+    return createTrayInstance();
+  });
 
   return {
     default: {
       BrowserWindow: MockBrowserWindow,
+      events: electrobunEvents,
     },
     Utils: {
       paths: {
@@ -111,7 +129,7 @@ vi.mock("electrobun/bun", () => {
       isDockIconVisible: vi.fn(() => true),
       setDockIconVisible: vi.fn(),
     },
-    Tray: { create: vi.fn() },
+    Tray: MockTray,
     GlobalShortcut: { register: vi.fn(), unregister: vi.fn() },
     Updater: {
       localInfo: { version: vi.fn(async () => "2.0.0") },
@@ -172,7 +190,7 @@ vi.mock("electrobun/bun", () => {
     },
     BrowserView: MockBrowserView,
     BrowserWindow: MockBrowserWindow,
-    Electrobun: {},
+    events: electrobunEvents,
   };
 });
 
@@ -223,12 +241,24 @@ const mockBrowserView = electrobunBun.BrowserView as ReturnType<typeof vi.fn>;
 const mockBrowserWindow = (
   electrobunBun.default as { BrowserWindow: ReturnType<typeof vi.fn> }
 ).BrowserWindow;
+const mockTray = electrobunBun.Tray as ReturnType<typeof vi.fn>;
+const mockElectrobunEventsOn = (
+  electrobunBun.default as {
+    events: { on: ReturnType<typeof vi.fn>; off: ReturnType<typeof vi.fn> };
+  }
+).events.on;
+const mockElectrobunEventsOff = (
+  electrobunBun.default as {
+    events: { on: ReturnType<typeof vi.fn>; off: ReturnType<typeof vi.fn> };
+  }
+).events.off;
 const mockSpawn = (globalThis as { Bun: { spawn: ReturnType<typeof vi.fn> } })
   .Bun.spawn;
 const mockIsAppActive = macEffects.isAppActive as ReturnType<typeof vi.fn>;
 const mockMakeKeyAndOrderFront = macEffects.makeKeyAndOrderFront as ReturnType<
   typeof vi.fn
 >;
+const mockQuit = electrobunBun.Utils.quit as ReturnType<typeof vi.fn>;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -299,9 +329,13 @@ describe("DesktopManager", () => {
       }));
     mockBrowserView.mockClear();
     mockBrowserWindow.mockClear();
+    mockTray.mockClear();
+    mockElectrobunEventsOn.mockReset();
+    mockElectrobunEventsOff.mockReset();
     mockSpawn.mockReset().mockReturnValue(makeSpawnResult(""));
     mockIsAppActive.mockReset().mockReturnValue(false);
     mockMakeKeyAndOrderFront.mockReset().mockReturnValue(true);
+    mockQuit.mockReset();
   });
 
   afterEach(() => {
@@ -908,6 +942,141 @@ describe("DesktopManager", () => {
       expect(
         (manager as unknown as { getWindow: () => unknown }).getWindow(),
       ).toBeNull();
+    });
+
+    it("restores and shows a replacement window when the cached handle is stale", async () => {
+      const restoredWindow = {
+        show: vi.fn(),
+        focus: vi.fn(),
+        on: vi.fn(),
+        off: vi.fn(),
+        isMaximized: vi.fn(() => false),
+        isMinimized: vi.fn(() => false),
+      };
+      const staleWindow = {
+        show: vi.fn(() => {
+          throw new Error("stale window");
+        }),
+        focus: vi.fn(),
+        on: vi.fn(),
+        off: vi.fn(),
+        isMaximized: vi.fn(() => false),
+        isMinimized: vi.fn(() => false),
+      };
+      const restoreWindow = vi.fn(() => {
+        manager.setMainWindow(
+          restoredWindow as Parameters<DesktopManager["setMainWindow"]>[0],
+        );
+      });
+
+      manager.setRestoreMainWindowCallback(restoreWindow);
+      manager.setMainWindow(
+        staleWindow as Parameters<DesktopManager["setMainWindow"]>[0],
+      );
+
+      await manager.showWindow();
+
+      expect(staleWindow.show).toHaveBeenCalledTimes(1);
+      expect(restoreWindow).toHaveBeenCalledTimes(1);
+      expect(restoredWindow.show).toHaveBeenCalledTimes(1);
+      expect(restoredWindow.focus).toHaveBeenCalledTimes(1);
+    });
+
+    it("restores the same background process when the tray icon is clicked after close", async () => {
+      const restoredWindow = {
+        show: vi.fn(),
+        focus: vi.fn(),
+        on: vi.fn(),
+        off: vi.fn(),
+        isMaximized: vi.fn(() => false),
+        isMinimized: vi.fn(() => false),
+      };
+      const restoreWindow = vi.fn(() => {
+        manager.setMainWindow(
+          restoredWindow as Parameters<DesktopManager["setMainWindow"]>[0],
+        );
+      });
+
+      manager.setRestoreMainWindowCallback(restoreWindow);
+      await manager.createTray({
+        icon: "/mock/icon.png",
+        title: "Milady",
+        menu: [
+          { id: "tray-show-window", label: "Show Window", type: "normal" },
+        ],
+      });
+      manager.clearMainWindow();
+
+      const trayInstance = mockTray.mock.results.at(-1)?.value as {
+        on: ReturnType<typeof vi.fn>;
+      };
+      const trayClickHandler = trayInstance.on.mock.calls.find(
+        ([event]) => event === "tray-clicked",
+      )?.[1] as (() => void) | undefined;
+
+      expect(trayClickHandler).toBeTypeOf("function");
+      trayClickHandler?.();
+      await Promise.resolve();
+
+      expect(restoreWindow).toHaveBeenCalledTimes(1);
+      expect(restoredWindow.show).toHaveBeenCalledTimes(1);
+      expect(restoredWindow.focus).toHaveBeenCalledTimes(1);
+    });
+
+    it("restores the same background process from the tray show action after close", async () => {
+      const restoredWindow = {
+        show: vi.fn(),
+        focus: vi.fn(),
+        on: vi.fn(),
+        off: vi.fn(),
+        isMaximized: vi.fn(() => false),
+        isMinimized: vi.fn(() => false),
+      };
+      const restoreWindow = vi.fn(() => {
+        manager.setMainWindow(
+          restoredWindow as Parameters<DesktopManager["setMainWindow"]>[0],
+        );
+      });
+
+      manager.setRestoreMainWindowCallback(restoreWindow);
+      await manager.createTray({
+        icon: "/mock/icon.png",
+        title: "Milady",
+        menu: [
+          { id: "tray-show-window", label: "Show Window", type: "normal" },
+        ],
+      });
+      manager.clearMainWindow();
+
+      const contextMenuHandler = mockElectrobunEventsOn.mock.calls.find(
+        ([event]) => event === "tray-clicked",
+      )?.[1] as ((event: { data?: { action?: string } }) => void) | undefined;
+
+      expect(contextMenuHandler).toBeTypeOf("function");
+      contextMenuHandler?.({ data: { action: "tray-show-window" } });
+      await Promise.resolve();
+
+      expect(restoreWindow).toHaveBeenCalledTimes(1);
+      expect(restoredWindow.show).toHaveBeenCalledTimes(1);
+      expect(restoredWindow.focus).toHaveBeenCalledTimes(1);
+    });
+
+    it("still quits from the tray menu when no window is attached", async () => {
+      await manager.createTray({
+        icon: "/mock/icon.png",
+        title: "Milady",
+        menu: [{ id: "quit", label: "Quit", type: "normal" }],
+      });
+      manager.clearMainWindow();
+
+      const contextMenuHandler = mockElectrobunEventsOn.mock.calls.find(
+        ([event]) => event === "tray-clicked",
+      )?.[1] as ((event: { data?: { action?: string } }) => void) | undefined;
+
+      expect(contextMenuHandler).toBeTypeOf("function");
+      contextMenuHandler?.({ data: { action: "quit" } });
+
+      expect(mockQuit).toHaveBeenCalledTimes(1);
     });
 
     it("restores a minimized macOS window when the app becomes active", async () => {

--- a/apps/app/electrobun/src/native/desktop.ts
+++ b/apps/app/electrobun/src/native/desktop.ts
@@ -166,6 +166,7 @@ export class DesktopManager {
 
   // Callback to open the settings window (set by index.ts)
   private openSettingsCallback: ((tabHint?: string) => void) | null = null;
+  private restoreMainWindowCallback: (() => Promise<void> | void) | null = null;
   private openSurfaceWindowCallback:
     | ((
         surface:
@@ -226,6 +227,14 @@ export class DesktopManager {
   }
 
   /**
+   * Set the callback used to restore the main window when the app is still
+   * running in the background but no BrowserWindow is currently attached.
+   */
+  setRestoreMainWindowCallback(cb: (() => Promise<void> | void) | null): void {
+    this.restoreMainWindowCallback = cb;
+  }
+
+  /**
    * Set the callback used to open detached surface windows from RPC or menus.
    */
   setOpenSurfaceWindowCallback(
@@ -258,6 +267,16 @@ export class DesktopManager {
    */
   openSettings(tabHint?: string): void {
     this.openSettingsCallback?.(tabHint);
+  }
+
+  clearMainWindow(window?: BrowserWindow | null): void {
+    if (window && this.mainWindow !== window) {
+      return;
+    }
+    this.teardownWindowEvents(this.mainWindow);
+    this.mainWindow = null;
+    this._windowHidden = true;
+    this._windowFocused = false;
   }
 
   /**
@@ -874,16 +893,25 @@ X-GNOME-Autostart-enabled=true
   }
 
   async showWindow(): Promise<void> {
-    const win = this.mainWindow;
+    let win = this.mainWindow;
+    if (!win) {
+      await this.restoreMainWindowCallback?.();
+      win = this.mainWindow;
+    }
     if (!win) return;
     const ptr = (win as { ptr?: unknown }).ptr;
-    if (ptr && process.platform === "darwin") {
-      makeKeyAndOrderFront(ptr as Parameters<typeof makeKeyAndOrderFront>[0]);
-    } else {
-      win.show();
-      win.focus();
+    try {
+      if (ptr && process.platform === "darwin") {
+        makeKeyAndOrderFront(ptr as Parameters<typeof makeKeyAndOrderFront>[0]);
+      } else {
+        win.show();
+        win.focus();
+      }
+      this._windowHidden = false;
+    } catch {
+      this.clearMainWindow(win);
+      await this.restoreMainWindowCallback?.();
     }
-    this._windowHidden = false;
   }
 
   async hideWindow(): Promise<void> {
@@ -901,7 +929,12 @@ X-GNOME-Autostart-enabled=true
   }
 
   async focusWindow(): Promise<void> {
-    this.getWindow()?.focus();
+    let win = this.getWindow();
+    if (!win) {
+      await this.restoreMainWindowCallback?.();
+      win = this.getWindow();
+    }
+    win?.focus();
   }
 
   async isWindowMaximized(): Promise<{ maximized: boolean }> {
@@ -958,6 +991,7 @@ X-GNOME-Autostart-enabled=true
     win.on("blur", blurHandler);
 
     const closeHandler = () => {
+      this.clearMainWindow(win);
       this.send("desktopWindowClose");
     };
     this.windowEventHandlers.close = closeHandler;

--- a/apps/app/electrobun/src/native/desktop.ts
+++ b/apps/app/electrobun/src/native/desktop.ts
@@ -899,18 +899,14 @@ X-GNOME-Autostart-enabled=true
       win = this.mainWindow;
     }
     if (!win) return;
-    const ptr = (win as { ptr?: unknown }).ptr;
     try {
-      if (ptr && process.platform === "darwin") {
-        makeKeyAndOrderFront(ptr as Parameters<typeof makeKeyAndOrderFront>[0]);
-      } else {
-        win.show();
-        win.focus();
-      }
-      this._windowHidden = false;
+      this.showMainWindow(win);
     } catch {
       this.clearMainWindow(win);
       await this.restoreMainWindowCallback?.();
+      win = this.mainWindow;
+      if (!win) return;
+      this.showMainWindow(win);
     }
   }
 
@@ -969,6 +965,17 @@ X-GNOME-Autostart-enabled=true
 
   async setOpacity(_options: SetOpacityOptions): Promise<void> {
     // No-op: Electrobun BrowserWindow does not support setOpacity
+  }
+
+  private showMainWindow(win: BrowserWindow): void {
+    const ptr = (win as { ptr?: unknown }).ptr;
+    if (ptr && process.platform === "darwin") {
+      makeKeyAndOrderFront(ptr as Parameters<typeof makeKeyAndOrderFront>[0]);
+    } else {
+      win.show();
+      win.focus();
+    }
+    this._windowHidden = false;
   }
 
   private setupWindowEvents(): void {


### PR DESCRIPTION
## Summary
- restore the main Electrobun window from the existing background process instead of relying on a stale window handle
- clear the desktop manager's main-window reference when the user closes the window so tray and reopen actions recreate it correctly
- add regression coverage for background-only window restore and make the existing macOS updater-path assertion host-platform safe

## Root cause
Closing the window cleared `currentWindow` in the main process, but `DesktopManager` kept its old `mainWindow` reference. Tray and reopen paths then tried to act on that stale handle instead of restoring the hidden app process on Windows.

## Validation
- `vitest run apps/app/electrobun/src/native/__tests__/desktop.test.ts`
- `vitest run apps/app/electrobun/src/__tests__/startup-bootstrap.test.ts`
- `bun run lint`
- `bun run typecheck`
