### PR TITLE
fix: disable Open UI button during provisioning + adaptive polling

### DIFF
--- a/apps/homepage/src/components/dashboard/AgentCard.tsx
+++ b/apps/homepage/src/components/dashboard/AgentCard.tsx
@@ -163,7 +163,7 @@ export function AgentCard({
   busy = false,
 }: AgentCardProps) {
   const stateConfig = STATE_CONFIG[agent.state] ?? STATE_CONFIG.unknown;
-  const canOpenUI = agent.state === "running" || source === "cloud";
+  const canOpenUI = agent.state === "running";
   const uiUrl = webUiUrl || sourceUrl;
   const resolvedAvatarIndex =
     avatarIndexProp ?? getAvatarIndex(agent.agentName);

--- a/apps/homepage/src/components/dashboard/AgentDetail.tsx
+++ b/apps/homepage/src/components/dashboard/AgentDetail.tsx
@@ -178,7 +178,7 @@ export function AgentDetail({
 
         {/* Quick actions */}
         <div className="flex items-center gap-2">
-          {webUIUrl && (
+          {webUIUrl && agent.state === "running" && (
             <button
               type="button"
               onClick={() =>

--- a/apps/homepage/src/lib/AgentProvider.tsx
+++ b/apps/homepage/src/lib/AgentProvider.tsx
@@ -571,6 +571,22 @@ export function AgentProvider({ children }: { children: ReactNode }) {
     setIsRefreshing(false);
   }, []);
 
+  // Adaptive polling: 5s when any agent is provisioning, 30s otherwise
+  const activeIntervalMs = useRef<number>(30000);
+
+  useEffect(() => {
+    const hasProvisioning = agents.some((a) => a.status === "provisioning");
+    const desiredInterval = hasProvisioning ? 5000 : 30000;
+
+    if (desiredInterval !== activeIntervalMs.current) {
+      activeIntervalMs.current = desiredInterval;
+      if (intervalRef.current !== null) {
+        clearInterval(intervalRef.current);
+      }
+      intervalRef.current = setInterval(fetchAll, desiredInterval);
+    }
+  }, [agents, fetchAll]);
+
   useEffect(() => {
     void fetchAll();
     intervalRef.current = setInterval(fetchAll, 30000);


### PR DESCRIPTION
## Changes

### 1. Disable "Open Web UI" button during provisioning/stopped states

**AgentCard.tsx:** Changed `canOpenUI` from `agent.state === 'running' || source === 'cloud'` to `agent.state === 'running'`. Cloud agents in provisioning/stopped state no longer show a broken Open UI button.

**AgentDetail.tsx:** Added `agent.state === 'running'` gate to the OPEN UI button in the header bar.

### 2. Adaptive polling during provisioning

**AgentProvider.tsx:** Polling interval dynamically switches between:
- **5 seconds** when ANY agent has `status === 'provisioning'`
- **30 seconds** otherwise (normal state)

Interval is cleaned up properly on unmount.