### PR TITLE
fix(ci): trigger Docker build on GitHub Release publish

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -4,6 +4,7 @@
 #
 # Triggers:
 #   - Push of release tags: v2.0.0-alpha.*, v2.0.*
+#   - GitHub Release published (covers tags created via API/UI)
 #   - Reusable workflow call from agent-release.yml for validated releases
 #   - Manual dispatch (workflow_dispatch) with optional override
 #   - Push to develop branch (produces :dev tag, no :latest)
@@ -27,6 +28,8 @@ on:
       - 'v2.0.*'
     branches:
       - develop
+  release:
+    types: [published]
   workflow_call:
     inputs:
       version:
@@ -92,7 +95,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ inputs.source_sha || github.sha }}
+          ref: ${{ inputs.source_sha || github.event.release.tag_name || github.sha }}
 
       # ── 2. Set up Node 22 ───────────────────────────────────────────────────
       - name: Setup Node.js 22
@@ -149,6 +152,9 @@ jobs:
         run: |
           if [ -n "${{ inputs.version }}" ]; then
             VERSION="${{ inputs.version }}"
+          elif [ -n "${{ github.event.release.tag_name }}" ]; then
+            # Triggered by release event — use the release tag
+            VERSION="${{ github.event.release.tag_name }}"
           elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             VERSION="${GITHUB_REF#refs/tags/}"
           else
@@ -161,7 +167,7 @@ jobs:
           # Only treat explicit versioned builds as releases.
           IS_RELEASE="false"
           TAG_LATEST="false"
-          if [[ -n "${{ inputs.version }}" ]] || [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+          if [[ -n "${{ inputs.version }}" ]] || [[ -n "${{ github.event.release.tag_name }}" ]] || [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             IS_RELEASE="true"
             if [[ "${{ inputs.tag_latest }}" != "false" ]]; then
               TAG_LATEST="true"

--- a/scripts/docker-contract.test.ts
+++ b/scripts/docker-contract.test.ts
@@ -3,6 +3,10 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 const ROOT = path.resolve(import.meta.dirname, "..");
+const BUILD_DOCKER_WORKFLOW = path.join(
+  ROOT,
+  ".github/workflows/build-docker.yml",
+);
 const EXPECTED_NODE_VERSION = "22";
 const EXPECTED_BUN_VERSION = "1.3.10";
 const EXPECTED_EXPOSE_PORT = "2138";
@@ -97,6 +101,36 @@ describe("Docker contract", () => {
     expect(entrypoint).toContain(
       // biome-ignore lint/suspicious/noTemplateCurlyInString: shell variable assertion
       'export ELIZA_API_PORT="${ELIZA_API_PORT:-$resolved_port}"',
+    );
+  });
+
+  it("triggers on GitHub Release published and resolves ref and version from release tag", () => {
+    const workflow = read(BUILD_DOCKER_WORKFLOW);
+
+    // release trigger must be present
+    expect(workflow).toContain("release:");
+    expect(workflow).toContain("types: [published]");
+
+    // checkout ref must fall back to release tag_name so the correct commit is built
+    expect(workflow).toContain(
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: workflow expression assertion
+      "ref: ${{ inputs.source_sha || github.event.release.tag_name || github.sha }}",
+    );
+
+    // version determination must pick up the release tag
+    expect(workflow).toContain(
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: workflow expression assertion
+      'elif [ -n "${{ github.event.release.tag_name }}" ]',
+    );
+    expect(workflow).toContain(
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: workflow expression assertion
+      'VERSION="${{ github.event.release.tag_name }}"',
+    );
+
+    // release event must be treated as a release build (IS_RELEASE=true)
+    expect(workflow).toContain(
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: workflow expression assertion
+      '[[ -n "${{ github.event.release.tag_name }}" ]]',
     );
   });
 


### PR DESCRIPTION
## Problem

The `build-docker.yml` workflow triggers on `push: tags`, but GitHub Releases created via the UI or API create tags through the GitHub API — which does **not** fire `push` events. This caused v2.0.4 (and potentially other stable releases) to never get a Docker image built.

## Fix

- Add `release: types: [published]` trigger to `build-docker.yml`
- Handle `github.event.release.tag_name` in checkout ref and version detection
- All existing triggers preserved (push tags, workflow_call, workflow_dispatch, develop branch)

## What this changes

| Trigger | Before | After |
|---------|--------|-------|
| `git push --tags` | ✅ | ✅ |
| GitHub Release (UI/API) | ❌ | ✅ |
| `workflow_dispatch` | ✅ | ✅ |
| `workflow_call` | ✅ | ✅ |
| Push to develop | ✅ | ✅ |

## Note on duplicate triggers

When a release is created by pushing a tag (e.g. `git push origin v2.0.5`), both the `push` and `release` events fire. The existing `concurrency` group deduplication will cancel one, so no duplicate builds occur.

## Related

- v2.0.4 Docker build manually triggered via `workflow_dispatch` as a stopgap
- `build-cloud-image.yml` failures (separate issue: Dockerfile references paths that don't exist in alpha tag commits)