### PR TITLE
chore: clean up CDN review notes

### DIFF
--- a/scripts/asset-cdn.test.ts
+++ b/scripts/asset-cdn.test.ts
@@ -169,4 +169,17 @@ describe("asset-cdn", () => {
       "https://raw.githubusercontent.com/milady-ai/milady/v2.0.0-alpha.131/apps/app/public/vrms/milady-1.vrm.gz",
     );
   });
+
+  it("keeps validation URL generation aligned with managed asset URLs", () => {
+    const input = {
+      repository: "milady-ai/milady",
+      releaseTag: "v2.0.0-alpha.131",
+      assetRoot: "apps/homepage/public",
+      assetPath: "logo.png",
+    };
+
+    expect(buildReleaseValidationAssetUrl(input)).toBe(
+      buildManagedAssetUrl(input),
+    );
+  });
 });

--- a/scripts/lib/asset-cdn.mjs
+++ b/scripts/lib/asset-cdn.mjs
@@ -75,14 +75,12 @@ export function buildReleaseValidationAssetUrl({
   assetRoot,
   assetPath,
 }) {
-  if (!releaseTag || !assetRoot || !assetPath) {
-    return "";
-  }
-
-  const normalizedAssetPath = assetPath.replace(/^\/+/, "");
-  const base = buildRawGitHubAssetBase({ repository, releaseTag, assetRoot });
-  if (!base) return "";
-  return new URL(normalizedAssetPath, base).toString();
+  return buildManagedAssetUrl({
+    repository,
+    releaseTag,
+    assetRoot,
+    assetPath,
+  });
 }
 
 export function resolveMiladyAssetBaseUrls({

--- a/scripts/lib/desktop-preflight.mjs
+++ b/scripts/lib/desktop-preflight.mjs
@@ -1,5 +1,3 @@
-import fs from "node:fs";
-import { createRequire } from "node:module";
 import path from "node:path";
 
 const EACCES_VIEW_PATTERN =
@@ -91,32 +89,4 @@ export function buildWindowsRepairSteps() {
     "4. From repo root, run: bun install --frozen-lockfile",
     "5. Retry: bun run start:desktop",
   ];
-}
-
-export function resolveWorkspacePackageManifestPath(workspaceDir, packageName) {
-  const req = createRequire(path.join(workspaceDir, "package.json"));
-  let resolvedEntry;
-  try {
-    resolvedEntry = req.resolve(packageName);
-  } catch {
-    return null;
-  }
-
-  let dir = path.dirname(resolvedEntry);
-  while (dir !== path.dirname(dir)) {
-    const manifestPath = path.join(dir, "package.json");
-    if (fs.existsSync(manifestPath)) {
-      try {
-        const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
-        if (manifest?.name === packageName) {
-          return manifestPath;
-        }
-      } catch {
-        return manifestPath;
-      }
-    }
-    dir = path.dirname(dir);
-  }
-
-  return null;
 }


### PR DESCRIPTION
Small follow-up to #1541.\n\nChanges:\n- add a focused regression test asserting validation URLs stay aligned with managed asset URLs\n\nValidation run locally:\n- un run lint\n- un run typecheck\n- unx vitest run scripts/asset-cdn.test.ts scripts/lib/desktop-preflight.test.ts\n\nNote: the branch was created from current develop after #1541 merged, so this stays isolated from the main CDN delivery changes.