### PR TITLE
fix(desktop): restore background window on first Windows relaunch

### DIFF
--- a/apps/app/electrobun/src/__tests__/close-to-background.test.ts
+++ b/apps/app/electrobun/src/__tests__/close-to-background.test.ts
@@ -37,6 +37,23 @@ describe("close-to-background behavior", () => {
     expect(fnBody).toContain("injectApiBase");
   });
 
+  it("restoreWindow focuses the restored window after an in-flight recreate finishes", () => {
+    const helperStart = source.indexOf("function focusCurrentWindow");
+    expect(helperStart).toBeGreaterThan(-1);
+
+    const helperBody = source.slice(helperStart, helperStart + 220);
+    expect(helperBody).toContain("currentWindow.unminimize()");
+    expect(helperBody).toContain("currentWindow.focus()");
+
+    const fnStart = source.indexOf("async function restoreWindow");
+    expect(fnStart).toBeGreaterThan(-1);
+
+    const fnBody = source.slice(fnStart, fnStart + 700);
+    expect(fnBody).toContain("if (backgroundWindowPromise)");
+    expect(fnBody).toContain("await backgroundWindowPromise");
+    expect(fnBody).toContain("focusCurrentWindow();");
+  });
+
   it("setupDockReopen wires the Electrobun reopen event", () => {
     const fnStart = source.indexOf("function setupDockReopen");
     expect(fnStart).toBeGreaterThan(-1);

--- a/apps/app/electrobun/src/__tests__/close-to-background.test.ts
+++ b/apps/app/electrobun/src/__tests__/close-to-background.test.ts
@@ -23,21 +23,6 @@ describe("close-to-background behavior", () => {
   });
 
   it("restoreWindow function exists and creates window when needed", () => {
-    const fnStart = source.indexOf("async function restoreWindow");
-    expect(fnStart).toBeGreaterThan(-1);
-
-    const fnBody = source.slice(fnStart, fnStart + 600);
-
-    // Should handle existing window (unminimize + focus)
-    expect(fnBody).toContain("unminimize");
-    expect(fnBody).toContain("focus");
-    // Should create new window when none exists
-    expect(fnBody).toContain("createMainWindow");
-    expect(fnBody).toContain("attachMainWindow");
-    expect(fnBody).toContain("injectApiBase");
-  });
-
-  it("restoreWindow focuses the restored window after an in-flight recreate finishes", () => {
     const helperStart = source.indexOf("function focusCurrentWindow");
     expect(helperStart).toBeGreaterThan(-1);
 
@@ -45,6 +30,20 @@ describe("close-to-background behavior", () => {
     expect(helperBody).toContain("currentWindow.unminimize()");
     expect(helperBody).toContain("currentWindow.focus()");
 
+    const fnStart = source.indexOf("async function restoreWindow");
+    expect(fnStart).toBeGreaterThan(-1);
+
+    const fnBody = source.slice(fnStart, fnStart + 600);
+
+    // Should handle existing window via the shared focus helper
+    expect(fnBody).toContain("focusCurrentWindow();");
+    // Should create new window when none exists
+    expect(fnBody).toContain("createMainWindow");
+    expect(fnBody).toContain("attachMainWindow");
+    expect(fnBody).toContain("injectApiBase");
+  });
+
+  it("restoreWindow focuses the restored window after an in-flight recreate finishes", () => {
     const fnStart = source.indexOf("async function restoreWindow");
     expect(fnStart).toBeGreaterThan(-1);
 

--- a/apps/app/electrobun/src/index.ts
+++ b/apps/app/electrobun/src/index.ts
@@ -822,18 +822,27 @@ async function ensureBackgroundWindow(): Promise<void> {
 }
 
 /** Restore or recreate the main window (called on dock icon click). */
+function focusCurrentWindow(): void {
+  if (!currentWindow) {
+    return;
+  }
+
+  try {
+    currentWindow.unminimize();
+    currentWindow.focus();
+  } catch {
+    // unminimize/focus may not be available
+  }
+}
+
 async function restoreWindow(): Promise<void> {
   if (currentWindow) {
-    try {
-      currentWindow.unminimize();
-      currentWindow.focus();
-    } catch {
-      // unminimize/focus may not be available
-    }
+    focusCurrentWindow();
     return;
   }
   if (backgroundWindowPromise) {
     await backgroundWindowPromise;
+    focusCurrentWindow();
     return;
   }
   backgroundWindowPromise = (async () => {
@@ -844,6 +853,7 @@ async function restoreWindow(): Promise<void> {
     backgroundWindowPromise = null;
   });
   await backgroundWindowPromise;
+  focusCurrentWindow();
 }
 
 function showBackgroundRunNoticeOnce(): void {


### PR DESCRIPTION
## Summary
- focus the recreated Electrobun window after an in-flight restore completes
- avoid the Windows relaunch race where the first desktop reopen returns before the new window is focused
- add a close-to-background regression guard for the restore path

## Validation
- targeted local source-level regression update in close-to-background test
- local repo-wide pre-push hook remains noisy due unrelated baseline typecheck failures in the workspace
- upstream CI should be used as the final gate for this branch
