### PR TITLE
fix: cloud containers override disable-auto-token to prevent auth dead-lock

### DIFF
--- a/packages/agent/src/api/__tests__/cloud-token-override.test.ts
+++ b/packages/agent/src/api/__tests__/cloud-token-override.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Verifies that cloud-provisioned containers override the disableAutoApiToken
+ * flag and always generate an inbound API token, preventing auth dead-locks
+ * where isAuthorized() rejects every request (no token + cloud flag = 401).
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const serverSource = readFileSync(
+  path.resolve(import.meta.dirname, "..", "server.ts"),
+  "utf-8",
+);
+
+describe("cloud container token override (ensureApiTokenForBindHost)", () => {
+  it("overrides disableAutoApiToken when cloud-provisioned", () => {
+    // The guard must check cloudProvisioned before honoring disableAutoApiToken
+    const fnStart = serverSource.indexOf("export function ensureApiTokenForBindHost");
+    expect(fnStart).toBeGreaterThan(-1);
+    const fnBody = serverSource.slice(fnStart, fnStart + 1200);
+
+    // The disable flag must be checked together with !cloudProvisioned
+    expect(fnBody).toContain("disableAutoApiToken && !cloudProvisioned");
+  });
+
+  it("reads cloudProvisioned before the disableAutoApiToken early-return", () => {
+    const fnStart = serverSource.indexOf("export function ensureApiTokenForBindHost");
+    const fnBody = serverSource.slice(fnStart, fnStart + 1200);
+
+    const cloudProvisionedIdx = fnBody.indexOf("isCloudProvisionedContainer()");
+    const disableReturnIdx = fnBody.indexOf("disableAutoApiToken && !cloudProvisioned");
+
+    // cloudProvisioned must be assigned before it's used in the disable check
+    expect(cloudProvisionedIdx).toBeGreaterThan(-1);
+    expect(disableReturnIdx).toBeGreaterThan(-1);
+    expect(cloudProvisionedIdx).toBeLessThan(disableReturnIdx);
+  });
+
+  it("still respects disableAutoApiToken for non-cloud loopback hosts", () => {
+    const fnStart = serverSource.indexOf("export function ensureApiTokenForBindHost");
+    const fnBody = serverSource.slice(fnStart, fnStart + 1200);
+
+    // When not cloud-provisioned, disableAutoApiToken causes early return
+    expect(fnBody).toContain("if (disableAutoApiToken && !cloudProvisioned)");
+    // The early-return is followed by a plain return statement
+    const guardIdx = fnBody.indexOf("if (disableAutoApiToken && !cloudProvisioned)");
+    const afterGuard = fnBody.slice(guardIdx, guardIdx + 60);
+    expect(afterGuard).toContain("return");
+  });
+
+  it("generates a token for cloud containers even when disableAutoApiToken would fire", () => {
+    // Confirm that the code path continues past the disable-flag check for cloud
+    // containers and reaches the token generation (randomBytes + setApiToken).
+    const fnStart = serverSource.indexOf("export function ensureApiTokenForBindHost");
+    const fnEnd = serverSource.indexOf("\n}", fnStart);
+    const fnBody = serverSource.slice(fnStart, fnEnd);
+
+    expect(fnBody).toContain("crypto.randomBytes");
+    expect(fnBody).toContain("setApiToken");
+  });
+});

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -7617,13 +7617,21 @@ function isLoopbackBindHost(host: string): boolean {
 }
 
 export function ensureApiTokenForBindHost(host: string): void {
-  if (resolveApiSecurityConfig(process.env).disableAutoApiToken) {
-    return;
-  }
+  const { disableAutoApiToken } = resolveApiSecurityConfig(process.env);
 
   const token = getConfiguredApiToken();
   if (token) return;
+
   const cloudProvisioned = isCloudProvisionedContainer();
+
+  // Cloud-provisioned containers must never run without an inbound API token
+  // (isAuthorized rejects all requests when no token + cloud flag is set).
+  // Override the disable flag for cloud containers so they always get a
+  // fallback token rather than dead-locking into 401 on every request.
+  if (disableAutoApiToken && !cloudProvisioned) {
+    return;
+  }
+
   if (!cloudProvisioned && isLoopbackBindHost(host)) return;
 
   const generated = crypto.randomBytes(32).toString("hex");

--- a/packages/agent/test/api/ensure-api-token.test.ts
+++ b/packages/agent/test/api/ensure-api-token.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { ensureApiTokenForBindHost } from "../../src/api/server";
+
+const originalEnv = { ...process.env };
+
+function saveAndClearTokenEnv() {
+  delete process.env.MILADY_API_TOKEN;
+  delete process.env.ELIZA_API_TOKEN;
+  delete process.env.MILADY_DISABLE_AUTO_API_TOKEN;
+  delete process.env.ELIZA_DISABLE_AUTO_API_TOKEN;
+  delete process.env.MILADY_CLOUD_PROVISIONED;
+  delete process.env.ELIZA_CLOUD_PROVISIONED;
+  delete process.env.STEWARD_AGENT_TOKEN;
+}
+
+beforeEach(() => {
+  process.env = { ...originalEnv };
+  saveAndClearTokenEnv();
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+});
+
+describe("ensureApiTokenForBindHost", () => {
+  test("does not generate a token for loopback bind when not cloud-provisioned", () => {
+    ensureApiTokenForBindHost("127.0.0.1");
+    expect(process.env.MILADY_API_TOKEN).toBeUndefined();
+  });
+
+  test("generates a token for non-loopback bind", () => {
+    ensureApiTokenForBindHost("0.0.0.0");
+    expect(process.env.MILADY_API_TOKEN).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  test("respects disableAutoApiToken for non-cloud containers", () => {
+    process.env.MILADY_DISABLE_AUTO_API_TOKEN = "1";
+    ensureApiTokenForBindHost("0.0.0.0");
+    expect(process.env.MILADY_API_TOKEN).toBeUndefined();
+  });
+
+  test("overrides disableAutoApiToken for cloud-provisioned containers", () => {
+    process.env.MILADY_DISABLE_AUTO_API_TOKEN = "1";
+    process.env.MILADY_CLOUD_PROVISIONED = "1";
+    process.env.STEWARD_AGENT_TOKEN = "steward-test-token";
+    ensureApiTokenForBindHost("0.0.0.0");
+    expect(process.env.MILADY_API_TOKEN).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  test("does not overwrite an existing token", () => {
+    process.env.MILADY_API_TOKEN = "existing-token";
+    ensureApiTokenForBindHost("0.0.0.0");
+    expect(process.env.MILADY_API_TOKEN).toBe("existing-token");
+  });
+});


### PR DESCRIPTION
## Problem

v2.0.4 agent images 401 on every request when running as cloud-provisioned Docker containers.

`isAuthorized()` (changed in #1434) returns `false` when no API token is configured on a cloud container:
```ts
if (!expected) return !isCloudProvisionedContainer(); // no token + cloud = deny all
```

The Docker provider sets `MILADY_DISABLE_AUTO_API_TOKEN=1` which prevents `ensureApiTokenForBindHost` from generating a fallback token. Combined with clearing `MILADY_API_TOKEN`/`ELIZA_API_TOKEN` to empty strings, the container starts with zero tokens and rejects everything.

Old images (pre-#1434) used `if (!expected) return true` so they worked fine without tokens.

## Fix

`ensureApiTokenForBindHost` now overrides the `disableAutoApiToken` flag for cloud-provisioned containers. They always get a fallback inbound token so they never dead-lock into 401.

## Testing

- `packages/agent/test/api/auth-routes.test.ts` — 13 tests pass
- `packages/app-core/test/app/pairing-view.test.tsx` — 2 tests pass
- `packages/app-core/test/app/pairing-lock.test.ts` — 2 tests pass

Companion PR: elizaOS/cloud fix/consolidated-cloud-fixes (stops clearing tokens in Docker provider)