### PR TITLE
[codex] fix plugin-manager runtime loading and Windows quit

### DIFF
--- a/apps/app/electrobun/src/__tests__/kitchen-sink.test.ts
+++ b/apps/app/electrobun/src/__tests__/kitchen-sink.test.ts
@@ -1258,6 +1258,16 @@ describe("DesktopManager — app lifecycle", () => {
     expect(mockUtils.quit).toHaveBeenCalled();
   });
 
+  it("quit() uses the registered quit callback when provided", async () => {
+    const quitCallback = vi.fn();
+    manager.setRequestQuitCallback(quitCallback);
+
+    await manager.quit();
+
+    expect(quitCallback).toHaveBeenCalledTimes(1);
+    expect(mockUtils.quit).not.toHaveBeenCalled();
+  });
+
   it("relaunch() calls Utils.quit() (no native relaunch, falls back to quit)", async () => {
     await manager.relaunch();
     expect(mockUtils.quit).toHaveBeenCalled();

--- a/apps/app/electrobun/src/index.ts
+++ b/apps/app/electrobun/src/index.ts
@@ -547,6 +547,11 @@ let surfaceWindowManager: SurfaceWindowManager | null = null;
 let rendererUrlPromise: Promise<string> | null = null;
 let backgroundWindowPromise: Promise<void> | null = null;
 let isQuitting = false;
+
+function requestAppQuit(): void {
+  isQuitting = true;
+  Utils.quit();
+}
 const cleanupFns: Array<() => void | Promise<void>> = [];
 let lastFocusedWindow: ManagedWindowLike | null = null;
 
@@ -1345,7 +1350,7 @@ async function setupUpdater(): Promise<void> {
               console.error("[Main] Agent restart failed:", err);
             });
         } else if (action === "quit") {
-          Utils.quit();
+          requestAppQuit();
         } else if (action === "show") {
           void getDesktopManager().showWindow();
         } else if (action?.startsWith("navigate-")) {
@@ -1614,6 +1619,9 @@ async function main(): Promise<void> {
   // Wire detached window callbacks so menus and RPC can open them.
   getDesktopManager().setOpenSettingsCallback((tabHint) => {
     void createSettingsWindow(tabHint);
+  });
+  getDesktopManager().setRequestQuitCallback(() => {
+    requestAppQuit();
   });
   getDesktopManager().setOpenSurfaceWindowCallback((surface, browse) => {
     if (!surfaceWindowManager) {

--- a/apps/app/electrobun/src/native/desktop.ts
+++ b/apps/app/electrobun/src/native/desktop.ts
@@ -182,6 +182,7 @@ export class DesktopManager {
   private openExternalHandler:
     | ((url: string) => boolean | Promise<boolean>)
     | null = null;
+  private requestQuitCallback: (() => void | Promise<void>) | null = null;
 
   // Track menu items for context-menu-clicked matching
   private trayMenuItems: Map<string, TrayMenuItem> = new Map();
@@ -251,6 +252,10 @@ export class DesktopManager {
     cb: ((url: string) => boolean | Promise<boolean>) | null,
   ): void {
     this.openExternalHandler = cb;
+  }
+
+  setRequestQuitCallback(cb: (() => void | Promise<void>) | null): void {
+    this.requestQuitCallback = cb;
   }
 
   /**
@@ -502,7 +507,7 @@ export class DesktopManager {
       } else if (action === "restart-agent" || action === "tray-restart") {
         triggerAgentRestart();
       } else if (action === "quit") {
-        Utils.quit();
+        void this.quit();
       } else if (action === "open-settings") {
         this.openSettingsCallback?.();
       }
@@ -1109,6 +1114,10 @@ X-GNOME-Autostart-enabled=true
   // MARK: - App
 
   async quit(): Promise<void> {
+    if (this.requestQuitCallback) {
+      await this.requestQuitCallback();
+      return;
+    }
     Utils.quit();
   }
 

--- a/packages/agent/src/runtime/core-plugins.ts
+++ b/packages/agent/src/runtime/core-plugins.ts
@@ -17,9 +17,9 @@ export const CORE_PLUGINS: readonly string[] = [
   "@elizaos/plugin-shell", // shell command execution
   "@elizaos/plugin-agent-skills", // skill execution and marketplace runtime
   "@elizaos/plugin-commands", // slash command handling (skills auto-register as /commands)
+  "@elizaos/plugin-plugin-manager", // dynamic plugin management for registry/plugin installs
   // "@elizaos/plugin-secrets-manager", // secrets management — load early, other plugins depend on it
   // "@elizaos/plugin-rolodex", // contact graph and relationship/social memory
-  // "@elizaos/plugin-plugin-manager", // dynamic plugin management
   // "@elizaos/plugin-trust", // trust scoring and policy signals
   "@miladyai/plugin-roles", // role-based access control (OWNER/ADMIN/NONE)
   // "@elizaos/plugin-todo", // todo/task management

--- a/packages/app-core/src/actions/__tests__/install-plugin.test.ts
+++ b/packages/app-core/src/actions/__tests__/install-plugin.test.ts
@@ -1,4 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const ensurePluginManagerAllowedMock = vi.fn(() => "already-enabled");
+
+vi.mock("../../runtime/plugin-manager-guard", () => ({
+  ensurePluginManagerAllowed: (...args: unknown[]) =>
+    ensurePluginManagerAllowedMock(...args),
+}));
+
 import { installPluginAction } from "../../actions/install-plugin";
 
 function mockJsonResponse(response: {
@@ -21,6 +29,7 @@ function mockJsonResponse(response: {
 describe("installPluginAction", () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    ensurePluginManagerAllowedMock.mockReturnValue("already-enabled");
     vi.stubGlobal("fetch", vi.fn());
   });
 
@@ -155,5 +164,101 @@ describe("installPluginAction", () => {
 
     expect(result.success).toBe(true);
     expect(result.text).toBe("plugin-telegram installed and restart scheduled");
+  });
+
+  it("restarts and retries when plugin-manager is auto-enabled for install", async () => {
+    ensurePluginManagerAllowedMock.mockReturnValue("enabled");
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        mockJsonResponse({
+          ok: true,
+          status: 200,
+          body: { ok: true, restarting: true },
+        }),
+      )
+      .mockResolvedValueOnce(
+        mockJsonResponse({
+          ok: true,
+          status: 200,
+          body: { ok: true, message: "installed after restart" },
+        }),
+      );
+
+    const result = await installPluginAction.handler(
+      undefined,
+      { roomId: "room", content: { text: "" } },
+      undefined,
+      { parameters: { pluginId: "farcaster" } },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.text).toBe("installed after restart");
+    expect(vi.mocked(fetch)).toHaveBeenNthCalledWith(
+      1,
+      "http://localhost:31337/api/agent/restart",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(vi.mocked(fetch)).toHaveBeenNthCalledWith(
+      2,
+      "http://localhost:31337/api/plugins/install",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          name: "@elizaos/plugin-farcaster",
+          autoRestart: true,
+        }),
+      }),
+    );
+  });
+
+  it("restarts and retries when install reports missing plugin-manager service", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        mockJsonResponse({
+          ok: false,
+          status: 503,
+          body: { error: "Plugin manager service not found" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        mockJsonResponse({
+          ok: true,
+          status: 200,
+          body: { ok: true, restarting: true },
+        }),
+      )
+      .mockResolvedValueOnce(
+        mockJsonResponse({
+          ok: true,
+          status: 200,
+          body: { ok: true, message: "installed after retry" },
+        }),
+      );
+
+    const result = await installPluginAction.handler(
+      undefined,
+      { roomId: "room", content: { text: "" } },
+      undefined,
+      { parameters: { pluginId: "farcaster" } },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.text).toBe("installed after retry");
+    expect(vi.mocked(fetch)).toHaveBeenNthCalledWith(
+      2,
+      "http://localhost:31337/api/agent/restart",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(vi.mocked(fetch)).toHaveBeenNthCalledWith(
+      3,
+      "http://localhost:31337/api/plugins/install",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          name: "@elizaos/plugin-farcaster",
+          autoRestart: true,
+        }),
+      }),
+    );
   });
 });

--- a/packages/app-core/src/actions/install-plugin.ts
+++ b/packages/app-core/src/actions/install-plugin.ts
@@ -12,9 +12,37 @@
 
 import type { Action, HandlerOptions } from "@elizaos/core";
 import { resolveDesktopApiPort } from "@miladyai/shared/runtime-env";
+import { ensurePluginManagerAllowed } from "../runtime/plugin-manager-guard";
 
 /** API port for posting install requests. */
 const API_PORT = String(resolveDesktopApiPort(process.env));
+const PLUGIN_MANAGER_UNAVAILABLE_ERROR = "Plugin manager service not found";
+
+async function postInstallRequest(npmName: string): Promise<Response> {
+  return fetch(`http://localhost:${API_PORT}/api/plugins/install`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name: npmName, autoRestart: true }),
+  });
+}
+
+async function restartAgent(): Promise<void> {
+  const response = await fetch(
+    `http://localhost:${API_PORT}/api/agent/restart`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    },
+  );
+  if (!response.ok) {
+    const body = (await response.json().catch(() => ({}))) as Record<
+      string,
+      string
+    >;
+    throw new Error(body.error ?? `HTTP ${response.status}`);
+  }
+}
 
 export const installPluginAction: Action = {
   name: "INSTALL_PLUGIN",
@@ -51,24 +79,62 @@ export const installPluginAction: Action = {
       const npmName = pluginId.startsWith("@")
         ? pluginId
         : `@elizaos/plugin-${pluginId}`;
+      const pluginManagerGuard = ensurePluginManagerAllowed();
+      if (pluginManagerGuard === "disabled-by-user") {
+        return {
+          text: `Failed to install ${pluginId}: plugin-manager is explicitly disabled in config`,
+          success: false,
+        };
+      }
+      if (pluginManagerGuard === "enabled") {
+        await restartAgent();
+      }
 
-      const response = await fetch(
-        `http://localhost:${API_PORT}/api/plugins/install`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ name: npmName, autoRestart: true }),
-        },
-      );
+      let response = await postInstallRequest(npmName);
 
       if (!response.ok) {
-        const body = (await response.json().catch(() => ({}))) as Record<
+        let body = (await response.json().catch(() => ({}))) as Record<
           string,
           string
         >;
+        if ((body.error ?? "").includes(PLUGIN_MANAGER_UNAVAILABLE_ERROR)) {
+          const recoveryGuard = ensurePluginManagerAllowed();
+          if (recoveryGuard === "disabled-by-user") {
+            return {
+              text: `Failed to install ${pluginId}: plugin-manager is explicitly disabled in config`,
+              success: false,
+            };
+          }
+          await restartAgent();
+          response = await postInstallRequest(npmName);
+          body = (await response.json().catch(() => ({}))) as Record<
+            string,
+            string
+          >;
+        }
+        if (!response.ok) {
+          return {
+            text: `Failed to install ${pluginId}: ${body.error ?? `HTTP ${response.status}`}`,
+            success: false,
+          };
+        }
+        const result = body as {
+          ok: boolean;
+          message?: string;
+          error?: string;
+        };
+        if (!result.ok) {
+          return {
+            text: `Failed to install ${pluginId}: ${result.error ?? "unknown error"}`,
+            success: false,
+          };
+        }
         return {
-          text: `Failed to install ${pluginId}: ${body.error ?? `HTTP ${response.status}`}`,
-          success: false,
+          text:
+            result.message ??
+            `Plugin ${pluginId} installed successfully. The agent is restarting to load it.`,
+          success: true,
+          data: { pluginId, npmName },
         };
       }
 

--- a/packages/app-core/src/components/PluginsView.tsx
+++ b/packages/app-core/src/components/PluginsView.tsx
@@ -119,6 +119,7 @@ import {
   defaultRegistry,
   type JsonSchemaObject,
 } from "../config";
+import { ensurePluginManagerAllowed } from "../runtime/plugin-manager-guard";
 import { useApp } from "../state";
 import type { ConfigUiHint } from "../types";
 import { openExternalUrl, resolveAppAssetUrl } from "../utils";
@@ -1594,6 +1595,21 @@ function PluginListView({
   const handleInstallPlugin = async (pluginId: string, npmName: string) => {
     setInstallingPlugins((prev) => new Set(prev).add(pluginId));
     try {
+      const pluginManagerGuard = ensurePluginManagerAllowed();
+      if (pluginManagerGuard === "disabled-by-user") {
+        throw new Error("plugin-manager is explicitly disabled in config");
+      }
+      if (pluginManagerGuard === "enabled") {
+        setActionNotice(
+          t("pluginsview.PluginInstallPreparing", {
+            plugin: npmName,
+            defaultValue:
+              "Enabling plugin installs for {{plugin}} and restarting the agent...",
+          }),
+          "success",
+        );
+        await client.restartAndWait(120_000);
+      }
       await client.installRegistryPlugin(npmName);
       await loadPlugins();
       setActionNotice(
@@ -1604,10 +1620,47 @@ function PluginListView({
         "success",
       );
     } catch (err) {
+      let installError = err;
+      if (
+        installError instanceof Error &&
+        installError.message.includes("Plugin manager service not found")
+      ) {
+        try {
+          const pluginManagerGuard = ensurePluginManagerAllowed();
+          if (pluginManagerGuard === "disabled-by-user") {
+            throw new Error("plugin-manager is explicitly disabled in config");
+          }
+          setActionNotice(
+            t("pluginsview.PluginInstallRecovering", {
+              plugin: npmName,
+              defaultValue:
+                "Finishing plugin install setup for {{plugin}} and restarting the agent...",
+            }),
+            "success",
+          );
+          await client.restartAndWait(120_000);
+          await client.installRegistryPlugin(npmName);
+          await loadPlugins();
+          setActionNotice(
+            t("pluginsview.PluginInstalledRestartRequired", {
+              plugin: npmName,
+              defaultValue:
+                "{{plugin}} installed. Restart required to activate.",
+            }),
+            "success",
+          );
+          return;
+        } catch (recoveryErr) {
+          installError = recoveryErr;
+        }
+      }
       setActionNotice(
         t("pluginsview.PluginInstallFailed", {
           plugin: npmName,
-          message: err instanceof Error ? err.message : "unknown error",
+          message:
+            installError instanceof Error
+              ? installError.message
+              : "unknown error",
           defaultValue: "Failed to install {{plugin}}: {{message}}",
         }),
         "error",

--- a/packages/app-core/src/runtime/eliza.test.ts
+++ b/packages/app-core/src/runtime/eliza.test.ts
@@ -230,7 +230,7 @@ describe("collectPluginNames", () => {
 
   it("includes all core plugins for an empty config", () => {
     // Guard against accidental removal from CORE_PLUGINS array
-    expect(CORE_PLUGINS).toHaveLength(11);
+    expect(CORE_PLUGINS).toHaveLength(12);
 
     const expectedCorePlugins = [
       "@elizaos/plugin-sql",
@@ -243,6 +243,7 @@ describe("collectPluginNames", () => {
       "@elizaos/plugin-shell",
       "@elizaos/plugin-agent-skills",
       "@elizaos/plugin-commands",
+      "@elizaos/plugin-plugin-manager",
       "@miladyai/plugin-roles",
     ];
     const names = collectPluginNames({} as ElizaConfig);

--- a/packages/app-core/src/runtime/plugin-manager-guard.ts
+++ b/packages/app-core/src/runtime/plugin-manager-guard.ts
@@ -11,13 +11,22 @@ import {
   saveElizaConfig,
 } from "@miladyai/agent/config/config";
 
-let _checked = false;
+export type PluginManagerGuardResult =
+  | "enabled"
+  | "already-enabled"
+  | "disabled-by-user"
+  | "disabled-by-env"
+  | "error";
 
-export function ensurePluginManagerAllowed(): void {
-  if (_checked) return;
+let _checked = false;
+let _lastResult: PluginManagerGuardResult = "error";
+
+export function ensurePluginManagerAllowed(): PluginManagerGuardResult {
+  if (_checked) return _lastResult;
   if (process.env.MILADY_DISABLE_PLUGIN_MANAGER_AUTO_ENABLE === "1") {
     _checked = true;
-    return;
+    _lastResult = "disabled-by-env";
+    return _lastResult;
   }
   try {
     const config = loadElizaConfig();
@@ -26,11 +35,13 @@ export function ensurePluginManagerAllowed(): void {
     const id = "plugin-manager";
     if (entries[id]?.enabled === false) {
       _checked = true;
-      return; // explicitly disabled by user
+      _lastResult = "disabled-by-user";
+      return _lastResult;
     }
     if (entries[id]) {
       _checked = true;
-      return; // already present
+      _lastResult = "already-enabled";
+      return _lastResult;
     }
     // The upstream ElizaConfig type marks `plugins` as a complex branded type
     // that doesn't allow direct property assignment. We know the runtime shape
@@ -46,12 +57,18 @@ export function ensurePluginManagerAllowed(): void {
         "Set MILADY_DISABLE_PLUGIN_MANAGER_AUTO_ENABLE=1 to prevent this.",
     );
     _checked = true;
+    _lastResult = "enabled";
+    return _lastResult;
   } catch {
-    // Non-fatal — plugin install button won't work but everything else is fine
+    // Non-fatal; plugin install button will still fail until the service exists.
+    _checked = true;
+    _lastResult = "error";
+    return _lastResult;
   }
 }
 
 /** Reset the in-process guard (for testing only). @internal */
 export function _resetPluginManagerChecked(): void {
   _checked = false;
+  _lastResult = "error";
 }

--- a/packages/app-core/test/app/plugin-manager-auto-enable.test.ts
+++ b/packages/app-core/test/app/plugin-manager-auto-enable.test.ts
@@ -19,8 +19,8 @@ vi.mock("@miladyai/agent/config/config", () => ({
 }));
 
 import {
-  ensurePluginManagerAllowed,
   _resetPluginManagerChecked,
+  ensurePluginManagerAllowed,
 } from "../../src/runtime/plugin-manager-guard";
 
 describe("ensurePluginManagerAllowed", () => {
@@ -45,8 +45,9 @@ describe("ensurePluginManagerAllowed", () => {
     const config = { plugins: { entries: {} } };
     mockLoadElizaConfig.mockReturnValue(config);
 
-    ensurePluginManagerAllowed();
+    const result = ensurePluginManagerAllowed();
 
+    expect(result).toBe("enabled");
     expect(mockSaveElizaConfig).toHaveBeenCalledTimes(1);
     const saved = mockSaveElizaConfig.mock.calls[0][0];
     expect(saved.plugins.entries["plugin-manager"]).toEqual({ enabled: true });
@@ -57,8 +58,9 @@ describe("ensurePluginManagerAllowed", () => {
       plugins: { entries: { "plugin-manager": { enabled: true } } },
     });
 
-    ensurePluginManagerAllowed();
+    const result = ensurePluginManagerAllowed();
 
+    expect(result).toBe("already-enabled");
     expect(mockSaveElizaConfig).not.toHaveBeenCalled();
   });
 
@@ -67,8 +69,9 @@ describe("ensurePluginManagerAllowed", () => {
       plugins: { entries: { "plugin-manager": { enabled: false } } },
     });
 
-    ensurePluginManagerAllowed();
+    const result = ensurePluginManagerAllowed();
 
+    expect(result).toBe("disabled-by-user");
     expect(mockSaveElizaConfig).not.toHaveBeenCalled();
   });
 
@@ -77,8 +80,8 @@ describe("ensurePluginManagerAllowed", () => {
       plugins: { entries: { "plugin-manager": { enabled: true } } },
     });
 
-    ensurePluginManagerAllowed();
-    ensurePluginManagerAllowed();
+    expect(ensurePluginManagerAllowed()).toBe("already-enabled");
+    expect(ensurePluginManagerAllowed()).toBe("already-enabled");
 
     expect(mockLoadElizaConfig).toHaveBeenCalledTimes(1);
   });
@@ -86,7 +89,7 @@ describe("ensurePluginManagerAllowed", () => {
   it("skips entirely when MILADY_DISABLE_PLUGIN_MANAGER_AUTO_ENABLE=1", () => {
     process.env.MILADY_DISABLE_PLUGIN_MANAGER_AUTO_ENABLE = "1";
 
-    ensurePluginManagerAllowed();
+    expect(ensurePluginManagerAllowed()).toBe("disabled-by-env");
 
     expect(mockLoadElizaConfig).not.toHaveBeenCalled();
     expect(mockSaveElizaConfig).not.toHaveBeenCalled();


### PR DESCRIPTION
## What changed
- make `@elizaos/plugin-plugin-manager` a real core plugin so registry/plugin installs do not start from a broken runtime state
- keep the plugin install flows resilient by auto-restarting/retrying when the plugin-manager service was just enabled or missing
- unify Electrobun quit handling so tray/menu/RPC quit paths mark the app as actually quitting before native quit fires

## Why
- the Farcaster install flow exposed that `Install Plugin` assumed the plugin-manager service existed even though the runtime did not load it by default
- Windows quit paths were still bypassing the `isQuitting` guard, so close-to-background could swallow quit again

## Impact
- connector/plugin installs should work on first run instead of dead-ending on `Plugin manager service not found`
- Windows Electrobun quit should exit reliably from tray/menu/app quit paths

## Validation
- `bunx vitest run C:\Users\epj33\Documents\Playground\milady\packages\app-core\src\runtime\eliza.test.ts C:\Users\epj33\Documents\Playground\milady\packages\app-core\test\app\plugin-manager-auto-enable.test.ts C:\Users\epj33\Documents\Playground\milady\packages\app-core\src\actions\__tests__\install-plugin.test.ts`
- `bunx vitest run C:\Users\epj33\Documents\Playground\milady\apps\app\electrobun\src\__tests__\kitchen-sink.test.ts`
- `bunx @biomejs/biome check C:\Users\epj33\Documents\Playground\milady\packages\agent\src\runtime\core-plugins.ts C:\Users\epj33\Documents\Playground\milady\packages\app-core\src\runtime\eliza.test.ts C:\Users\epj33\Documents\Playground\milady\packages\app-core\src\runtime\plugin-manager-guard.ts C:\Users\epj33\Documents\Playground\milady\packages\app-core\src\actions\install-plugin.ts C:\Users\epj33\Documents\Playground\milady\packages\app-core\src\components\PluginsView.tsx C:\Users\epj33\Documents\Playground\milady\apps\app\electrobun\src\native\desktop.ts C:\Users\epj33\Documents\Playground\milady\apps\app\electrobun\src\index.ts C:\Users\epj33\Documents\Playground\milady\apps\app\electrobun\src\__tests__\kitchen-sink.test.ts`
