### PR TITLE
feat: scratch workspace settings UI

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "@electric-sql/pglite": "^0.3.16",
         "@elizaos/app-hyperscape": "1.0.0",
         "@elizaos/core": "2.0.0-alpha.109",
-        "@elizaos/plugin-agent-orchestrator": "0.4.1",
+        "@elizaos/plugin-agent-orchestrator": "0.4.2",
         "@elizaos/plugin-agent-skills": "^2.0.0-alpha.70",
         "@elizaos/plugin-anthropic": "^2.0.0-alpha.9",
         "@elizaos/plugin-commands": "alpha",
@@ -985,7 +985,7 @@
 
     "@elizaos/core": ["@elizaos/core@2.0.0-alpha.109", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "adze": "^2.2.5", "crypto-browserify": "^3.12.0", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-Ty2n1pyhxg9O54aWNPfIFp+Tu0PuwmsWqvzM5P2jmnlnZ3AMCHleDqDwJYappHhj6EfPhKZOs5Gy28rDMMlxvA=="],
 
-    "@elizaos/plugin-agent-orchestrator": ["@elizaos/plugin-agent-orchestrator@0.4.1", "", { "dependencies": { "coding-agent-adapters": "0.15.0", "pty-console": "0.3.1", "pty-state-capture": "0.2.0" }, "peerDependencies": { "@elizaos/core": ">=2.0.0-alpha.0", "git-workspace-service": "0.4.5", "pty-manager": "1.10.2" } }, "sha512-hCP43QpLK9KHuossdKJXyvoKCUa1toKbeczkVb7BXypTcsdXy6j92W8GXjhEV8YL76rgj6ta3aEBAKCgxeH4Ig=="],
+    "@elizaos/plugin-agent-orchestrator": ["@elizaos/plugin-agent-orchestrator@0.4.2", "", { "dependencies": { "coding-agent-adapters": "0.15.0", "pty-console": "0.3.1", "pty-state-capture": "0.2.0" }, "peerDependencies": { "@elizaos/core": ">=2.0.0-alpha.0", "git-workspace-service": "0.4.5", "pty-manager": "1.10.2" } }, "sha512-1lNVrih95FxhsWp5WsTZWqoiTqlMMHlrVP7PXW73uCoXDhfSDv43ELZo4JZUZhWnq36vLNq8YZAfcbAGB2qtRw=="],
 
     "@elizaos/plugin-agent-skills": ["@elizaos/plugin-agent-skills@2.0.0-alpha.70", "", { "dependencies": { "@elizaos/core": "alpha", "fflate": "^0.8.2" } }, "sha512-VIGpQY2YMeqeH7llCr0YTOrUlVZjOEogg/Ur6v2HAIUgIYt0X9C82vDxcW9ff8F87/epcGqK//6ODXAF248Dhw=="],
 

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "@electric-sql/pglite": "^0.3.16",
     "@elizaos/app-hyperscape": "1.0.0",
     "@elizaos/core": "2.0.0-alpha.109",
-    "@elizaos/plugin-agent-orchestrator": "0.4.1",
+    "@elizaos/plugin-agent-orchestrator": "0.4.2",
     "@elizaos/plugin-agent-skills": "^2.0.0-alpha.70",
     "@elizaos/plugin-commands": "alpha",
     "@elizaos/plugin-anthropic": "^2.0.0-alpha.9",

--- a/packages/app-core/src/components/CodingAgentSettingsSection.tsx
+++ b/packages/app-core/src/components/CodingAgentSettingsSection.tsx
@@ -107,6 +107,28 @@ const ENV_PREFIX: Record<AgentTab, string> = {
   aider: "PARALLAX_AIDER",
 };
 
+/** Text input that uses local state while typing and only syncs on blur/enter. */
+function CodingDirInput({
+  initial,
+  onCommit,
+}: { initial: string; onCommit: (val: string) => void }) {
+  const [val, setVal] = useState(initial);
+  return (
+    <SettingsControls.Input
+      className="w-full"
+      variant="compact"
+      type="text"
+      placeholder="~/Projects"
+      value={val}
+      onChange={(e) => setVal(e.target.value)}
+      onBlur={() => onCommit(val)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") onCommit(val);
+      }}
+    />
+  );
+}
+
 export function CodingAgentSettingsSection() {
   const { setTimeout } = useTimeout();
   const { t } = useApp();
@@ -166,6 +188,12 @@ export function CodingAgentSettingsSection() {
         }
         if (env.PARALLAX_DEFAULT_AGENT_TYPE) {
           loaded.PARALLAX_DEFAULT_AGENT_TYPE = env.PARALLAX_DEFAULT_AGENT_TYPE;
+        }
+        if (env.PARALLAX_SCRATCH_RETENTION) {
+          loaded.PARALLAX_SCRATCH_RETENTION = env.PARALLAX_SCRATCH_RETENTION;
+        }
+        if (env.PARALLAX_CODING_DIRECTORY) {
+          loaded.PARALLAX_CODING_DIRECTORY = env.PARALLAX_CODING_DIRECTORY;
         }
         setPrefs(loaded);
 
@@ -423,6 +451,65 @@ export function CodingAgentSettingsSection() {
               )
             : ""}
           {t("codingagentsettingssection.AppliesToAllNewlySpawned")}
+        </SettingsControls.FieldDescription>
+      </SettingsControls.Field>
+
+      <SettingsControls.Field>
+        <SettingsControls.FieldLabel>
+          {t("codingagentsettingssection.ScratchRetention", {
+            defaultValue: "Scratch Retention",
+          })}
+        </SettingsControls.FieldLabel>
+        <Select
+          value={prefs.PARALLAX_SCRATCH_RETENTION || "pending_decision"}
+          onValueChange={(value) =>
+            setPref("PARALLAX_SCRATCH_RETENTION", value)
+          }
+        >
+          <SettingsControls.SelectTrigger variant="compact">
+            <SelectValue />
+          </SettingsControls.SelectTrigger>
+          <SelectContent>
+            <SelectItem value="ephemeral">
+              {t("codingagentsettingssection.RetentionEphemeral", {
+                defaultValue: "Auto-delete",
+              })}
+            </SelectItem>
+            <SelectItem value="pending_decision">
+              {t("codingagentsettingssection.RetentionAskMe", {
+                defaultValue: "Ask me (default)",
+              })}
+            </SelectItem>
+            <SelectItem value="persistent">
+              {t("codingagentsettingssection.RetentionAlwaysKeep", {
+                defaultValue: "Always keep",
+              })}
+            </SelectItem>
+          </SelectContent>
+        </Select>
+        <SettingsControls.FieldDescription>
+          {t("codingagentsettingssection.ScratchRetentionDesc", {
+            defaultValue:
+              "What happens to scratch workspace code when a task finishes.",
+          })}
+        </SettingsControls.FieldDescription>
+      </SettingsControls.Field>
+
+      <SettingsControls.Field>
+        <SettingsControls.FieldLabel>
+          {t("codingagentsettingssection.CodingDirectory", {
+            defaultValue: "Coding Directory",
+          })}
+        </SettingsControls.FieldLabel>
+        <CodingDirInput
+          initial={prefs.PARALLAX_CODING_DIRECTORY || ""}
+          onCommit={(val) => setPref("PARALLAX_CODING_DIRECTORY", val)}
+        />
+        <SettingsControls.FieldDescription>
+          {t("codingagentsettingssection.CodingDirectoryDesc", {
+            defaultValue:
+              "Where scratch task code is saved. Leave empty for default (~/.milady/workspaces/).",
+          })}
         </SettingsControls.FieldDescription>
       </SettingsControls.Field>
 

--- a/packages/app-core/src/components/CodingAgentSettingsSection.tsx
+++ b/packages/app-core/src/components/CodingAgentSettingsSection.tsx
@@ -107,7 +107,11 @@ const ENV_PREFIX: Record<AgentTab, string> = {
   aider: "PARALLAX_AIDER",
 };
 
-/** Text input that uses local state while typing and only syncs on blur/enter. */
+/**
+ * Text input that uses local state while typing and only syncs on blur/enter.
+ * `initial` is only read on mount — safe because the parent guards rendering
+ * behind `if (loading) return …`, so `initial` is always the loaded value.
+ */
 function CodingDirInput({
   initial,
   onCommit,
@@ -284,7 +288,7 @@ export function CodingAgentSettingsSection() {
     try {
       const envPatch: Record<string, string> = {};
       for (const [key, value] of Object.entries(prefs)) {
-        if (value) {
+        if (value != null) {
           envPatch[key] = value;
         }
       }
@@ -462,9 +466,12 @@ export function CodingAgentSettingsSection() {
         </SettingsControls.FieldLabel>
         <Select
           value={prefs.PARALLAX_SCRATCH_RETENTION || "pending_decision"}
-          onValueChange={(value) =>
-            setPref("PARALLAX_SCRATCH_RETENTION", value)
-          }
+          onValueChange={(value) => {
+            // Skip if user re-selects the visual default that was never stored
+            if (!prefs.PARALLAX_SCRATCH_RETENTION && value === "pending_decision")
+              return;
+            setPref("PARALLAX_SCRATCH_RETENTION", value);
+          }}
         >
           <SettingsControls.SelectTrigger variant="compact">
             <SelectValue />

--- a/packages/app-core/test/app/coding-agent-settings.test.ts
+++ b/packages/app-core/test/app/coding-agent-settings.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for CodingAgentSettingsSection save logic.
+ *
+ * Covers:
+ * - Persistence round-trip (prefs → envPatch)
+ * - Empty-string handling (clearing coding directory)
+ * - Default retention value not polluting save payload
+ */
+import { describe, expect, it } from "vitest";
+
+/**
+ * Replicate the envPatch builder from handleSave so we can test it in
+ * isolation without rendering the full component tree.
+ */
+function buildEnvPatch(prefs: Record<string, string>): Record<string, string> {
+  const envPatch: Record<string, string> = {};
+  for (const [key, value] of Object.entries(prefs)) {
+    if (value != null) {
+      envPatch[key] = value;
+    }
+  }
+  return envPatch;
+}
+
+/**
+ * Replicate the retention onValueChange guard from the Select component.
+ */
+function shouldSetRetentionPref(
+  currentPref: string | undefined,
+  newValue: string,
+): boolean {
+  if (!currentPref && newValue === "pending_decision") return false;
+  return true;
+}
+
+describe("CodingAgentSettingsSection save logic", () => {
+  describe("buildEnvPatch", () => {
+    it("includes non-empty string values", () => {
+      const prefs = {
+        PARALLAX_APPROVAL_MODE: "standard",
+        PARALLAX_CODING_DIRECTORY: "~/Projects",
+      };
+      const patch = buildEnvPatch(prefs);
+      expect(patch).toEqual({
+        PARALLAX_APPROVAL_MODE: "standard",
+        PARALLAX_CODING_DIRECTORY: "~/Projects",
+      });
+    });
+
+    it("includes empty strings (allows clearing coding directory)", () => {
+      const prefs = {
+        PARALLAX_APPROVAL_MODE: "standard",
+        PARALLAX_CODING_DIRECTORY: "",
+      };
+      const patch = buildEnvPatch(prefs);
+      expect(patch).toHaveProperty("PARALLAX_CODING_DIRECTORY", "");
+    });
+
+    it("round-trips: loaded prefs survive save without mutation", () => {
+      const loaded = {
+        PARALLAX_APPROVAL_MODE: "permissive",
+        PARALLAX_DEFAULT_AGENT_TYPE: "claude",
+        PARALLAX_CODING_DIRECTORY: "~/dev",
+        PARALLAX_SCRATCH_RETENTION: "persistent",
+      };
+      const patch = buildEnvPatch(loaded);
+      expect(patch).toEqual(loaded);
+    });
+  });
+
+  describe("retention default pollution guard", () => {
+    it("blocks setting pending_decision when pref was never stored", () => {
+      expect(shouldSetRetentionPref(undefined, "pending_decision")).toBe(false);
+    });
+
+    it("allows setting pending_decision when pref was explicitly stored", () => {
+      expect(shouldSetRetentionPref("ephemeral", "pending_decision")).toBe(
+        true,
+      );
+    });
+
+    it("allows setting non-default values when pref was never stored", () => {
+      expect(shouldSetRetentionPref(undefined, "ephemeral")).toBe(true);
+      expect(shouldSetRetentionPref(undefined, "persistent")).toBe(true);
+    });
+
+    it("does not write retention to payload when user never touched dropdown", () => {
+      // Simulate: config has no retention, user only changes coding dir
+      const prefs: Record<string, string> = {
+        PARALLAX_APPROVAL_MODE: "standard",
+        PARALLAX_CODING_DIRECTORY: "~/Projects",
+      };
+      // PARALLAX_SCRATCH_RETENTION is absent from prefs
+      const patch = buildEnvPatch(prefs);
+      expect(patch).not.toHaveProperty("PARALLAX_SCRATCH_RETENTION");
+    });
+  });
+
+  describe("clear-directory edge case", () => {
+    it("clearing coding directory results in empty string in payload", () => {
+      const prefs = {
+        PARALLAX_APPROVAL_MODE: "standard",
+        PARALLAX_CODING_DIRECTORY: "", // user cleared the input
+      };
+      const patch = buildEnvPatch(prefs);
+      expect(patch.PARALLAX_CODING_DIRECTORY).toBe("");
+    });
+
+    it("absent coding directory is not included in payload", () => {
+      const prefs = {
+        PARALLAX_APPROVAL_MODE: "standard",
+      };
+      const patch = buildEnvPatch(prefs);
+      expect(patch).not.toHaveProperty("PARALLAX_CODING_DIRECTORY");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add **Scratch Retention** dropdown (auto-delete / ask me / always keep) to Coding Agent settings
- Add **Coding Directory** text input for user-configured scratch workspace location (e.g. `~/Projects`)
- Bump `@elizaos/plugin-agent-orchestrator` 0.4.1 → 0.4.2 (scratch workspace lifecycle support)

Depends on plugin PR: https://github.com/milady-ai/plugin-agent-orchestrator/pull/24

## Test plan
- [ ] Settings page loads without errors
- [ ] Scratch Retention dropdown persists selection to `milady.json`
- [ ] Coding Directory input saves on blur/enter
- [ ] Scratch tasks use configured coding directory when set
- [ ] Retention policy respected on task completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)