### PR TITLE
chore: bump plugin-agent-orchestrator 0.4.2 → 0.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "@electric-sql/pglite": "^0.3.16",
     "@elizaos/app-hyperscape": "1.0.0",
     "@elizaos/core": "2.0.0-alpha.109",
-    "@elizaos/plugin-agent-orchestrator": "0.4.2",
+    "@elizaos/plugin-agent-orchestrator": "0.4.3",
     "@elizaos/plugin-agent-skills": "^2.0.0-alpha.70",
     "@elizaos/plugin-commands": "alpha",
     "@elizaos/plugin-anthropic": "^2.0.0-alpha.9",


### PR DESCRIPTION
## Summary
- Bump `@elizaos/plugin-agent-orchestrator` 0.4.2 → 0.4.3
- Picks up scratch workspace lifecycle fixes from plugin PR #24:
  - Tilde expansion in allowed dirs safety check
  - Registration retry on failure (scratchRegistered deferred)
  - Shared `readConfigEnvKey` utility (deduped)
  - Computed TTL in save prompt (no more hardcoded "24 hours")
  - `expiresAt` type fix on scratch decision callback

## Test plan
- [ ] `bun install` resolves 0.4.3 from npm
- [ ] Scratch tasks use correct retention policy
- [ ] Coding directory with `~` prefix works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)