### PR TITLE
fix: dashboard asset URLs use correct path for v2.0.4 tag

### DIFF
--- a/apps/web/src/generated/release-data.ts
+++ b/apps/web/src/generated/release-data.ts
@@ -15,7 +15,7 @@ export const releaseData = {
     appAssetBaseUrl:
       "https://raw.githubusercontent.com/milady-ai/milady/v2.0.4/apps/app/public/",
     homepageAssetBaseUrl:
-      "https://raw.githubusercontent.com/milady-ai/milady/v2.0.4/apps/web/public/",
+      "https://raw.githubusercontent.com/milady-ai/milady/v2.0.4/apps/homepage/public/",
   },
   release: {
     tagName: "v2.0.4",


### PR DESCRIPTION
## Summary
The `apps/homepage` → `apps/web` rename happened after v2.0.4 was tagged. `release-data.ts` pointed to `apps/web/public/` which 404s on the v2.0.4 tag since those files are at `apps/homepage/public/`.

## Fix
Updated `homepageAssetBaseUrl` in `release-data.ts` to use `apps/homepage/public/` which exists at v2.0.4.

## Impact
Fixes broken logo and icon images on the milady.ai dashboard.

**Before:** `https://raw.githubusercontent.com/milady-ai/milady/v2.0.4/apps/web/public/logo.png` → 404
**After:** `https://raw.githubusercontent.com/milady-ai/milady/v2.0.4/apps/homepage/public/logo.png` → 200 ✅

1 file changed, 1 line.