### PR TITLE
fix: correct homepage release asset base path

### DIFF
--- a/apps/web/src/generated/release-data.ts
+++ b/apps/web/src/generated/release-data.ts
@@ -15,7 +15,7 @@ export const releaseData = {
     appAssetBaseUrl:
       "https://raw.githubusercontent.com/milady-ai/milady/v2.0.4/apps/app/public/",
     homepageAssetBaseUrl:
-      "https://raw.githubusercontent.com/milady-ai/milady/v2.0.4/apps/homepage/public/",
+      "https://raw.githubusercontent.com/milady-ai/milady/v2.0.4/apps/web/public/",
   },
   release: {
     tagName: "v2.0.4",

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -28,6 +28,9 @@ const autonomousElizaPathCandidates = [
   "node_modules/@miladyai/agent/packages/agent/src/runtime/eliza.js",
   "packages/agent/src/runtime/eliza.ts",
 ] as const;
+const homepageReleaseDataPathCandidates = [
+  "apps/web/src/generated/release-data.ts",
+] as const;
 const requiredWorkflowSnippets = [
   'BUN_VERSION: "1.3.9"',
   "workflow_call:",
@@ -1030,6 +1033,34 @@ function assertStaticAssetManifestIsCurrent() {
   process.exit(1);
 }
 
+function assertHomepageReleaseDataUsesCurrentAssetRoot() {
+  const releaseDataSource = readExistingReleaseCheckFile(
+    "generated homepage release data",
+    homepageReleaseDataPathCandidates,
+  );
+
+  if (!releaseDataSource.includes("homepageAssetBaseUrl:")) {
+    console.error(
+      "release-check: generated homepage release data is missing homepageAssetBaseUrl.",
+    );
+    process.exit(1);
+  }
+
+  if (!releaseDataSource.includes("/apps/web/public/")) {
+    console.error(
+      "release-check: generated homepage release data must point homepageAssetBaseUrl at /apps/web/public/.",
+    );
+    process.exit(1);
+  }
+
+  if (releaseDataSource.includes("/apps/homepage/public/")) {
+    console.error(
+      "release-check: generated homepage release data still points at legacy /apps/homepage/public/. Regenerate it with node scripts/write-homepage-release-data.mjs.",
+    );
+    process.exit(1);
+  }
+}
+
 function main() {
   assertReleaseWorkflowHasNotaryWrapper();
   assertElectrobunPrWorkflowExists();
@@ -1043,6 +1074,7 @@ function main() {
   assertServerDynamicHyperscapeImport();
   assertStartApiServerCatchBlockSafety();
   assertStaticAssetManifestIsCurrent();
+  assertHomepageReleaseDataUsesCurrentAssetRoot();
   maybeValidateCdnAssets();
   assertBundledAgentOrchestratorInstallFix();
   assertOrchestratorVersionPinned();


### PR DESCRIPTION
## Summary
- point generated homepage release metadata at `apps/web/public` instead of the legacy `apps/homepage/public` path
- fail `release:check` if generated release data ever drifts back to the old homepage asset root

## Validation
- `cd apps/web && bunx vitest run src/__tests__/asset-url.test.ts src/__tests__/release-data.test.ts`
- `bun run release:check`
- `codex review --uncommitted`