### PR TITLE
fix: recover plugin installs when plugin manager is unavailable

### DIFF
--- a/packages/app-core/src/actions/__tests__/install-plugin.test.ts
+++ b/packages/app-core/src/actions/__tests__/install-plugin.test.ts
@@ -117,7 +117,9 @@ describe("installPluginAction", () => {
     );
 
     expect(result.success).toBe(false);
-    expect(result.text).toBe("Failed to install discord: Invalid install response");
+    expect(result.text).toBe(
+      "Failed to install discord: Invalid install response",
+    );
   });
 
   it("returns a failure message when install service reports ok:false", async () => {

--- a/packages/app-core/src/actions/__tests__/install-plugin.test.ts
+++ b/packages/app-core/src/actions/__tests__/install-plugin.test.ts
@@ -259,4 +259,83 @@ describe("installPluginAction", () => {
       }),
     );
   });
+
+  it("does not restart twice when plugin-manager was already auto-enabled", async () => {
+    ensurePluginManagerAllowedMock.mockReturnValue("enabled");
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        mockJsonResponse({
+          ok: true,
+          status: 200,
+          body: { ok: true },
+        }),
+      )
+      .mockResolvedValueOnce(
+        mockJsonResponse({
+          ok: false,
+          status: 503,
+          body: { error: "Plugin manager service not found" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        mockJsonResponse({
+          ok: true,
+          status: 200,
+          body: { ok: true, message: "installed after existing restart" },
+        }),
+      );
+
+    const result = await installPluginAction.handler(
+      undefined,
+      { roomId: "room", content: { text: "" } },
+      undefined,
+      { parameters: { pluginId: "telegram" } },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.text).toBe("installed after existing restart");
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(3);
+    expect(vi.mocked(fetch)).toHaveBeenNthCalledWith(
+      1,
+      "http://localhost:31337/api/agent/restart",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(vi.mocked(fetch)).toHaveBeenNthCalledWith(
+      2,
+      "http://localhost:31337/api/plugins/install",
+      expect.objectContaining({
+        body: JSON.stringify({
+          name: "@elizaos/plugin-telegram",
+          autoRestart: true,
+        }),
+      }),
+    );
+    expect(vi.mocked(fetch)).toHaveBeenNthCalledWith(
+      3,
+      "http://localhost:31337/api/plugins/install",
+      expect.objectContaining({
+        body: JSON.stringify({
+          name: "@elizaos/plugin-telegram",
+          autoRestart: true,
+        }),
+      }),
+    );
+  });
+
+  it("fails fast when env disables plugin-manager auto-enable", async () => {
+    ensurePluginManagerAllowedMock.mockReturnValue("disabled-by-env");
+
+    const result = await installPluginAction.handler(
+      undefined,
+      { roomId: "room", content: { text: "" } },
+      undefined,
+      { parameters: { pluginId: "telegram" } },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.text).toBe(
+      "Failed to install telegram: plugin-manager auto-enable is disabled by MILADY_DISABLE_PLUGIN_MANAGER_AUTO_ENABLE=1",
+    );
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+  });
 });

--- a/packages/app-core/src/actions/__tests__/install-plugin.test.ts
+++ b/packages/app-core/src/actions/__tests__/install-plugin.test.ts
@@ -4,9 +4,8 @@ import { installPluginAction } from "../../actions/install-plugin";
 const ensurePluginManagerAllowedMock = vi.fn(() => "already-enabled");
 
 vi.mock("../../runtime/plugin-manager-guard", async (importOriginal) => {
-  const actual = await importOriginal<
-    typeof import("../../runtime/plugin-manager-guard")
-  >();
+  const actual =
+    await importOriginal<typeof import("../../runtime/plugin-manager-guard")>();
 
   return {
     ...actual,

--- a/packages/app-core/src/actions/__tests__/install-plugin.test.ts
+++ b/packages/app-core/src/actions/__tests__/install-plugin.test.ts
@@ -117,7 +117,7 @@ describe("installPluginAction", () => {
     );
 
     expect(result.success).toBe(false);
-    expect(result.text).toBe("Failed to install discord: HTTP 502");
+    expect(result.text).toBe("Failed to install discord: Invalid install response");
   });
 
   it("returns a failure message when install service reports ok:false", async () => {

--- a/packages/app-core/src/actions/__tests__/install-plugin.test.ts
+++ b/packages/app-core/src/actions/__tests__/install-plugin.test.ts
@@ -3,10 +3,17 @@ import { installPluginAction } from "../../actions/install-plugin";
 
 const ensurePluginManagerAllowedMock = vi.fn(() => "already-enabled");
 
-vi.mock("../../runtime/plugin-manager-guard", () => ({
-  ensurePluginManagerAllowed: (...args: unknown[]) =>
-    ensurePluginManagerAllowedMock(...args),
-}));
+vi.mock("../../runtime/plugin-manager-guard", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("../../runtime/plugin-manager-guard")
+  >();
+
+  return {
+    ...actual,
+    ensurePluginManagerAllowed: (...args: unknown[]) =>
+      ensurePluginManagerAllowedMock(...args),
+  };
+});
 
 function mockJsonResponse(response: {
   ok: boolean;

--- a/packages/app-core/src/actions/__tests__/install-plugin.test.ts
+++ b/packages/app-core/src/actions/__tests__/install-plugin.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { installPluginAction } from "../../actions/install-plugin";
 
+const ensurePluginManagerAllowedMock = vi.fn(() => "already-enabled");
+
+vi.mock("../../runtime/plugin-manager-guard", () => ({
+  ensurePluginManagerAllowed: (...args: unknown[]) =>
+    ensurePluginManagerAllowedMock(...args),
+}));
+
 function mockJsonResponse(response: {
   ok: boolean;
   status: number;
@@ -21,6 +28,7 @@ function mockJsonResponse(response: {
 describe("installPluginAction", () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    ensurePluginManagerAllowedMock.mockReturnValue("already-enabled");
     vi.stubGlobal("fetch", vi.fn());
   });
 
@@ -155,5 +163,98 @@ describe("installPluginAction", () => {
 
     expect(result.success).toBe(true);
     expect(result.text).toBe("plugin-telegram installed and restart scheduled");
+  });
+
+  it("restarts first when plugin-manager was just auto-enabled", async () => {
+    ensurePluginManagerAllowedMock.mockReturnValue("enabled");
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        mockJsonResponse({
+          ok: true,
+          status: 200,
+          body: { ok: true },
+        }),
+      )
+      .mockResolvedValueOnce(
+        mockJsonResponse({
+          ok: true,
+          status: 200,
+          body: { ok: true },
+        }),
+      );
+
+    const result = await installPluginAction.handler(
+      undefined,
+      { roomId: "room", content: { text: "" } },
+      undefined,
+      { parameters: { pluginId: "telegram" } },
+    );
+
+    expect(result.success).toBe(true);
+    expect(vi.mocked(fetch)).toHaveBeenNthCalledWith(
+      1,
+      "http://localhost:31337/api/agent/restart",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(vi.mocked(fetch)).toHaveBeenNthCalledWith(
+      2,
+      "http://localhost:31337/api/plugins/install",
+      expect.objectContaining({
+        body: JSON.stringify({
+          name: "@elizaos/plugin-telegram",
+          autoRestart: true,
+        }),
+      }),
+    );
+  });
+
+  it("retries after plugin-manager service missing by restarting the agent", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        mockJsonResponse({
+          ok: false,
+          status: 503,
+          body: { error: "Plugin manager service not found" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        mockJsonResponse({
+          ok: true,
+          status: 200,
+          body: { ok: true },
+        }),
+      )
+      .mockResolvedValueOnce(
+        mockJsonResponse({
+          ok: true,
+          status: 200,
+          body: { ok: true, message: "installed after restart" },
+        }),
+      );
+
+    const result = await installPluginAction.handler(
+      undefined,
+      { roomId: "room", content: { text: "" } },
+      undefined,
+      { parameters: { pluginId: "telegram" } },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.text).toBe("installed after restart");
+    expect(vi.mocked(fetch)).toHaveBeenNthCalledWith(
+      2,
+      "http://localhost:31337/api/agent/restart",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(vi.mocked(fetch)).toHaveBeenNthCalledWith(
+      3,
+      "http://localhost:31337/api/plugins/install",
+      expect.objectContaining({
+        body: JSON.stringify({
+          name: "@elizaos/plugin-telegram",
+          autoRestart: true,
+        }),
+      }),
+    );
   });
 });

--- a/packages/app-core/src/actions/install-plugin.ts
+++ b/packages/app-core/src/actions/install-plugin.ts
@@ -18,6 +18,25 @@ import { ensurePluginManagerAllowed } from "../runtime/plugin-manager-guard";
 const API_PORT = String(resolveDesktopApiPort(process.env));
 const PLUGIN_MANAGER_UNAVAILABLE_ERROR = "Plugin manager service not found";
 
+type InstallPluginResponse = {
+  ok: boolean;
+  message?: string;
+  error?: string;
+};
+
+function parseInstallPluginResponse(value: unknown): InstallPluginResponse {
+  if (!value || typeof value !== "object") {
+    return { ok: false, error: "Invalid install response" };
+  }
+
+  const record = value as Record<string, unknown>;
+  return {
+    ok: record.ok === true,
+    message: typeof record.message === "string" ? record.message : undefined,
+    error: typeof record.error === "string" ? record.error : undefined,
+  };
+}
+
 async function postInstallRequest(npmName: string): Promise<Response> {
   return fetch(`http://localhost:${API_PORT}/api/plugins/install`, {
     method: "POST",
@@ -36,10 +55,9 @@ async function restartAgent(): Promise<void> {
     },
   );
   if (!response.ok) {
-    const body = (await response.json().catch(() => ({}))) as Record<
-      string,
-      string
-    >;
+    const body = parseInstallPluginResponse(
+      await response.json().catch(() => null),
+    );
     throw new Error(body.error ?? `HTTP ${response.status}`);
   }
 }
@@ -93,10 +111,9 @@ export const installPluginAction: Action = {
       let response = await postInstallRequest(npmName);
 
       if (!response.ok) {
-        let body = (await response.json().catch(() => ({}))) as Record<
-          string,
-          string
-        >;
+        let body = parseInstallPluginResponse(
+          await response.json().catch(() => null),
+        );
         if ((body.error ?? "").includes(PLUGIN_MANAGER_UNAVAILABLE_ERROR)) {
           const recoveryGuard = ensurePluginManagerAllowed();
           if (recoveryGuard === "disabled-by-user") {
@@ -107,10 +124,9 @@ export const installPluginAction: Action = {
           }
           await restartAgent();
           response = await postInstallRequest(npmName);
-          body = (await response.json().catch(() => ({}))) as Record<
-            string,
-            string
-          >;
+          body = parseInstallPluginResponse(
+            await response.json().catch(() => null),
+          );
         }
         if (!response.ok) {
           return {
@@ -118,11 +134,7 @@ export const installPluginAction: Action = {
             success: false,
           };
         }
-        const result = body as unknown as {
-          ok: boolean;
-          message?: string;
-          error?: string;
-        };
+        const result = body;
         if (!result.ok) {
           return {
             text: `Failed to install ${pluginId}: ${result.error ?? "unknown error"}`,
@@ -138,11 +150,7 @@ export const installPluginAction: Action = {
         };
       }
 
-      const result = (await response.json()) as {
-        ok: boolean;
-        message?: string;
-        error?: string;
-      };
+      const result = parseInstallPluginResponse(await response.json());
 
       if (!result.ok) {
         return {

--- a/packages/app-core/src/actions/install-plugin.ts
+++ b/packages/app-core/src/actions/install-plugin.ts
@@ -12,7 +12,10 @@
 
 import type { Action, HandlerOptions } from "@elizaos/core";
 import { resolveDesktopApiPort } from "@miladyai/shared/runtime-env";
-import { ensurePluginManagerAllowed } from "../runtime/plugin-manager-guard";
+import {
+  ensurePluginManagerAllowed,
+  type PluginManagerGuardResult,
+} from "../runtime/plugin-manager-guard";
 
 /** API port for posting install requests. */
 const API_PORT = String(resolveDesktopApiPort(process.env));
@@ -23,6 +26,18 @@ type InstallPluginResponse = {
   message?: string;
   error?: string;
 };
+
+function getPluginManagerBlockReason(
+  result: PluginManagerGuardResult,
+): string | null {
+  if (result === "disabled-by-user") {
+    return "plugin-manager is explicitly disabled in config";
+  }
+  if (result === "disabled-by-env") {
+    return "plugin-manager auto-enable is disabled by MILADY_DISABLE_PLUGIN_MANAGER_AUTO_ENABLE=1";
+  }
+  return null;
+}
 
 function parseInstallPluginResponse(value: unknown): InstallPluginResponse {
   if (!value || typeof value !== "object") {
@@ -98,14 +113,18 @@ export const installPluginAction: Action = {
         ? pluginId
         : `@elizaos/plugin-${pluginId}`;
       const pluginManagerGuard = ensurePluginManagerAllowed();
-      if (pluginManagerGuard === "disabled-by-user") {
+      const pluginManagerBlockReason =
+        getPluginManagerBlockReason(pluginManagerGuard);
+      if (pluginManagerBlockReason) {
         return {
-          text: `Failed to install ${pluginId}: plugin-manager is explicitly disabled in config`,
+          text: `Failed to install ${pluginId}: ${pluginManagerBlockReason}`,
           success: false,
         };
       }
+      let restartedForPluginManager = false;
       if (pluginManagerGuard === "enabled") {
         await restartAgent();
+        restartedForPluginManager = true;
       }
 
       let response = await postInstallRequest(npmName);
@@ -116,13 +135,18 @@ export const installPluginAction: Action = {
         );
         if ((body.error ?? "").includes(PLUGIN_MANAGER_UNAVAILABLE_ERROR)) {
           const recoveryGuard = ensurePluginManagerAllowed();
-          if (recoveryGuard === "disabled-by-user") {
+          const recoveryBlockReason =
+            getPluginManagerBlockReason(recoveryGuard);
+          if (recoveryBlockReason) {
             return {
-              text: `Failed to install ${pluginId}: plugin-manager is explicitly disabled in config`,
+              text: `Failed to install ${pluginId}: ${recoveryBlockReason}`,
               success: false,
             };
           }
-          await restartAgent();
+          if (!restartedForPluginManager) {
+            await restartAgent();
+            restartedForPluginManager = true;
+          }
           response = await postInstallRequest(npmName);
           body = parseInstallPluginResponse(
             await response.json().catch(() => null),

--- a/packages/app-core/src/actions/install-plugin.ts
+++ b/packages/app-core/src/actions/install-plugin.ts
@@ -118,7 +118,7 @@ export const installPluginAction: Action = {
             success: false,
           };
         }
-        const result = body as {
+        const result = body as unknown as {
           ok: boolean;
           message?: string;
           error?: string;

--- a/packages/app-core/src/actions/install-plugin.ts
+++ b/packages/app-core/src/actions/install-plugin.ts
@@ -12,9 +12,37 @@
 
 import type { Action, HandlerOptions } from "@elizaos/core";
 import { resolveDesktopApiPort } from "@miladyai/shared/runtime-env";
+import { ensurePluginManagerAllowed } from "../runtime/plugin-manager-guard";
 
 /** API port for posting install requests. */
 const API_PORT = String(resolveDesktopApiPort(process.env));
+const PLUGIN_MANAGER_UNAVAILABLE_ERROR = "Plugin manager service not found";
+
+async function postInstallRequest(npmName: string): Promise<Response> {
+  return fetch(`http://localhost:${API_PORT}/api/plugins/install`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name: npmName, autoRestart: true }),
+  });
+}
+
+async function restartAgent(): Promise<void> {
+  const response = await fetch(
+    `http://localhost:${API_PORT}/api/agent/restart`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    },
+  );
+  if (!response.ok) {
+    const body = (await response.json().catch(() => ({}))) as Record<
+      string,
+      string
+    >;
+    throw new Error(body.error ?? `HTTP ${response.status}`);
+  }
+}
 
 export const installPluginAction: Action = {
   name: "INSTALL_PLUGIN",
@@ -51,24 +79,62 @@ export const installPluginAction: Action = {
       const npmName = pluginId.startsWith("@")
         ? pluginId
         : `@elizaos/plugin-${pluginId}`;
+      const pluginManagerGuard = ensurePluginManagerAllowed();
+      if (pluginManagerGuard === "disabled-by-user") {
+        return {
+          text: `Failed to install ${pluginId}: plugin-manager is explicitly disabled in config`,
+          success: false,
+        };
+      }
+      if (pluginManagerGuard === "enabled") {
+        await restartAgent();
+      }
 
-      const response = await fetch(
-        `http://localhost:${API_PORT}/api/plugins/install`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ name: npmName, autoRestart: true }),
-        },
-      );
+      let response = await postInstallRequest(npmName);
 
       if (!response.ok) {
-        const body = (await response.json().catch(() => ({}))) as Record<
+        let body = (await response.json().catch(() => ({}))) as Record<
           string,
           string
         >;
+        if ((body.error ?? "").includes(PLUGIN_MANAGER_UNAVAILABLE_ERROR)) {
+          const recoveryGuard = ensurePluginManagerAllowed();
+          if (recoveryGuard === "disabled-by-user") {
+            return {
+              text: `Failed to install ${pluginId}: plugin-manager is explicitly disabled in config`,
+              success: false,
+            };
+          }
+          await restartAgent();
+          response = await postInstallRequest(npmName);
+          body = (await response.json().catch(() => ({}))) as Record<
+            string,
+            string
+          >;
+        }
+        if (!response.ok) {
+          return {
+            text: `Failed to install ${pluginId}: ${body.error ?? `HTTP ${response.status}`}`,
+            success: false,
+          };
+        }
+        const result = body as {
+          ok: boolean;
+          message?: string;
+          error?: string;
+        };
+        if (!result.ok) {
+          return {
+            text: `Failed to install ${pluginId}: ${result.error ?? "unknown error"}`,
+            success: false,
+          };
+        }
         return {
-          text: `Failed to install ${pluginId}: ${body.error ?? `HTTP ${response.status}`}`,
-          success: false,
+          text:
+            result.message ??
+            `Plugin ${pluginId} installed successfully. The agent is restarting to load it.`,
+          success: true,
+          data: { pluginId, npmName },
         };
       }
 

--- a/packages/app-core/src/actions/install-plugin.ts
+++ b/packages/app-core/src/actions/install-plugin.ts
@@ -14,30 +14,18 @@ import type { Action, HandlerOptions } from "@elizaos/core";
 import { resolveDesktopApiPort } from "@miladyai/shared/runtime-env";
 import {
   ensurePluginManagerAllowed,
-  type PluginManagerGuardResult,
+  getPluginManagerBlockReason,
+  PLUGIN_MANAGER_UNAVAILABLE_ERROR,
 } from "../runtime/plugin-manager-guard";
 
 /** API port for posting install requests. */
 const API_PORT = String(resolveDesktopApiPort(process.env));
-const PLUGIN_MANAGER_UNAVAILABLE_ERROR = "Plugin manager service not found";
 
 type InstallPluginResponse = {
   ok: boolean;
   message?: string;
   error?: string;
 };
-
-function getPluginManagerBlockReason(
-  result: PluginManagerGuardResult,
-): string | null {
-  if (result === "disabled-by-user") {
-    return "plugin-manager is explicitly disabled in config";
-  }
-  if (result === "disabled-by-env") {
-    return "plugin-manager auto-enable is disabled by MILADY_DISABLE_PLUGIN_MANAGER_AUTO_ENABLE=1";
-  }
-  return null;
-}
 
 function parseInstallPluginResponse(value: unknown): InstallPluginResponse {
   if (!value || typeof value !== "object") {

--- a/packages/app-core/src/actions/install-plugin.ts
+++ b/packages/app-core/src/actions/install-plugin.ts
@@ -19,168 +19,168 @@ const API_PORT = String(resolveDesktopApiPort(process.env));
 const PLUGIN_MANAGER_UNAVAILABLE_ERROR = "Plugin manager service not found";
 
 type InstallPluginResponse = {
-  ok: boolean;
-  message?: string;
-  error?: string;
+	ok: boolean;
+	message?: string;
+	error?: string;
 };
 
 function parseInstallPluginResponse(value: unknown): InstallPluginResponse {
-  if (!value || typeof value !== "object") {
-    return { ok: false, error: "Invalid install response" };
-  }
+	if (!value || typeof value !== "object") {
+		return { ok: false, error: "Invalid install response" };
+	}
 
-  const record = value as Record<string, unknown>;
-  return {
-    ok: record.ok === true,
-    message: typeof record.message === "string" ? record.message : undefined,
-    error: typeof record.error === "string" ? record.error : undefined,
-  };
+	const record = value as Record<string, unknown>;
+	return {
+		ok: record.ok === true,
+		message: typeof record.message === "string" ? record.message : undefined,
+		error: typeof record.error === "string" ? record.error : undefined,
+	};
 }
 
 async function postInstallRequest(npmName: string): Promise<Response> {
-  return fetch(`http://localhost:${API_PORT}/api/plugins/install`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ name: npmName, autoRestart: true }),
-  });
+	return fetch(`http://localhost:${API_PORT}/api/plugins/install`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ name: npmName, autoRestart: true }),
+	});
 }
 
 async function restartAgent(): Promise<void> {
-  const response = await fetch(
-    `http://localhost:${API_PORT}/api/agent/restart`,
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({}),
-    },
-  );
-  if (!response.ok) {
-    const body = parseInstallPluginResponse(
-      await response.json().catch(() => null),
-    );
-    throw new Error(body.error ?? `HTTP ${response.status}`);
-  }
+	const response = await fetch(
+		`http://localhost:${API_PORT}/api/agent/restart`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({}),
+		},
+	);
+	if (!response.ok) {
+		const body = parseInstallPluginResponse(
+			await response.json().catch(() => null),
+		);
+		throw new Error(body.error ?? `HTTP ${response.status}`);
+	}
 }
 
 export const installPluginAction: Action = {
-  name: "INSTALL_PLUGIN",
+	name: "INSTALL_PLUGIN",
 
-  similes: [
-    "INSTALL",
-    "ADD_PLUGIN",
-    "ENABLE_PLUGIN",
-    "SETUP_PLUGIN",
-    "GET_PLUGIN",
-  ],
+	similes: [
+		"INSTALL",
+		"ADD_PLUGIN",
+		"ENABLE_PLUGIN",
+		"SETUP_PLUGIN",
+		"GET_PLUGIN",
+	],
 
-  description:
-    "Install a plugin that is not yet installed. Use this when a user asks to " +
-    "use, enable, set up, or install a plugin that is marked [available] " +
-    "(not yet loaded). The plugin will be downloaded and the agent will " +
-    "restart to load it.",
+	description:
+		"Install a plugin that is not yet installed. Use this when a user asks to " +
+		"use, enable, set up, or install a plugin that is marked [available] " +
+		"(not yet loaded). The plugin will be downloaded and the agent will " +
+		"restart to load it.",
 
-  validate: async () => true,
+	validate: async () => true,
 
-  handler: async (_runtime, _message, _state, options) => {
-    try {
-      const params = (options as HandlerOptions | undefined)?.parameters;
-      const pluginId =
-        typeof params?.pluginId === "string"
-          ? params.pluginId.trim()
-          : undefined;
+	handler: async (_runtime, _message, _state, options) => {
+		try {
+			const params = (options as HandlerOptions | undefined)?.parameters;
+			const pluginId =
+				typeof params?.pluginId === "string"
+					? params.pluginId.trim()
+					: undefined;
 
-      if (!pluginId) {
-        return { text: "I need a plugin ID to install.", success: false };
-      }
+			if (!pluginId) {
+				return { text: "I need a plugin ID to install.", success: false };
+			}
 
-      // The API expects the full npm package name
-      const npmName = pluginId.startsWith("@")
-        ? pluginId
-        : `@elizaos/plugin-${pluginId}`;
-      const pluginManagerGuard = ensurePluginManagerAllowed();
-      if (pluginManagerGuard === "disabled-by-user") {
-        return {
-          text: `Failed to install ${pluginId}: plugin-manager is explicitly disabled in config`,
-          success: false,
-        };
-      }
-      if (pluginManagerGuard === "enabled") {
-        await restartAgent();
-      }
+			// The API expects the full npm package name
+			const npmName = pluginId.startsWith("@")
+				? pluginId
+				: `@elizaos/plugin-${pluginId}`;
+			const pluginManagerGuard = ensurePluginManagerAllowed();
+			if (pluginManagerGuard === "disabled-by-user") {
+				return {
+					text: `Failed to install ${pluginId}: plugin-manager is explicitly disabled in config`,
+					success: false,
+				};
+			}
+			if (pluginManagerGuard === "enabled") {
+				await restartAgent();
+			}
 
-      let response = await postInstallRequest(npmName);
+			let response = await postInstallRequest(npmName);
 
-      if (!response.ok) {
-        let body = parseInstallPluginResponse(
-          await response.json().catch(() => null),
-        );
-        if ((body.error ?? "").includes(PLUGIN_MANAGER_UNAVAILABLE_ERROR)) {
-          const recoveryGuard = ensurePluginManagerAllowed();
-          if (recoveryGuard === "disabled-by-user") {
-            return {
-              text: `Failed to install ${pluginId}: plugin-manager is explicitly disabled in config`,
-              success: false,
-            };
-          }
-          await restartAgent();
-          response = await postInstallRequest(npmName);
-          body = parseInstallPluginResponse(
-            await response.json().catch(() => null),
-          );
-        }
-        if (!response.ok) {
-          return {
-            text: `Failed to install ${pluginId}: ${body.error ?? `HTTP ${response.status}`}`,
-            success: false,
-          };
-        }
-        const result = body;
-        if (!result.ok) {
-          return {
-            text: `Failed to install ${pluginId}: ${result.error ?? "unknown error"}`,
-            success: false,
-          };
-        }
-        return {
-          text:
-            result.message ??
-            `Plugin ${pluginId} installed successfully. The agent is restarting to load it.`,
-          success: true,
-          data: { pluginId, npmName },
-        };
-      }
+			if (!response.ok) {
+				let body = parseInstallPluginResponse(
+					await response.json().catch(() => null),
+				);
+				if ((body.error ?? "").includes(PLUGIN_MANAGER_UNAVAILABLE_ERROR)) {
+					const recoveryGuard = ensurePluginManagerAllowed();
+					if (recoveryGuard === "disabled-by-user") {
+						return {
+							text: `Failed to install ${pluginId}: plugin-manager is explicitly disabled in config`,
+							success: false,
+						};
+					}
+					await restartAgent();
+					response = await postInstallRequest(npmName);
+					body = parseInstallPluginResponse(
+						await response.json().catch(() => null),
+					);
+				}
+				if (!response.ok) {
+					return {
+						text: `Failed to install ${pluginId}: ${body.error ?? `HTTP ${response.status}`}`,
+						success: false,
+					};
+				}
+				const result = body;
+				if (!result.ok) {
+					return {
+						text: `Failed to install ${pluginId}: ${result.error ?? "unknown error"}`,
+						success: false,
+					};
+				}
+				return {
+					text:
+						result.message ??
+						`Plugin ${pluginId} installed successfully. The agent is restarting to load it.`,
+					success: true,
+					data: { pluginId, npmName },
+				};
+			}
 
-      const result = parseInstallPluginResponse(await response.json());
+			const result = parseInstallPluginResponse(await response.json());
 
-      if (!result.ok) {
-        return {
-          text: `Failed to install ${pluginId}: ${result.error ?? "unknown error"}`,
-          success: false,
-        };
-      }
+			if (!result.ok) {
+				return {
+					text: `Failed to install ${pluginId}: ${result.error ?? "unknown error"}`,
+					success: false,
+				};
+			}
 
-      return {
-        text:
-          result.message ??
-          `Plugin ${pluginId} installed successfully. The agent is restarting to load it.`,
-        success: true,
-        data: { pluginId, npmName },
-      };
-    } catch (err) {
-      return {
-        text: `Install failed: ${err instanceof Error ? err.message : String(err)}`,
-        success: false,
-      };
-    }
-  },
+			return {
+				text:
+					result.message ??
+					`Plugin ${pluginId} installed successfully. The agent is restarting to load it.`,
+				success: true,
+				data: { pluginId, npmName },
+			};
+		} catch (err) {
+			return {
+				text: `Install failed: ${err instanceof Error ? err.message : String(err)}`,
+				success: false,
+			};
+		}
+	},
 
-  parameters: [
-    {
-      name: "pluginId",
-      description:
-        "The short plugin ID to install (e.g. 'telegram', 'discord', 'polymarket')",
-      required: true,
-      schema: { type: "string" as const },
-    },
-  ],
+	parameters: [
+		{
+			name: "pluginId",
+			description:
+				"The short plugin ID to install (e.g. 'telegram', 'discord', 'polymarket')",
+			required: true,
+			schema: { type: "string" as const },
+		},
+	],
 };

--- a/packages/app-core/src/actions/install-plugin.ts
+++ b/packages/app-core/src/actions/install-plugin.ts
@@ -19,168 +19,168 @@ const API_PORT = String(resolveDesktopApiPort(process.env));
 const PLUGIN_MANAGER_UNAVAILABLE_ERROR = "Plugin manager service not found";
 
 type InstallPluginResponse = {
-	ok: boolean;
-	message?: string;
-	error?: string;
+  ok: boolean;
+  message?: string;
+  error?: string;
 };
 
 function parseInstallPluginResponse(value: unknown): InstallPluginResponse {
-	if (!value || typeof value !== "object") {
-		return { ok: false, error: "Invalid install response" };
-	}
+  if (!value || typeof value !== "object") {
+    return { ok: false, error: "Invalid install response" };
+  }
 
-	const record = value as Record<string, unknown>;
-	return {
-		ok: record.ok === true,
-		message: typeof record.message === "string" ? record.message : undefined,
-		error: typeof record.error === "string" ? record.error : undefined,
-	};
+  const record = value as Record<string, unknown>;
+  return {
+    ok: record.ok === true,
+    message: typeof record.message === "string" ? record.message : undefined,
+    error: typeof record.error === "string" ? record.error : undefined,
+  };
 }
 
 async function postInstallRequest(npmName: string): Promise<Response> {
-	return fetch(`http://localhost:${API_PORT}/api/plugins/install`, {
-		method: "POST",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({ name: npmName, autoRestart: true }),
-	});
+  return fetch(`http://localhost:${API_PORT}/api/plugins/install`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name: npmName, autoRestart: true }),
+  });
 }
 
 async function restartAgent(): Promise<void> {
-	const response = await fetch(
-		`http://localhost:${API_PORT}/api/agent/restart`,
-		{
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({}),
-		},
-	);
-	if (!response.ok) {
-		const body = parseInstallPluginResponse(
-			await response.json().catch(() => null),
-		);
-		throw new Error(body.error ?? `HTTP ${response.status}`);
-	}
+  const response = await fetch(
+    `http://localhost:${API_PORT}/api/agent/restart`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    },
+  );
+  if (!response.ok) {
+    const body = parseInstallPluginResponse(
+      await response.json().catch(() => null),
+    );
+    throw new Error(body.error ?? `HTTP ${response.status}`);
+  }
 }
 
 export const installPluginAction: Action = {
-	name: "INSTALL_PLUGIN",
+  name: "INSTALL_PLUGIN",
 
-	similes: [
-		"INSTALL",
-		"ADD_PLUGIN",
-		"ENABLE_PLUGIN",
-		"SETUP_PLUGIN",
-		"GET_PLUGIN",
-	],
+  similes: [
+    "INSTALL",
+    "ADD_PLUGIN",
+    "ENABLE_PLUGIN",
+    "SETUP_PLUGIN",
+    "GET_PLUGIN",
+  ],
 
-	description:
-		"Install a plugin that is not yet installed. Use this when a user asks to " +
-		"use, enable, set up, or install a plugin that is marked [available] " +
-		"(not yet loaded). The plugin will be downloaded and the agent will " +
-		"restart to load it.",
+  description:
+    "Install a plugin that is not yet installed. Use this when a user asks to " +
+    "use, enable, set up, or install a plugin that is marked [available] " +
+    "(not yet loaded). The plugin will be downloaded and the agent will " +
+    "restart to load it.",
 
-	validate: async () => true,
+  validate: async () => true,
 
-	handler: async (_runtime, _message, _state, options) => {
-		try {
-			const params = (options as HandlerOptions | undefined)?.parameters;
-			const pluginId =
-				typeof params?.pluginId === "string"
-					? params.pluginId.trim()
-					: undefined;
+  handler: async (_runtime, _message, _state, options) => {
+    try {
+      const params = (options as HandlerOptions | undefined)?.parameters;
+      const pluginId =
+        typeof params?.pluginId === "string"
+          ? params.pluginId.trim()
+          : undefined;
 
-			if (!pluginId) {
-				return { text: "I need a plugin ID to install.", success: false };
-			}
+      if (!pluginId) {
+        return { text: "I need a plugin ID to install.", success: false };
+      }
 
-			// The API expects the full npm package name
-			const npmName = pluginId.startsWith("@")
-				? pluginId
-				: `@elizaos/plugin-${pluginId}`;
-			const pluginManagerGuard = ensurePluginManagerAllowed();
-			if (pluginManagerGuard === "disabled-by-user") {
-				return {
-					text: `Failed to install ${pluginId}: plugin-manager is explicitly disabled in config`,
-					success: false,
-				};
-			}
-			if (pluginManagerGuard === "enabled") {
-				await restartAgent();
-			}
+      // The API expects the full npm package name
+      const npmName = pluginId.startsWith("@")
+        ? pluginId
+        : `@elizaos/plugin-${pluginId}`;
+      const pluginManagerGuard = ensurePluginManagerAllowed();
+      if (pluginManagerGuard === "disabled-by-user") {
+        return {
+          text: `Failed to install ${pluginId}: plugin-manager is explicitly disabled in config`,
+          success: false,
+        };
+      }
+      if (pluginManagerGuard === "enabled") {
+        await restartAgent();
+      }
 
-			let response = await postInstallRequest(npmName);
+      let response = await postInstallRequest(npmName);
 
-			if (!response.ok) {
-				let body = parseInstallPluginResponse(
-					await response.json().catch(() => null),
-				);
-				if ((body.error ?? "").includes(PLUGIN_MANAGER_UNAVAILABLE_ERROR)) {
-					const recoveryGuard = ensurePluginManagerAllowed();
-					if (recoveryGuard === "disabled-by-user") {
-						return {
-							text: `Failed to install ${pluginId}: plugin-manager is explicitly disabled in config`,
-							success: false,
-						};
-					}
-					await restartAgent();
-					response = await postInstallRequest(npmName);
-					body = parseInstallPluginResponse(
-						await response.json().catch(() => null),
-					);
-				}
-				if (!response.ok) {
-					return {
-						text: `Failed to install ${pluginId}: ${body.error ?? `HTTP ${response.status}`}`,
-						success: false,
-					};
-				}
-				const result = body;
-				if (!result.ok) {
-					return {
-						text: `Failed to install ${pluginId}: ${result.error ?? "unknown error"}`,
-						success: false,
-					};
-				}
-				return {
-					text:
-						result.message ??
-						`Plugin ${pluginId} installed successfully. The agent is restarting to load it.`,
-					success: true,
-					data: { pluginId, npmName },
-				};
-			}
+      if (!response.ok) {
+        let body = parseInstallPluginResponse(
+          await response.json().catch(() => null),
+        );
+        if ((body.error ?? "").includes(PLUGIN_MANAGER_UNAVAILABLE_ERROR)) {
+          const recoveryGuard = ensurePluginManagerAllowed();
+          if (recoveryGuard === "disabled-by-user") {
+            return {
+              text: `Failed to install ${pluginId}: plugin-manager is explicitly disabled in config`,
+              success: false,
+            };
+          }
+          await restartAgent();
+          response = await postInstallRequest(npmName);
+          body = parseInstallPluginResponse(
+            await response.json().catch(() => null),
+          );
+        }
+        if (!response.ok) {
+          return {
+            text: `Failed to install ${pluginId}: ${body.error ?? `HTTP ${response.status}`}`,
+            success: false,
+          };
+        }
+        const result = body;
+        if (!result.ok) {
+          return {
+            text: `Failed to install ${pluginId}: ${result.error ?? "unknown error"}`,
+            success: false,
+          };
+        }
+        return {
+          text:
+            result.message ??
+            `Plugin ${pluginId} installed successfully. The agent is restarting to load it.`,
+          success: true,
+          data: { pluginId, npmName },
+        };
+      }
 
-			const result = parseInstallPluginResponse(await response.json());
+      const result = parseInstallPluginResponse(await response.json());
 
-			if (!result.ok) {
-				return {
-					text: `Failed to install ${pluginId}: ${result.error ?? "unknown error"}`,
-					success: false,
-				};
-			}
+      if (!result.ok) {
+        return {
+          text: `Failed to install ${pluginId}: ${result.error ?? "unknown error"}`,
+          success: false,
+        };
+      }
 
-			return {
-				text:
-					result.message ??
-					`Plugin ${pluginId} installed successfully. The agent is restarting to load it.`,
-				success: true,
-				data: { pluginId, npmName },
-			};
-		} catch (err) {
-			return {
-				text: `Install failed: ${err instanceof Error ? err.message : String(err)}`,
-				success: false,
-			};
-		}
-	},
+      return {
+        text:
+          result.message ??
+          `Plugin ${pluginId} installed successfully. The agent is restarting to load it.`,
+        success: true,
+        data: { pluginId, npmName },
+      };
+    } catch (err) {
+      return {
+        text: `Install failed: ${err instanceof Error ? err.message : String(err)}`,
+        success: false,
+      };
+    }
+  },
 
-	parameters: [
-		{
-			name: "pluginId",
-			description:
-				"The short plugin ID to install (e.g. 'telegram', 'discord', 'polymarket')",
-			required: true,
-			schema: { type: "string" as const },
-		},
-	],
+  parameters: [
+    {
+      name: "pluginId",
+      description:
+        "The short plugin ID to install (e.g. 'telegram', 'discord', 'polymarket')",
+      required: true,
+      schema: { type: "string" as const },
+    },
+  ],
 };

--- a/packages/app-core/src/components/pages/PluginsView.tsx
+++ b/packages/app-core/src/components/pages/PluginsView.tsx
@@ -28,7 +28,8 @@ import type { PluginInfo } from "../../api";
 import { client } from "../../api";
 import {
   ensurePluginManagerAllowed,
-  type PluginManagerGuardResult,
+  getPluginManagerBlockReason,
+  PLUGIN_MANAGER_UNAVAILABLE_ERROR,
 } from "../../runtime/plugin-manager-guard";
 import { useApp } from "../../state";
 import { openExternalUrl } from "../../utils";
@@ -53,18 +54,6 @@ import {
 import { PluginSettingsDialog } from "./plugin-view-dialogs";
 import { PluginGameModal } from "./plugin-view-modal";
 import { ConnectorSidebar } from "./plugin-view-sidebar";
-
-function getPluginManagerBlockReason(
-  result: PluginManagerGuardResult,
-): string | null {
-  if (result === "disabled-by-user") {
-    return "plugin-manager is explicitly disabled in config";
-  }
-  if (result === "disabled-by-env") {
-    return "plugin-manager auto-enable is disabled by MILADY_DISABLE_PLUGIN_MANAGER_AUTO_ENABLE=1";
-  }
-  return null;
-}
 
 /* ── Shared PluginListView ─────────────────────────────────────────── */
 
@@ -482,7 +471,7 @@ function PluginListView({
       let installError = err;
       if (
         installError instanceof Error &&
-        installError.message.includes("Plugin manager service not found")
+        installError.message.includes(PLUGIN_MANAGER_UNAVAILABLE_ERROR)
       ) {
         try {
           const pluginManagerGuard = ensurePluginManagerAllowed();

--- a/packages/app-core/src/components/pages/PluginsView.tsx
+++ b/packages/app-core/src/components/pages/PluginsView.tsx
@@ -26,6 +26,7 @@ import {
 } from "react";
 import type { PluginInfo } from "../../api";
 import { client } from "../../api";
+import { ensurePluginManagerAllowed } from "../../runtime/plugin-manager-guard";
 import { useApp } from "../../state";
 import { openExternalUrl } from "../../utils";
 
@@ -434,6 +435,21 @@ function PluginListView({
   const handleInstallPlugin = async (pluginId: string, npmName: string) => {
     setInstallingPlugins((prev) => new Set(prev).add(pluginId));
     try {
+      const pluginManagerGuard = ensurePluginManagerAllowed();
+      if (pluginManagerGuard === "disabled-by-user") {
+        throw new Error("plugin-manager is explicitly disabled in config");
+      }
+      if (pluginManagerGuard === "enabled") {
+        setActionNotice(
+          t("pluginsview.PluginInstallPreparing", {
+            plugin: npmName,
+            defaultValue:
+              "Enabling plugin installs for {{plugin}} and restarting the agent...",
+          }),
+          "success",
+        );
+        await client.restartAndWait(120_000);
+      }
       await client.installRegistryPlugin(npmName);
       await loadPlugins();
       setActionNotice(
@@ -444,10 +460,47 @@ function PluginListView({
         "success",
       );
     } catch (err) {
+      let installError = err;
+      if (
+        installError instanceof Error &&
+        installError.message.includes("Plugin manager service not found")
+      ) {
+        try {
+          const pluginManagerGuard = ensurePluginManagerAllowed();
+          if (pluginManagerGuard === "disabled-by-user") {
+            throw new Error("plugin-manager is explicitly disabled in config");
+          }
+          setActionNotice(
+            t("pluginsview.PluginInstallRecovering", {
+              plugin: npmName,
+              defaultValue:
+                "Finishing plugin install setup for {{plugin}} and restarting the agent...",
+            }),
+            "success",
+          );
+          await client.restartAndWait(120_000);
+          await client.installRegistryPlugin(npmName);
+          await loadPlugins();
+          setActionNotice(
+            t("pluginsview.PluginInstalledRestartRequired", {
+              plugin: npmName,
+              defaultValue:
+                "{{plugin}} installed. Restart required to activate.",
+            }),
+            "success",
+          );
+          return;
+        } catch (recoveryErr) {
+          installError = recoveryErr;
+        }
+      }
       setActionNotice(
         t("pluginsview.PluginInstallFailed", {
           plugin: npmName,
-          message: err instanceof Error ? err.message : "unknown error",
+          message:
+            installError instanceof Error
+              ? installError.message
+              : "unknown error",
           defaultValue: "Failed to install {{plugin}}: {{message}}",
         }),
         "error",

--- a/packages/app-core/src/components/pages/PluginsView.tsx
+++ b/packages/app-core/src/components/pages/PluginsView.tsx
@@ -26,7 +26,10 @@ import {
 } from "react";
 import type { PluginInfo } from "../../api";
 import { client } from "../../api";
-import { ensurePluginManagerAllowed } from "../../runtime/plugin-manager-guard";
+import {
+  ensurePluginManagerAllowed,
+  type PluginManagerGuardResult,
+} from "../../runtime/plugin-manager-guard";
 import { useApp } from "../../state";
 import { openExternalUrl } from "../../utils";
 
@@ -50,6 +53,18 @@ import {
 import { PluginSettingsDialog } from "./plugin-view-dialogs";
 import { PluginGameModal } from "./plugin-view-modal";
 import { ConnectorSidebar } from "./plugin-view-sidebar";
+
+function getPluginManagerBlockReason(
+  result: PluginManagerGuardResult,
+): string | null {
+  if (result === "disabled-by-user") {
+    return "plugin-manager is explicitly disabled in config";
+  }
+  if (result === "disabled-by-env") {
+    return "plugin-manager auto-enable is disabled by MILADY_DISABLE_PLUGIN_MANAGER_AUTO_ENABLE=1";
+  }
+  return null;
+}
 
 /* ── Shared PluginListView ─────────────────────────────────────────── */
 
@@ -434,10 +449,13 @@ function PluginListView({
 
   const handleInstallPlugin = async (pluginId: string, npmName: string) => {
     setInstallingPlugins((prev) => new Set(prev).add(pluginId));
+    let restartedForPluginManager = false;
     try {
       const pluginManagerGuard = ensurePluginManagerAllowed();
-      if (pluginManagerGuard === "disabled-by-user") {
-        throw new Error("plugin-manager is explicitly disabled in config");
+      const pluginManagerBlockReason =
+        getPluginManagerBlockReason(pluginManagerGuard);
+      if (pluginManagerBlockReason) {
+        throw new Error(pluginManagerBlockReason);
       }
       if (pluginManagerGuard === "enabled") {
         setActionNotice(
@@ -449,6 +467,7 @@ function PluginListView({
           "success",
         );
         await client.restartAndWait(120_000);
+        restartedForPluginManager = true;
       }
       await client.installRegistryPlugin(npmName);
       await loadPlugins();
@@ -467,18 +486,23 @@ function PluginListView({
       ) {
         try {
           const pluginManagerGuard = ensurePluginManagerAllowed();
-          if (pluginManagerGuard === "disabled-by-user") {
-            throw new Error("plugin-manager is explicitly disabled in config");
+          const pluginManagerBlockReason =
+            getPluginManagerBlockReason(pluginManagerGuard);
+          if (pluginManagerBlockReason) {
+            throw new Error(pluginManagerBlockReason);
           }
-          setActionNotice(
-            t("pluginsview.PluginInstallRecovering", {
-              plugin: npmName,
-              defaultValue:
-                "Finishing plugin install setup for {{plugin}} and restarting the agent...",
-            }),
-            "success",
-          );
-          await client.restartAndWait(120_000);
+          if (!restartedForPluginManager) {
+            setActionNotice(
+              t("pluginsview.PluginInstallRecovering", {
+                plugin: npmName,
+                defaultValue:
+                  "Finishing plugin install setup for {{plugin}} and restarting the agent...",
+              }),
+              "success",
+            );
+            await client.restartAndWait(120_000);
+            restartedForPluginManager = true;
+          }
           await client.installRegistryPlugin(npmName);
           await loadPlugins();
           setActionNotice(

--- a/packages/app-core/src/runtime/plugin-manager-guard.ts
+++ b/packages/app-core/src/runtime/plugin-manager-guard.ts
@@ -14,12 +14,27 @@ import {
 let _checked = false;
 let _lastResult: PluginManagerGuardResult = "error";
 
+export const PLUGIN_MANAGER_UNAVAILABLE_ERROR =
+  "Plugin manager service not found";
+
 export type PluginManagerGuardResult =
   | "enabled"
   | "already-enabled"
   | "disabled-by-user"
   | "disabled-by-env"
   | "error";
+
+export function getPluginManagerBlockReason(
+  result: PluginManagerGuardResult,
+): string | null {
+  if (result === "disabled-by-user") {
+    return "plugin-manager is explicitly disabled in config";
+  }
+  if (result === "disabled-by-env") {
+    return "plugin-manager auto-enable is disabled by MILADY_DISABLE_PLUGIN_MANAGER_AUTO_ENABLE=1";
+  }
+  return null;
+}
 
 export function ensurePluginManagerAllowed(): PluginManagerGuardResult {
   if (_checked) return _lastResult;

--- a/packages/app-core/src/runtime/plugin-manager-guard.ts
+++ b/packages/app-core/src/runtime/plugin-manager-guard.ts
@@ -12,12 +12,21 @@ import {
 } from "@miladyai/agent/config/config";
 
 let _checked = false;
+let _lastResult: PluginManagerGuardResult = "error";
 
-export function ensurePluginManagerAllowed(): void {
-  if (_checked) return;
+export type PluginManagerGuardResult =
+  | "enabled"
+  | "already-enabled"
+  | "disabled-by-user"
+  | "disabled-by-env"
+  | "error";
+
+export function ensurePluginManagerAllowed(): PluginManagerGuardResult {
+  if (_checked) return _lastResult;
   if (process.env.MILADY_DISABLE_PLUGIN_MANAGER_AUTO_ENABLE === "1") {
     _checked = true;
-    return;
+    _lastResult = "disabled-by-env";
+    return _lastResult;
   }
   try {
     const config = loadElizaConfig();
@@ -26,11 +35,13 @@ export function ensurePluginManagerAllowed(): void {
     const id = "plugin-manager";
     if (entries[id]?.enabled === false) {
       _checked = true;
-      return; // explicitly disabled by user
+      _lastResult = "disabled-by-user";
+      return _lastResult;
     }
     if (entries[id]) {
       _checked = true;
-      return; // already present
+      _lastResult = "already-enabled";
+      return _lastResult;
     }
     // The upstream ElizaConfig type marks `plugins` as a complex branded type
     // that doesn't allow direct property assignment. We know the runtime shape
@@ -46,12 +57,18 @@ export function ensurePluginManagerAllowed(): void {
         "Set MILADY_DISABLE_PLUGIN_MANAGER_AUTO_ENABLE=1 to prevent this.",
     );
     _checked = true;
+    _lastResult = "enabled";
+    return _lastResult;
   } catch {
     // Non-fatal — plugin install button won't work but everything else is fine
+    _checked = true;
+    _lastResult = "error";
+    return _lastResult;
   }
 }
 
 /** Reset the in-process guard (for testing only). @internal */
 export function _resetPluginManagerChecked(): void {
   _checked = false;
+  _lastResult = "error";
 }

--- a/packages/app-core/test/app/plugin-manager-auto-enable.test.ts
+++ b/packages/app-core/test/app/plugin-manager-auto-enable.test.ts
@@ -19,8 +19,8 @@ vi.mock("@miladyai/agent/config/config", () => ({
 }));
 
 import {
-  ensurePluginManagerAllowed,
   _resetPluginManagerChecked,
+  ensurePluginManagerAllowed,
 } from "../../src/runtime/plugin-manager-guard";
 
 describe("ensurePluginManagerAllowed", () => {
@@ -45,8 +45,9 @@ describe("ensurePluginManagerAllowed", () => {
     const config = { plugins: { entries: {} } };
     mockLoadElizaConfig.mockReturnValue(config);
 
-    ensurePluginManagerAllowed();
+    const result = ensurePluginManagerAllowed();
 
+    expect(result).toBe("enabled");
     expect(mockSaveElizaConfig).toHaveBeenCalledTimes(1);
     const saved = mockSaveElizaConfig.mock.calls[0][0];
     expect(saved.plugins.entries["plugin-manager"]).toEqual({ enabled: true });
@@ -57,8 +58,9 @@ describe("ensurePluginManagerAllowed", () => {
       plugins: { entries: { "plugin-manager": { enabled: true } } },
     });
 
-    ensurePluginManagerAllowed();
+    const result = ensurePluginManagerAllowed();
 
+    expect(result).toBe("already-enabled");
     expect(mockSaveElizaConfig).not.toHaveBeenCalled();
   });
 
@@ -67,8 +69,9 @@ describe("ensurePluginManagerAllowed", () => {
       plugins: { entries: { "plugin-manager": { enabled: false } } },
     });
 
-    ensurePluginManagerAllowed();
+    const result = ensurePluginManagerAllowed();
 
+    expect(result).toBe("disabled-by-user");
     expect(mockSaveElizaConfig).not.toHaveBeenCalled();
   });
 
@@ -77,8 +80,8 @@ describe("ensurePluginManagerAllowed", () => {
       plugins: { entries: { "plugin-manager": { enabled: true } } },
     });
 
-    ensurePluginManagerAllowed();
-    ensurePluginManagerAllowed();
+    expect(ensurePluginManagerAllowed()).toBe("already-enabled");
+    expect(ensurePluginManagerAllowed()).toBe("already-enabled");
 
     expect(mockLoadElizaConfig).toHaveBeenCalledTimes(1);
   });
@@ -86,8 +89,9 @@ describe("ensurePluginManagerAllowed", () => {
   it("skips entirely when MILADY_DISABLE_PLUGIN_MANAGER_AUTO_ENABLE=1", () => {
     process.env.MILADY_DISABLE_PLUGIN_MANAGER_AUTO_ENABLE = "1";
 
-    ensurePluginManagerAllowed();
+    const result = ensurePluginManagerAllowed();
 
+    expect(result).toBe("disabled-by-env");
     expect(mockLoadElizaConfig).not.toHaveBeenCalled();
     expect(mockSaveElizaConfig).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- recover dashboard/plugin-page installs when the plugin manager service is not yet available on `develop`
- auto-enable the plugin-manager entry when allowed, restart the agent, and retry the install once
- cover the new guard/restart/retry behavior with targeted tests

## Context
This ports the plugin-install recovery behavior that already existed in prior work onto current `develop`, where installs can still fail with `Plugin manager service not found`.

## Validation
- `bunx @biomejs/biome check packages/app-core/src/runtime/plugin-manager-guard.ts packages/app-core/src/actions/install-plugin.ts packages/app-core/src/actions/__tests__/install-plugin.test.ts packages/app-core/src/components/pages/PluginsView.tsx packages/app-core/test/app/plugin-manager-auto-enable.test.ts`
- `git diff --check`

## Notes
- `bunx vitest run packages/app-core/test/app/plugin-manager-auto-enable.test.ts packages/app-core/src/actions/__tests__/install-plugin.test.ts` is currently blocked in this local environment by a `bunx`/`vite` temp-install startup error (`CLIENT_ENTRY does not point to an existing file`), so I pushed this for CI to validate in GitHub.
