### PR TITLE
feat: add Edge TTS fallback for onboarding voice previews

### DIFF
--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import http from "node:http";
 import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { type AgentRuntime, logger } from "@elizaos/core";
@@ -711,7 +712,6 @@ async function _handleEdgeTtsRoute(
           : "en-US-AriaNeural";
 
     // Resolve node-edge-tts from @elizaos/plugin-edge-tts's dependency tree
-    const { createRequire } = await import("node:module");
     const pluginPkg = "@elizaos/plugin-edge-tts/package.json";
     const pluginRequire = createRequire(
       createRequire(import.meta.url).resolve(pluginPkg),
@@ -723,19 +723,18 @@ async function _handleEdgeTtsRoute(
       }) => { ttsPromise(text: string, path: string): Promise<unknown> };
     };
 
-    // EdgeTTS writes to a file — use a temp path
-    const { mkdtempSync, readFileSync, rmSync } = await import("node:fs");
-    const { tmpdir } = await import("node:os");
-    const { join } = await import("node:path");
-    const tmpDir = mkdtempSync(join(tmpdir(), "milady-edge-tts-"));
-    const audioPath = join(tmpDir, "preview.mp3");
+    // EdgeTTS writes to a file — use a temp path then async-read it back
+    const tmpDir = await fs.promises.mkdtemp(
+      path.join(tmpdir(), "milady-edge-tts-"),
+    );
+    const audioPath = path.join(tmpDir, "preview.mp3");
     try {
       const tts = new EdgeTTS({
         voice,
         outputFormat: "audio-24khz-48kbitrate-mono-mp3",
       });
       await tts.ttsPromise(text, audioPath);
-      const mp3 = readFileSync(audioPath);
+      const mp3 = await fs.promises.readFile(audioPath);
 
       res.writeHead(200, {
         "Content-Type": "audio/mpeg",
@@ -743,14 +742,12 @@ async function _handleEdgeTtsRoute(
       });
       res.end(mp3);
     } finally {
-      rmSync(tmpDir, { recursive: true, force: true });
+      await fs.promises.rm(tmpDir, { recursive: true, force: true });
     }
   } catch (err) {
     console.error("[api/tts/edge] Error:", err);
     res.writeHead(500, { "Content-Type": "application/json" });
-    res.end(
-      JSON.stringify({ error: "Edge TTS failed", detail: String(err) }),
-    );
+    res.end(JSON.stringify({ error: "Edge TTS synthesis failed" }));
   }
   return true;
 }
@@ -805,6 +802,7 @@ async function handleMiladyCompatRoute(
   }
 
   if (method === "POST" && url.pathname === "/api/tts/edge") {
+    if (!ensureCompatApiAuthorized(req, res)) return true;
     return await _handleEdgeTtsRoute(req, res);
   }
 

--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -704,12 +704,21 @@ async function _handleEdgeTtsRoute(
       res.end(JSON.stringify({ error: "Missing text" }));
       return true;
     }
-    const voice =
+    if (text.length > 500) {
+      res.writeHead(400, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Text too long" }));
+      return true;
+    }
+    const rawVoice =
       typeof body.voiceId === "string" && body.voiceId.trim()
         ? body.voiceId.trim()
         : typeof body.voice === "string" && body.voice.trim()
           ? body.voice.trim()
           : "en-US-AriaNeural";
+    // Validate Azure Neural voice ID format to prevent SSML injection
+    const voice = /^[a-z]{2}-[A-Z]{2}-[A-Za-z]+Neural$/i.test(rawVoice)
+      ? rawVoice
+      : "en-US-AriaNeural";
 
     // Resolve node-edge-tts from @elizaos/plugin-edge-tts's dependency tree
     const pluginPkg = "@elizaos/plugin-edge-tts/package.json";

--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -681,6 +681,80 @@ function resolveCloudConfig(runtime?: unknown): ElizaConfig {
   return config;
 }
 
+/**
+ * Free Edge TTS endpoint using Microsoft's node-edge-tts. No API key required.
+ * Used as the final fallback for onboarding voice previews when cloud/ElevenLabs
+ * keys are not configured.
+ *
+ * node-edge-tts is a transitive dep of @elizaos/plugin-edge-tts (not hoisted),
+ * so we resolve it via createRequire from the plugin's package.json location.
+ */
+async function _handleEdgeTtsRoute(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+): Promise<boolean> {
+  try {
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) chunks.push(chunk as Buffer);
+    const body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+    const text = typeof body.text === "string" ? body.text.trim() : "";
+    if (!text) {
+      res.writeHead(400, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Missing text" }));
+      return true;
+    }
+    const voice =
+      typeof body.voiceId === "string" && body.voiceId.trim()
+        ? body.voiceId.trim()
+        : typeof body.voice === "string" && body.voice.trim()
+          ? body.voice.trim()
+          : "en-US-AriaNeural";
+
+    // Resolve node-edge-tts from @elizaos/plugin-edge-tts's dependency tree
+    const { createRequire } = await import("node:module");
+    const pluginPkg = "@elizaos/plugin-edge-tts/package.json";
+    const pluginRequire = createRequire(
+      createRequire(import.meta.url).resolve(pluginPkg),
+    );
+    const { EdgeTTS } = pluginRequire("node-edge-tts") as {
+      EdgeTTS: new (cfg?: {
+        voice?: string;
+        outputFormat?: string;
+      }) => { ttsPromise(text: string, path: string): Promise<unknown> };
+    };
+
+    // EdgeTTS writes to a file — use a temp path
+    const { mkdtempSync, readFileSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const tmpDir = mkdtempSync(join(tmpdir(), "milady-edge-tts-"));
+    const audioPath = join(tmpDir, "preview.mp3");
+    try {
+      const tts = new EdgeTTS({
+        voice,
+        outputFormat: "audio-24khz-48kbitrate-mono-mp3",
+      });
+      await tts.ttsPromise(text, audioPath);
+      const mp3 = readFileSync(audioPath);
+
+      res.writeHead(200, {
+        "Content-Type": "audio/mpeg",
+        "Content-Length": String(mp3.length),
+      });
+      res.end(mp3);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  } catch (err) {
+    console.error("[api/tts/edge] Error:", err);
+    res.writeHead(500, { "Content-Type": "application/json" });
+    res.end(
+      JSON.stringify({ error: "Edge TTS failed", detail: String(err) }),
+    );
+  }
+  return true;
+}
+
 async function handleMiladyCompatRoute(
   req: http.IncomingMessage,
   res: http.ServerResponse,
@@ -728,6 +802,10 @@ async function handleMiladyCompatRoute(
     // Eliza server handler, not by the Milady API layer. Returning false
     // lets the request fall through to the next handler in the chain.
     return false;
+  }
+
+  if (method === "POST" && url.pathname === "/api/tts/edge") {
+    return await _handleEdgeTtsRoute(req, res);
   }
 
   // Workbench / todos routes — extracted to workbench-compat-routes.ts

--- a/packages/app-core/src/components/onboarding/IdentityStep.test.tsx
+++ b/packages/app-core/src/components/onboarding/IdentityStep.test.tsx
@@ -1,0 +1,183 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/* ── Hoisted mocks ─────────────────────────────────────────────────── */
+
+const { useAppMock, fetchWithTimeoutMock } = vi.hoisted(() => ({
+  useAppMock: vi.fn(),
+  fetchWithTimeoutMock: vi.fn(),
+}));
+
+vi.mock("@miladyai/app-core/state", () => ({
+  useApp: () => useAppMock(),
+}));
+
+vi.mock("@miladyai/app-core/events", () => ({
+  dispatchAppEmoteEvent: vi.fn(),
+  dispatchWindowEvent: vi.fn(),
+  ONBOARDING_VOICE_PREVIEW_AWAIT_TELEPORT_EVENT:
+    "eliza:onboarding-voice-preview-await-teleport",
+  VRM_TELEPORT_COMPLETE_EVENT: "eliza:vrm-teleport-complete",
+}));
+
+vi.mock("@miladyai/shared/onboarding-presets", () => ({
+  getStylePresets: () => [
+    {
+      id: "chen",
+      name: "Chen",
+      avatarIndex: 1,
+      voicePresetId: "alice",
+      catchphrase: "I can't wait!",
+    },
+    {
+      id: "tanya",
+      name: "Tanya",
+      avatarIndex: 2,
+      voicePresetId: "rachel",
+      catchphrase: "Let's go!",
+    },
+  ],
+}));
+
+vi.mock("../../utils/api-request", () => ({
+  fetchWithTimeout: (...args: unknown[]) => fetchWithTimeoutMock(...args),
+  resolveCompatApiToken: () => null,
+}));
+
+vi.mock("../../utils/asset-url", () => ({
+  resolveApiUrl: (url: string) => `http://localhost${url}`,
+}));
+
+vi.mock("../../voice/types", () => ({
+  PREMADE_VOICES: [
+    {
+      id: "alice",
+      name: "Alice",
+      voiceId: "Xb7hH8MSUJpSbSDYk0k2",
+      gender: "female",
+    },
+    {
+      id: "rachel",
+      name: "Rachel",
+      voiceId: "21m00Tcm4TlvDq8ikWAM",
+      gender: "female",
+    },
+  ],
+}));
+
+vi.mock("../character/CharacterRoster", () => ({
+  CharacterRoster: ({
+    onSelect,
+    entries,
+  }: {
+    onSelect: (entry: unknown) => void;
+    entries: unknown[];
+  }) =>
+    React.createElement(
+      "div",
+      { "data-testid": "roster" },
+      (entries as Array<{ id: string; name: string }>).map((e) =>
+        React.createElement("button", {
+          key: e.id,
+          "data-testid": `roster-${e.id}`,
+          onClick: () => onSelect(e),
+        }),
+      ),
+    ),
+  resolveRosterEntries: (styles: Array<{ id: string; name: string; avatarIndex?: number; voicePresetId?: string; catchphrase?: string }>) =>
+    styles.map((s, i) => ({
+      id: s.id,
+      name: s.name,
+      avatarIndex: s.avatarIndex ?? i + 1,
+      voicePresetId: s.voicePresetId,
+      catchphrase: s.catchphrase,
+      preset: s,
+    })),
+}));
+
+vi.mock("../character/character-greeting", () => ({
+  resolveCharacterGreetingAnimation: () => null,
+}));
+
+vi.mock("@miladyai/ui", () => ({
+  Button: (props: React.PropsWithChildren<{ onClick?: () => void }>) =>
+    React.createElement("button", { onClick: props.onClick }, props.children),
+  Input: (props: { value?: string; onChange?: (v: string) => void }) =>
+    React.createElement("input", {
+      value: props.value,
+      onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+        props.onChange?.(e.target.value),
+    }),
+}));
+
+/* ── Import under test (after mocks) ──────────────────────────────── */
+
+import { IdentityStep } from "./IdentityStep";
+
+/* ── Helpers ──────────────────────────────────────────────────────── */
+
+function makeAppState(overrides: Record<string, unknown> = {}) {
+  return {
+    onboardingStyle: "",
+    handleOnboardingNext: vi.fn(),
+    setState: vi.fn(),
+    t: (key: string) => key,
+    uiLanguage: "en",
+    ...overrides,
+  };
+}
+
+/** Return a successful response with a tiny audio blob so the fallback chain
+ *  short-circuits after the first endpoint. One fetch call = one preview. */
+function successResponse() {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    blob: () => Promise.resolve(new Blob(["fake-audio"], { type: "audio/mpeg" })),
+  });
+}
+
+/* ── Tests ────────────────────────────────────────────────────────── */
+
+describe("IdentityStep", () => {
+  beforeEach(() => {
+    useAppMock.mockReset();
+    fetchWithTimeoutMock.mockReset().mockImplementation(successResponse);
+  });
+
+  it("plays preview exactly once on mount with pre-set onboardingStyle", async () => {
+    useAppMock.mockReturnValue(makeAppState({ onboardingStyle: "chen" }));
+
+    await act(async () => {
+      TestRenderer.create(
+        React.createElement(IdentityStep, {
+          gateVoicePreviewOnTeleport: false,
+        }),
+      );
+    });
+
+    // Should have been called exactly once (for the initial preview)
+    expect(fetchWithTimeoutMock).toHaveBeenCalledTimes(1);
+    expect(fetchWithTimeoutMock.mock.calls[0][0]).toContain("/api/tts/");
+  });
+
+  it("does not double-fire preview when onboardingStyle is unset on mount", async () => {
+    const setState = vi.fn();
+    useAppMock.mockReturnValue(makeAppState({ onboardingStyle: "", setState }));
+
+    await act(async () => {
+      TestRenderer.create(
+        React.createElement(IdentityStep, {
+          gateVoicePreviewOnTeleport: false,
+        }),
+      );
+    });
+
+    // handleSelect(firstEntry, true) fires once → one TTS fetch
+    // The effect should NOT re-fire a second playSelectionPreview
+    expect(fetchWithTimeoutMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/app-core/src/components/onboarding/IdentityStep.tsx
+++ b/packages/app-core/src/components/onboarding/IdentityStep.tsx
@@ -209,8 +209,13 @@ export function IdentityStep({
   useEffect(() => {
     if (!onboardingStyle && firstEntry) {
       handleSelect(firstEntry, true);
+    } else if (onboardingStyle) {
+      const entry = entries.find((e) => e.id === onboardingStyle);
+      if (entry) {
+        void playSelectionPreview(entry);
+      }
     }
-  }, [onboardingStyle, handleSelect, firstEntry]);
+  }, [onboardingStyle, handleSelect, firstEntry, entries, playSelectionPreview]);
 
   useEffect(() => {
     if (typeof window === "undefined") {

--- a/packages/app-core/src/components/onboarding/IdentityStep.tsx
+++ b/packages/app-core/src/components/onboarding/IdentityStep.tsx
@@ -70,6 +70,7 @@ export function IdentityStep({
   const previewAbortControllerRef = useRef<AbortController | null>(null);
   const previewRequestIdRef = useRef(0);
   const pendingPreviewEntryRef = useRef<CharacterRosterEntry | null>(null);
+  const hasPlayedInitialPreviewRef = useRef(false);
 
   const stopPreviewAudio = useCallback(() => {
     previewAbortControllerRef.current?.abort();
@@ -209,7 +210,8 @@ export function IdentityStep({
   useEffect(() => {
     if (!onboardingStyle && firstEntry) {
       handleSelect(firstEntry, true);
-    } else if (onboardingStyle) {
+    } else if (onboardingStyle && !hasPlayedInitialPreviewRef.current) {
+      hasPlayedInitialPreviewRef.current = true;
       const entry = entries.find((e) => e.id === onboardingStyle);
       if (entry) {
         void playSelectionPreview(entry);

--- a/packages/app-core/src/components/onboarding/identity-preview-tts.test.ts
+++ b/packages/app-core/src/components/onboarding/identity-preview-tts.test.ts
@@ -10,19 +10,23 @@ describe("resolvePreviewTtsEndpoints", () => {
     expect(resolvePreviewTtsEndpoints("nova")).toEqual([
       "/api/tts/cloud",
       "/api/tts/elevenlabs",
+      "/api/tts/edge",
     ]);
     expect(resolvePreviewTtsEndpoints("  SHIMMER  ")).toEqual([
       "/api/tts/cloud",
       "/api/tts/elevenlabs",
+      "/api/tts/edge",
     ]);
   });
 
-  it("uses only elevenlabs route for preset/custom elevenlabs voice IDs", () => {
+  it("uses elevenlabs then edge for preset/custom elevenlabs voice IDs", () => {
     expect(resolvePreviewTtsEndpoints("21m00Tcm4TlvDq8ikWAM")).toEqual([
       "/api/tts/elevenlabs",
+      "/api/tts/edge",
     ]);
     expect(resolvePreviewTtsEndpoints("cNYrMw9glwJZXR8RwbuR")).toEqual([
       "/api/tts/elevenlabs",
+      "/api/tts/edge",
     ]);
   });
 
@@ -31,19 +35,18 @@ describe("resolvePreviewTtsEndpoints", () => {
       resolvePreviewTtsEndpoints("EXAVITQu4vr4xnSDxMaL", {
         preferCloudProxy: true,
       }),
-    ).toEqual(["/api/tts/cloud", "/api/tts/elevenlabs"]);
+    ).toEqual(["/api/tts/cloud", "/api/tts/elevenlabs", "/api/tts/edge"]);
   });
 });
 
 describe("buildPreviewTtsRequestPlans", () => {
-  it("builds cloud-first request plans for catchphrase previews", () => {
-    expect(
-      buildPreviewTtsRequestPlans({
-        text: "what's the play?",
-        voiceId: "nPczCjzI2devNBz1zQrb",
-        preferCloudProxy: true,
-      }),
-    ).toEqual([
+  it("builds cloud-first request plans with edge fallback", () => {
+    const plans = buildPreviewTtsRequestPlans({
+      text: "what's the play?",
+      voiceId: "nPczCjzI2devNBz1zQrb",
+      preferCloudProxy: true,
+    });
+    expect(plans).toEqual([
       {
         endpoint: "/api/tts/cloud",
         body: {
@@ -62,6 +65,15 @@ describe("buildPreviewTtsRequestPlans", () => {
           outputFormat: "mp3_44100_128",
         },
       },
+      {
+        endpoint: "/api/tts/edge",
+        body: {
+          text: "what's the play?",
+          voiceId: "en-US-GuyNeural",
+          modelId: DEFAULT_PREVIEW_TTS_MODEL_ID,
+          outputFormat: "mp3_44100_128",
+        },
+      },
     ]);
   });
 
@@ -72,5 +84,49 @@ describe("buildPreviewTtsRequestPlans", () => {
         voiceId: "nPczCjzI2devNBz1zQrb",
       }),
     ).toEqual([]);
+  });
+
+  it("maps male voice preset to en-US-GuyNeural for edge endpoint", () => {
+    // nPczCjzI2devNBz1zQrb = brian (male)
+    const plans = buildPreviewTtsRequestPlans({
+      text: "hello",
+      voiceId: "nPczCjzI2devNBz1zQrb",
+      preferCloudProxy: true,
+    });
+    const edgePlan = plans.find((p) => p.endpoint === "/api/tts/edge");
+    expect(edgePlan?.body.voiceId).toBe("en-US-GuyNeural");
+  });
+
+  it("maps female voice preset to en-US-AriaNeural for edge endpoint", () => {
+    // 21m00Tcm4TlvDq8ikWAM = rachel (female)
+    const plans = buildPreviewTtsRequestPlans({
+      text: "hello",
+      voiceId: "21m00Tcm4TlvDq8ikWAM",
+      preferCloudProxy: true,
+    });
+    const edgePlan = plans.find((p) => p.endpoint === "/api/tts/edge");
+    expect(edgePlan?.body.voiceId).toBe("en-US-AriaNeural");
+  });
+
+  it("defaults unknown voice ID to en-US-AriaNeural for edge endpoint", () => {
+    const plans = buildPreviewTtsRequestPlans({
+      text: "hello",
+      voiceId: "unknownVoiceId123",
+      preferCloudProxy: true,
+    });
+    const edgePlan = plans.find((p) => p.endpoint === "/api/tts/edge");
+    expect(edgePlan?.body.voiceId).toBe("en-US-AriaNeural");
+  });
+
+  it("preserves original voiceId for non-edge endpoints", () => {
+    const plans = buildPreviewTtsRequestPlans({
+      text: "hello",
+      voiceId: "nPczCjzI2devNBz1zQrb",
+      preferCloudProxy: true,
+    });
+    const cloudPlan = plans.find((p) => p.endpoint === "/api/tts/cloud");
+    const elevenPlan = plans.find((p) => p.endpoint === "/api/tts/elevenlabs");
+    expect(cloudPlan?.body.voiceId).toBe("nPczCjzI2devNBz1zQrb");
+    expect(elevenPlan?.body.voiceId).toBe("nPczCjzI2devNBz1zQrb");
   });
 });

--- a/packages/app-core/src/components/onboarding/identity-preview-tts.ts
+++ b/packages/app-core/src/components/onboarding/identity-preview-tts.ts
@@ -1,3 +1,5 @@
+import { PREMADE_VOICES } from "../../voice/types";
+
 const CLOUD_TTS_VOICE_IDS = new Set([
   "alloy",
   "ash",
@@ -26,18 +28,24 @@ export interface PreviewTtsRequestPlan {
   };
 }
 
+/** Map an ElevenLabs voice ID to a free Edge TTS voice by gender. */
+function resolveEdgeVoiceId(elevenLabsVoiceId: string): string {
+  const preset = PREMADE_VOICES.find((v) => v.voiceId === elevenLabsVoiceId);
+  return preset?.gender === "male" ? "en-US-GuyNeural" : "en-US-AriaNeural";
+}
+
 export function resolvePreviewTtsEndpoints(
   voiceId: string,
   options?: ResolvePreviewTtsEndpointsOptions,
 ): string[] {
   const normalizedVoiceId = voiceId.trim().toLowerCase();
   if (options?.preferCloudProxy === true) {
-    return ["/api/tts/cloud", "/api/tts/elevenlabs"];
+    return ["/api/tts/cloud", "/api/tts/elevenlabs", "/api/tts/edge"];
   }
   const isCloudVoice = CLOUD_TTS_VOICE_IDS.has(normalizedVoiceId);
   return isCloudVoice
-    ? ["/api/tts/cloud", "/api/tts/elevenlabs"]
-    : ["/api/tts/elevenlabs"];
+    ? ["/api/tts/cloud", "/api/tts/elevenlabs", "/api/tts/edge"]
+    : ["/api/tts/elevenlabs", "/api/tts/edge"];
 }
 
 export function buildPreviewTtsRequestPlans(args: {
@@ -58,7 +66,14 @@ export function buildPreviewTtsRequestPlans(args: {
     endpoint,
     body: {
       text,
-      ...(voiceId ? { voiceId } : {}),
+      ...(voiceId
+        ? {
+            voiceId:
+              endpoint === "/api/tts/edge"
+                ? resolveEdgeVoiceId(voiceId)
+                : voiceId,
+          }
+        : {}),
       modelId: args.modelId ?? DEFAULT_PREVIEW_TTS_MODEL_ID,
       outputFormat: "mp3_44100_128",
     },


### PR DESCRIPTION
## Summary
- Character selection voicelines failed silently when cloud/ElevenLabs API keys were not configured (`/api/tts/cloud` → 401, `/api/tts/elevenlabs` → 400)
- Added free Edge TTS (Microsoft, no API key) as the final fallback in the preview endpoint chain
- New `POST /api/tts/edge` route using `node-edge-tts` resolved via `@elizaos/plugin-edge-tts`
- ElevenLabs voice presets are mapped to Edge TTS voices by gender (`en-US-AriaNeural` / `en-US-GuyNeural`)
- No impact when cloud/ElevenLabs keys are configured — Edge TTS is only reached if both fail

## Test plan
- [x] Verified `/api/tts/edge` returns 200 with audio on Windows
- [x] Verified voiceline plays on character selection without any API keys configured
- [ ] Verify no regression when cloud/ElevenLabs keys are present (Edge TTS should not be reached)
- [ ] Verify on macOS/Linux