### PR TITLE
milady: harden startup gateway restore paths

### DIFF
--- a/packages/app-core/src/api/client-base.ts
+++ b/packages/app-core/src/api/client-base.ts
@@ -76,20 +76,21 @@ export class MiladyClient {
     this.clientId = MiladyClient.generateClientId();
     this._token = token?.trim() || null;
 
+    const bootBase = getBootConfig().apiBase;
     const injectedBase = getElizaApiBase();
     const storedBase =
       typeof window !== "undefined"
         ? window.sessionStorage.getItem(SESSION_STORAGE_API_BASE_KEY)
         : null;
-    const bootBase = getBootConfig().apiBase;
 
-    this._explicitBase = baseUrl != null || Boolean(storedBase?.trim());
+    this._explicitBase =
+      baseUrl != null || Boolean(bootBase?.trim() || storedBase?.trim());
 
-    // Priority: explicit arg > desktop injection > boot config > session storage > same origin.
-    // Injected global (window.__MILADY_API_BASE__) must beat stale sessionStorage
-    // from a prior cloud/remote session so the desktop always connects to the
-    // correct local agent.
-    this._baseUrl = baseUrl ?? injectedBase ?? bootBase ?? storedBase ?? "";
+    // Priority: explicit arg > boot config > desktop injection > session storage > same origin.
+    // `client.setBaseUrl()` updates the boot config, so it must beat the
+    // shell-injected local default once the user has chosen a different
+    // server. Injection still beats stale session state from prior sessions.
+    this._baseUrl = baseUrl ?? bootBase ?? injectedBase ?? storedBase ?? "";
   }
 
   /**
@@ -101,9 +102,11 @@ export class MiladyClient {
    */
   protected get baseUrl(): string {
     if (!this._explicitBase) {
-      const bootBase = getBootConfig().apiBase ?? getElizaApiBase();
-      if (bootBase && bootBase !== this._baseUrl) {
-        this._baseUrl = bootBase;
+      const bootBase = getBootConfig().apiBase;
+      const injectedBase = getElizaApiBase();
+      const preferredBase = bootBase ?? injectedBase;
+      if (preferredBase && preferredBase !== this._baseUrl) {
+        this._baseUrl = preferredBase;
       }
     }
     return this._baseUrl;

--- a/packages/app-core/src/api/client.api-base.test.ts
+++ b/packages/app-core/src/api/client.api-base.test.ts
@@ -90,6 +90,30 @@ describe("MiladyClient runtime API base/token fallback", () => {
     expect(client.getRestAuthToken()).toBe("rotated-token");
   });
 
+  it("prefers boot config over stale session storage when there is no injected base", async () => {
+    const { setBootConfig, DEFAULT_BOOT_CONFIG } = await import(
+      "../config/boot-config"
+    );
+    const { MiladyClient } = await import("./client");
+
+    const mockWindow = globalThis.window as MockWindow & {
+      sessionStorage: Storage;
+    };
+    delete mockWindow.__MILADY_API_BASE__;
+    setBootConfig({
+      ...DEFAULT_BOOT_CONFIG,
+      apiBase: "http://127.0.0.1:2138",
+    });
+    mockWindow.sessionStorage.setItem(
+      "milady_api_base",
+      "https://ren.example.com",
+    );
+
+    const client = new MiladyClient();
+
+    expect(client.getBaseUrl()).toBe("http://127.0.0.1:2138");
+  });
+
   it("keeps auth tokens in memory instead of sessionStorage", async () => {
     const { setBootConfig, DEFAULT_BOOT_CONFIG, getBootConfig } = await import(
       "../config/boot-config"

--- a/packages/app-core/src/components/shell/StartupShell.test.tsx
+++ b/packages/app-core/src/components/shell/StartupShell.test.tsx
@@ -9,12 +9,14 @@ const {
   clearPersistedConnectionModeMock,
   discoverGatewayEndpointsMock,
   mockUseApp,
+  savePersistedActiveServerMock,
 } = vi.hoisted(() => ({
   clientSetBaseUrlMock: vi.fn(),
   clientSetTokenMock: vi.fn(),
   clearPersistedConnectionModeMock: vi.fn(),
   discoverGatewayEndpointsMock: vi.fn(),
   mockUseApp: vi.fn(),
+  savePersistedActiveServerMock: vi.fn(),
 }));
 
 vi.mock("../../api", () => ({
@@ -26,6 +28,7 @@ vi.mock("../../api", () => ({
 
 vi.mock("../../state", () => ({
   clearPersistedConnectionMode: clearPersistedConnectionModeMock,
+  savePersistedActiveServer: savePersistedActiveServerMock,
   useApp: () => mockUseApp(),
 }));
 
@@ -48,6 +51,7 @@ describe("StartupShell", () => {
     clientSetTokenMock.mockReset();
     clearPersistedConnectionModeMock.mockReset();
     discoverGatewayEndpointsMock.mockReset();
+    savePersistedActiveServerMock.mockReset();
     discoverGatewayEndpointsMock.mockResolvedValue([]);
   });
 
@@ -122,6 +126,7 @@ describe("StartupShell", () => {
     expect(clientSetTokenMock).toHaveBeenCalledWith(null);
     expect(clientSetBaseUrlMock).toHaveBeenCalledWith(null);
     expect(clearPersistedConnectionModeMock).toHaveBeenCalledTimes(1);
+    expect(savePersistedActiveServerMock).not.toHaveBeenCalled();
     expect(goToOnboardingStep).toHaveBeenCalledWith("identity");
     expect(setState).toHaveBeenCalledWith("onboardingRunMode", "local");
     expect(setState).toHaveBeenCalledWith("onboardingRemoteApiBase", "");
@@ -160,15 +165,15 @@ describe("StartupShell", () => {
 
     expect(clientSetTokenMock).toHaveBeenCalledWith(null);
     expect(clientSetBaseUrlMock).toHaveBeenCalledWith(null);
-    expect(clearPersistedConnectionModeMock).toHaveBeenCalledTimes(1);
-    expect(goToOnboardingStep).toHaveBeenCalledWith("identity");
-    expect(setState).toHaveBeenCalledWith("onboardingRunMode", "cloud");
-    expect(setState).toHaveBeenCalledWith("onboardingCloudProvider", "remote");
-    expect(setState).toHaveBeenCalledWith("onboardingRemoteConnected", true);
-    expect(setState).toHaveBeenCalledWith(
-      "onboardingRemoteApiBase",
-      "http://kei.local:18789",
-    );
+    expect(clearPersistedConnectionModeMock).not.toHaveBeenCalled();
+    expect(savePersistedActiveServerMock).toHaveBeenCalledWith({
+      id: "remote:kei",
+      kind: "remote",
+      label: "Kei",
+      apiBase: "http://kei.local:18789",
+    });
+    expect(goToOnboardingStep).not.toHaveBeenCalled();
+    expect(setState).not.toHaveBeenCalledWith("onboardingRunMode", "cloud");
     expect(dispatch).toHaveBeenCalledWith({ type: "SPLASH_CONTINUE" });
   });
 });

--- a/packages/app-core/src/components/shell/StartupShell.test.tsx
+++ b/packages/app-core/src/components/shell/StartupShell.test.tsx
@@ -9,14 +9,12 @@ const {
   clearPersistedConnectionModeMock,
   discoverGatewayEndpointsMock,
   mockUseApp,
-  savePersistedConnectionModeMock,
 } = vi.hoisted(() => ({
   clientSetBaseUrlMock: vi.fn(),
   clientSetTokenMock: vi.fn(),
   clearPersistedConnectionModeMock: vi.fn(),
   discoverGatewayEndpointsMock: vi.fn(),
   mockUseApp: vi.fn(),
-  savePersistedConnectionModeMock: vi.fn(),
 }));
 
 vi.mock("../../api", () => ({
@@ -28,7 +26,6 @@ vi.mock("../../api", () => ({
 
 vi.mock("../../state", () => ({
   clearPersistedConnectionMode: clearPersistedConnectionModeMock,
-  savePersistedConnectionMode: savePersistedConnectionModeMock,
   useApp: () => mockUseApp(),
 }));
 
@@ -51,7 +48,6 @@ describe("StartupShell", () => {
     clientSetTokenMock.mockReset();
     clearPersistedConnectionModeMock.mockReset();
     discoverGatewayEndpointsMock.mockReset();
-    savePersistedConnectionModeMock.mockReset();
     discoverGatewayEndpointsMock.mockResolvedValue([]);
   });
 
@@ -132,8 +128,8 @@ describe("StartupShell", () => {
     expect(dispatch).toHaveBeenCalledWith({ type: "SPLASH_CONTINUE" });
   });
 
-  it("saves a discovered gateway as the next remote target", async () => {
-    const { dispatch } = mockSplashApp();
+  it("seeds a discovered gateway through the remote onboarding path", async () => {
+    const { dispatch, goToOnboardingStep, setState } = mockSplashApp();
     discoverGatewayEndpointsMock.mockResolvedValue([
       {
         stableId: "kei",
@@ -163,11 +159,16 @@ describe("StartupShell", () => {
     });
 
     expect(clientSetTokenMock).toHaveBeenCalledWith(null);
-    expect(clientSetBaseUrlMock).toHaveBeenCalledWith("http://kei.local:18789");
-    expect(savePersistedConnectionModeMock).toHaveBeenCalledWith({
-      runMode: "remote",
-      remoteApiBase: "http://kei.local:18789",
-    });
+    expect(clientSetBaseUrlMock).toHaveBeenCalledWith(null);
+    expect(clearPersistedConnectionModeMock).toHaveBeenCalledTimes(1);
+    expect(goToOnboardingStep).toHaveBeenCalledWith("identity");
+    expect(setState).toHaveBeenCalledWith("onboardingRunMode", "cloud");
+    expect(setState).toHaveBeenCalledWith("onboardingCloudProvider", "remote");
+    expect(setState).toHaveBeenCalledWith("onboardingRemoteConnected", true);
+    expect(setState).toHaveBeenCalledWith(
+      "onboardingRemoteApiBase",
+      "http://kei.local:18789",
+    );
     expect(dispatch).toHaveBeenCalledWith({ type: "SPLASH_CONTINUE" });
   });
 });

--- a/packages/app-core/src/components/shell/StartupShell.tsx
+++ b/packages/app-core/src/components/shell/StartupShell.tsx
@@ -18,6 +18,7 @@ import {
 } from "../../bridge/gateway-discovery";
 import {
   clearPersistedConnectionMode,
+  savePersistedActiveServer,
   useApp,
 } from "../../state";
 import type { StartupErrorState } from "../../state/types";
@@ -175,10 +176,16 @@ export function StartupShell() {
   const handleConnectGateway = useCallback(
     (gateway: GatewayDiscoveryEndpoint) => {
       const remoteApiBase = gatewayEndpointToApiBase(gateway);
-      seedSplashTarget("remote", remoteApiBase);
+      clearClientConnectionIntent();
+      savePersistedActiveServer({
+        id: `remote:${gateway.stableId}`,
+        kind: "remote",
+        label: gateway.name.trim() || remoteApiBase,
+        apiBase: remoteApiBase,
+      });
       continueToOnboarding();
     },
-    [continueToOnboarding, seedSplashTarget],
+    [clearClientConnectionIntent, continueToOnboarding],
   );
 
   // Error — delegate

--- a/packages/app-core/src/components/shell/StartupShell.tsx
+++ b/packages/app-core/src/components/shell/StartupShell.tsx
@@ -18,7 +18,6 @@ import {
 } from "../../bridge/gateway-discovery";
 import {
   clearPersistedConnectionMode,
-  savePersistedConnectionMode,
   useApp,
 } from "../../state";
 import type { StartupErrorState } from "../../state/types";
@@ -176,15 +175,10 @@ export function StartupShell() {
   const handleConnectGateway = useCallback(
     (gateway: GatewayDiscoveryEndpoint) => {
       const remoteApiBase = gatewayEndpointToApiBase(gateway);
-      client.setToken(null);
-      client.setBaseUrl(remoteApiBase);
-      savePersistedConnectionMode({
-        runMode: "remote",
-        remoteApiBase,
-      });
+      seedSplashTarget("remote", remoteApiBase);
       continueToOnboarding();
     },
-    [continueToOnboarding],
+    [continueToOnboarding, seedSplashTarget],
   );
 
   // Error — delegate

--- a/packages/app-core/src/components/shell/StartupShell.tsx
+++ b/packages/app-core/src/components/shell/StartupShell.tsx
@@ -16,10 +16,7 @@ import {
   type GatewayDiscoveryEndpoint,
   gatewayEndpointToApiBase,
 } from "../../bridge/gateway-discovery";
-import {
-  clearPersistedConnectionMode,
-  useApp,
-} from "../../state";
+import { clearPersistedConnectionMode, useApp } from "../../state";
 import type { StartupErrorState } from "../../state/types";
 import { OnboardingWizard } from "../onboarding/OnboardingWizard";
 import { PairingView } from "./PairingView";

--- a/packages/app-core/src/config/boot-config.ts
+++ b/packages/app-core/src/config/boot-config.ts
@@ -113,12 +113,11 @@ interface BootConfigStore {
 }
 
 function getBootConfigStore(): BootConfigStore {
-  const globalObject = (typeof window !== "undefined"
-    ? (window as unknown as Record<PropertyKey, unknown>)
-    : (globalThis as Record<PropertyKey, unknown>)) as Record<
-    PropertyKey,
-    unknown
-  > & {
+  const globalObject = (
+    typeof window !== "undefined"
+      ? (window as unknown as Record<PropertyKey, unknown>)
+      : (globalThis as Record<PropertyKey, unknown>)
+  ) as Record<PropertyKey, unknown> & {
     [BOOT_CONFIG_WINDOW_KEY]?: AppBootConfig;
   };
   const mirroredWindowConfig = globalObject[BOOT_CONFIG_WINDOW_KEY];
@@ -146,12 +145,11 @@ function getBootConfigStore(): BootConfigStore {
 export function setBootConfig(config: AppBootConfig): void {
   const store = getBootConfigStore();
   store.current = config;
-  const globalObject = (typeof window !== "undefined"
-    ? (window as unknown as Record<PropertyKey, unknown>)
-    : (globalThis as Record<PropertyKey, unknown>)) as Record<
-    PropertyKey,
-    unknown
-  > & {
+  const globalObject = (
+    typeof window !== "undefined"
+      ? (window as unknown as Record<PropertyKey, unknown>)
+      : (globalThis as Record<PropertyKey, unknown>)
+  ) as Record<PropertyKey, unknown> & {
     [BOOT_CONFIG_WINDOW_KEY]?: AppBootConfig;
   };
   globalObject[BOOT_CONFIG_WINDOW_KEY] = config;

--- a/packages/app-core/src/config/boot-config.ts
+++ b/packages/app-core/src/config/boot-config.ts
@@ -100,19 +100,66 @@ export const DEFAULT_BOOT_CONFIG: AppBootConfig = {
 };
 
 // ---------------------------------------------------------------------------
-// Module-level config ref (for non-React code like client.ts, asset-url.ts)
+// Process-global config ref (for non-React code like client.ts, asset-url.ts)
+// Use a Symbol-backed slot on globalThis so duplicated module instances
+// still read/write the same live boot config.
 // ---------------------------------------------------------------------------
 
-let _bootConfig: AppBootConfig = DEFAULT_BOOT_CONFIG;
+const BOOT_CONFIG_STORE_KEY = Symbol.for("milady.app.boot-config");
+const BOOT_CONFIG_WINDOW_KEY = "__MILADY_APP_BOOT_CONFIG__";
+
+interface BootConfigStore {
+  current: AppBootConfig;
+}
+
+function getBootConfigStore(): BootConfigStore {
+  const globalObject = (typeof window !== "undefined"
+    ? (window as unknown as Record<PropertyKey, unknown>)
+    : (globalThis as Record<PropertyKey, unknown>)) as Record<
+    PropertyKey,
+    unknown
+  > & {
+    [BOOT_CONFIG_WINDOW_KEY]?: AppBootConfig;
+  };
+  const mirroredWindowConfig = globalObject[BOOT_CONFIG_WINDOW_KEY];
+  if (mirroredWindowConfig) {
+    const mirroredStore: BootConfigStore = { current: mirroredWindowConfig };
+    globalObject[BOOT_CONFIG_STORE_KEY] = mirroredStore;
+    return mirroredStore;
+  }
+  const existing = globalObject[BOOT_CONFIG_STORE_KEY];
+  if (
+    existing &&
+    typeof existing === "object" &&
+    "current" in (existing as Record<string, unknown>)
+  ) {
+    return existing as BootConfigStore;
+  }
+
+  const store: BootConfigStore = { current: DEFAULT_BOOT_CONFIG };
+  globalObject[BOOT_CONFIG_STORE_KEY] = store;
+  globalObject[BOOT_CONFIG_WINDOW_KEY] = store.current;
+  return store;
+}
 
 /** Set the boot config. Called by AppBootProvider on mount. */
 export function setBootConfig(config: AppBootConfig): void {
-  _bootConfig = config;
+  const store = getBootConfigStore();
+  store.current = config;
+  const globalObject = (typeof window !== "undefined"
+    ? (window as unknown as Record<PropertyKey, unknown>)
+    : (globalThis as Record<PropertyKey, unknown>)) as Record<
+    PropertyKey,
+    unknown
+  > & {
+    [BOOT_CONFIG_WINDOW_KEY]?: AppBootConfig;
+  };
+  globalObject[BOOT_CONFIG_WINDOW_KEY] = config;
 }
 
 /** Read the boot config from non-React code. */
 export function getBootConfig(): AppBootConfig {
-  return _bootConfig;
+  return getBootConfigStore().current;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/app-core/src/state/startup-phase-restore.test.ts
+++ b/packages/app-core/src/state/startup-phase-restore.test.ts
@@ -1,33 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import {
-  applyRestoredConnection,
-  deriveSessionConnectionMode,
-} from "./startup-phase-restore";
-
-describe("deriveSessionConnectionMode", () => {
-  it("returns null when there is no explicit session api base", () => {
-    expect(
-      deriveSessionConnectionMode({
-        sessionApiBase: "",
-        sessionApiToken: null,
-      }),
-    ).toBeNull();
-  });
-
-  it("normalizes an explicit session api base into a remote restore target", () => {
-    expect(
-      deriveSessionConnectionMode({
-        sessionApiBase: "https://remote.example/api/",
-        sessionApiToken: "remote-token",
-      }),
-    ).toEqual({
-      runMode: "remote",
-      remoteApiBase: "https://remote.example/api",
-      remoteAccessToken: "remote-token",
-    });
-  });
-});
+import { applyRestoredConnection } from "./startup-phase-restore";
 
 describe("applyRestoredConnection", () => {
   it("clears stale session state before restoring a local runtime", async () => {

--- a/packages/app-core/src/state/startup-phase-restore.ts
+++ b/packages/app-core/src/state/startup-phase-restore.ts
@@ -40,48 +40,6 @@ export interface RestoringSessionCtx {
   hadPriorOnboarding: boolean;
 }
 
-const SESSION_STORAGE_API_BASE_KEY = "milady_api_base";
-
-function trimSessionValue(
-  value: string | null | undefined,
-): string | undefined {
-  const trimmed = value?.trim().replace(/\/+$/, "");
-  return trimmed ? trimmed : undefined;
-}
-
-export function deriveSessionConnectionMode(args: {
-  sessionApiBase?: string | null;
-  sessionApiToken?: string | null;
-}) {
-  const sessionApiBase = trimSessionValue(args.sessionApiBase);
-  if (!sessionApiBase) {
-    return null;
-  }
-
-  const sessionApiToken = trimSessionValue(args.sessionApiToken);
-  return {
-    runMode: "remote" as const,
-    remoteApiBase: sessionApiBase,
-    ...(sessionApiToken ? { remoteAccessToken: sessionApiToken } : {}),
-  };
-}
-
-function loadSessionConnectionModeOverride() {
-  if (typeof window === "undefined") {
-    return null;
-  }
-
-  const sessionApiToken =
-    typeof client.getRestAuthToken === "function"
-      ? client.getRestAuthToken()
-      : null;
-
-  return deriveSessionConnectionMode({
-    sessionApiBase: window.sessionStorage.getItem(SESSION_STORAGE_API_BASE_KEY),
-    sessionApiToken,
-  });
-}
-
 export async function applyRestoredConnection(args: {
   restoredConnection: PersistedConnectionMode;
   clientRef: Pick<typeof client, "setBaseUrl" | "setToken">;
@@ -134,9 +92,6 @@ export async function runRestoringSession(
   deps.forceLocalBootstrapRef.current = false;
   const persistedActiveServer = loadPersistedActiveServer();
   const persisted = loadPersistedConnectionMode();
-  const sessionConnection = !persistedActiveServer
-    ? loadSessionConnectionModeOverride()
-    : null;
   const hadPrior = loadPersistedOnboardingComplete();
   if (cancelled.current) return;
 
@@ -161,7 +116,7 @@ export async function runRestoringSession(
       : null;
   if (cancelled.current) return;
 
-  const restored = persisted ?? sessionConnection ?? probed?.connection ?? null;
+  const restored = persisted ?? probed?.connection ?? null;
   const preserveCompleted =
     hadPrior && !deps.onboardingCompletionCommittedRef.current;
 

--- a/packages/app-core/src/state/useOnboardingCallbacks.test.ts
+++ b/packages/app-core/src/state/useOnboardingCallbacks.test.ts
@@ -2,7 +2,7 @@
 
 import { act, renderHook } from "@testing-library/react";
 import { MiladyClient } from "../api";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildOnboardingStyleVoiceConfig,
   useOnboardingCallbacks,
@@ -47,6 +47,12 @@ describe("buildOnboardingStyleVoiceConfig", () => {
 });
 
 describe("useOnboardingCallbacks", () => {
+  afterEach(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+
   it("records detected providers without rewriting the hosting target", () => {
     const setOnboardingDetectedProviders = vi.fn();
     const setOnboardingRunMode = vi.fn();
@@ -99,5 +105,68 @@ describe("useOnboardingCallbacks", () => {
       { id: "openrouter", apiKey: "sk-or-test" },
     ]);
     expect(setOnboardingRunMode).not.toHaveBeenCalled();
+  });
+
+  it("clears a persisted remote target before retrying local bootstrap", () => {
+    window.localStorage.setItem(
+      "milady:active-server",
+      JSON.stringify({
+        id: "remote:https://ren.example.com",
+        kind: "remote",
+        label: "ren.example.com",
+        apiBase: "https://ren.example.com",
+      }),
+    );
+
+    const retryStartup = vi.fn();
+    const client = {
+      setBaseUrl: vi.fn(),
+      setToken: vi.fn(),
+    } as unknown as MiladyClient;
+
+    const { result } = renderHook(() => {
+      const onboarding = useOnboardingState();
+      return useOnboardingCallbacks({
+        onboarding,
+        setOnboardingStep: vi.fn(),
+        setOnboardingMode: vi.fn(),
+        setOnboardingActiveGuide: vi.fn(),
+        addDeferredOnboardingTask: vi.fn(),
+        setOnboardingDetectedProviders: vi.fn(),
+        setOnboardingRunMode: vi.fn(),
+        setOnboardingCloudProvider: vi.fn(),
+        setOnboardingCloudApiKey: vi.fn(),
+        setOnboardingProvider: vi.fn(),
+        setOnboardingApiKey: vi.fn(),
+        setOnboardingPrimaryModel: vi.fn(),
+        setOnboardingRemoteApiBase: vi.fn(),
+        setOnboardingRemoteToken: vi.fn(),
+        setOnboardingRemoteConnecting: vi.fn(),
+        setOnboardingRemoteError: vi.fn(),
+        setOnboardingRemoteConnected: vi.fn(),
+        setPostOnboardingChecklistDismissed: vi.fn(),
+        setOnboardingComplete: vi.fn(),
+        coordinatorOnboardingCompleteRef: { current: null },
+        initialTabSetRef: { current: false },
+        setTab: vi.fn(),
+        defaultLandingTab: "chat",
+        loadCharacter: async () => {},
+        uiLanguage: "en",
+        selectedVrmIndex: 1,
+        walletConfig: {},
+        elizaCloudConnected: false,
+        setActionNotice: vi.fn(),
+        retryStartup,
+        forceLocalBootstrapRef: { current: false },
+        client,
+      });
+    });
+
+    act(() => {
+      result.current.handleOnboardingUseLocalBackend();
+    });
+
+    expect(window.localStorage.getItem("milady:active-server")).toBeNull();
+    expect(retryStartup).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/app-core/src/state/useOnboardingCallbacks.ts
+++ b/packages/app-core/src/state/useOnboardingCallbacks.ts
@@ -26,8 +26,11 @@ import {
 } from "../onboarding/flow";
 import { buildOnboardingRuntimeConfig } from "../onboarding-config";
 import {
+  clearPersistedConnectionMode,
   clearPersistedOnboardingStep,
+  connectionModeToActiveServer,
   type OnboardingNextOptions,
+  savePersistedActiveServer,
   savePersistedConnectionMode,
 } from "./internal";
 import type { OnboardingStateHook } from "./useOnboardingState";
@@ -701,6 +704,7 @@ export function useOnboardingCallbacks(deps: OnboardingCallbacksDeps) {
 
   const handleOnboardingUseLocalBackend = useCallback(() => {
     forceLocalBootstrapRef.current = true;
+    clearPersistedConnectionMode();
     client.setBaseUrl(null);
     client.setToken(null);
     setOnboardingRemoteConnecting(false);
@@ -728,6 +732,7 @@ export function useOnboardingCallbacks(deps: OnboardingCallbacksDeps) {
     setOnboardingRemoteToken,
     setOnboardingRunMode,
     client,
+    clearPersistedConnectionMode,
   ]);
 
   // ── handleOnboardingRemoteConnect ────────────────────────────────
@@ -754,8 +759,13 @@ export function useOnboardingCallbacks(deps: OnboardingCallbacksDeps) {
         throw new Error("This backend requires an access key.");
       }
       await probe.getOnboardingStatus();
-      client.setBaseUrl(normalizedBase);
-      client.setToken(accessKey || null);
+      savePersistedActiveServer(
+        connectionModeToActiveServer({
+          runMode: "remote",
+          remoteApiBase: normalizedBase,
+          ...(accessKey ? { remoteAccessToken: accessKey } : {}),
+        }),
+      );
       setOnboardingRunMode("cloud");
       setOnboardingCloudProvider("remote");
       setOnboardingRemoteApiBase(normalizedBase);
@@ -787,7 +797,8 @@ export function useOnboardingCallbacks(deps: OnboardingCallbacksDeps) {
     setOnboardingRemoteError,
     setOnboardingRemoteToken,
     setOnboardingRunMode,
-    client,
+    savePersistedActiveServer,
+    connectionModeToActiveServer,
   ]);
 
   // ── handleCloudOnboardingFinish ──────────────────────────────────

--- a/packages/app-core/src/state/useOnboardingState.test.ts
+++ b/packages/app-core/src/state/useOnboardingState.test.ts
@@ -41,4 +41,23 @@ describe("useOnboardingState", () => {
       "review-logs",
     ]);
   });
+
+  it("hydrates the remote onboarding fields from the active server record", () => {
+    window.localStorage.setItem(
+      "milady:active-server",
+      JSON.stringify({
+        id: "remote:https://ren.example.com",
+        kind: "remote",
+        label: "ren.example.com",
+        apiBase: "https://ren.example.com",
+        accessToken: "token-123",
+      }),
+    );
+
+    const { result } = renderHook(() => useOnboardingState());
+
+    expect(result.current.state.remote.status).toBe("connected");
+    expect(result.current.state.remoteApiBase).toBe("https://ren.example.com");
+    expect(result.current.state.remoteToken).toBe("token-123");
+  });
 });

--- a/packages/app-core/src/state/useOnboardingState.test.ts
+++ b/packages/app-core/src/state/useOnboardingState.test.ts
@@ -9,6 +9,29 @@ describe("useOnboardingState", () => {
     window.sessionStorage.clear();
   });
 
+  it("initializes remote onboarding state from the active server record", () => {
+    window.localStorage.setItem(
+      "milady:active-server",
+      JSON.stringify({
+        id: "remote:kei",
+        kind: "remote",
+        label: "Kei",
+        apiBase: "https://kei.example/api",
+        accessToken: "remote-token",
+      }),
+    );
+    window.sessionStorage.setItem(
+      "milady_api_base",
+      "https://stale-session.example/api",
+    );
+
+    const { result } = renderHook(() => useOnboardingState());
+
+    expect(result.current.state.remote.status).toBe("connected");
+    expect(result.current.state.remoteApiBase).toBe("https://kei.example/api");
+    expect(result.current.state.remoteToken).toBe("remote-token");
+  });
+
   it("replaces deferred tasks exactly when requested", () => {
     const { result } = renderHook(() => useOnboardingState());
 
@@ -59,5 +82,43 @@ describe("useOnboardingState", () => {
     expect(result.current.state.remote.status).toBe("connected");
     expect(result.current.state.remoteApiBase).toBe("https://ren.example.com");
     expect(result.current.state.remoteToken).toBe("token-123");
+  });
+
+  it("hydrates local hosting from the active server record", () => {
+    window.localStorage.setItem(
+      "milady:active-server",
+      JSON.stringify({
+        id: "local:embedded",
+        kind: "local",
+        label: "This device",
+      }),
+    );
+
+    const { result } = renderHook(() => useOnboardingState());
+
+    expect(result.current.state.runMode).toBe("local");
+    expect(result.current.state.cloudProvider).toBe("");
+    expect(result.current.state.remote.status).toBe("idle");
+    expect(result.current.state.remoteApiBase).toBe("");
+  });
+
+  it("hydrates Eliza Cloud hosting from the active server record", () => {
+    window.localStorage.setItem(
+      "milady:active-server",
+      JSON.stringify({
+        id: "cloud:https://api.eliza.ai",
+        kind: "cloud",
+        label: "Eliza Cloud",
+        apiBase: "https://api.eliza.ai",
+        accessToken: "cloud-token",
+      }),
+    );
+
+    const { result } = renderHook(() => useOnboardingState());
+
+    expect(result.current.state.runMode).toBe("cloud");
+    expect(result.current.state.cloudProvider).toBe("elizacloud");
+    expect(result.current.state.remote.status).toBe("idle");
+    expect(result.current.state.remoteToken).toBe("cloud-token");
   });
 });

--- a/packages/app-core/src/state/useOnboardingState.ts
+++ b/packages/app-core/src/state/useOnboardingState.ts
@@ -8,7 +8,11 @@
 
 import { useCallback, useReducer, useRef } from "react";
 import type { OnboardingOptions } from "../api";
-import { loadPersistedOnboardingStep, saveOnboardingStep } from "./persistence";
+import {
+  loadPersistedActiveServer,
+  loadPersistedOnboardingStep,
+  saveOnboardingStep,
+} from "./persistence";
 import type { AppState, OnboardingStep } from "./types";
 
 // ── Connector token keys ───────────────────────────────────────────────
@@ -85,11 +89,6 @@ export interface OnboardingState {
   restarting: boolean;
 }
 
-function loadSessionApiBase(): string {
-  if (typeof window === "undefined") return "";
-  return window.sessionStorage.getItem("milady_api_base")?.trim() ?? "";
-}
-
 function isRemoteApiBase(baseUrl: string): boolean {
   if (!baseUrl || typeof window === "undefined") return false;
   try {
@@ -117,8 +116,30 @@ const EMPTY_TOKENS: Record<ConnectorTokenKey, string> = {
   githubToken: "",
 };
 
+function loadInitialRemoteSelection(): {
+  apiBase: string;
+  accessToken: string;
+  connected: boolean;
+} {
+  const activeServer = loadPersistedActiveServer();
+  if (activeServer?.kind !== "remote") {
+    return {
+      apiBase: "",
+      accessToken: "",
+      connected: false,
+    };
+  }
+
+  const apiBase = activeServer.apiBase?.trim() ?? "";
+  return {
+    apiBase,
+    accessToken: activeServer.accessToken?.trim() ?? "",
+    connected: isRemoteApiBase(apiBase),
+  };
+}
+
 function createInitialState(cloudOnly?: boolean): OnboardingState {
-  const savedApiBase = loadSessionApiBase();
+  const initialRemote = loadInitialRemoteSelection();
   return {
     step: loadPersistedOnboardingStep() ?? "identity",
     mode: "basic",
@@ -145,11 +166,11 @@ function createInitialState(cloudOnly?: boolean): OnboardingState {
     detectedProviders: [],
     connectorTokens: { ...EMPTY_TOKENS },
     remote: {
-      status: isRemoteApiBase(savedApiBase) ? "connected" : "idle",
+      status: initialRemote.connected ? "connected" : "idle",
       error: null,
     },
-    remoteApiBase: savedApiBase,
-    remoteToken: "",
+    remoteApiBase: initialRemote.apiBase,
+    remoteToken: initialRemote.accessToken,
     subscriptionTab: "token",
     elizaCloudTab: "login",
     selectedChains: new Set(["evm", "solana"]),

--- a/packages/app-core/src/state/useOnboardingState.ts
+++ b/packages/app-core/src/state/useOnboardingState.ts
@@ -116,30 +116,65 @@ const EMPTY_TOKENS: Record<ConnectorTokenKey, string> = {
   githubToken: "",
 };
 
-function loadInitialRemoteSelection(): {
-  apiBase: string;
-  accessToken: string;
-  connected: boolean;
-} {
+function loadInitialServerSelection(): Pick<
+  OnboardingState,
+  "runMode" | "cloudProvider" | "remote" | "remoteApiBase" | "remoteToken"
+> {
   const activeServer = loadPersistedActiveServer();
-  if (activeServer?.kind !== "remote") {
+  if (!activeServer) {
     return {
-      apiBase: "",
-      accessToken: "",
-      connected: false,
+      runMode: "",
+      cloudProvider: "",
+      remote: {
+        status: "idle",
+        error: null,
+      },
+      remoteApiBase: "",
+      remoteToken: "",
+    };
+  }
+
+  if (activeServer.kind === "local") {
+    return {
+      runMode: "local",
+      cloudProvider: "",
+      remote: {
+        status: "idle",
+        error: null,
+      },
+      remoteApiBase: "",
+      remoteToken: "",
+    };
+  }
+
+  if (activeServer.kind === "cloud") {
+    return {
+      runMode: "cloud",
+      cloudProvider: "elizacloud",
+      remote: {
+        status: "idle",
+        error: null,
+      },
+      remoteApiBase: "",
+      remoteToken: activeServer.accessToken?.trim() ?? "",
     };
   }
 
   const apiBase = activeServer.apiBase?.trim() ?? "";
   return {
-    apiBase,
-    accessToken: activeServer.accessToken?.trim() ?? "",
-    connected: isRemoteApiBase(apiBase),
+    runMode: "cloud",
+    cloudProvider: "remote",
+    remote: {
+      status: isRemoteApiBase(apiBase) ? "connected" : "idle",
+      error: null,
+    },
+    remoteApiBase: apiBase,
+    remoteToken: activeServer.accessToken?.trim() ?? "",
   };
 }
 
 function createInitialState(cloudOnly?: boolean): OnboardingState {
-  const initialRemote = loadInitialRemoteSelection();
+  const initialServer = loadInitialServerSelection();
   return {
     step: loadPersistedOnboardingStep() ?? "identity",
     mode: "basic",
@@ -151,8 +186,8 @@ function createInitialState(cloudOnly?: boolean): OnboardingState {
     ownerName: "anon",
     style: "chen",
     avatar: 1,
-    runMode: cloudOnly ? "cloud" : "",
-    cloudProvider: cloudOnly ? "elizacloud" : "",
+    runMode: cloudOnly ? "cloud" : initialServer.runMode,
+    cloudProvider: cloudOnly ? "elizacloud" : initialServer.cloudProvider,
     cloudApiKey: "",
     provider: "",
     apiKey: "",
@@ -165,12 +200,9 @@ function createInitialState(cloudOnly?: boolean): OnboardingState {
     existingInstallDetected: false,
     detectedProviders: [],
     connectorTokens: { ...EMPTY_TOKENS },
-    remote: {
-      status: initialRemote.connected ? "connected" : "idle",
-      error: null,
-    },
-    remoteApiBase: initialRemote.apiBase,
-    remoteToken: initialRemote.accessToken,
+    remote: initialServer.remote,
+    remoteApiBase: initialServer.remoteApiBase,
+    remoteToken: initialServer.remoteToken,
     subscriptionTab: "token",
     elizaCloudTab: "login",
     selectedChains: new Set(["evm", "solana"]),

--- a/packages/app-core/src/utils/asset-url.ts
+++ b/packages/app-core/src/utils/asset-url.ts
@@ -131,11 +131,11 @@ function readSessionStorageApiBase(): string | undefined {
  * the renderer. In desktop shells the page origin is electrobun:// or
  * file://, so bare /api/... paths resolve to the SPA instead of the backend.
  *
- * Resolution order: `sessionStorage` (user/session override) → shell-injected
- * `__MILADY_API_BASE__` → boot `apiBase`. Injected is preferred over boot so
- * Electrobun/desktop dev is not stuck on a stale UI-only boot URL (e.g. Vite
- * :2138) after `setBootConfig` omitted `apiBase` or set it wrong — otherwise
- * `/api/tts/cloud` hits the wrong host and TTS falls back to Web Speech.
+ * Resolution order: shell-injected `__MILADY_API_BASE__` → boot `apiBase` →
+ * `sessionStorage` fallback. This mirrors `MiladyClient`: desktop injection
+ * must beat stale session state from a prior remote/cloud session, while boot
+ * config should still reflect an explicit `client.setBaseUrl()` update before
+ * we fall back to the old session key.
  */
 export function resolveApiUrl(apiPath: string): string {
   const stored = readSessionStorageApiBase();
@@ -144,7 +144,7 @@ export function resolveApiUrl(apiPath: string): string {
   const injectedRaw = getElizaApiBase()?.trim();
   const injected =
     injectedRaw && injectedRaw.length > 0 ? injectedRaw : undefined;
-  const base = stored ?? injected ?? boot;
+  const base = injected ?? boot ?? stored;
   if (!base) return apiPath;
   const normalized = base.replace(/\/+$/, "");
   const suffix = apiPath.startsWith("/") ? apiPath : `/${apiPath}`;

--- a/packages/app-core/src/utils/asset-url.ts
+++ b/packages/app-core/src/utils/asset-url.ts
@@ -131,20 +131,21 @@ function readSessionStorageApiBase(): string | undefined {
  * the renderer. In desktop shells the page origin is electrobun:// or
  * file://, so bare /api/... paths resolve to the SPA instead of the backend.
  *
- * Resolution order: shell-injected `__MILADY_API_BASE__` → boot `apiBase` →
- * `sessionStorage` fallback. This mirrors `MiladyClient`: desktop injection
- * must beat stale session state from a prior remote/cloud session, while boot
- * config should still reflect an explicit `client.setBaseUrl()` update before
- * we fall back to the old session key.
+ * Resolution order: boot `apiBase` → shell-injected `__MILADY_API_BASE__` →
+ * `sessionStorage` fallback. The boot config is the current client-owned
+ * source of truth because `client.setBaseUrl()` updates it whenever the user
+ * switches servers. Injection still beats stale session state from prior
+ * sessions, but it must not override the active runtime target once the client
+ * has changed it.
  */
 export function resolveApiUrl(apiPath: string): string {
-  const stored = readSessionStorageApiBase();
   const bootRaw = getBootConfig().apiBase?.trim();
   const boot = bootRaw && bootRaw.length > 0 ? bootRaw : undefined;
   const injectedRaw = getElizaApiBase()?.trim();
   const injected =
     injectedRaw && injectedRaw.length > 0 ? injectedRaw : undefined;
-  const base = injected ?? boot ?? stored;
+  const stored = readSessionStorageApiBase();
+  const base = boot ?? injected ?? stored;
   if (!base) return apiPath;
   const normalized = base.replace(/\/+$/, "");
   const suffix = apiPath.startsWith("/") ? apiPath : `/${apiPath}`;

--- a/packages/app-core/test/avatar/asset-url-resolve-api-session.test.ts
+++ b/packages/app-core/test/avatar/asset-url-resolve-api-session.test.ts
@@ -9,14 +9,14 @@ describe("resolveApiUrl (sessionStorage, jsdom)", () => {
     window.sessionStorage.removeItem("milady_api_base");
   });
 
-  it("prefers sessionStorage milady_api_base over boot when both are set", () => {
+  it("prefers boot apiBase over stale sessionStorage state", () => {
     window.sessionStorage.setItem(
       "milady_api_base",
       "http://127.0.0.1:31337",
     );
     setBootConfig({ branding: {}, apiBase: "http://localhost:2138" });
     expect(resolveApiUrl("/api/tts/cloud")).toBe(
-      "http://127.0.0.1:31337/api/tts/cloud",
+      "http://localhost:2138/api/tts/cloud",
     );
   });
 

--- a/packages/app-core/test/avatar/asset-url-resolve-api-session.test.ts
+++ b/packages/app-core/test/avatar/asset-url-resolve-api-session.test.ts
@@ -1,26 +1,61 @@
 // @vitest-environment jsdom
-import { setBootConfig } from "@miladyai/app-core/config";
-import { resolveApiUrl } from "@miladyai/app-core/utils";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const DEFAULT_BOOT_CONFIG = {
+  branding: {},
+  cloudApiBase: "https://www.elizacloud.ai",
+};
+
+const bootConfigState: {
+  current: {
+    branding: Record<string, unknown>;
+    cloudApiBase: string;
+    apiBase?: string;
+  };
+} = {
+  current: DEFAULT_BOOT_CONFIG,
+};
+
+async function loadResolveApiUrl() {
+  vi.resetModules();
+  vi.doMock("../../src/config/boot-config", () => ({
+    DEFAULT_BOOT_CONFIG,
+    getBootConfig: () => bootConfigState.current,
+    setBootConfig: (config: typeof bootConfigState.current) => {
+      bootConfigState.current = config;
+    },
+  }));
+  const mod = await import("../../src/utils/asset-url");
+  return mod.resolveApiUrl;
+}
 
 describe("resolveApiUrl (sessionStorage, jsdom)", () => {
   beforeEach(() => {
-    setBootConfig({ branding: {} });
+    bootConfigState.current = DEFAULT_BOOT_CONFIG;
     window.sessionStorage.removeItem("milady_api_base");
+    const w = window as Window & {
+      __MILADY_API_BASE__?: string;
+      __ELIZA_API_BASE__?: string;
+    };
+    delete w.__MILADY_API_BASE__;
+    delete w.__ELIZA_API_BASE__;
   });
 
-  it("prefers boot apiBase over stale sessionStorage state", () => {
+  it("prefers injected api base over stale sessionStorage when boot is unset", async () => {
+    const resolveApiUrl = await loadResolveApiUrl();
     window.sessionStorage.setItem(
       "milady_api_base",
       "http://127.0.0.1:31337",
     );
-    setBootConfig({ branding: {}, apiBase: "http://localhost:2138" });
+    const w = window as Window & { __MILADY_API_BASE__?: string };
+    w.__MILADY_API_BASE__ = "http://127.0.0.1:41414";
     expect(resolveApiUrl("/api/tts/cloud")).toBe(
-      "http://localhost:2138/api/tts/cloud",
+      "http://127.0.0.1:41414/api/tts/cloud",
     );
   });
 
-  it("uses sessionStorage when boot apiBase is unset", () => {
+  it("uses sessionStorage when boot apiBase is unset", async () => {
+    const resolveApiUrl = await loadResolveApiUrl();
     window.sessionStorage.setItem(
       "milady_api_base",
       "http://127.0.0.1:40000",
@@ -30,13 +65,42 @@ describe("resolveApiUrl (sessionStorage, jsdom)", () => {
     );
   });
 
-  it("prefers __MILADY_API_BASE__ over boot when session is unset (desktop TTS)", () => {
+  it("keeps boot config ahead of sessionStorage", async () => {
+    const resolveApiUrl = await loadResolveApiUrl();
+    window.sessionStorage.setItem(
+      "milady_api_base",
+      "https://ren.example.com",
+    );
+    bootConfigState.current = {
+      ...DEFAULT_BOOT_CONFIG,
+      apiBase: "http://127.0.0.1:2138",
+    };
+    expect(resolveApiUrl("/api/status")).toBe(
+      "http://127.0.0.1:2138/api/status",
+    );
+  });
+
+  it("falls back to boot apiBase after injected and session values are absent", async () => {
+    const resolveApiUrl = await loadResolveApiUrl();
+    bootConfigState.current = {
+      ...DEFAULT_BOOT_CONFIG,
+      apiBase: "http://127.0.0.1:2138",
+    };
+    expect(resolveApiUrl("/api/tts/cloud")).toBe(
+      "http://127.0.0.1:2138/api/tts/cloud",
+    );
+  });
+
+  it("keeps boot config ahead of injected api base", async () => {
+    const resolveApiUrl = await loadResolveApiUrl();
     const w = window as Window & { __MILADY_API_BASE__?: string };
     w.__MILADY_API_BASE__ = "http://127.0.0.1:31337";
-    setBootConfig({ branding: {}, apiBase: "http://127.0.0.1:2138" });
+    bootConfigState.current = {
+      ...DEFAULT_BOOT_CONFIG,
+      apiBase: "http://127.0.0.1:2138",
+    };
     expect(resolveApiUrl("/api/tts/cloud")).toBe(
-      "http://127.0.0.1:31337/api/tts/cloud",
+      "http://127.0.0.1:2138/api/tts/cloud",
     );
-    delete w.__MILADY_API_BASE__;
   });
 });


### PR DESCRIPTION
## Summary
- remove sessionStorage as a startup restore source of truth and rely on the persisted active-server record instead
- route discovered gateway and remote onboarding handoff through the same canonical startup path
- align API base resolution across startup/client/asset helpers

## Validation
- bunx vitest run packages/app-core/src/components/shell/StartupShell.test.tsx packages/app-core/src/state/useOnboardingState.test.ts packages/app-core/src/state/startup-phase-restore.test.ts packages/app-core/test/avatar/asset-url-resolve-api-session.test.ts packages/app-core/test/app/connection-mode-persistence.test.ts packages/app-core/test/app/startup-backend-missing.e2e.test.ts packages/app-core/test/app/startup-onboarding-recovery.test.tsx packages/app-core/test/app/startup-conversation-restore.test.tsx
- bunx vitest run packages/app-core/src/state/useOnboardingCallbacks.test.ts
- bun run test:startup:e2e
- bun run lint
- git diff --check
- MILADY_PRE_REVIEW_BASE=origin/develop bun run pre-review:local