### PR TITLE
milady: persist active server directly during startup

### DIFF
--- a/packages/app-core/src/components/shell/StartupShell.tsx
+++ b/packages/app-core/src/components/shell/StartupShell.tsx
@@ -21,6 +21,7 @@ import {
   savePersistedActiveServer,
   useApp,
 } from "../../state";
+import { buildOnboardingServerSelection } from "../../onboarding/server-target";
 import type { StartupErrorState } from "../../state/types";
 import { OnboardingWizard } from "../onboarding/OnboardingWizard";
 import { PairingView } from "./PairingView";
@@ -131,6 +132,7 @@ export function StartupShell() {
 
   const seedSplashTarget = useCallback(
     (target: "local" | "remote" | "elizacloud", remoteApiBase?: string) => {
+      const selection = buildOnboardingServerSelection(target);
       clearClientConnectionIntent();
       clearPersistedConnectionMode();
       goToOnboardingStep("identity");
@@ -140,18 +142,15 @@ export function StartupShell() {
       setState("onboardingRemoteToken", "");
 
       if (target === "local") {
-        setState("onboardingRunMode", "local");
-        setState("onboardingCloudProvider", "");
+        setState("onboardingRunMode", selection.runMode);
+        setState("onboardingCloudProvider", selection.cloudProvider);
         setState("onboardingRemoteConnected", false);
         setState("onboardingRemoteApiBase", "");
         return;
       }
 
-      setState("onboardingRunMode", "cloud");
-      setState(
-        "onboardingCloudProvider",
-        target === "elizacloud" ? "elizacloud" : "remote",
-      );
+      setState("onboardingRunMode", selection.runMode);
+      setState("onboardingCloudProvider", selection.cloudProvider);
       setState("onboardingRemoteConnected", Boolean(remoteApiBase));
       setState("onboardingRemoteApiBase", remoteApiBase ?? "");
     },

--- a/packages/app-core/src/onboarding-config.ts
+++ b/packages/app-core/src/onboarding-config.ts
@@ -9,6 +9,7 @@ import type {
   LinkedAccountsConfig,
   ServiceRoutingConfig,
 } from "@miladyai/shared/contracts/service-routing";
+import { resolveOnboardingServerTarget } from "./onboarding/server-target";
 
 export interface BuildOnboardingConnectionArgs {
   onboardingRunMode: "local" | "cloud" | "";
@@ -61,6 +62,11 @@ export function resolveOnboardingPrimaryModel(args: {
 export function buildOnboardingConnectionConfig(
   args: BuildOnboardingConnectionArgs,
 ): OnboardingConnection | null {
+  const serverTarget = resolveOnboardingServerTarget({
+    runMode: args.onboardingRunMode,
+    cloudProvider: args.onboardingCloudProvider,
+  });
+
   if (args.onboardingProvider === "elizacloud") {
     return {
       kind: "cloud-managed",
@@ -77,7 +83,7 @@ export function buildOnboardingConnectionConfig(
 
   const providerId = resolveLocalProviderId(args.onboardingProvider);
   if (!providerId) {
-    if (args.onboardingCloudProvider === "remote") {
+    if (serverTarget === "remote") {
       return {
         kind: "remote-provider",
         remoteApiBase: args.onboardingRemoteApiBase.trim(),
@@ -93,10 +99,7 @@ export function buildOnboardingConnectionConfig(
     onboardingOpenRouterModel: args.onboardingOpenRouterModel,
   });
 
-  if (
-    args.onboardingRunMode === "cloud" &&
-    args.onboardingCloudProvider === "remote"
-  ) {
+  if (serverTarget === "remote") {
     return {
       kind: "remote-provider",
       remoteApiBase: args.onboardingRemoteApiBase.trim(),
@@ -119,6 +122,10 @@ export function buildOnboardingRuntimeConfig(
   args: BuildOnboardingConnectionArgs,
 ): BuildOnboardingRuntimeConfigResult {
   const connection = buildOnboardingConnectionConfig(args);
+  const serverTarget = resolveOnboardingServerTarget({
+    runMode: args.onboardingRunMode,
+    cloudProvider: args.onboardingCloudProvider,
+  });
   const linkedAccounts: LinkedAccountsConfig = {};
   const cloudApiKey = trimToUndefined(args.onboardingCloudApiKey);
   if (cloudApiKey) {
@@ -129,7 +136,7 @@ export function buildOnboardingRuntimeConfig(
   }
 
   const deploymentTarget: DeploymentTargetConfig =
-    args.onboardingCloudProvider === "remote"
+    serverTarget === "remote"
       ? {
           runtime: "remote",
           provider: "remote",
@@ -138,9 +145,7 @@ export function buildOnboardingRuntimeConfig(
             ? { remoteAccessToken: trimToUndefined(args.onboardingRemoteToken) }
             : {}),
         }
-      : args.onboardingRunMode === "cloud" &&
-          args.onboardingCloudProvider === "elizacloud" &&
-          !args.onboardingRemoteConnected
+      : serverTarget === "elizacloud" && !args.onboardingRemoteConnected
         ? {
             runtime: "cloud",
             provider: "elizacloud",

--- a/packages/app-core/src/onboarding/connection-flow.ts
+++ b/packages/app-core/src/onboarding/connection-flow.ts
@@ -34,6 +34,11 @@ import type {
   ConnectionTransitionResult,
   ConnectionUiSpec,
 } from "./types";
+import {
+  buildOnboardingServerSelection,
+  resolveOnboardingServerTarget,
+  type OnboardingServerTarget,
+} from "./server-target";
 
 export type {
   ConnectionEffect,
@@ -106,14 +111,34 @@ export const CONNECTION_TRANSITIONS: ReadonlyArray<ConnectionTransitionDocRow> =
     },
   ];
 
+function toOnboardingTargetPatch(
+  target: OnboardingServerTarget,
+): ConnectionStatePatch {
+  const selection = buildOnboardingServerSelection(target);
+  return {
+    onboardingRunMode: selection.runMode,
+    onboardingCloudProvider: selection.cloudProvider,
+  };
+}
+
 /** **Why exported:** tests and docs; also shared by `derive` and `resolveConnectionUiSpec` so policy lives once. */
 export function getEffectiveRunMode(
   snapshot: ConnectionFlowSnapshot,
 ): "local" | "cloud" | "" {
+  return toOnboardingTargetPatch(getEffectiveServerTarget(snapshot))
+    .onboardingRunMode as "local" | "cloud" | "";
+}
+
+export function getEffectiveServerTarget(
+  snapshot: ConnectionFlowSnapshot,
+): OnboardingServerTarget {
   if (snapshot.forceCloud && snapshot.onboardingRunMode === "") {
     return "local";
   }
-  return snapshot.onboardingRunMode;
+  return resolveOnboardingServerTarget({
+    runMode: snapshot.onboardingRunMode,
+    cloudProvider: snapshot.onboardingCloudProvider,
+  });
 }
 
 /** True when the neural link grid path is active (local run mode or already connected to remote). */
@@ -124,12 +149,12 @@ export function computeShowProviderSelection(
     return true;
   }
 
-  const runMode = getEffectiveRunMode(snapshot);
-  if (!runMode) {
+  const target = getEffectiveServerTarget(snapshot);
+  if (!target) {
     return false;
   }
 
-  return runMode === "local" || snapshot.onboardingCloudProvider !== "remote";
+  return target !== "remote";
 }
 
 /**
@@ -169,7 +194,7 @@ export function resolveConnectionUiSpec(
 }
 
 const resetCloudSelectionPatch = (): ConnectionStatePatch => ({
-  onboardingCloudProvider: "",
+  ...toOnboardingTargetPatch(""),
   onboardingApiKey: "",
   onboardingRemoteError: null,
   onboardingRemoteConnecting: false,
@@ -177,7 +202,6 @@ const resetCloudSelectionPatch = (): ConnectionStatePatch => ({
 
 const resetHostingSelectionPatch = (): ConnectionStatePatch => ({
   ...resetCloudSelectionPatch(),
-  onboardingRunMode: "",
 });
 
 /**
@@ -211,7 +235,7 @@ export function applyConnectionTransition(
       return {
         kind: "patch",
         patch: {
-          onboardingRunMode: "local",
+          ...toOnboardingTargetPatch("local"),
           onboardingProvider: "",
           onboardingApiKey: "",
           onboardingPrimaryModel: "",
@@ -222,8 +246,7 @@ export function applyConnectionTransition(
       return {
         kind: "patch",
         patch: {
-          onboardingRunMode: "local",
-          onboardingCloudProvider: "",
+          ...toOnboardingTargetPatch("local"),
           onboardingRemoteError: null,
           onboardingRemoteConnecting: false,
         },
@@ -232,8 +255,7 @@ export function applyConnectionTransition(
       return {
         kind: "patch",
         patch: {
-          onboardingRunMode: "cloud",
-          onboardingCloudProvider: "remote",
+          ...toOnboardingTargetPatch("remote"),
           onboardingProvider: "",
           onboardingApiKey: "",
           onboardingPrimaryModel: "",
@@ -243,8 +265,7 @@ export function applyConnectionTransition(
       return {
         kind: "patch",
         patch: {
-          onboardingRunMode: "cloud",
-          onboardingCloudProvider: "elizacloud",
+          ...toOnboardingTargetPatch("elizacloud"),
           onboardingProvider: "",
           onboardingApiKey: "",
           onboardingPrimaryModel: "",

--- a/packages/app-core/src/onboarding/server-target.test.ts
+++ b/packages/app-core/src/onboarding/server-target.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  activeServerKindToOnboardingServerTarget,
+  buildOnboardingServerSelection,
+  resolveOnboardingServerTarget,
+} from "./server-target";
+
+describe("server-target", () => {
+  it("resolves the canonical onboarding server target from legacy fields", () => {
+    expect(
+      resolveOnboardingServerTarget({ runMode: "", cloudProvider: "" }),
+    ).toBe("");
+    expect(
+      resolveOnboardingServerTarget({ runMode: "local", cloudProvider: "" }),
+    ).toBe("local");
+    expect(
+      resolveOnboardingServerTarget({
+        runMode: "cloud",
+        cloudProvider: "remote",
+      }),
+    ).toBe("remote");
+    expect(
+      resolveOnboardingServerTarget({
+        runMode: "cloud",
+        cloudProvider: "elizacloud",
+      }),
+    ).toBe("elizacloud");
+  });
+
+  it("builds the legacy onboarding field pair from the canonical target", () => {
+    expect(buildOnboardingServerSelection("")).toEqual({
+      runMode: "",
+      cloudProvider: "",
+    });
+    expect(buildOnboardingServerSelection("local")).toEqual({
+      runMode: "local",
+      cloudProvider: "",
+    });
+    expect(buildOnboardingServerSelection("remote")).toEqual({
+      runMode: "cloud",
+      cloudProvider: "remote",
+    });
+    expect(buildOnboardingServerSelection("elizacloud")).toEqual({
+      runMode: "cloud",
+      cloudProvider: "elizacloud",
+    });
+  });
+
+  it("maps persisted active-server kinds to onboarding targets", () => {
+    expect(activeServerKindToOnboardingServerTarget("local")).toBe("local");
+    expect(activeServerKindToOnboardingServerTarget("remote")).toBe("remote");
+    expect(activeServerKindToOnboardingServerTarget("cloud")).toBe(
+      "elizacloud",
+    );
+  });
+});

--- a/packages/app-core/src/onboarding/server-target.ts
+++ b/packages/app-core/src/onboarding/server-target.ts
@@ -1,0 +1,55 @@
+export type OnboardingRunMode = "local" | "cloud" | "";
+
+export type OnboardingServerTarget = "" | "local" | "remote" | "elizacloud";
+
+export interface OnboardingServerSelection {
+  runMode: OnboardingRunMode;
+  cloudProvider: string;
+}
+
+export function resolveOnboardingServerTarget(args: {
+  runMode: OnboardingRunMode;
+  cloudProvider?: string | null;
+}): OnboardingServerTarget {
+  if (args.runMode === "local") {
+    return "local";
+  }
+
+  if (args.runMode === "cloud" && args.cloudProvider === "remote") {
+    return "remote";
+  }
+
+  if (args.runMode === "cloud") {
+    return "elizacloud";
+  }
+
+  return "";
+}
+
+export function buildOnboardingServerSelection(
+  target: OnboardingServerTarget,
+): OnboardingServerSelection {
+  switch (target) {
+    case "local":
+      return { runMode: "local", cloudProvider: "" };
+    case "remote":
+      return { runMode: "cloud", cloudProvider: "remote" };
+    case "elizacloud":
+      return { runMode: "cloud", cloudProvider: "elizacloud" };
+    case "":
+      return { runMode: "", cloudProvider: "" };
+  }
+}
+
+export function activeServerKindToOnboardingServerTarget(
+  kind: "local" | "cloud" | "remote",
+): Exclude<OnboardingServerTarget, ""> {
+  switch (kind) {
+    case "local":
+      return "local";
+    case "cloud":
+      return "elizacloud";
+    case "remote":
+      return "remote";
+  }
+}

--- a/packages/app-core/src/platform/browser-launch.test.ts
+++ b/packages/app-core/src/platform/browser-launch.test.ts
@@ -1,7 +1,10 @@
 // @vitest-environment jsdom
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { loadPersistedConnectionMode } from "../state/persistence";
+import {
+  loadPersistedActiveServer,
+  loadPersistedConnectionMode,
+} from "../state/persistence";
 
 const { fetchMock, mockClient } = vi.hoisted(() => ({
   fetchMock: vi.fn(),
@@ -67,6 +70,13 @@ describe("applyLaunchConnectionFromUrl", () => {
       "https://agent-123.containers.elizacloud.ai",
     );
     expect(mockClient.setToken).toHaveBeenCalledWith("managed-backend-token");
+    expect(loadPersistedActiveServer()).toEqual({
+      id: "cloud:https://agent-123.containers.elizacloud.ai",
+      kind: "cloud",
+      label: "Eliza Cloud",
+      apiBase: "https://agent-123.containers.elizacloud.ai",
+      accessToken: "managed-backend-token",
+    });
     expect(loadPersistedConnectionMode()).toEqual({
       runMode: "cloud",
       cloudApiBase: "https://agent-123.containers.elizacloud.ai",
@@ -121,6 +131,13 @@ describe("applyLaunchConnectionFromUrl", () => {
       "https://agent-legacy.containers.elizacloud.ai",
     );
     expect(mockClient.setToken).toHaveBeenCalledWith("legacy-token");
+    expect(loadPersistedActiveServer()).toEqual({
+      id: "cloud:https://agent-legacy.containers.elizacloud.ai",
+      kind: "cloud",
+      label: "Eliza Cloud",
+      apiBase: "https://agent-legacy.containers.elizacloud.ai",
+      accessToken: "legacy-token",
+    });
     expect(loadPersistedConnectionMode()).toEqual({
       runMode: "cloud",
       cloudApiBase: "https://agent-legacy.containers.elizacloud.ai",
@@ -140,6 +157,13 @@ describe("applyLaunchConnectionFromUrl", () => {
       "https://agent-456.containers.elizacloud.ai",
     );
     expect(mockClient.setToken).toHaveBeenCalledWith("backend-token");
+    expect(loadPersistedActiveServer()).toEqual({
+      id: "remote:https://agent-456.containers.elizacloud.ai",
+      kind: "remote",
+      label: "agent-456.containers.elizacloud.ai",
+      apiBase: "https://agent-456.containers.elizacloud.ai",
+      accessToken: "backend-token",
+    });
     expect(loadPersistedConnectionMode()).toEqual({
       runMode: "remote",
       remoteApiBase: "https://agent-456.containers.elizacloud.ai",

--- a/packages/app-core/src/platform/browser-launch.ts
+++ b/packages/app-core/src/platform/browser-launch.ts
@@ -1,5 +1,8 @@
 import { client } from "../api";
-import { savePersistedConnectionMode } from "../state/persistence";
+import {
+  createPersistedActiveServer,
+  savePersistedActiveServer,
+} from "../state/persistence";
 
 function getSearchParams(): URLSearchParams {
   if (typeof window === "undefined") {
@@ -148,11 +151,13 @@ export async function applyLaunchConnectionFromUrl(): Promise<boolean> {
     );
     client.setBaseUrl(connection.apiBase);
     client.setToken(connection.token);
-    savePersistedConnectionMode({
-      runMode: "cloud",
-      cloudApiBase: connection.apiBase,
-      cloudAuthToken: connection.token,
-    });
+    savePersistedActiveServer(
+      createPersistedActiveServer({
+        kind: "cloud",
+        apiBase: connection.apiBase,
+        accessToken: connection.token,
+      }),
+    );
     stripLaunchParams();
     return true;
   }
@@ -167,11 +172,13 @@ export async function applyLaunchConnectionFromUrl(): Promise<boolean> {
 
   client.setBaseUrl(normalizedApiBase);
   client.setToken(launchToken);
-  savePersistedConnectionMode({
-    runMode: "remote",
-    remoteApiBase: normalizedApiBase,
-    ...(launchToken ? { remoteAccessToken: launchToken } : {}),
-  });
+  savePersistedActiveServer(
+    createPersistedActiveServer({
+      kind: "remote",
+      apiBase: normalizedApiBase,
+      ...(launchToken ? { accessToken: launchToken } : {}),
+    }),
+  );
   stripLaunchParams();
   return true;
 }

--- a/packages/app-core/src/state/internal.ts
+++ b/packages/app-core/src/state/internal.ts
@@ -38,6 +38,7 @@ export {
   clearAvatarIndex,
   clearPersistedActiveServer,
   clearPersistedConnectionMode,
+  createPersistedActiveServer,
   clearPersistedOnboardingStep,
   connectionModeToActiveServer,
   loadActiveConversationId,

--- a/packages/app-core/src/state/onboarding-resume.ts
+++ b/packages/app-core/src/state/onboarding-resume.ts
@@ -4,6 +4,7 @@ import {
   resolveDeploymentTargetInConfig,
   type OnboardingConnection,
 } from "@miladyai/shared/contracts";
+import { buildOnboardingServerSelection } from "../onboarding/server-target";
 import type { BuildOnboardingConnectionArgs } from "../onboarding-config";
 import { asRecord } from "./config-readers";
 import type { OnboardingStep } from "./types";
@@ -64,10 +65,11 @@ export function deriveOnboardingResumeFields(
   }
 
   switch (connection.kind) {
-    case "cloud-managed":
+    case "cloud-managed": {
+      const selection = buildOnboardingServerSelection("elizacloud");
       return {
-        onboardingRunMode: "cloud",
-        onboardingCloudProvider: "elizacloud",
+        onboardingRunMode: selection.runMode,
+        onboardingCloudProvider: selection.cloudProvider,
         onboardingCloudApiKey: connection.apiKey ?? "",
         onboardingVoiceProvider: "",
         onboardingVoiceApiKey: "",
@@ -80,10 +82,12 @@ export function deriveOnboardingResumeFields(
         onboardingPrimaryModel: "",
         onboardingOpenRouterModel: "",
       };
-    case "local-provider":
+    }
+    case "local-provider": {
+      const selection = buildOnboardingServerSelection("local");
       return {
-        onboardingRunMode: "local",
-        onboardingCloudProvider: "",
+        onboardingRunMode: selection.runMode,
+        onboardingCloudProvider: selection.cloudProvider,
         onboardingProvider: connection.provider,
         onboardingApiKey: connection.apiKey ?? "",
         onboardingVoiceProvider: "",
@@ -100,10 +104,12 @@ export function deriveOnboardingResumeFields(
         onboardingRemoteApiBase: "",
         onboardingRemoteToken: "",
       };
-    case "remote-provider":
+    }
+    case "remote-provider": {
+      const selection = buildOnboardingServerSelection("remote");
       return {
-        onboardingRunMode: "cloud",
-        onboardingCloudProvider: "remote",
+        onboardingRunMode: selection.runMode,
+        onboardingCloudProvider: selection.cloudProvider,
         onboardingProvider: connection.provider ?? "",
         onboardingApiKey: connection.apiKey ?? "",
         onboardingVoiceProvider: "",
@@ -120,6 +126,7 @@ export function deriveOnboardingResumeFields(
         onboardingRemoteApiBase: connection.remoteApiBase,
         onboardingRemoteToken: connection.remoteAccessToken ?? "",
       };
+    }
   }
 }
 
@@ -130,18 +137,20 @@ export function deriveOnboardingResumeFieldsFromConfig(
   if (!connection) {
     const deploymentTarget = resolveDeploymentTargetInConfig(config);
     if (deploymentTarget.runtime === "remote") {
+      const selection = buildOnboardingServerSelection("remote");
       return {
-        onboardingRunMode: "cloud",
-        onboardingCloudProvider: "remote",
+        onboardingRunMode: selection.runMode,
+        onboardingCloudProvider: selection.cloudProvider,
         onboardingRemoteConnected: Boolean(deploymentTarget.remoteApiBase),
         onboardingRemoteApiBase: deploymentTarget.remoteApiBase ?? "",
         onboardingRemoteToken: deploymentTarget.remoteAccessToken ?? "",
       };
     }
     if (deploymentTarget.runtime === "cloud") {
+      const selection = buildOnboardingServerSelection("elizacloud");
       return {
-        onboardingRunMode: "cloud",
-        onboardingCloudProvider: "elizacloud",
+        onboardingRunMode: selection.runMode,
+        onboardingCloudProvider: selection.cloudProvider,
       };
     }
     return {};

--- a/packages/app-core/src/state/persistence.ts
+++ b/packages/app-core/src/state/persistence.ts
@@ -594,32 +594,34 @@ function normalizePersistedConnectionMode(
   }
 }
 
-export function connectionModeToActiveServer(
-  mode: PersistedConnectionMode,
-): PersistedActiveServer {
-  switch (mode.runMode) {
+export function createPersistedActiveServer(args: {
+  kind: PersistedActiveServer["kind"];
+  apiBase?: string;
+  accessToken?: string;
+  label?: string;
+}): PersistedActiveServer {
+  const apiBase = normalizeApiBase(args.apiBase);
+  const accessToken = trimPersistedValue(args.accessToken);
+  const explicitLabel = trimPersistedValue(args.label);
+
+  switch (args.kind) {
     case "local":
       return {
         id: "local:embedded",
         kind: "local",
-        label: "This device",
+        label: explicitLabel ?? "This device",
       };
-    case "cloud": {
-      const apiBase = normalizeApiBase(mode.cloudApiBase);
+    case "cloud":
       return {
         id: `cloud:${apiBase ?? "managed"}`,
         kind: "cloud",
-        label: "Eliza Cloud",
+        label: explicitLabel ?? "Eliza Cloud",
         ...(apiBase ? { apiBase } : {}),
-        ...(trimPersistedValue(mode.cloudAuthToken)
-          ? { accessToken: trimPersistedValue(mode.cloudAuthToken) }
-          : {}),
+        ...(accessToken ? { accessToken } : {}),
       };
-    }
     case "remote": {
-      const apiBase = normalizeApiBase(mode.remoteApiBase);
-      let label = "Remote server";
-      if (apiBase) {
+      let label = explicitLabel ?? "Remote server";
+      if (!explicitLabel && apiBase) {
         try {
           label = new URL(apiBase).host || label;
         } catch {
@@ -631,10 +633,31 @@ export function connectionModeToActiveServer(
         kind: "remote",
         label,
         ...(apiBase ? { apiBase } : {}),
-        ...(trimPersistedValue(mode.remoteAccessToken)
-          ? { accessToken: trimPersistedValue(mode.remoteAccessToken) }
-          : {}),
+        ...(accessToken ? { accessToken } : {}),
       };
+    }
+  }
+}
+
+export function connectionModeToActiveServer(
+  mode: PersistedConnectionMode,
+): PersistedActiveServer {
+  switch (mode.runMode) {
+    case "local":
+      return createPersistedActiveServer({ kind: "local" });
+    case "cloud": {
+      return createPersistedActiveServer({
+        kind: "cloud",
+        apiBase: mode.cloudApiBase,
+        accessToken: mode.cloudAuthToken,
+      });
+    }
+    case "remote": {
+      return createPersistedActiveServer({
+        kind: "remote",
+        apiBase: mode.remoteApiBase,
+        accessToken: mode.remoteAccessToken,
+      });
     }
   }
 }

--- a/packages/app-core/src/state/startup-phase-poll.ts
+++ b/packages/app-core/src/state/startup-phase-poll.ts
@@ -121,7 +121,11 @@ export async function runPollingBackend(
         deps.onboardingCompletionCommittedRef.current ||
         (ctx?.shouldPreserveCompletedOnboarding ?? false);
 
-      if (sessionComplete && !ctx?.persistedActiveServer && !ctx?.hadPriorOnboarding) {
+      if (
+        sessionComplete &&
+        !ctx?.persistedActiveServer &&
+        !ctx?.hadPriorOnboarding
+      ) {
         sessionComplete = false;
       }
 

--- a/packages/app-core/src/state/startup-phase-poll.ts
+++ b/packages/app-core/src/state/startup-phase-poll.ts
@@ -22,7 +22,6 @@ import {
   loadPersistedOnboardingStep,
   savePersistedActiveServer,
 } from "./persistence";
-import { connectionModeToActiveServer } from "./internal";
 import { getStylePresets } from "@miladyai/shared/onboarding-presets";
 import type { StartupEvent, PlatformPolicy } from "./startup-coordinator";
 import type { StartupCoordinatorDeps } from "./useStartupCoordinator";
@@ -122,11 +121,7 @@ export async function runPollingBackend(
         deps.onboardingCompletionCommittedRef.current ||
         (ctx?.shouldPreserveCompletedOnboarding ?? false);
 
-      if (
-        sessionComplete &&
-        !ctx?.persistedConnection &&
-        !ctx?.hadPriorOnboarding
-      ) {
+      if (sessionComplete && !ctx?.persistedActiveServer && !ctx?.hadPriorOnboarding) {
         sessionComplete = false;
       }
 
@@ -137,11 +132,9 @@ export async function runPollingBackend(
       if (
         sessionComplete &&
         !ctx?.persistedActiveServer &&
-        ctx?.restoredConnection
+        ctx?.restoredActiveServer
       ) {
-        savePersistedActiveServer(
-          connectionModeToActiveServer(ctx.restoredConnection),
-        );
+        savePersistedActiveServer(ctx.restoredActiveServer);
       }
       if (!complete && ctx?.shouldPreserveCompletedOnboarding)
         console.warn(

--- a/packages/app-core/src/state/startup-phase-restore.test.ts
+++ b/packages/app-core/src/state/startup-phase-restore.test.ts
@@ -11,7 +11,11 @@ describe("applyRestoredConnection", () => {
     const startLocalRuntime = vi.fn(async () => {});
 
     await applyRestoredConnection({
-      restoredConnection: { runMode: "local" },
+      restoredActiveServer: {
+        id: "local:embedded",
+        kind: "local",
+        label: "This device",
+      },
       clientRef,
       startLocalRuntime,
     });
@@ -28,9 +32,11 @@ describe("applyRestoredConnection", () => {
     };
 
     await applyRestoredConnection({
-      restoredConnection: {
-        runMode: "remote",
-        remoteApiBase: "https://remote.example/api",
+      restoredActiveServer: {
+        id: "remote:https://remote.example/api",
+        kind: "remote",
+        label: "remote.example",
+        apiBase: "https://remote.example/api",
       },
       clientRef,
     });

--- a/packages/app-core/src/state/startup-phase-restore.ts
+++ b/packages/app-core/src/state/startup-phase-restore.ts
@@ -21,33 +21,31 @@ import {
 } from "./internal";
 import { detectExistingOnboardingConnection } from "./onboarding-bootstrap";
 import {
-  loadPersistedConnectionMode,
+  createPersistedActiveServer,
   loadPersistedActiveServer,
   loadPersistedOnboardingComplete,
-  type PersistedConnectionMode,
+  type PersistedActiveServer,
 } from "./persistence";
 import {
-  connectionModeToTarget,
   type StartupEvent,
 } from "./startup-coordinator";
 import type { StartupCoordinatorDeps } from "./useStartupCoordinator";
 
 export interface RestoringSessionCtx {
   persistedActiveServer: ReturnType<typeof loadPersistedActiveServer>;
-  persistedConnection: ReturnType<typeof loadPersistedConnectionMode>;
-  restoredConnection: PersistedConnectionMode;
+  restoredActiveServer: PersistedActiveServer;
   shouldPreserveCompletedOnboarding: boolean;
   hadPriorOnboarding: boolean;
 }
 
 export async function applyRestoredConnection(args: {
-  restoredConnection: PersistedConnectionMode;
+  restoredActiveServer: PersistedActiveServer;
   clientRef: Pick<typeof client, "setBaseUrl" | "setToken">;
   startLocalRuntime?: () => Promise<void>;
 }) {
-  const { restoredConnection, clientRef, startLocalRuntime } = args;
+  const { restoredActiveServer, clientRef, startLocalRuntime } = args;
 
-  if (restoredConnection.runMode === "local") {
+  if (restoredActiveServer.kind === "local") {
     clientRef.setToken(null);
     clientRef.setBaseUrl(null);
     if (startLocalRuntime) {
@@ -56,14 +54,27 @@ export async function applyRestoredConnection(args: {
     return;
   }
 
-  if (restoredConnection.runMode === "cloud") {
-    clientRef.setBaseUrl(restoredConnection.cloudApiBase ?? null);
-    clientRef.setToken(restoredConnection.cloudAuthToken ?? null);
+  if (restoredActiveServer.kind === "cloud") {
+    clientRef.setBaseUrl(restoredActiveServer.apiBase ?? null);
+    clientRef.setToken(restoredActiveServer.accessToken ?? null);
     return;
   }
 
-  clientRef.setBaseUrl(restoredConnection.remoteApiBase ?? null);
-  clientRef.setToken(restoredConnection.remoteAccessToken ?? null);
+  clientRef.setBaseUrl(restoredActiveServer.apiBase ?? null);
+  clientRef.setToken(restoredActiveServer.accessToken ?? null);
+}
+
+function activeServerToTarget(
+  kind: PersistedActiveServer["kind"],
+): "embedded-local" | "cloud-managed" | "remote-backend" {
+  switch (kind) {
+    case "local":
+      return "embedded-local";
+    case "cloud":
+      return "cloud-managed";
+    case "remote":
+      return "remote-backend";
+  }
 }
 
 /**
@@ -91,12 +102,11 @@ export async function runRestoringSession(
   const forceLocal = deps.forceLocalBootstrapRef.current;
   deps.forceLocalBootstrapRef.current = false;
   const persistedActiveServer = loadPersistedActiveServer();
-  const persisted = loadPersistedConnectionMode();
   const hadPrior = loadPersistedOnboardingComplete();
   if (cancelled.current) return;
 
   const desktopInstall =
-    !persisted && isElectrobunRuntime()
+    !persistedActiveServer && isElectrobunRuntime()
       ? await inspectExistingElizaInstall().catch(() => null)
       : null;
   if (cancelled.current) return;
@@ -106,7 +116,7 @@ export async function runRestoringSession(
 
   // Only probe the API when there is evidence of a prior install.
   const probed =
-    !persisted && hasExistingEvidence
+    !persistedActiveServer && hasExistingEvidence
       ? await detectExistingOnboardingConnection({
           client,
           timeoutMs: isDesktop
@@ -116,7 +126,11 @@ export async function runRestoringSession(
       : null;
   if (cancelled.current) return;
 
-  const restored = persisted ?? probed?.connection ?? null;
+  const restoredActiveServer =
+    persistedActiveServer ??
+    (probed
+      ? createPersistedActiveServer({ kind: probed.connection.runMode })
+      : null);
   const preserveCompleted =
     hadPrior && !deps.onboardingCompletionCommittedRef.current;
 
@@ -126,7 +140,7 @@ export async function runRestoringSession(
     ),
   );
 
-  if (!restored) {
+  if (!restoredActiveServer) {
     // No evidence of a prior connection — show onboarding.
     const { resolveStartupWithoutRestoredConnection } = await import(
       "./onboarding-bootstrap"
@@ -175,7 +189,7 @@ export async function runRestoringSession(
   }
 
   await applyRestoredConnection({
-    restoredConnection: restored,
+    restoredActiveServer,
     clientRef: client,
     startLocalRuntime: async () => {
       try {
@@ -189,13 +203,12 @@ export async function runRestoringSession(
 
   ctxRef.current = {
     persistedActiveServer,
-    persistedConnection: persisted,
-    restoredConnection: restored,
+    restoredActiveServer,
     shouldPreserveCompletedOnboarding: preserveCompleted,
     hadPriorOnboarding: hadPrior,
   };
   dispatch({
     type: "SESSION_RESTORED",
-    target: connectionModeToTarget(restored.runMode),
+    target: activeServerToTarget(restoredActiveServer.kind),
   });
 }

--- a/packages/app-core/src/state/startup-phase-restore.ts
+++ b/packages/app-core/src/state/startup-phase-restore.ts
@@ -26,9 +26,7 @@ import {
   loadPersistedOnboardingComplete,
   type PersistedActiveServer,
 } from "./persistence";
-import {
-  type StartupEvent,
-} from "./startup-coordinator";
+import { type StartupEvent } from "./startup-coordinator";
 import type { StartupCoordinatorDeps } from "./useStartupCoordinator";
 
 export interface RestoringSessionCtx {

--- a/packages/app-core/src/state/useOnboardingCallbacks.ts
+++ b/packages/app-core/src/state/useOnboardingCallbacks.ts
@@ -26,6 +26,9 @@ import {
 } from "../onboarding/flow";
 import { buildOnboardingRuntimeConfig } from "../onboarding-config";
 import {
+  resolveOnboardingServerTarget,
+} from "../onboarding/server-target";
+import {
   clearPersistedConnectionMode,
   clearPersistedOnboardingStep,
   createPersistedActiveServer,
@@ -363,10 +366,13 @@ export function useOnboardingCallbacks(deps: OnboardingCallbacksDeps) {
         },
       });
 
-      const isSandboxMode =
-        onboardingRunMode === "cloud" &&
-        onboardingCloudProvider === "elizacloud";
-      const isLocalMode = onboardingRunMode === "local" || !onboardingRunMode;
+      const serverTarget = resolveOnboardingServerTarget({
+        runMode: onboardingRunMode,
+        cloudProvider: onboardingCloudProvider,
+      });
+      const isSandboxMode = serverTarget === "elizacloud";
+      const isLocalMode = serverTarget === "local" || !serverTarget;
+      const isRemoteMode = serverTarget === "remote";
 
       if (isSandboxMode) {
         const cloudApiBase =
@@ -430,10 +436,7 @@ export function useOnboardingCallbacks(deps: OnboardingCallbacksDeps) {
         savePersistedActiveServer(
           createPersistedActiveServer({ kind: "local" }),
         );
-      } else if (
-        onboardingRunMode === "cloud" &&
-        onboardingCloudProvider === "remote"
-      ) {
+      } else if (isRemoteMode) {
         savePersistedActiveServer(
           createPersistedActiveServer({
             kind: "remote",
@@ -608,8 +611,10 @@ export function useOnboardingCallbacks(deps: OnboardingCallbacksDeps) {
       // Skip voice provider selection if they set up Eliza Cloud
       if (
         nextStep === "voice" &&
-        onboardingRunMode === "cloud" &&
-        onboardingCloudProvider === "elizacloud"
+        resolveOnboardingServerTarget({
+          runMode: onboardingRunMode,
+          cloudProvider: onboardingCloudProvider,
+        }) === "elizacloud"
       ) {
         nextStep = resolveOnboardingNextStep(nextStep);
       }
@@ -653,8 +658,10 @@ export function useOnboardingCallbacks(deps: OnboardingCallbacksDeps) {
     // Skip voice provider selection if they set up Eliza Cloud
     if (
       previousStep === "voice" &&
-      onboardingRunMode === "cloud" &&
-      onboardingCloudProvider === "elizacloud"
+      resolveOnboardingServerTarget({
+        runMode: onboardingRunMode,
+        cloudProvider: onboardingCloudProvider,
+      }) === "elizacloud"
     ) {
       previousStep = resolveOnboardingPreviousStep(previousStep);
     }

--- a/packages/app-core/src/state/useOnboardingCallbacks.ts
+++ b/packages/app-core/src/state/useOnboardingCallbacks.ts
@@ -28,10 +28,9 @@ import { buildOnboardingRuntimeConfig } from "../onboarding-config";
 import {
   clearPersistedConnectionMode,
   clearPersistedOnboardingStep,
-  connectionModeToActiveServer,
+  createPersistedActiveServer,
   type OnboardingNextOptions,
   savePersistedActiveServer,
-  savePersistedConnectionMode,
 } from "./internal";
 import type { OnboardingStateHook } from "./useOnboardingState";
 import type { AppState, OnboardingStep } from "./types";
@@ -393,11 +392,13 @@ export function useOnboardingCallbacks(deps: OnboardingCallbacksDeps) {
 
         client.setBaseUrl(cloudApiBase);
         client.setToken(authToken);
-        savePersistedConnectionMode({
-          runMode: "cloud",
-          cloudApiBase,
-          cloudAuthToken: authToken,
-        });
+        savePersistedActiveServer(
+          createPersistedActiveServer({
+            kind: "cloud",
+            apiBase: cloudApiBase,
+            accessToken: authToken,
+          }),
+        );
       } else if (isLocalMode) {
         try {
           await invokeDesktopBridgeRequest({
@@ -426,16 +427,20 @@ export function useOnboardingCallbacks(deps: OnboardingCallbacksDeps) {
           }
         }
 
-        savePersistedConnectionMode({ runMode: "local" });
+        savePersistedActiveServer(
+          createPersistedActiveServer({ kind: "local" }),
+        );
       } else if (
         onboardingRunMode === "cloud" &&
         onboardingCloudProvider === "remote"
       ) {
-        savePersistedConnectionMode({
-          runMode: "remote",
-          remoteApiBase: onboardingRemoteApiBase,
-          remoteAccessToken: onboardingRemoteToken || undefined,
-        });
+        savePersistedActiveServer(
+          createPersistedActiveServer({
+            kind: "remote",
+            apiBase: onboardingRemoteApiBase,
+            accessToken: onboardingRemoteToken || undefined,
+          }),
+        );
       }
 
       const sandboxMode = isSandboxMode ? "standard" : "off";
@@ -760,10 +765,10 @@ export function useOnboardingCallbacks(deps: OnboardingCallbacksDeps) {
       }
       await probe.getOnboardingStatus();
       savePersistedActiveServer(
-        connectionModeToActiveServer({
-          runMode: "remote",
-          remoteApiBase: normalizedBase,
-          ...(accessKey ? { remoteAccessToken: accessKey } : {}),
+        createPersistedActiveServer({
+          kind: "remote",
+          apiBase: normalizedBase,
+          ...(accessKey ? { accessToken: accessKey } : {}),
         }),
       );
       setOnboardingRunMode("cloud");
@@ -798,7 +803,6 @@ export function useOnboardingCallbacks(deps: OnboardingCallbacksDeps) {
     setOnboardingRemoteToken,
     setOnboardingRunMode,
     savePersistedActiveServer,
-    connectionModeToActiveServer,
   ]);
 
   // ── handleCloudOnboardingFinish ──────────────────────────────────

--- a/packages/app-core/src/state/useOnboardingCallbacks.ts
+++ b/packages/app-core/src/state/useOnboardingCallbacks.ts
@@ -25,9 +25,7 @@ import {
   resolveOnboardingPreviousStep,
 } from "../onboarding/flow";
 import { buildOnboardingRuntimeConfig } from "../onboarding-config";
-import {
-  resolveOnboardingServerTarget,
-} from "../onboarding/server-target";
+import { resolveOnboardingServerTarget } from "../onboarding/server-target";
 import {
   clearPersistedConnectionMode,
   clearPersistedOnboardingStep,

--- a/packages/app-core/src/state/useOnboardingState.ts
+++ b/packages/app-core/src/state/useOnboardingState.ts
@@ -9,6 +9,10 @@
 import { useCallback, useReducer, useRef } from "react";
 import type { OnboardingOptions } from "../api";
 import {
+  activeServerKindToOnboardingServerTarget,
+  buildOnboardingServerSelection,
+} from "../onboarding/server-target";
+import {
   loadPersistedActiveServer,
   loadPersistedOnboardingStep,
   saveOnboardingStep,
@@ -135,9 +139,12 @@ function loadInitialServerSelection(): Pick<
   }
 
   if (activeServer.kind === "local") {
+    const selection = buildOnboardingServerSelection(
+      activeServerKindToOnboardingServerTarget(activeServer.kind),
+    );
     return {
-      runMode: "local",
-      cloudProvider: "",
+      runMode: selection.runMode,
+      cloudProvider: selection.cloudProvider,
       remote: {
         status: "idle",
         error: null,
@@ -148,9 +155,12 @@ function loadInitialServerSelection(): Pick<
   }
 
   if (activeServer.kind === "cloud") {
+    const selection = buildOnboardingServerSelection(
+      activeServerKindToOnboardingServerTarget(activeServer.kind),
+    );
     return {
-      runMode: "cloud",
-      cloudProvider: "elizacloud",
+      runMode: selection.runMode,
+      cloudProvider: selection.cloudProvider,
       remote: {
         status: "idle",
         error: null,
@@ -161,9 +171,12 @@ function loadInitialServerSelection(): Pick<
   }
 
   const apiBase = activeServer.apiBase?.trim() ?? "";
+  const selection = buildOnboardingServerSelection(
+    activeServerKindToOnboardingServerTarget(activeServer.kind),
+  );
   return {
-    runMode: "cloud",
-    cloudProvider: "remote",
+    runMode: selection.runMode,
+    cloudProvider: selection.cloudProvider,
     remote: {
       status: isRemoteApiBase(apiBase) ? "connected" : "idle",
       error: null,

--- a/packages/app-core/src/state/useStartupCoordinator.ts
+++ b/packages/app-core/src/state/useStartupCoordinator.ts
@@ -33,7 +33,6 @@ import {
   type StartupErrorState,
 } from "./internal";
 import {
-  loadPersistedConnectionMode,
   loadPersistedOnboardingComplete,
 } from "./persistence";
 import { resolveApiUrl } from "../utils";

--- a/packages/app-core/src/state/useStartupCoordinator.ts
+++ b/packages/app-core/src/state/useStartupCoordinator.ts
@@ -32,9 +32,7 @@ import {
   type deriveOnboardingResumeConnection,
   type StartupErrorState,
 } from "./internal";
-import {
-  loadPersistedOnboardingComplete,
-} from "./persistence";
+import { loadPersistedOnboardingComplete } from "./persistence";
 import { resolveApiUrl } from "../utils";
 import { COMPANION_ENABLED, type Tab } from "../navigation";
 import {


### PR DESCRIPTION
## Summary
- persist the canonical active-server record directly from startup launch and onboarding completion paths
- make startup restore and polling consume active-server as the live model instead of reconstructing through connection-mode
- keep legacy connection-mode as mirrored compatibility storage only, with updated startup regression coverage

## Testing
- bunx vitest run packages/app-core/src/platform/browser-launch.test.ts packages/app-core/src/state/startup-phase-restore.test.ts packages/app-core/src/components/shell/StartupShell.test.tsx packages/app-core/src/state/useOnboardingState.test.ts packages/app-core/src/api/client.api-base.test.ts packages/app-core/test/avatar/asset-url-resolve-api-session.test.ts packages/app-core/test/app/connection-mode-persistence.test.ts packages/app-core/test/app/startup-onboarding-recovery.test.tsx packages/app-core/test/app/startup-conversation-restore.test.tsx packages/app-core/test/app/startup-backend-missing.e2e.test.ts
- bun run lint
- bun run typecheck
- bun run test:startup:e2e
- MILADY_PRE_REVIEW_BASE=origin/develop bun run pre-review:local