### PR TITLE
milady: fix Windows packaged port probe hang

### DIFF
--- a/apps/app/electrobun/src/__tests__/loopback-port.test.ts
+++ b/apps/app/electrobun/src/__tests__/loopback-port.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createServerMock, serverQueue } = vi.hoisted(() => ({
+  createServerMock: vi.fn(),
+  serverQueue: [] as Array<ReturnType<typeof createMockServer>>,
+}));
+
+vi.mock("node:net", () => ({
+  createServer: createServerMock,
+}));
+
+function createMockServer(opts?: {
+  errorOnListen?: boolean;
+  skipCloseCallback?: boolean;
+}) {
+  let errorHandler: (() => void) | null = null;
+
+  const server = {
+    removeAllListeners: vi.fn(),
+    unref: vi.fn(),
+    once: vi.fn((event: string, handler: () => void) => {
+      if (event === "error") {
+        errorHandler = handler;
+      }
+      return server;
+    }),
+    listen: vi.fn((_options: unknown, onListen: () => void) => {
+      setTimeout(() => {
+        if (opts?.errorOnListen) {
+          errorHandler?.();
+          return;
+        }
+        onListen();
+      }, 0);
+      return server;
+    }),
+    close: vi.fn((onClose?: () => void) => {
+      if (!opts?.skipCloseCallback && onClose) {
+        setTimeout(() => onClose(), 0);
+      }
+      return server;
+    }),
+  };
+
+  return server;
+}
+
+import { findFirstAvailableLoopbackPort } from "../native/loopback-port";
+
+describe("findFirstAvailableLoopbackPort", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    serverQueue.length = 0;
+    createServerMock.mockReset();
+    createServerMock.mockImplementation(() => {
+      const next = serverQueue.shift();
+      if (!next) {
+        throw new Error("No queued mock server");
+      }
+      return next;
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns the preferred port when bind and close succeed", async () => {
+    serverQueue.push(createMockServer());
+
+    const portPromise = findFirstAvailableLoopbackPort(31337);
+    await vi.runAllTimersAsync();
+
+    await expect(portPromise).resolves.toBe(31337);
+  });
+
+  it("falls forward when the preferred port errors", async () => {
+    serverQueue.push(createMockServer({ errorOnListen: true }));
+    serverQueue.push(createMockServer());
+
+    const portPromise = findFirstAvailableLoopbackPort(31337);
+    await vi.runAllTimersAsync();
+
+    await expect(portPromise).resolves.toBe(31338);
+  });
+
+  it("does not hang when the close callback never fires after a successful bind", async () => {
+    const hangingCloseServer = createMockServer({ skipCloseCallback: true });
+    serverQueue.push(hangingCloseServer);
+
+    let resolvedPort: number | null = null;
+    const portPromise = findFirstAvailableLoopbackPort(31337).then((port) => {
+      resolvedPort = port;
+      return port;
+    });
+
+    await vi.advanceTimersByTimeAsync(249);
+    expect(resolvedPort).toBeNull();
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    await expect(portPromise).resolves.toBe(31337);
+    expect(hangingCloseServer.unref).toHaveBeenCalledTimes(1);
+    expect(hangingCloseServer.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/app/electrobun/src/native/loopback-port.ts
+++ b/apps/app/electrobun/src/native/loopback-port.ts
@@ -1,30 +1,55 @@
 import { createServer } from "node:net";
 
+const LISTEN_TIMEOUT_MS = 3000;
+const CLOSE_GRACE_MS = 250;
+
 function tryBindOnce(
   port: number,
   host: string,
 ): Promise<{ ok: true } | { ok: false }> {
   return new Promise((resolve) => {
     const server = createServer();
-    // Timeout prevents hanging on Windows when firewall silently blocks
-    const timer = setTimeout(() => {
+    let settled = false;
+
+    const finish = (result: { ok: true } | { ok: false }) => {
+      if (settled) return;
+      settled = true;
       server.removeAllListeners();
+      resolve(result);
+    };
+
+    const listenTimer = setTimeout(() => {
       try {
         server.close();
       } catch {
         /* already closed */
       }
-      resolve({ ok: false });
-    }, 3000);
+      finish({ ok: false });
+    }, LISTEN_TIMEOUT_MS);
+
     const fail = () => {
-      clearTimeout(timer);
-      server.removeAllListeners();
-      resolve({ ok: false });
+      clearTimeout(listenTimer);
+      finish({ ok: false });
     };
+
     server.once("error", fail);
     server.listen({ port, host }, () => {
-      clearTimeout(timer);
-      server.close(() => resolve({ ok: true }));
+      clearTimeout(listenTimer);
+      server.unref?.();
+
+      // Bun on packaged Windows can occasionally never invoke the close
+      // callback even though the listen succeeded. Without this grace timer
+      // startup stalls before `port_selected`.
+      const closeTimer = setTimeout(() => finish({ ok: true }), CLOSE_GRACE_MS);
+      try {
+        server.close(() => {
+          clearTimeout(closeTimer);
+          finish({ ok: true });
+        });
+      } catch {
+        clearTimeout(closeTimer);
+        finish({ ok: true });
+      }
     });
   });
 }


### PR DESCRIPTION
## Summary\n- fix the desktop loopback port probe so packaged Windows startup cannot hang waiting for a close callback that never arrives\n- add a focused unit test covering the Windows-style successful-bind / missing-close-callback path\n\n## Validation\n- bunx vitest run apps/app/electrobun/src/__tests__/loopback-port.test.ts apps/app/electrobun/src/__tests__/agent.test.ts\n- bunx vitest run apps/app/electrobun/src/__tests__/smoke-test-script.test.ts apps/app/electrobun/src/__tests__/startup-bootstrap.test.ts\n- bun run lint\n- bun run typecheck\n- MILADY_PRE_REVIEW_BASE=origin/develop bun run pre-review:local