### PR TITLE
milady: remove onboarding compat layer

### DIFF
--- a/apps/app/electrobun/src/__tests__/runtime-layout.test.ts
+++ b/apps/app/electrobun/src/__tests__/runtime-layout.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolvePreloadBaseDir,
+  resolveRendererAssetDir,
+} from "../runtime-layout";
+
+describe("runtime-layout", () => {
+  it("resolves renderer assets from the source tree during local development", () => {
+    const moduleDir = "/repo/apps/app/electrobun/src";
+    const rendererDir = resolveRendererAssetDir(
+      moduleDir,
+      "/repo/apps/app/electrobun/build/bun",
+      "darwin",
+      {
+        existsSync: (filePath) =>
+          filePath === "/repo/apps/app/electrobun/renderer",
+      },
+    );
+
+    expect(rendererDir).toBe("/repo/apps/app/electrobun/renderer");
+  });
+
+  it("prefers packaged Windows renderer assets under resources/app", () => {
+    const execPath = "C:\\mi\\bin\\launcher.exe";
+    const rendererDir = resolveRendererAssetDir(
+      "C:\\mi\\Resources\\app\\bun",
+      execPath,
+      "win32",
+      {
+        existsSync: (filePath) =>
+          filePath === "C:\\mi\\resources\\app\\renderer" ||
+          filePath === "C:\\mi\\Resources\\app\\renderer",
+      },
+    );
+
+    expect(rendererDir.toLowerCase()).toBe("c:\\mi\\resources\\app\\renderer");
+  });
+
+  it("resolves the packaged Windows preload from resources/app/bun", () => {
+    const calls: string[] = [];
+    const preloadBaseDir = resolvePreloadBaseDir(
+      "C:\\mi\\Resources",
+      "C:\\mi\\bin\\launcher.exe",
+      "win32",
+      {
+        existsSync: (filePath) => {
+          calls.push(filePath);
+          return (
+            filePath === "C:\\mi\\resources\\app\\bun\\preload.js" ||
+            filePath === "C:\\mi\\Resources\\app\\bun\\preload.js"
+          );
+        },
+      },
+    );
+
+    expect(preloadBaseDir.toLowerCase()).toBe("c:\\mi\\resources\\app\\bun");
+    expect(
+      calls.some((filePath) =>
+        filePath.toLowerCase().includes("resources\\app\\bun\\preload.js"),
+      ),
+    ).toBe(true);
+  });
+});

--- a/apps/app/electrobun/src/__tests__/startup-bootstrap.test.ts
+++ b/apps/app/electrobun/src/__tests__/startup-bootstrap.test.ts
@@ -40,7 +40,7 @@ describe("Electrobun startup bootstrap", () => {
   it("validates the built preload before creating the BrowserWindow", () => {
     const source = fs.readFileSync(INDEX_PATH, "utf8");
     const validateIndex = source.indexOf(
-      "preload = readBuiltPreloadScript(import.meta.dir);",
+      "preload = readResolvedPreloadScript(import.meta.dir);",
     );
     const browserWindowIndex = source.indexOf("const win = new BrowserWindow(");
 
@@ -69,6 +69,13 @@ describe("Electrobun startup bootstrap", () => {
 
     expect(source).toContain("resolveDesktopRuntimeMode");
     expect(source).toContain("resolveInitialApiBase");
+  });
+
+  it("resolves packaged renderer and preload assets from the app resource root", () => {
+    const source = fs.readFileSync(INDEX_PATH, "utf8");
+
+    expect(source).toContain("resolveRendererAssetDir(import.meta.dir)");
+    expect(source).toContain("readResolvedPreloadScript(import.meta.dir)");
   });
 
   it("guards embedded agent startup behind local runtime mode", () => {

--- a/apps/app/electrobun/src/index.ts
+++ b/apps/app/electrobun/src/index.ts
@@ -51,9 +51,12 @@ import {
 } from "./native/mac-window-effects";
 import { getPermissionManager } from "./native/permissions";
 import { checkWebGpuSupport } from "./native/webgpu-browser-support";
-import { readBuiltPreloadScript } from "./preload-validation";
 import { resolveRendererAsset } from "./renderer-static";
 import { registerRpcHandlers } from "./rpc-handlers";
+import {
+  readResolvedPreloadScript,
+  resolveRendererAssetDir,
+} from "./runtime-layout";
 import { startScreenshotDevServer } from "./screenshot-dev-server";
 import { recordStartupPhase, resolveStartupBundlePath } from "./startup-trace";
 import {
@@ -575,7 +578,7 @@ function sendToActiveRenderer(message: string, payload?: unknown): void {
  * Returns the base URL e.g. "http://localhost:5174".
  */
 async function startRendererServer(): Promise<string> {
-  const rendererDir = path.resolve(import.meta.dir, "../renderer");
+  const rendererDir = resolveRendererAssetDir(import.meta.dir);
   if (!fs.existsSync(rendererDir)) {
     console.warn("[Renderer] renderer dir not found:", rendererDir);
     return "";
@@ -699,7 +702,7 @@ async function resolveRendererUrl(): Promise<string> {
 
   if (!rendererUrl) {
     // Last resort: file:// (may have CORS issues with crossorigin module scripts)
-    rendererUrl = `file://${path.resolve(import.meta.dir, "../renderer/index.html")}`;
+    rendererUrl = `file://${path.join(resolveRendererAssetDir(import.meta.dir), "index.html")}`;
     console.warn(
       "[Main] Falling back to file:// renderer URL — CORS issues possible",
     );
@@ -720,7 +723,7 @@ async function createMainWindow(): Promise<BrowserWindow> {
   // setting up Milady's direct Electrobun RPC bridge on the window.
   let preload: string;
   try {
-    preload = readBuiltPreloadScript(import.meta.dir);
+    preload = readResolvedPreloadScript(import.meta.dir);
   } catch (err) {
     console.error("[Main] Failed to read preload script:", err);
     preload = "// preload unavailable";
@@ -1596,7 +1599,7 @@ async function main(): Promise<void> {
     createWindow: (options) =>
       new BrowserWindow(options) as unknown as ManagedWindowLike,
     resolveRendererUrl,
-    readPreload: () => readBuiltPreloadScript(import.meta.dir),
+    readPreload: () => readResolvedPreloadScript(import.meta.dir),
     wireRpc: (window) => wireSettingsRpc(window as unknown as BrowserWindow),
     injectApiBase: (window) =>
       injectApiBase(window as unknown as BrowserWindow),

--- a/apps/app/electrobun/src/runtime-layout.ts
+++ b/apps/app/electrobun/src/runtime-layout.ts
@@ -1,0 +1,150 @@
+import fs from "node:fs";
+import path from "node:path";
+import { readBuiltPreloadScript } from "./preload-validation";
+
+type ExistsSyncLike = Pick<typeof fs, "existsSync">;
+
+function usesWindowsPathSyntax(value: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(value) || value.includes("\\");
+}
+
+function joinPortable(base: string, ...parts: string[]): string {
+  return usesWindowsPathSyntax(base)
+    ? path.win32.join(base, ...parts)
+    : path.posix.join(base, ...parts);
+}
+
+function resolveRelativePortable(base: string, relativePath: string): string {
+  return usesWindowsPathSyntax(base)
+    ? path.win32.resolve(base, relativePath)
+    : path.posix.resolve(base, relativePath);
+}
+
+function dirnamePortable(value: string): string {
+  return usesWindowsPathSyntax(value)
+    ? path.win32.dirname(value)
+    : path.posix.dirname(value);
+}
+
+function isMacAppBundle(
+  bundlePath: string,
+  platform: NodeJS.Platform,
+): boolean {
+  return (
+    platform === "darwin" && bundlePath.replaceAll("\\", "/").endsWith(".app")
+  );
+}
+
+function resolvePackagedBundlePath(
+  execPath: string,
+  platform: NodeJS.Platform,
+): string | null {
+  const normalizedExecPath = execPath.replaceAll("\\", "/");
+  const appBundleMatch = normalizedExecPath.match(/^(.*?\.app)(?:\/|$)/);
+  if (appBundleMatch) {
+    return usesWindowsPathSyntax(execPath)
+      ? appBundleMatch[1].replaceAll("/", "\\")
+      : appBundleMatch[1];
+  }
+
+  if (platform !== "win32" && !normalizedExecPath.includes("/bin/")) {
+    return null;
+  }
+
+  const binSegment = normalizedExecPath.lastIndexOf("/bin/");
+  if (binSegment < 0) {
+    return null;
+  }
+
+  const bundlePath = normalizedExecPath.slice(0, binSegment);
+  if (!bundlePath) {
+    return null;
+  }
+
+  return usesWindowsPathSyntax(execPath)
+    ? bundlePath.replaceAll("/", "\\")
+    : bundlePath;
+}
+
+function getPackagedAppRootCandidates(
+  execPath: string,
+  platform: NodeJS.Platform,
+): string[] {
+  const bundlePath = resolvePackagedBundlePath(execPath, platform);
+  if (!bundlePath) {
+    return [];
+  }
+
+  if (isMacAppBundle(bundlePath, platform)) {
+    return [joinPortable(bundlePath, "Contents", "Resources", "app")];
+  }
+
+  return [
+    joinPortable(bundlePath, "resources", "app"),
+    joinPortable(bundlePath, "Resources", "app"),
+  ];
+}
+
+function chooseFirstExisting(
+  candidates: string[],
+  existsSync: ExistsSyncLike["existsSync"],
+): string | null {
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return candidates[0] ?? null;
+}
+
+export function resolveRendererAssetDir(
+  moduleDir: string,
+  execPath: string = process.execPath,
+  platform: NodeJS.Platform = process.platform,
+  fileSystem: ExistsSyncLike = fs,
+): string {
+  const candidates = [
+    ...getPackagedAppRootCandidates(execPath, platform).map((root) =>
+      joinPortable(root, "renderer"),
+    ),
+    resolveRelativePortable(moduleDir, "../renderer"),
+  ];
+
+  return (
+    chooseFirstExisting(candidates, fileSystem.existsSync) ??
+    candidates[candidates.length - 1] ??
+    "renderer"
+  );
+}
+
+export function readResolvedPreloadScript(
+  moduleDir: string,
+  execPath: string = process.execPath,
+  platform: NodeJS.Platform = process.platform,
+  fileSystem: ExistsSyncLike = fs,
+): string {
+  return readBuiltPreloadScript(
+    resolvePreloadBaseDir(moduleDir, execPath, platform, fileSystem),
+  );
+}
+
+export function resolvePreloadBaseDir(
+  moduleDir: string,
+  execPath: string = process.execPath,
+  platform: NodeJS.Platform = process.platform,
+  fileSystem: ExistsSyncLike = fs,
+): string {
+  const candidates = [
+    ...getPackagedAppRootCandidates(execPath, platform).map((root) =>
+      joinPortable(root, "bun"),
+    ),
+    moduleDir,
+  ];
+  const preloadPath = chooseFirstExisting(
+    candidates.map((candidate) => joinPortable(candidate, "preload.js")),
+    fileSystem.existsSync,
+  );
+  return preloadPath
+    ? dirnamePortable(preloadPath)
+    : (candidates[candidates.length - 1] ?? moduleDir);
+}

--- a/packages/agent/src/api/provider-switch-config.ts
+++ b/packages/agent/src/api/provider-switch-config.ts
@@ -9,14 +9,12 @@ import {
   getOnboardingProviderOption,
   getOnboardingProviderSignalEnvKeys,
   getStoredOnboardingProviderId,
-  isCloudManagedConnection,
-  isLocalProviderConnection,
-  isRemoteProviderConnection,
   migrateLegacyRuntimeConfig,
   normalizeOnboardingProviderId,
   normalizeOnboardingCredentialInputs,
   type OnboardingCredentialInputs,
   type OnboardingConnection,
+  type OnboardingLlmPersistenceSelection,
   type OnboardingLocalProviderId,
 } from "../contracts/onboarding";
 import type {
@@ -328,9 +326,13 @@ function persistLinkedCloudApiKey(
 
 function applyLocalProviderCapabilities(
   config: MutableElizaConfig,
-  connection: Extract<OnboardingConnection, { kind: "local-provider" }>,
+  selection: {
+    backend: OnboardingLocalProviderId;
+    apiKey?: string;
+    primaryModel?: string;
+  },
 ): Promise<void> {
-  const normalizedProvider = normalizeOnboardingProviderId(connection.provider);
+  const normalizedProvider = normalizeOnboardingProviderId(selection.backend);
   if (!normalizedProvider || normalizedProvider === "elizacloud") {
     return Promise.resolve();
   }
@@ -353,7 +355,7 @@ function applyLocalProviderCapabilities(
 
     const setupToken =
       storedProviderId === "anthropic-subscription"
-        ? trimToUndefined(connection.apiKey)
+        ? trimToUndefined(selection.apiKey)
         : undefined;
 
     if (setupToken?.startsWith("sk-ant-")) {
@@ -370,7 +372,7 @@ function applyLocalProviderCapabilities(
 
   const providerOption = getOnboardingProviderOption(normalizedProvider);
   if (providerOption?.envKey) {
-    const apiKey = trimToUndefined(connection.apiKey);
+    const apiKey = trimToUndefined(selection.apiKey);
     if (apiKey) {
       setEnvValue(config, providerOption.envKey, apiKey);
     }
@@ -378,7 +380,7 @@ function applyLocalProviderCapabilities(
     for (const envKey of getOnboardingProviderSignalEnvKeys(
       normalizedProvider,
     )) {
-      const value = trimToUndefined(connection.apiKey);
+      const value = trimToUndefined(selection.apiKey);
       if (value) {
         setEnvValue(config, envKey, value);
       }
@@ -389,7 +391,7 @@ function applyLocalProviderCapabilities(
   // If the user didn't pick a specific model, resolve from the provider's
   // plugin name so the correct provider wins the TEXT_SMALL/TEXT_LARGE
   // handler registration.
-  const explicitPrimary = trimToUndefined(connection.primaryModel);
+  const explicitPrimary = trimToUndefined(selection.primaryModel);
   const resolvedPrimary =
     explicitPrimary ?? providerOption?.pluginName ?? undefined;
   setPrimaryModel(config, resolvedPrimary);

--- a/packages/agent/src/api/provider-switch-config.ts
+++ b/packages/agent/src/api/provider-switch-config.ts
@@ -443,6 +443,64 @@ function applyDefaultModelNames(
   }
 }
 
+function toOnboardingConnectionFromSelection(
+  selection: OnboardingLlmPersistenceSelection,
+): OnboardingConnection | null {
+  if (selection.transport === "cloud-proxy") {
+    return {
+      kind: "cloud-managed",
+      cloudProvider: "elizacloud",
+      ...(trimToUndefined(selection.apiKey)
+        ? { apiKey: trimToUndefined(selection.apiKey) }
+        : {}),
+      ...(trimToUndefined(selection.smallModel)
+        ? { smallModel: trimToUndefined(selection.smallModel) }
+        : {}),
+      ...(trimToUndefined(selection.largeModel)
+        ? { largeModel: trimToUndefined(selection.largeModel) }
+        : {}),
+    };
+  }
+
+  const normalizedProvider = normalizeOnboardingProviderId(selection.backend);
+  if (!normalizedProvider || normalizedProvider === "elizacloud") {
+    return null;
+  }
+
+  if (selection.transport === "remote") {
+    const remoteApiBase = trimToUndefined(selection.remoteApiBase);
+    if (!remoteApiBase) {
+      return null;
+    }
+
+    return {
+      kind: "remote-provider",
+      remoteApiBase,
+      provider: normalizedProvider,
+      ...(trimToUndefined(selection.remoteAccessToken)
+        ? { remoteAccessToken: trimToUndefined(selection.remoteAccessToken) }
+        : {}),
+      ...(trimToUndefined(selection.apiKey)
+        ? { apiKey: trimToUndefined(selection.apiKey) }
+        : {}),
+      ...(trimToUndefined(selection.primaryModel)
+        ? { primaryModel: trimToUndefined(selection.primaryModel) }
+        : {}),
+    };
+  }
+
+  return {
+    kind: "local-provider",
+    provider: normalizedProvider as OnboardingLocalProviderId,
+    ...(trimToUndefined(selection.apiKey)
+      ? { apiKey: trimToUndefined(selection.apiKey) }
+      : {}),
+    ...(trimToUndefined(selection.primaryModel)
+      ? { primaryModel: trimToUndefined(selection.primaryModel) }
+      : {}),
+  };
+}
+
 /**
  * Apply subscription provider configuration to the config object.
  *
@@ -689,7 +747,15 @@ export async function applyOnboardingConnectionConfig(
     return;
   }
 
-  await applyLocalProviderCapabilities(config, normalizedConnection);
+  await applyLocalProviderCapabilities(config, {
+    backend: normalizedConnection.provider,
+    ...(normalizedConnection.apiKey
+      ? { apiKey: normalizedConnection.apiKey }
+      : {}),
+    ...(normalizedConnection.primaryModel
+      ? { primaryModel: normalizedConnection.primaryModel }
+      : {}),
+  });
   const linkedAccounts: LinkedAccountsConfig | undefined =
     normalizedConnection.provider === "anthropic-subscription" ||
     normalizedConnection.provider === "openai-subscription"
@@ -737,8 +803,11 @@ export async function applyOnboardingCredentialPersistence(
     serviceRouting: args.serviceRouting,
   });
 
-  if (plan.llmConnection) {
-    await applyOnboardingConnectionConfig(config, plan.llmConnection);
+  if (plan.llmSelection) {
+    const llmConnection = toOnboardingConnectionFromSelection(plan.llmSelection);
+    if (llmConnection) {
+      await applyOnboardingConnectionConfig(config, llmConnection);
+    }
   }
 
   if (plan.cloudApiKey) {
@@ -747,9 +816,14 @@ export async function applyOnboardingCredentialPersistence(
 
   migrateLegacyRuntimeConfig(config as Record<string, unknown>);
 
-  if (!isLocalProviderConnection(plan.llmConnection)) {
+  if (plan.llmSelection?.transport !== "direct") {
     return null;
   }
 
-  return getOnboardingProviderOption(plan.llmConnection.provider)?.envKey ?? null;
+  const provider = normalizeOnboardingProviderId(plan.llmSelection.backend);
+  if (!provider || provider === "elizacloud") {
+    return null;
+  }
+
+  return getOnboardingProviderOption(provider)?.envKey ?? null;
 }

--- a/packages/app-core/src/api/server-onboarding-compat.ts
+++ b/packages/app-core/src/api/server-onboarding-compat.ts
@@ -127,56 +127,71 @@ export async function extractAndPersistOnboardingApiKey(
     deploymentTarget: explicitDeploymentTarget,
     serviceRouting: explicitServiceRouting,
   });
-  let llmConnection = initialPlan.llmConnection;
-  if (!llmConnection && !initialPlan.cloudApiKey) {
+  let effectiveCredentialInputs = credentialInputs;
+  let effectiveServiceRouting = explicitServiceRouting;
+  let llmSelection = initialPlan.llmSelection;
+
+  if (!llmSelection && !initialPlan.cloudApiKey) {
     logger.warn(
       "[onboarding] No onboarding credentials resolved from request body",
     );
     return null;
   }
   logger.info(
-    `[onboarding] Resolved connection: kind=${llmConnection?.kind ?? "none"}, provider=${llmConnection && "provider" in llmConnection ? llmConnection.provider : "N/A"}, hasKey=${Boolean(llmConnection && "apiKey" in llmConnection && llmConnection.apiKey)}, hasCloudKey=${Boolean(initialPlan.cloudApiKey)}`,
+    `[onboarding] Resolved selection: transport=${llmSelection?.transport ?? "none"}, provider=${llmSelection?.backend ?? "N/A"}, hasKey=${Boolean(llmSelection?.apiKey)}, hasCloudKey=${Boolean(initialPlan.cloudApiKey)}`,
   );
 
   // If the key is masked (from IPC) or missing, try to resolve the real
   // key from local credential stores (files, keychain, env).
   if (
-    llmConnection?.kind === "local-provider" &&
-    (!llmConnection.apiKey || llmConnection.apiKey.startsWith("****"))
+    llmSelection?.transport === "direct" &&
+    llmSelection.backend !== "elizacloud" &&
+    (!llmSelection.apiKey || llmSelection.apiKey.startsWith("****"))
   ) {
-    const resolved = resolveProviderCredential(llmConnection.provider);
+    const resolved = resolveProviderCredential(llmSelection.backend);
     if (resolved && resolved.authType === "subscription") {
-      // OAuth tokens (e.g. Claude Code) go through the subscription auth
-      // flow — they can't be used as direct API keys. Rewrite the
-      // connection to use the subscription path.
-      (llmConnection as unknown as Record<string, unknown>).kind =
-        "local-provider";
-      (llmConnection as unknown as Record<string, unknown>).provider =
-        "anthropic-subscription";
-      (llmConnection as unknown as Record<string, unknown>).apiKey =
-        resolved.apiKey;
+      effectiveCredentialInputs = {
+        ...(effectiveCredentialInputs ?? {}),
+        llmApiKey: resolved.apiKey,
+      };
+      effectiveServiceRouting = normalizeServiceRoutingConfig({
+        ...(effectiveServiceRouting ?? {}),
+        llmText: {
+          ...(effectiveServiceRouting?.llmText ?? {}),
+          backend: resolved.providerId,
+          transport: "direct",
+        },
+      });
       logger.info(
         `[onboarding] Using subscription auth for ${resolved.providerId}`,
       );
     } else if (resolved) {
-      (llmConnection as unknown as Record<string, unknown>).apiKey =
-        resolved.apiKey;
+      effectiveCredentialInputs = {
+        ...(effectiveCredentialInputs ?? {}),
+        llmApiKey: resolved.apiKey,
+      };
       logger.info(
-        `[onboarding] Resolved real key for ${llmConnection.provider} via credential-resolver`,
+        `[onboarding] Resolved real key for ${llmSelection.backend} via credential-resolver`,
       );
-    } else if (!llmConnection.apiKey) {
+    } else if (!llmSelection.apiKey) {
       logger.warn(
-        `[onboarding] No key found for ${llmConnection.provider} — cannot persist`,
+        `[onboarding] No key found for ${llmSelection.backend} — cannot persist`,
       );
       return null;
     }
+
+    llmSelection = deriveOnboardingCredentialPersistencePlan({
+      credentialInputs: effectiveCredentialInputs,
+      deploymentTarget: explicitDeploymentTarget,
+      serviceRouting: effectiveServiceRouting,
+    }).llmSelection;
   }
 
   const config = loadElizaConfig();
   const result = await applyOnboardingCredentialPersistence(config, {
-    credentialInputs,
+    credentialInputs: effectiveCredentialInputs,
     deploymentTarget: explicitDeploymentTarget,
-    serviceRouting: explicitServiceRouting,
+    serviceRouting: effectiveServiceRouting,
   });
   saveElizaConfig(config);
 

--- a/packages/shared/src/contracts/onboarding.ts
+++ b/packages/shared/src/contracts/onboarding.ts
@@ -464,6 +464,17 @@ export interface OnboardingCredentialInputs {
   cloudApiKey?: string;
 }
 
+export interface OnboardingLlmPersistenceSelection {
+  backend: OnboardingProviderId;
+  transport: "direct" | "remote" | "cloud-proxy";
+  apiKey?: string;
+  primaryModel?: string;
+  smallModel?: string;
+  largeModel?: string;
+  remoteApiBase?: string;
+  remoteAccessToken?: string;
+}
+
 export interface OnboardingData {
   name: string;
   avatarIndex?: number;
@@ -1260,7 +1271,7 @@ export function normalizeOnboardingCredentialInputs(
 }
 
 export interface OnboardingCredentialPersistencePlan {
-  llmConnection: OnboardingConnection | null;
+  llmSelection: OnboardingLlmPersistenceSelection | null;
   cloudApiKey?: string;
 }
 
@@ -1287,9 +1298,9 @@ export function deriveOnboardingCredentialPersistencePlan(args: {
     cloudApiKey
   ) {
     return {
-      llmConnection: {
-        kind: "cloud-managed",
-        cloudProvider: "elizacloud",
+      llmSelection: {
+        backend: "elizacloud",
+        transport: "cloud-proxy",
         apiKey: cloudApiKey,
         ...(llmRoute.smallModel ? { smallModel: llmRoute.smallModel } : {}),
         ...(llmRoute.largeModel ? { largeModel: llmRoute.largeModel } : {}),
@@ -1302,9 +1313,9 @@ export function deriveOnboardingCredentialPersistencePlan(args: {
     const provider = normalizeOnboardingProviderId(llmRoute.backend);
     if (provider && provider !== "elizacloud") {
       return {
-        llmConnection: {
-          kind: "local-provider",
-          provider,
+        llmSelection: {
+          backend: provider,
+          transport: "direct",
           apiKey: llmApiKey,
           ...(llmRoute.primaryModel
             ? { primaryModel: llmRoute.primaryModel }
@@ -1321,13 +1332,13 @@ export function deriveOnboardingCredentialPersistencePlan(args: {
       llmRoute.remoteApiBase ?? deploymentTarget?.remoteApiBase;
     if (provider && provider !== "elizacloud" && remoteApiBase) {
       return {
-        llmConnection: {
-          kind: "remote-provider",
+        llmSelection: {
+          backend: provider,
+          transport: "remote",
           remoteApiBase,
           ...(deploymentTarget?.remoteAccessToken
             ? { remoteAccessToken: deploymentTarget.remoteAccessToken }
             : {}),
-          provider,
           apiKey: llmApiKey,
           ...(llmRoute.primaryModel
             ? { primaryModel: llmRoute.primaryModel }
@@ -1339,7 +1350,7 @@ export function deriveOnboardingCredentialPersistencePlan(args: {
   }
 
   return {
-    llmConnection: null,
+    llmSelection: null,
     ...(cloudApiKey ? { cloudApiKey } : {}),
   };
 }


### PR DESCRIPTION
## Summary
- stop treating `connection` as the active onboarding credential source and persist canonical selections end-to-end
- fix packaged Electrobun Windows runtime path resolution so the renderer/preload bootstrap uses the packaged app layout
- add regression coverage for canonical onboarding persistence and packaged Windows layout resolution

## Validation
- `bun run typecheck`
- `bun run lint`
- `bunx vitest run packages/app-core/src/api/__tests__/onboarding-api-key-persistence.test.ts packages/app-core/src/api/__tests__/cloud-api-key-persistence.test.ts packages/app-core/src/api/server.onboarding-compat-replay.test.ts packages/agent/src/api/provider-switch-config.test.ts`
- `bunx vitest run apps/app/electrobun/src/__tests__/runtime-layout.test.ts apps/app/electrobun/src/__tests__/startup-bootstrap.test.ts apps/app/test/electrobun-packaged/windows-test-env.spec.ts`
- `MILADY_PRE_REVIEW_BASE=origin/develop bun run pre-review:local`