### PR TITLE
milady: isolate packaged windows bootstrap env

### DIFF
--- a/.github/workflows/release-electrobun.yml
+++ b/.github/workflows/release-electrobun.yml
@@ -703,6 +703,12 @@ jobs:
 
       - name: Run Windows packaged renderer bootstrap check
         if: matrix.platform.os == 'windows'
+        env:
+          # Keep the packaged renderer bootstrap probe isolated from stale
+          # Windows smoke env while still matching the earlier packaged launch
+          # safety net for the full process tree.
+          MILADY_DISABLE_LOCAL_EMBEDDINGS: "1"
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: bun run test:desktop:playwright
 
       - name: Upload Windows Playwright UI diagnostics

--- a/apps/app/test/electrobun-packaged/windows-test-env.spec.ts
+++ b/apps/app/test/electrobun-packaged/windows-test-env.spec.ts
@@ -3,12 +3,20 @@ import { describe, expect, it } from "vitest";
 import { createPackagedWindowsAppEnv } from "./windows-test-env";
 
 describe("createPackagedWindowsAppEnv", () => {
-  it("overrides both Windows profile roots for packaged bootstrap tests", () => {
+  it("isolates packaged bootstrap tests from stale desktop env overrides", () => {
     const env = createPackagedWindowsAppEnv({
       baseEnv: {
         APPDATA: "C:\\Users\\runner\\AppData\\Roaming",
+        ELIZA_API_PORT: "31337",
         LOCALAPPDATA: "C:\\Users\\runner\\AppData\\Local",
         KEEP_ME: "1",
+        MILADY_API_BASE: "http://127.0.0.1:31337",
+        MILADY_DESKTOP_API_BASE: "http://127.0.0.1:31337",
+        MILADY_RENDERER_URL: "http://127.0.0.1:5173",
+        MILADY_STARTUP_SESSION_ID: "stale-session",
+        MILADY_TEST_WINDOWS_APPDATA_PATH: "C:\\stale\\roaming",
+        MILADY_TEST_WINDOWS_LAUNCHER_PATH: "C:\\mi\\bin\\launcher.exe",
+        VITE_DEV_SERVER_URL: "http://127.0.0.1:5174",
       },
       apiBase: "http://127.0.0.1:43123",
       appData: "C:\\tmp\\milady-roaming",
@@ -16,8 +24,18 @@ describe("createPackagedWindowsAppEnv", () => {
     });
 
     expect(env.MILADY_DESKTOP_TEST_API_BASE).toBe("http://127.0.0.1:43123");
+    expect(env.MILADY_DISABLE_LOCAL_EMBEDDINGS).toBe("1");
+    expect(env.ELECTROBUN_CONSOLE).toBe("1");
     expect(env.APPDATA).toBe("C:\\tmp\\milady-roaming");
     expect(env.LOCALAPPDATA).toBe("C:\\tmp\\milady-local");
     expect(env.KEEP_ME).toBe("1");
+    expect(env.ELIZA_API_PORT).toBeUndefined();
+    expect(env.MILADY_API_BASE).toBeUndefined();
+    expect(env.MILADY_DESKTOP_API_BASE).toBeUndefined();
+    expect(env.MILADY_RENDERER_URL).toBeUndefined();
+    expect(env.MILADY_STARTUP_SESSION_ID).toBeUndefined();
+    expect(env.MILADY_TEST_WINDOWS_APPDATA_PATH).toBeUndefined();
+    expect(env.MILADY_TEST_WINDOWS_LAUNCHER_PATH).toBeUndefined();
+    expect(env.VITE_DEV_SERVER_URL).toBeUndefined();
   });
 });

--- a/apps/app/test/electrobun-packaged/windows-test-env.ts
+++ b/apps/app/test/electrobun-packaged/windows-test-env.ts
@@ -1,12 +1,42 @@
+const STRIPPED_ENV_KEYS = [
+  "ELIZA_API_PORT",
+  "ELIZA_PORT",
+  "MILADY_API_BASE",
+  "MILADY_API_BASE_URL",
+  "MILADY_API_PORT",
+  "MILADY_DESKTOP_API_BASE",
+  "MILADY_RENDERER_URL",
+  "MILADY_STARTUP_EVENTS_FILE",
+  "MILADY_STARTUP_SESSION_ID",
+  "MILADY_STARTUP_STATE_FILE",
+  "MILADY_TEST_WINDOWS_APPDATA_PATH",
+  "MILADY_TEST_WINDOWS_BACKEND_PORT",
+  "MILADY_TEST_WINDOWS_INSTALL_DIR",
+  "MILADY_TEST_WINDOWS_LAUNCHER_PATH",
+  "MILADY_TEST_WINDOWS_LOCALAPPDATA_PATH",
+  "MILADY_WINDOWS_SMOKE_REQUIRE_INSTALLER",
+  "VITE_DEV_SERVER_URL",
+] as const;
+
 export function createPackagedWindowsAppEnv(args: {
   baseEnv: NodeJS.ProcessEnv;
   apiBase: string;
   appData: string;
   localAppData: string;
 }): NodeJS.ProcessEnv {
-  return {
+  const env = {
     ...args.baseEnv,
+  };
+
+  for (const key of STRIPPED_ENV_KEYS) {
+    delete env[key];
+  }
+
+  return {
+    ...env,
     MILADY_DESKTOP_TEST_API_BASE: args.apiBase,
+    MILADY_DISABLE_LOCAL_EMBEDDINGS: "1",
+    ELECTROBUN_CONSOLE: "1",
     // Redirect both Windows profile roots so the packaged shell does not
     // reuse stale CEF/runtime state from the host machine.
     APPDATA: args.appData,

--- a/scripts/electrobun-release-workflow-drift.test.ts
+++ b/scripts/electrobun-release-workflow-drift.test.ts
@@ -897,6 +897,9 @@ describe("Electrobun release workflow drift", () => {
     );
     expect(workflow).toContain("bun run test:desktop:playwright");
     expect(workflow).toContain('MILADY_DISABLE_LOCAL_EMBEDDINGS: "1"');
+    expect(workflow).toContain(
+      "ANTHROPIC_API_KEY: $" + "{{ secrets.ANTHROPIC_API_KEY }}",
+    );
     expect(workflow).not.toContain(
       "name: Install Playwright Chromium (Windows)",
     );
@@ -931,6 +934,11 @@ describe("Electrobun release workflow drift", () => {
     expect(windowsEnvHelper).toContain(
       "MILADY_DESKTOP_TEST_API_BASE: args.apiBase",
     );
+    expect(windowsEnvHelper).toContain('MILADY_DISABLE_LOCAL_EMBEDDINGS: "1"');
+    expect(windowsEnvHelper).toContain('ELECTROBUN_CONSOLE: "1"');
+    expect(windowsEnvHelper).toContain('"MILADY_RENDERER_URL"');
+    expect(windowsEnvHelper).toContain('"VITE_DEV_SERVER_URL"');
+    expect(windowsEnvHelper).toContain("for (const key of STRIPPED_ENV_KEYS)");
     expect(windowsEnvHelper).toContain("APPDATA: args.appData");
     expect(windowsEnvHelper).toContain("LOCALAPPDATA: args.localAppData");
     expect(windowsBootstrapHelper).toContain('"/api/status"');


### PR DESCRIPTION
## Summary
- sanitize inherited env before spawning the packaged Windows bootstrap app
- force the release bootstrap step to inherit the same Windows-safe embedding env as packaged smoke
- lock the helper and workflow contract with regression tests

## Testing
- bunx vitest run apps/app/test/electrobun-packaged/windows-test-env.spec.ts scripts/electrobun-release-workflow-drift.test.ts
- bun run typecheck
- git diff --check
- MILADY_PRE_REVIEW_BASE=origin/develop bun run pre-review:local