### PR TITLE
milady: stop clearing live CEF profile on first boot

### DIFF
--- a/apps/app/electrobun/src/__tests__/windows-cef-profile.test.ts
+++ b/apps/app/electrobun/src/__tests__/windows-cef-profile.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveDesktopBundleVersion,
+  shouldResetWindowsCefProfile,
+} from "../windows-cef-profile";
+
+describe("resolveDesktopBundleVersion", () => {
+  it("prefers packaged Windows Resources/version.json", () => {
+    const version = resolveDesktopBundleVersion(
+      "C:\\mi\\Resources\\app\\bun",
+      "C:\\mi\\bin\\bun.exe",
+      "win32",
+      {
+        existsSync: (filePath) =>
+          filePath === "C:\\mi\\Resources\\version.json",
+        readFileSync: (filePath) => {
+          if (filePath !== "C:\\mi\\Resources\\version.json") {
+            throw new Error(`unexpected path: ${filePath}`);
+          }
+          return JSON.stringify({ version: "2.0.0-alpha.87" });
+        },
+      },
+    );
+
+    expect(version).toBe("2.0.0-alpha.87");
+  });
+
+  it("falls back to the local package.json in dev", () => {
+    const version = resolveDesktopBundleVersion(
+      "/repo/apps/app/electrobun/src",
+      "/usr/local/bin/bun",
+      "darwin",
+      {
+        existsSync: (filePath) =>
+          filePath === "/repo/apps/app/electrobun/package.json",
+        readFileSync: (filePath) => {
+          if (filePath !== "/repo/apps/app/electrobun/package.json") {
+            throw new Error(`unexpected path: ${filePath}`);
+          }
+          return JSON.stringify({ version: "2.0.0-dev" });
+        },
+      },
+    );
+
+    expect(version).toBe("2.0.0-dev");
+  });
+});
+
+describe("shouldResetWindowsCefProfile", () => {
+  it("does not reset on first run without a prior marker", () => {
+    expect(shouldResetWindowsCefProfile(null, "2.0.0")).toBe(false);
+  });
+
+  it("does not reset when the current version is unknown", () => {
+    expect(shouldResetWindowsCefProfile("1.9.0", "unknown")).toBe(false);
+  });
+
+  it("resets only on a real version change", () => {
+    expect(shouldResetWindowsCefProfile("1.9.0", "2.0.0")).toBe(true);
+    expect(shouldResetWindowsCefProfile("2.0.0", "2.0.0")).toBe(false);
+  });
+});

--- a/apps/app/electrobun/src/index.ts
+++ b/apps/app/electrobun/src/index.ts
@@ -65,6 +65,10 @@ import {
   SurfaceWindowManager,
 } from "./surface-windows";
 import type { SendToWebview } from "./types.js";
+import {
+  resolveDesktopBundleVersion,
+  shouldResetWindowsCefProfile,
+} from "./windows-cef-profile";
 
 type HeartbeatMenuTriggerSummary = {
   enabled: boolean;
@@ -1528,21 +1532,18 @@ async function main(): Promise<void> {
     try {
       const cefDir = path.join(Utils.paths.userData, "CEF");
       const cefVersionMarker = path.join(cefDir, ".milady-version");
-      let currentVersion = "unknown";
-      try {
-        const pkgPath = path.join(import.meta.dir, "..", "package.json");
-        currentVersion =
-          JSON.parse(fs.readFileSync(pkgPath, "utf-8")).version ?? "unknown";
-      } catch {
-        // Fallback — version marker will still trigger cleanup on next real version.
-      }
+      const currentVersion =
+        resolveDesktopBundleVersion(import.meta.dir) ?? "unknown";
       let previousVersion: string | null = null;
       try {
         previousVersion = fs.readFileSync(cefVersionMarker, "utf-8").trim();
       } catch {
         // No marker — first run or pre-fix install.
       }
-      if (previousVersion !== currentVersion && fs.existsSync(cefDir)) {
+      if (
+        shouldResetWindowsCefProfile(previousVersion, currentVersion) &&
+        fs.existsSync(cefDir)
+      ) {
         console.log(
           `[Main] CEF version mismatch (${previousVersion ?? "none"} → ${currentVersion}), clearing stale CEF profile`,
         );
@@ -1558,8 +1559,10 @@ async function main(): Promise<void> {
         }
       }
       // Write/update version marker so we don't clear again on next launch.
-      fs.mkdirSync(cefDir, { recursive: true });
-      fs.writeFileSync(cefVersionMarker, currentVersion);
+      if (currentVersion !== "unknown") {
+        fs.mkdirSync(cefDir, { recursive: true });
+        fs.writeFileSync(cefVersionMarker, currentVersion);
+      }
     } catch (err) {
       console.warn("[Main] CEF profile cleanup failed (non-fatal):", err);
     }

--- a/apps/app/electrobun/src/windows-cef-profile.ts
+++ b/apps/app/electrobun/src/windows-cef-profile.ts
@@ -1,0 +1,120 @@
+import fs from "node:fs";
+import path from "node:path";
+
+type ExistsSyncLike = Pick<typeof fs, "existsSync" | "readFileSync">;
+
+function usesWindowsPathSyntax(value: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(value) || value.includes("\\");
+}
+
+function joinPortable(base: string, ...parts: string[]): string {
+  return usesWindowsPathSyntax(base)
+    ? path.win32.join(base, ...parts)
+    : path.posix.join(base, ...parts);
+}
+
+function resolveRelativePortable(base: string, relativePath: string): string {
+  return usesWindowsPathSyntax(base)
+    ? path.win32.resolve(base, relativePath)
+    : path.posix.resolve(base, relativePath);
+}
+
+function trimToNull(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function resolveBundlePathPortable(
+  execPath: string,
+  platform: NodeJS.Platform,
+): string | null {
+  const normalizedExecPath = execPath.replaceAll("\\", "/");
+  const appBundleMatch = normalizedExecPath.match(/^(.*?\.app)(?:\/|$)/);
+  if (appBundleMatch) {
+    return usesWindowsPathSyntax(execPath)
+      ? appBundleMatch[1].replaceAll("/", "\\")
+      : appBundleMatch[1];
+  }
+
+  if (platform !== "win32" && !normalizedExecPath.includes("/bin/")) {
+    return null;
+  }
+
+  const binSegment = normalizedExecPath.lastIndexOf("/bin/");
+  if (binSegment < 0) {
+    return null;
+  }
+
+  const bundlePath = normalizedExecPath.slice(0, binSegment);
+  if (!bundlePath) {
+    return null;
+  }
+
+  return usesWindowsPathSyntax(execPath)
+    ? bundlePath.replaceAll("/", "\\")
+    : bundlePath;
+}
+
+function readVersionFromJson(
+  versionFilePath: string,
+  fileSystem: ExistsSyncLike,
+): string | null {
+  if (!fileSystem.existsSync(versionFilePath)) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(
+      fileSystem.readFileSync(versionFilePath, "utf8"),
+    ) as { version?: unknown };
+    return typeof parsed.version === "string"
+      ? trimToNull(parsed.version)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveDesktopBundleVersion(
+  moduleDir: string,
+  execPath: string = process.execPath,
+  platform: NodeJS.Platform = process.platform,
+  fileSystem: ExistsSyncLike = fs,
+): string | null {
+  const bundlePath = resolveBundlePathPortable(execPath, platform);
+  const resourceCandidates = bundlePath
+    ? platform === "darwin" && bundlePath.replaceAll("\\", "/").endsWith(".app")
+      ? [joinPortable(bundlePath, "Contents", "Resources", "version.json")]
+      : [
+          joinPortable(bundlePath, "Resources", "version.json"),
+          joinPortable(bundlePath, "resources", "version.json"),
+        ]
+    : [];
+
+  for (const candidate of resourceCandidates) {
+    const version = readVersionFromJson(candidate, fileSystem);
+    if (version) {
+      return version;
+    }
+  }
+
+  return readVersionFromJson(
+    resolveRelativePortable(moduleDir, "../package.json"),
+    fileSystem,
+  );
+}
+
+export function shouldResetWindowsCefProfile(
+  previousVersion: string | null,
+  currentVersion: string | null,
+): boolean {
+  const previous = trimToNull(previousVersion);
+  const current = trimToNull(currentVersion);
+  if (!previous || !current) {
+    return false;
+  }
+  if (current === "unknown") {
+    return false;
+  }
+  return previous !== current;
+}


### PR DESCRIPTION
## Summary
- resolve packaged Electrobun version from bundled version metadata before falling back to package.json
- stop clearing the live Windows CEF profile on first packaged boot when the current bundle version is unknown
- add regression tests for packaged version resolution and CEF profile reset gating

## Testing
- bunx vitest run apps/app/electrobun/src/__tests__/windows-cef-profile.test.ts apps/app/electrobun/src/__tests__/startup-bootstrap.test.ts apps/app/test/electrobun-packaged/windows-test-env.spec.ts scripts/electrobun-release-workflow-drift.test.ts
- bunx @biomejs/biome check apps/app/electrobun/src/windows-cef-profile.ts apps/app/electrobun/src/__tests__/windows-cef-profile.test.ts apps/app/electrobun/src/index.ts apps/app/test/electrobun-packaged/windows-test-env.ts apps/app/test/electrobun-packaged/windows-test-env.spec.ts .github/workflows/release-electrobun.yml scripts/electrobun-release-workflow-drift.test.ts
- bun run typecheck
- MILADY_PRE_REVIEW_BASE=origin/develop bun run pre-review:local