### PR TITLE
milady: isolate packaged windows bootstrap session

### DIFF
--- a/apps/app/electrobun/src/__tests__/main-window-session.test.ts
+++ b/apps/app/electrobun/src/__tests__/main-window-session.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveMainWindowPartition } from "../main-window-session";
+
+describe("resolveMainWindowPartition", () => {
+  it("returns null by default", () => {
+    expect(resolveMainWindowPartition({})).toBeNull();
+  });
+
+  it("returns the explicit desktop test partition override", () => {
+    expect(
+      resolveMainWindowPartition({
+        MILADY_DESKTOP_TEST_PARTITION: "bootstrap-isolated",
+      }),
+    ).toBe("bootstrap-isolated");
+  });
+
+  it("ignores blank partition overrides", () => {
+    expect(
+      resolveMainWindowPartition({
+        MILADY_DESKTOP_TEST_PARTITION: "   ",
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/app/electrobun/src/__tests__/startup-bootstrap.test.ts
+++ b/apps/app/electrobun/src/__tests__/startup-bootstrap.test.ts
@@ -78,6 +78,13 @@ describe("Electrobun startup bootstrap", () => {
     expect(source).toContain("readResolvedPreloadScript(import.meta.dir)");
   });
 
+  it("allows the packaged Windows bootstrap harness to override the main window partition", () => {
+    const source = fs.readFileSync(INDEX_PATH, "utf8");
+
+    expect(source).toContain("resolveMainWindowPartition(process.env)");
+    expect(source).toContain("browserWindowOptions.partition");
+  });
+
   it("guards embedded agent startup behind local runtime mode", () => {
     const source = fs.readFileSync(INDEX_PATH, "utf8");
 

--- a/apps/app/electrobun/src/__tests__/windows-cef-profile.test.ts
+++ b/apps/app/electrobun/src/__tests__/windows-cef-profile.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveDesktopBundleVersion,
+  shouldResetWindowsCefProfile,
+} from "../windows-cef-profile";
+
+describe("resolveDesktopBundleVersion", () => {
+  it("prefers packaged Windows Resources/version.json", () => {
+    const version = resolveDesktopBundleVersion(
+      "C:\\mi\\Resources\\app\\bun",
+      "C:\\mi\\bin\\bun.exe",
+      "win32",
+      {
+        existsSync: (filePath) =>
+          filePath === "C:\\mi\\Resources\\version.json",
+        readFileSync: (filePath) => {
+          if (filePath !== "C:\\mi\\Resources\\version.json") {
+            throw new Error(`unexpected path: ${filePath}`);
+          }
+          return JSON.stringify({ version: "2.0.0-alpha.87" });
+        },
+      },
+    );
+
+    expect(version).toBe("2.0.0-alpha.87");
+  });
+
+  it("falls back to the local package.json in dev", () => {
+    const version = resolveDesktopBundleVersion(
+      "/repo/apps/app/electrobun/src",
+      "/usr/local/bin/bun",
+      "darwin",
+      {
+        existsSync: (filePath) =>
+          filePath === "/repo/apps/app/electrobun/package.json",
+        readFileSync: (filePath) => {
+          if (filePath !== "/repo/apps/app/electrobun/package.json") {
+            throw new Error(`unexpected path: ${filePath}`);
+          }
+          return JSON.stringify({ version: "2.0.0-dev" });
+        },
+      },
+    );
+
+    expect(version).toBe("2.0.0-dev");
+  });
+});
+
+describe("shouldResetWindowsCefProfile", () => {
+  it("does not reset on first run without a prior marker", () => {
+    expect(shouldResetWindowsCefProfile(null, "2.0.0")).toBe(false);
+  });
+
+  it("does not reset when the current version is unknown", () => {
+    expect(shouldResetWindowsCefProfile("1.9.0", "unknown")).toBe(false);
+  });
+
+  it("resets only on a real version change", () => {
+    expect(shouldResetWindowsCefProfile("1.9.0", "2.0.0")).toBe(true);
+    expect(shouldResetWindowsCefProfile("2.0.0", "2.0.0")).toBe(false);
+  });
+});

--- a/apps/app/electrobun/src/index.ts
+++ b/apps/app/electrobun/src/index.ts
@@ -28,6 +28,7 @@ import {
 } from "./application-menu";
 import { showBackgroundNoticeOnce } from "./background-notice";
 import { readNavigationEventUrl } from "./cloud-auth-window";
+import { resolveMainWindowPartition } from "./main-window-session";
 import {
   buildMainMenuResetApiCandidates,
   pickReachableMenuResetApiBase,
@@ -717,6 +718,7 @@ async function resolveRendererUrl(): Promise<string> {
 
 async function createMainWindow(): Promise<BrowserWindow> {
   const rendererUrl = await resolveRendererUrl();
+  const mainWindowPartition = resolveMainWindowPartition(process.env);
 
   // Load persisted window state
   const statePath = path.join(Utils.paths.userData, "window-state.json");
@@ -733,7 +735,7 @@ async function createMainWindow(): Promise<BrowserWindow> {
     preload = "// preload unavailable";
   }
 
-  const win = new BrowserWindow({
+  const browserWindowOptions = {
     title: "Milady",
     // @ts-expect-error: Electrobun doesn't expose icon in JS typings yet
     icon: resolveDesktopAppIconPath(),
@@ -751,7 +753,16 @@ async function createMainWindow(): Promise<BrowserWindow> {
     // Transparent background for vibrancy — macOS only.
     // On Windows/Linux a solid background prevents rendering artifacts.
     transparent: process.platform === "darwin",
-  });
+  };
+  if (mainWindowPartition) {
+    // The packaged Windows bootstrap probe only needs to validate renderer
+    // startup against an external API override. An in-memory partition avoids
+    // depending on CEF persistent profile creation in that harness.
+    // @ts-expect-error — partition is a valid Electrobun option not yet typed
+    browserWindowOptions.partition = mainWindowPartition;
+  }
+
+  const win = new BrowserWindow(browserWindowOptions);
 
   // Apply native macOS vibrancy, shadow, and traffic light positioning
   applyMacOSWindowEffects(win);

--- a/apps/app/electrobun/src/index.ts
+++ b/apps/app/electrobun/src/index.ts
@@ -65,6 +65,10 @@ import {
   SurfaceWindowManager,
 } from "./surface-windows";
 import type { SendToWebview } from "./types.js";
+import {
+  resolveDesktopBundleVersion,
+  shouldResetWindowsCefProfile,
+} from "./windows-cef-profile";
 
 type HeartbeatMenuTriggerSummary = {
   enabled: boolean;
@@ -1528,21 +1532,18 @@ async function main(): Promise<void> {
     try {
       const cefDir = path.join(Utils.paths.userData, "CEF");
       const cefVersionMarker = path.join(cefDir, ".milady-version");
-      let currentVersion = "unknown";
-      try {
-        const pkgPath = path.join(import.meta.dir, "..", "package.json");
-        currentVersion =
-          JSON.parse(fs.readFileSync(pkgPath, "utf-8")).version ?? "unknown";
-      } catch {
-        // Fallback — version marker will still trigger cleanup on next real version.
-      }
+      const currentVersion =
+        resolveDesktopBundleVersion(import.meta.dir) ?? "unknown";
       let previousVersion: string | null = null;
       try {
         previousVersion = fs.readFileSync(cefVersionMarker, "utf-8").trim();
       } catch {
         // No marker — first run or pre-fix install.
       }
-      if (previousVersion !== currentVersion && fs.existsSync(cefDir)) {
+      if (
+        shouldResetWindowsCefProfile(previousVersion, currentVersion) &&
+        fs.existsSync(cefDir)
+      ) {
         console.log(
           `[Main] CEF version mismatch (${previousVersion ?? "none"} → ${currentVersion}), clearing stale CEF profile`,
         );
@@ -1558,8 +1559,10 @@ async function main(): Promise<void> {
         }
       }
       // Write/update version marker so we don't clear again on next launch.
-      fs.mkdirSync(cefDir, { recursive: true });
-      fs.writeFileSync(cefVersionMarker, currentVersion);
+      if (currentVersion !== "unknown") {
+        fs.mkdirSync(cefDir, { recursive: true });
+        fs.writeFileSync(cefVersionMarker, currentVersion);
+      }
     } catch (err) {
       console.warn("[Main] CEF profile cleanup failed (non-fatal):", err);
     }

--- a/apps/app/electrobun/src/main-window-session.ts
+++ b/apps/app/electrobun/src/main-window-session.ts
@@ -1,0 +1,15 @@
+function trimToNull(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+export function resolveMainWindowPartition(
+  env: NodeJS.ProcessEnv = process.env,
+): string | null {
+  const explicitPartition = trimToNull(env.MILADY_DESKTOP_TEST_PARTITION);
+  if (explicitPartition) {
+    return explicitPartition;
+  }
+
+  return null;
+}

--- a/apps/app/electrobun/src/windows-cef-profile.ts
+++ b/apps/app/electrobun/src/windows-cef-profile.ts
@@ -1,0 +1,120 @@
+import fs from "node:fs";
+import path from "node:path";
+
+type ExistsSyncLike = Pick<typeof fs, "existsSync" | "readFileSync">;
+
+function usesWindowsPathSyntax(value: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(value) || value.includes("\\");
+}
+
+function joinPortable(base: string, ...parts: string[]): string {
+  return usesWindowsPathSyntax(base)
+    ? path.win32.join(base, ...parts)
+    : path.posix.join(base, ...parts);
+}
+
+function resolveRelativePortable(base: string, relativePath: string): string {
+  return usesWindowsPathSyntax(base)
+    ? path.win32.resolve(base, relativePath)
+    : path.posix.resolve(base, relativePath);
+}
+
+function trimToNull(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function resolveBundlePathPortable(
+  execPath: string,
+  platform: NodeJS.Platform,
+): string | null {
+  const normalizedExecPath = execPath.replaceAll("\\", "/");
+  const appBundleMatch = normalizedExecPath.match(/^(.*?\.app)(?:\/|$)/);
+  if (appBundleMatch) {
+    return usesWindowsPathSyntax(execPath)
+      ? appBundleMatch[1].replaceAll("/", "\\")
+      : appBundleMatch[1];
+  }
+
+  if (platform !== "win32" && !normalizedExecPath.includes("/bin/")) {
+    return null;
+  }
+
+  const binSegment = normalizedExecPath.lastIndexOf("/bin/");
+  if (binSegment < 0) {
+    return null;
+  }
+
+  const bundlePath = normalizedExecPath.slice(0, binSegment);
+  if (!bundlePath) {
+    return null;
+  }
+
+  return usesWindowsPathSyntax(execPath)
+    ? bundlePath.replaceAll("/", "\\")
+    : bundlePath;
+}
+
+function readVersionFromJson(
+  versionFilePath: string,
+  fileSystem: ExistsSyncLike,
+): string | null {
+  if (!fileSystem.existsSync(versionFilePath)) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(
+      fileSystem.readFileSync(versionFilePath, "utf8"),
+    ) as { version?: unknown };
+    return typeof parsed.version === "string"
+      ? trimToNull(parsed.version)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveDesktopBundleVersion(
+  moduleDir: string,
+  execPath: string = process.execPath,
+  platform: NodeJS.Platform = process.platform,
+  fileSystem: ExistsSyncLike = fs,
+): string | null {
+  const bundlePath = resolveBundlePathPortable(execPath, platform);
+  const resourceCandidates = bundlePath
+    ? platform === "darwin" && bundlePath.replaceAll("\\", "/").endsWith(".app")
+      ? [joinPortable(bundlePath, "Contents", "Resources", "version.json")]
+      : [
+          joinPortable(bundlePath, "Resources", "version.json"),
+          joinPortable(bundlePath, "resources", "version.json"),
+        ]
+    : [];
+
+  for (const candidate of resourceCandidates) {
+    const version = readVersionFromJson(candidate, fileSystem);
+    if (version) {
+      return version;
+    }
+  }
+
+  return readVersionFromJson(
+    resolveRelativePortable(moduleDir, "../package.json"),
+    fileSystem,
+  );
+}
+
+export function shouldResetWindowsCefProfile(
+  previousVersion: string | null,
+  currentVersion: string | null,
+): boolean {
+  const previous = trimToNull(previousVersion);
+  const current = trimToNull(currentVersion);
+  if (!previous || !current) {
+    return false;
+  }
+  if (current === "unknown") {
+    return false;
+  }
+  return previous !== current;
+}

--- a/apps/app/test/electrobun-packaged/windows-test-env.spec.ts
+++ b/apps/app/test/electrobun-packaged/windows-test-env.spec.ts
@@ -12,6 +12,7 @@ describe("createPackagedWindowsAppEnv", () => {
         KEEP_ME: "1",
         MILADY_API_BASE: "http://127.0.0.1:31337",
         MILADY_DESKTOP_API_BASE: "http://127.0.0.1:31337",
+        MILADY_DESKTOP_TEST_PARTITION: "persist:stale",
         MILADY_RENDERER_URL: "http://127.0.0.1:5173",
         MILADY_STARTUP_SESSION_ID: "stale-session",
         MILADY_TEST_WINDOWS_APPDATA_PATH: "C:\\stale\\roaming",
@@ -24,6 +25,7 @@ describe("createPackagedWindowsAppEnv", () => {
     });
 
     expect(env.MILADY_DESKTOP_TEST_API_BASE).toBe("http://127.0.0.1:43123");
+    expect(env.MILADY_DESKTOP_TEST_PARTITION).toBe("bootstrap-isolated");
     expect(env.MILADY_DISABLE_LOCAL_EMBEDDINGS).toBe("1");
     expect(env.ELECTROBUN_CONSOLE).toBe("1");
     expect(env.APPDATA).toBe("C:\\tmp\\milady-roaming");

--- a/apps/app/test/electrobun-packaged/windows-test-env.ts
+++ b/apps/app/test/electrobun-packaged/windows-test-env.ts
@@ -5,6 +5,7 @@ const STRIPPED_ENV_KEYS = [
   "MILADY_API_BASE_URL",
   "MILADY_API_PORT",
   "MILADY_DESKTOP_API_BASE",
+  "MILADY_DESKTOP_TEST_PARTITION",
   "MILADY_RENDERER_URL",
   "MILADY_STARTUP_EVENTS_FILE",
   "MILADY_STARTUP_SESSION_ID",
@@ -35,6 +36,7 @@ export function createPackagedWindowsAppEnv(args: {
   return {
     ...env,
     MILADY_DESKTOP_TEST_API_BASE: args.apiBase,
+    MILADY_DESKTOP_TEST_PARTITION: "bootstrap-isolated",
     MILADY_DISABLE_LOCAL_EMBEDDINGS: "1",
     ELECTROBUN_CONSOLE: "1",
     // Redirect both Windows profile roots so the packaged shell does not


### PR DESCRIPTION
## Summary
- isolate the packaged Windows Playwright bootstrap run behind an explicit main-window session partition override
- keep the normal production default session behavior unchanged
- extend Electrobun regression coverage for the session override and packaged Windows env wiring

## Testing
- bunx vitest run apps/app/electrobun/src/__tests__/main-window-session.test.ts apps/app/electrobun/src/__tests__/startup-bootstrap.test.ts apps/app/test/electrobun-packaged/windows-test-env.spec.ts apps/app/electrobun/src/__tests__/windows-cef-profile.test.ts
- bunx @biomejs/biome check apps/app/electrobun/src/main-window-session.ts apps/app/electrobun/src/index.ts apps/app/electrobun/src/__tests__/main-window-session.test.ts apps/app/electrobun/src/__tests__/startup-bootstrap.test.ts apps/app/test/electrobun-packaged/windows-test-env.ts apps/app/test/electrobun-packaged/windows-test-env.spec.ts
- bun run typecheck
- MILADY_PRE_REVIEW_BASE=origin/develop bun run pre-review:local