### PR TITLE
milady: stabilize windows release launcher path

### DIFF
--- a/.github/workflows/windows-desktop-preload-smoke.yml
+++ b/.github/workflows/windows-desktop-preload-smoke.yml
@@ -3,6 +3,11 @@ name: Windows Desktop Preload Smoke
 on:
   pull_request:
     branches: [main, develop]
+    paths:
+      - "scripts/**"
+      - "apps/app/electrobun/**"
+      - "package.json"
+      - "bun.lock"
   workflow_dispatch:
 
 concurrency:

--- a/apps/app/electrobun/scripts/smoke-test-windows.ps1
+++ b/apps/app/electrobun/scripts/smoke-test-windows.ps1
@@ -41,12 +41,12 @@ if ($env:GITHUB_ENV) {
 # Unix-style ~/.config/Milady path used on macOS/Linux.
 $startupLog = Join-Path $env:APPDATA "Milady\\milady-startup.log"
 $selfExtractionRoot = Join-Path $env:LOCALAPPDATA "com.miladyai.milady"
-$tempExtractDir = Join-Path $env:RUNNER_TEMP ("milady-windows-smoke-" + [Guid]::NewGuid().ToString("N"))
+$tempExtractDir = Join-Path $tempRoot ("milady-windows-smoke-" + [Guid]::NewGuid().ToString("N"))
 $persistLauncherDir = $env:MILADY_TEST_WINDOWS_LAUNCHER_DIR
 $persistLauncherPathFile = $env:MILADY_TEST_WINDOWS_LAUNCHER_PATH_FILE
 $startupSessionId = "milady-windows-smoke-" + [Guid]::NewGuid().ToString("N")
-$startupStateFile = Join-Path $env:RUNNER_TEMP ($startupSessionId + ".state.json")
-$startupEventsFile = Join-Path $env:RUNNER_TEMP ($startupSessionId + ".events.jsonl")
+$startupStateFile = Join-Path $tempRoot ($startupSessionId + ".state.json")
+$startupEventsFile = Join-Path $tempRoot ($startupSessionId + ".events.jsonl")
 $startupBootstrapFile = $null
 $stopProtectedProcessIds = [System.Collections.Generic.HashSet[int]]::new()
 [void]$stopProtectedProcessIds.Add([int]$PID)
@@ -92,7 +92,7 @@ function Write-ReusableLauncherPath([System.IO.FileInfo]$Launcher, [string]$Temp
     $launcherPath.StartsWith($TemporaryRoot, [System.StringComparison]::OrdinalIgnoreCase)
   ) {
     $stageDir = if ([string]::IsNullOrWhiteSpace($persistLauncherDir)) {
-      Join-Path $env:RUNNER_TEMP "milady-windows-ui-launcher"
+      Join-Path $tempRoot "milady-windows-ui-launcher"
     } else {
       $persistLauncherDir
     }
@@ -201,7 +201,7 @@ function Assert-PackagedArchiveAssetVariants(
       continue
     }
 
-    $extractDir = Join-Path $env:RUNNER_TEMP ("milady-archive-asset-check-" + [Guid]::NewGuid().ToString("N"))
+    $extractDir = Join-Path $tempRoot ("milady-archive-asset-check-" + [Guid]::NewGuid().ToString("N"))
     New-Item -ItemType Directory -Force -Path $extractDir | Out-Null
     try {
       & $tarCommand -xf $ArchivePath -C $extractDir $member 2>$null | Out-Null
@@ -377,7 +377,7 @@ $requireInstaller = $env:MILADY_WINDOWS_SMOKE_REQUIRE_INSTALLER -eq "1"
 $installerRoot = if ($env:MILADY_TEST_WINDOWS_INSTALL_DIR) {
   $env:MILADY_TEST_WINDOWS_INSTALL_DIR
 } else {
-  Join-Path $env:RUNNER_TEMP ("milady-windows-installed-" + [Guid]::NewGuid().ToString("N"))
+  Join-Path $tempRoot ("milady-windows-installed-" + [Guid]::NewGuid().ToString("N"))
 }
 if ($requireInstaller) {
   $launcher = $null

--- a/apps/app/electrobun/src/__tests__/main-window-session.test.ts
+++ b/apps/app/electrobun/src/__tests__/main-window-session.test.ts
@@ -10,25 +10,9 @@ describe("resolveMainWindowPartition", () => {
   it("returns the explicit desktop test partition override", () => {
     expect(
       resolveMainWindowPartition({
-        MILADY_DESKTOP_TEST_PARTITION: "persist:bootstrap-isolated",
-      }),
-    ).toBe("persist:bootstrap-isolated");
-  });
-
-  it("normalizes bare desktop test partition overrides to persistent CEF partitions", () => {
-    expect(
-      resolveMainWindowPartition({
         MILADY_DESKTOP_TEST_PARTITION: "bootstrap-isolated",
       }),
-    ).toBe("persist:bootstrap-isolated");
-  });
-
-  it("falls back to the packaged bootstrap partition when the external test API is enabled", () => {
-    expect(
-      resolveMainWindowPartition({
-        MILADY_DESKTOP_TEST_API_BASE: "http://127.0.0.1:43123",
-      }),
-    ).toBe("persist:bootstrap-isolated");
+    ).toBe("bootstrap-isolated");
   });
 
   it("ignores blank partition overrides", () => {

--- a/apps/app/electrobun/src/__tests__/startup-bootstrap.test.ts
+++ b/apps/app/electrobun/src/__tests__/startup-bootstrap.test.ts
@@ -43,7 +43,7 @@ describe("Electrobun startup bootstrap", () => {
       "preload = readResolvedPreloadScript(import.meta.dir);",
     );
     const browserWindowIndex = source.indexOf(
-      "new BrowserWindow({",
+      "const win = new BrowserWindow(browserWindowOptions);",
       validateIndex,
     );
 
@@ -85,10 +85,7 @@ describe("Electrobun startup bootstrap", () => {
     const source = fs.readFileSync(INDEX_PATH, "utf8");
 
     expect(source).toContain("resolveMainWindowPartition(process.env)");
-    expect(source).toContain('renderer: "native"');
-    expect(source).toContain("const mainView = new BrowserView({");
-    expect(source).toContain("partition: mainWindowPartition");
-    expect(source).toContain("win.webviewId = mainView.id");
+    expect(source).toContain("browserWindowOptions.partition");
   });
 
   it("guards embedded agent startup behind local runtime mode", () => {

--- a/apps/app/electrobun/src/__tests__/windows-test-env-contract.test.ts
+++ b/apps/app/electrobun/src/__tests__/windows-test-env-contract.test.ts
@@ -21,17 +21,14 @@ describe("createPackagedWindowsAppEnv", () => {
       },
       apiBase: "http://127.0.0.1:43123",
       appData: "C:\\tmp\\milady-roaming",
-      localAppData: "C:\\tmp\\milady-local",
     });
 
     expect(env.MILADY_DESKTOP_TEST_API_BASE).toBe("http://127.0.0.1:43123");
-    expect(env.MILADY_DESKTOP_TEST_PARTITION).toBe(
-      "persist:bootstrap-isolated",
-    );
+    expect(env.MILADY_DESKTOP_TEST_PARTITION).toBeUndefined();
     expect(env.MILADY_DISABLE_LOCAL_EMBEDDINGS).toBe("1");
     expect(env.ELECTROBUN_CONSOLE).toBe("1");
     expect(env.APPDATA).toBe("C:\\tmp\\milady-roaming");
-    expect(env.LOCALAPPDATA).toBe("C:\\tmp\\milady-local");
+    expect(env.LOCALAPPDATA).toBe("C:\\Users\\runner\\AppData\\Local");
     expect(env.KEEP_ME).toBe("1");
     expect(env.ELIZA_API_PORT).toBeUndefined();
     expect(env.MILADY_API_BASE).toBeUndefined();
@@ -39,6 +36,7 @@ describe("createPackagedWindowsAppEnv", () => {
     expect(env.MILADY_RENDERER_URL).toBeUndefined();
     expect(env.MILADY_STARTUP_SESSION_ID).toBeUndefined();
     expect(env.MILADY_TEST_WINDOWS_APPDATA_PATH).toBeUndefined();
+    expect(env.MILADY_TEST_WINDOWS_LOCALAPPDATA_PATH).toBeUndefined();
     expect(env.MILADY_TEST_WINDOWS_LAUNCHER_PATH).toBeUndefined();
     expect(env.VITE_DEV_SERVER_URL).toBeUndefined();
   });

--- a/apps/app/electrobun/src/index.ts
+++ b/apps/app/electrobun/src/index.ts
@@ -8,7 +8,6 @@ import {
 } from "@miladyai/shared/runtime-env";
 import Electrobun, {
   ApplicationMenu,
-  BrowserView,
   BrowserWindow,
   Updater,
   Utils,
@@ -747,57 +746,29 @@ async function createMainWindow(): Promise<BrowserWindow> {
     x: state.x,
     y: state.y,
   };
-  const titleBarStyle =
-    process.platform === "darwin" ? "hiddenInset" : "default";
-  const transparent = process.platform === "darwin";
-
-  let win: BrowserWindow;
+  const browserWindowOptions = {
+    title: "Milady",
+    // @ts-expect-error: Electrobun doesn't expose icon in JS typings yet
+    icon: resolveDesktopAppIconPath(),
+    url: rendererUrl,
+    preload,
+    frame: windowFrame,
+    // hiddenInset hides the title bar and insets traffic lights — macOS only.
+    // On Windows/Linux use the default title bar so the window remains draggable.
+    titleBarStyle: process.platform === "darwin" ? "hiddenInset" : "default",
+    // Transparent background for vibrancy — macOS only.
+    // On Windows/Linux a solid background prevents rendering artifacts.
+    transparent: process.platform === "darwin",
+  };
   if (mainWindowPartition) {
-    // BrowserWindow always creates a default BrowserView. For the packaged
-    // Windows bootstrap probe, force that throwaway view to stay native so the
-    // real CEF renderer can boot inside an explicit isolated partition.
-    win = new BrowserWindow({
-      title: "Milady",
-      // @ts-expect-error: Electrobun doesn't expose icon in JS typings yet
-      icon: resolveDesktopAppIconPath(),
-      url: null,
-      preload: null,
-      frame: windowFrame,
-      renderer: "native",
-      titleBarStyle,
-      transparent,
-    });
-    win.webview.remove();
-    const mainView = new BrowserView({
-      url: rendererUrl,
-      preload,
-      renderer: "cef",
-      partition: mainWindowPartition,
-      frame: {
-        x: 0,
-        y: 0,
-        width: state.width,
-        height: state.height,
-      },
-      windowId: win.id,
-    });
-    win.webviewId = mainView.id;
-  } else {
-    win = new BrowserWindow({
-      title: "Milady",
-      // @ts-expect-error: Electrobun doesn't expose icon in JS typings yet
-      icon: resolveDesktopAppIconPath(),
-      url: rendererUrl,
-      preload,
-      frame: windowFrame,
-      // hiddenInset hides the title bar and insets traffic lights — macOS only.
-      // On Windows/Linux use the default title bar so the window remains draggable.
-      titleBarStyle,
-      // Transparent background for vibrancy — macOS only.
-      // On Windows/Linux a solid background prevents rendering artifacts.
-      transparent,
-    });
+    // The packaged Windows bootstrap probe only needs to validate renderer
+    // startup against an external API override. An in-memory partition avoids
+    // depending on CEF persistent profile creation in that harness.
+    // @ts-expect-error — partition is a valid Electrobun option not yet typed
+    browserWindowOptions.partition = mainWindowPartition;
   }
+
+  const win = new BrowserWindow(browserWindowOptions);
 
   // Apply native macOS vibrancy, shadow, and traffic light positioning
   applyMacOSWindowEffects(win);

--- a/apps/app/electrobun/src/main-window-session.ts
+++ b/apps/app/electrobun/src/main-window-session.ts
@@ -3,22 +3,12 @@ function trimToNull(value: string | undefined): string | null {
   return trimmed ? trimmed : null;
 }
 
-const PACKAGED_BOOTSTRAP_PARTITION = "persist:bootstrap-isolated";
-
-function normalizePartition(partition: string): string {
-  return partition.includes(":") ? partition : `persist:${partition}`;
-}
-
 export function resolveMainWindowPartition(
   env: NodeJS.ProcessEnv = process.env,
 ): string | null {
   const explicitPartition = trimToNull(env.MILADY_DESKTOP_TEST_PARTITION);
   if (explicitPartition) {
-    return normalizePartition(explicitPartition);
-  }
-
-  if (trimToNull(env.MILADY_DESKTOP_TEST_API_BASE)) {
-    return PACKAGED_BOOTSTRAP_PARTITION;
+    return explicitPartition;
   }
 
   return null;

--- a/apps/app/test/electrobun-packaged/electrobun-windows-startup.e2e.spec.ts
+++ b/apps/app/test/electrobun-packaged/electrobun-windows-startup.e2e.spec.ts
@@ -196,9 +196,6 @@ test("packaged Windows app bootstraps the renderer against the external API over
   const userDataDir = await fs.mkdtemp(
     path.join(os.tmpdir(), "milady-win-userdata-"),
   );
-  const localUserDataDir = await fs.mkdtemp(
-    path.join(os.tmpdir(), "milady-win-localappdata-"),
-  );
 
   const executablePath = await resolveWindowsLauncher(tempExtractDir);
 
@@ -215,7 +212,6 @@ test("packaged Windows app bootstraps the renderer against the external API over
         baseEnv: process.env,
         apiBase: api.baseUrl,
         appData: userDataDir,
-        localAppData: localUserDataDir,
       }),
       stdio: ["ignore", "pipe", "pipe"],
     });

--- a/apps/app/test/electrobun-packaged/windows-test-env.spec.ts
+++ b/apps/app/test/electrobun-packaged/windows-test-env.spec.ts
@@ -21,17 +21,14 @@ describe("createPackagedWindowsAppEnv", () => {
       },
       apiBase: "http://127.0.0.1:43123",
       appData: "C:\\tmp\\milady-roaming",
-      localAppData: "C:\\tmp\\milady-local",
     });
 
     expect(env.MILADY_DESKTOP_TEST_API_BASE).toBe("http://127.0.0.1:43123");
-    expect(env.MILADY_DESKTOP_TEST_PARTITION).toBe(
-      "persist:bootstrap-isolated",
-    );
+    expect(env.MILADY_DESKTOP_TEST_PARTITION).toBeUndefined();
     expect(env.MILADY_DISABLE_LOCAL_EMBEDDINGS).toBe("1");
     expect(env.ELECTROBUN_CONSOLE).toBe("1");
     expect(env.APPDATA).toBe("C:\\tmp\\milady-roaming");
-    expect(env.LOCALAPPDATA).toBe("C:\\tmp\\milady-local");
+    expect(env.LOCALAPPDATA).toBe("C:\\Users\\runner\\AppData\\Local");
     expect(env.KEEP_ME).toBe("1");
     expect(env.ELIZA_API_PORT).toBeUndefined();
     expect(env.MILADY_API_BASE).toBeUndefined();
@@ -39,6 +36,7 @@ describe("createPackagedWindowsAppEnv", () => {
     expect(env.MILADY_RENDERER_URL).toBeUndefined();
     expect(env.MILADY_STARTUP_SESSION_ID).toBeUndefined();
     expect(env.MILADY_TEST_WINDOWS_APPDATA_PATH).toBeUndefined();
+    expect(env.MILADY_TEST_WINDOWS_LOCALAPPDATA_PATH).toBeUndefined();
     expect(env.MILADY_TEST_WINDOWS_LAUNCHER_PATH).toBeUndefined();
     expect(env.VITE_DEV_SERVER_URL).toBeUndefined();
   });

--- a/apps/app/test/electrobun-packaged/windows-test-env.ts
+++ b/apps/app/test/electrobun-packaged/windows-test-env.ts
@@ -23,7 +23,6 @@ export function createPackagedWindowsAppEnv(args: {
   baseEnv: NodeJS.ProcessEnv;
   apiBase: string;
   appData: string;
-  localAppData: string;
 }): NodeJS.ProcessEnv {
   const env = {
     ...args.baseEnv,
@@ -36,12 +35,10 @@ export function createPackagedWindowsAppEnv(args: {
   return {
     ...env,
     MILADY_DESKTOP_TEST_API_BASE: args.apiBase,
-    MILADY_DESKTOP_TEST_PARTITION: "persist:bootstrap-isolated",
     MILADY_DISABLE_LOCAL_EMBEDDINGS: "1",
     ELECTROBUN_CONSOLE: "1",
-    // Redirect both Windows profile roots so the packaged shell does not
-    // reuse stale CEF/runtime state from the host machine.
+    // Match the last known-good release harness: isolate Roaming AppData
+    // without relocating LocalAppData.
     APPDATA: args.appData,
-    LOCALAPPDATA: args.localAppData,
   };
 }

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "test:desktop:contract": "cd apps/app/electrobun && bun run test",
     "test:desktop:packaged": "bash apps/app/electrobun/scripts/smoke-test.sh",
     "test:desktop:packaged:unsigned": "SKIP_SIGNATURE_CHECK=1 ELECTROBUN_SKIP_CODESIGN=1 bash apps/app/electrobun/scripts/smoke-test.sh",
-    "test:desktop:packaged:windows": "pwsh -File apps/app/electrobun/scripts/smoke-test-windows.ps1",
+    "test:desktop:packaged:windows": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/run-windows-smoke-launcher.ps1 apps/app/electrobun/scripts/smoke-test-windows.ps1",
     "test:desktop:playwright": "node scripts/run-desktop-playwright.mjs",
     "test:desktop:playwright:windows": "cd apps/app && bunx playwright test --config playwright.electrobun.packaged.config.ts test/electrobun-packaged/electrobun-windows-startup.e2e.spec.ts",
     "test:e2e": "bunx vitest run --config vitest.e2e.config.ts --exclude packages/agent/test/anvil-contracts.e2e.test.ts --exclude packages/agent/test/apps-e2e.e2e.test.ts",

--- a/scripts/electrobun-release-workflow-drift.test.ts
+++ b/scripts/electrobun-release-workflow-drift.test.ts
@@ -652,9 +652,7 @@ describe("Electrobun release workflow drift", () => {
     expect(smokeScript).toContain(
       '$startupSessionId = "milady-windows-smoke-"',
     );
-    expect(smokeScript).toContain(
-      "$startupStateFile = Join-Path $tempRoot",
-    );
+    expect(smokeScript).toContain("$startupStateFile = Join-Path $tempRoot");
     expect(smokeScript).toContain(
       '$startupBootstrapFile = Join-Path $startupBundleRoot "startup-session.json"',
     );

--- a/scripts/electrobun-release-workflow-drift.test.ts
+++ b/scripts/electrobun-release-workflow-drift.test.ts
@@ -653,7 +653,7 @@ describe("Electrobun release workflow drift", () => {
       '$startupSessionId = "milady-windows-smoke-"',
     );
     expect(smokeScript).toContain(
-      "$startupStateFile = Join-Path $env:RUNNER_TEMP",
+      "$startupStateFile = Join-Path $tempRoot",
     );
     expect(smokeScript).toContain(
       '$startupBootstrapFile = Join-Path $startupBundleRoot "startup-session.json"',
@@ -926,7 +926,6 @@ describe("Electrobun release workflow drift", () => {
     expect(windowsPackagedTest).toContain("createPackagedWindowsAppEnv({");
     expect(windowsPackagedTest).toContain("apiBase: api.baseUrl");
     expect(windowsPackagedTest).toContain("appData: userDataDir");
-    expect(windowsPackagedTest).toContain("localAppData: localUserDataDir");
     expect(windowsPackagedTest).toContain('from "./windows-bootstrap"');
     expect(windowsPackagedTest).toContain(
       "hasPackagedRendererBootstrapRequests(api.requests)",
@@ -940,7 +939,7 @@ describe("Electrobun release workflow drift", () => {
     expect(windowsEnvHelper).toContain('"VITE_DEV_SERVER_URL"');
     expect(windowsEnvHelper).toContain("for (const key of STRIPPED_ENV_KEYS)");
     expect(windowsEnvHelper).toContain("APPDATA: args.appData");
-    expect(windowsEnvHelper).toContain("LOCALAPPDATA: args.localAppData");
+    expect(windowsEnvHelper).not.toContain("LOCALAPPDATA: args.localAppData");
     expect(windowsBootstrapHelper).toContain('"/api/status"');
     expect(windowsBootstrapHelper).toContain('"/api/config"');
     expect(windowsBootstrapHelper).toContain('"/api/drop/status"');

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -755,7 +755,7 @@ function assertWindowsSmokeScriptHasLeadingParamBlock() {
     "Find-Launcher $selfExtractionRoot",
     "Started extracted launcher:",
     '$startupSessionId = "milady-windows-smoke-"',
-    "$startupStateFile = Join-Path $env:RUNNER_TEMP",
+    "$startupStateFile = Join-Path $tempRoot",
     '$startupBootstrapFile = Join-Path $startupBundleRoot "startup-session.json"',
     "Write-StartupBootstrap",
     "function Resolve-BackendPort",

--- a/scripts/run-windows-smoke-launcher.ps1
+++ b/scripts/run-windows-smoke-launcher.ps1
@@ -1,0 +1,35 @@
+param(
+  [Parameter(Mandatory = $true, Position = 0)]
+  [string]$ScriptPath,
+
+  [Parameter(ValueFromRemainingArguments = $true)]
+  [string[]]$ScriptArgs
+)
+
+$pwshCandidates = @(
+  "pwsh.exe",
+  (Join-Path $env:ProgramFiles "PowerShell\7\pwsh.exe"),
+  (Join-Path $env:ProgramFiles "PowerShell\6\pwsh.exe")
+)
+
+$pwsh = $null
+foreach ($candidate in $pwshCandidates) {
+  if ($candidate -eq "pwsh.exe") {
+    $command = Get-Command $candidate -ErrorAction SilentlyContinue
+    if ($command) {
+      $pwsh = $command.Source
+      break
+    }
+  } elseif (Test-Path $candidate) {
+    $pwsh = $candidate
+    break
+  }
+}
+
+if (-not $pwsh) {
+  Write-Error "PowerShell 7 (pwsh) is required to run $ScriptPath because the Windows smoke script uses PowerShell 7 syntax."
+  exit 1
+}
+
+& $pwsh -NoProfile -ExecutionPolicy Bypass -File $ScriptPath @ScriptArgs
+exit $LASTEXITCODE

--- a/scripts/windows-smoke-launcher.test.ts
+++ b/scripts/windows-smoke-launcher.test.ts
@@ -1,0 +1,65 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = path.resolve(import.meta.dirname, "..");
+const PACKAGE_JSON_PATH = path.join(ROOT, "package.json");
+const LAUNCHER_PATH = path.join(ROOT, "scripts/run-windows-smoke-launcher.ps1");
+const SMOKE_SCRIPT_PATH = path.join(
+  ROOT,
+  "apps/app/electrobun/scripts/smoke-test-windows.ps1",
+);
+const PRELOAD_WORKFLOW_PATH = path.join(
+  ROOT,
+  ".github/workflows/windows-desktop-preload-smoke.yml",
+);
+
+describe("windows packaged smoke launcher", () => {
+  it("routes the package script through the launcher shim", () => {
+    const pkg = JSON.parse(fs.readFileSync(PACKAGE_JSON_PATH, "utf8")) as {
+      scripts?: Record<string, string>;
+    };
+
+    expect(pkg.scripts?.["test:desktop:packaged:windows"]).toBe(
+      "powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/run-windows-smoke-launcher.ps1 apps/app/electrobun/scripts/smoke-test-windows.ps1",
+    );
+  });
+
+  it("resolves a PowerShell 7 host before invoking the smoke script", () => {
+    const launcher = fs.readFileSync(LAUNCHER_PATH, "utf8");
+
+    expect(launcher).toContain("[string]$ScriptPath");
+    expect(launcher).toContain('"pwsh.exe"');
+    expect(launcher).toContain("PowerShell\\7\\pwsh.exe");
+    expect(launcher).toContain(
+      "& $pwsh -NoProfile -ExecutionPolicy Bypass -File $ScriptPath @ScriptArgs",
+    );
+  });
+
+  it("uses the resolved temp root for local smoke-script scratch paths", () => {
+    const smokeScript = fs.readFileSync(SMOKE_SCRIPT_PATH, "utf8");
+
+    expect(smokeScript).toContain("$tempExtractDir = Join-Path $tempRoot");
+    expect(smokeScript).toContain("$startupStateFile = Join-Path $tempRoot");
+    expect(smokeScript).toContain("$startupEventsFile = Join-Path $tempRoot");
+    expect(smokeScript).toContain(
+      'Join-Path $tempRoot "milady-windows-ui-launcher"',
+    );
+    expect(smokeScript).toContain(
+      'Join-Path $tempRoot ("milady-archive-asset-check-"',
+    );
+    expect(smokeScript).toContain(
+      'Join-Path $tempRoot ("milady-windows-installed-"',
+    );
+  });
+
+  it("scopes the preload smoke workflow to desktop-related changes", () => {
+    const workflow = fs.readFileSync(PRELOAD_WORKFLOW_PATH, "utf8");
+
+    expect(workflow).toContain("pull_request:");
+    expect(workflow).toContain('      - "scripts/**"');
+    expect(workflow).toContain('      - "apps/app/electrobun/**"');
+    expect(workflow).toContain('      - "package.json"');
+    expect(workflow).toContain('      - "bun.lock"');
+  });
+});


### PR DESCRIPTION
## Summary\n- route the Windows smoke entrypoint through a stable PowerShell launcher wrapper\n- restore the packaged Windows bootstrap harness to the simpler last-known-good release shape\n- path-gate the extra Windows preload smoke workflow so unrelated PRs do not rerun it\n\n## Testing\n- bunx vitest run apps/app/electrobun/src/__tests__/main-window-session.test.ts apps/app/electrobun/src/__tests__/startup-bootstrap.test.ts apps/app/electrobun/src/__tests__/windows-test-env-contract.test.ts apps/app/test/electrobun-packaged/windows-test-env.spec.ts scripts/electrobun-release-workflow-drift.test.ts scripts/windows-smoke-launcher.test.ts\n- bun run typecheck\n- bun run test:release:contract\n- bun run test:regression-matrix:release-contract