### PR TITLE
fix: update homepage release data to v2.0.5

### DIFF
--- a/apps/web/src/generated/release-data.ts
+++ b/apps/web/src/generated/release-data.ts
@@ -1,5 +1,5 @@
 export const releaseData = {
-  generatedAt: "2026-04-02T01:41:54.000Z",
+  generatedAt: "2026-04-04T00:22:30.639Z",
   scripts: {
     shell: {
       url: "https://milady.ai/install.sh",
@@ -11,48 +11,48 @@ export const releaseData = {
     },
   },
   cdn: {
-    tagName: "v2.0.4",
+    tagName: "v2.0.5",
     appAssetBaseUrl:
-      "https://raw.githubusercontent.com/milady-ai/milady/v2.0.4/apps/app/public/",
+      "https://raw.githubusercontent.com/milady-ai/milady/v2.0.5/apps/app/public/",
     homepageAssetBaseUrl:
-      "https://raw.githubusercontent.com/milady-ai/milady/v2.0.4/apps/web/public/",
+      "https://raw.githubusercontent.com/milady-ai/milady/v2.0.5/apps/web/public/",
   },
   release: {
-    tagName: "v2.0.4",
-    publishedAtLabel: "Mar 31, 2026",
+    tagName: "v2.0.5",
+    publishedAtLabel: "Apr 2, 2026",
     prerelease: false,
-    url: "https://github.com/milady-ai/milady/releases/tag/v2.0.4",
+    url: "https://github.com/milady-ai/milady/releases/tag/v2.0.5",
     downloads: [
       {
         id: "macos-arm64",
         label: "macOS (Apple Silicon)",
         fileName: "stable-macos-arm64-Milady.dmg",
-        url: "https://github.com/milady-ai/milady/releases/download/v2.0.4/stable-macos-arm64-Milady.dmg",
-        sizeLabel: "597.6 MB",
+        url: "https://github.com/milady-ai/milady/releases/download/v2.0.5/stable-macos-arm64-Milady.dmg",
+        sizeLabel: "581.3 MB",
         note: "DMG installer",
       },
       {
         id: "macos-x64",
         label: "macOS (Intel)",
         fileName: "stable-macos-x64-Milady.dmg",
-        url: "https://github.com/milady-ai/milady/releases/download/v2.0.4/stable-macos-x64-Milady.dmg",
-        sizeLabel: "597.5 MB",
+        url: "https://github.com/milady-ai/milady/releases/download/v2.0.5/stable-macos-x64-Milady.dmg",
+        sizeLabel: "597.0 MB",
         note: "DMG installer",
       },
       {
         id: "windows-x64",
         label: "Windows",
         fileName: "Milady-Setup-stable.exe",
-        url: "https://github.com/milady-ai/milady/releases/download/v2.0.4/Milady-Setup-stable.exe",
-        sizeLabel: "672.6 MB",
+        url: "https://github.com/milady-ai/milady/releases/download/v2.0.5/Milady-Setup-stable.exe",
+        sizeLabel: "672.9 MB",
         note: "Windows installer",
       },
       {
         id: "linux-x64",
         label: "Linux",
         fileName: "stable-linux-x64-Milady-Setup.tar.gz",
-        url: "https://github.com/milady-ai/milady/releases/download/v2.0.4/stable-linux-x64-Milady-Setup.tar.gz",
-        sizeLabel: "653.9 MB",
+        url: "https://github.com/milady-ai/milady/releases/download/v2.0.5/stable-linux-x64-Milady-Setup.tar.gz",
+        sizeLabel: "654.2 MB",
         note: "tar.gz package",
       },
       {
@@ -66,7 +66,7 @@ export const releaseData = {
     ],
     checksum: {
       fileName: "SHA256SUMS.txt",
-      url: "https://github.com/milady-ai/milady/releases/download/v2.0.4/SHA256SUMS.txt",
+      url: "https://github.com/milady-ai/milady/releases/download/v2.0.5/SHA256SUMS.txt",
     },
   },
 } as const;


### PR DESCRIPTION
Homepage was showing `v3.0.0-dex-v3-dev` as the latest version. That GitHub release was not marked as prerelease, so `write-homepage-release-data.mjs` picked it up.

**Fix:**
- Marked `v3.0.0-dex-v3-dev` as prerelease on GitHub
- Regenerated `apps/web/src/generated/release-data.ts` → now shows `v2.0.5`