### PR TITLE
milady: restore stable windows installer profile roots

### DIFF
--- a/apps/app/electrobun/scripts/smoke-test-windows.ps1
+++ b/apps/app/electrobun/scripts/smoke-test-windows.ps1
@@ -19,15 +19,25 @@ $tempRoot = if ($env:RUNNER_TEMP) {
 } else {
   [System.IO.Path]::GetTempPath()
 }
+$defaultAppDataRoot = if ([string]::IsNullOrWhiteSpace($env:APPDATA)) {
+  Join-Path $tempRoot ("milady-windows-appdata-" + [Guid]::NewGuid().ToString("N"))
+} else {
+  $env:APPDATA
+}
+$defaultLocalAppDataRoot = if ([string]::IsNullOrWhiteSpace($env:LOCALAPPDATA)) {
+  Join-Path $tempRoot ("milady-windows-localappdata-" + [Guid]::NewGuid().ToString("N"))
+} else {
+  $env:LOCALAPPDATA
+}
 $testAppDataRoot = if ($env:MILADY_TEST_WINDOWS_APPDATA_PATH) {
   $env:MILADY_TEST_WINDOWS_APPDATA_PATH
 } else {
-  Join-Path $tempRoot ("milady-windows-appdata-" + [Guid]::NewGuid().ToString("N"))
+  $defaultAppDataRoot
 }
 $testLocalAppDataRoot = if ($env:MILADY_TEST_WINDOWS_LOCALAPPDATA_PATH) {
   $env:MILADY_TEST_WINDOWS_LOCALAPPDATA_PATH
 } else {
-  Join-Path $tempRoot ("milady-windows-localappdata-" + [Guid]::NewGuid().ToString("N"))
+  $defaultLocalAppDataRoot
 }
 $env:APPDATA = $testAppDataRoot
 $env:LOCALAPPDATA = $testLocalAppDataRoot

--- a/scripts/electrobun-release-workflow-drift.test.ts
+++ b/scripts/electrobun-release-workflow-drift.test.ts
@@ -776,11 +776,17 @@ describe("Electrobun release workflow drift", () => {
     expect(workflow).not.toContain("env.USERPROFILE }}\\.config\\Milady");
   });
 
-  it("isolates Windows smoke runs from the runner's stable profile and exports the chosen backend port", () => {
+  it("defaults Windows smoke runs to the stable runner profile unless explicit overrides are provided, while still exporting the chosen backend port", () => {
     const smokeScript = fs.readFileSync(WINDOWS_SMOKE_PATH, "utf8");
 
     expect(smokeScript).toContain("MILADY_TEST_WINDOWS_APPDATA_PATH");
     expect(smokeScript).toContain("MILADY_TEST_WINDOWS_LOCALAPPDATA_PATH");
+    expect(smokeScript).toContain(
+      '$defaultAppDataRoot = if ([string]::IsNullOrWhiteSpace($env:APPDATA)) {',
+    );
+    expect(smokeScript).toContain(
+      '$defaultLocalAppDataRoot = if ([string]::IsNullOrWhiteSpace($env:LOCALAPPDATA)) {',
+    );
     expect(smokeScript).toContain("$env:APPDATA = $testAppDataRoot");
     expect(smokeScript).toContain("$env:LOCALAPPDATA = $testLocalAppDataRoot");
     expect(smokeScript).toContain(


### PR DESCRIPTION
## Summary
- default the Windows release smoke script back to the runner's real APPDATA/LOCALAPPDATA roots unless explicit test overrides are provided
- keep the newer dynamic backend port export and packaged launcher handoff logic intact
- update the release workflow drift test to lock that contract

## Validation
- bunx vitest run scripts/electrobun-release-workflow-drift.test.ts
- bun run test:release:contract
- bun run typecheck
- MILADY_PRE_REVIEW_BASE=origin/develop bun run pre-review:local