### PR TITLE
milady: run windows smoke script directly in release CI

### DIFF
--- a/.github/workflows/release-electrobun.yml
+++ b/.github/workflows/release-electrobun.yml
@@ -655,11 +655,12 @@ jobs:
           Remove-Item $env:MILADY_TEST_WINDOWS_LAUNCHER_DIR -Recurse -Force -ErrorAction SilentlyContinue
           Remove-Item $env:MILADY_TEST_WINDOWS_LAUNCHER_PATH_FILE -Force -ErrorAction SilentlyContinue
 
-          bun run test:desktop:packaged:windows
-          if ($LASTEXITCODE -ne 0) {
-            Write-Error "Packaged Windows smoke test exited with code $LASTEXITCODE."
-            exit $LASTEXITCODE
-          }
+          # Invoke the smoke script directly from pwsh so installer/runtime
+          # failures surface with their original exception instead of bun /
+          # Windows PowerShell collapsing them into a generic -1 wrapper.
+          & (Join-Path $PWD "apps/app/electrobun/scripts/smoke-test-windows.ps1") `
+            -ArtifactsDir (Join-Path $PWD "apps/app/electrobun/artifacts") `
+            -BuildDir (Join-Path $PWD "apps/app/electrobun/build")
 
           if (-not (Test-Path $env:MILADY_TEST_WINDOWS_LAUNCHER_PATH_FILE)) {
             Write-Error "Smoke test did not emit a reusable Windows launcher path."

--- a/scripts/electrobun-release-workflow-drift.test.ts
+++ b/scripts/electrobun-release-workflow-drift.test.ts
@@ -742,9 +742,18 @@ describe("Electrobun release workflow drift", () => {
     expect(workflow).toContain('MILADY_WINDOWS_SMOKE_REQUIRE_INSTALLER: "1"');
     expect(workflow).toContain("MILADY_TEST_WINDOWS_INSTALL_DIR: C:\\mi");
     expect(workflow).toContain(
-      'Add-Content -Path $env:GITHUB_ENV -Value "MILADY_TEST_WINDOWS_LAUNCHER_PATH=$launcherPath"',
+      '& (Join-Path $PWD "apps/app/electrobun/scripts/smoke-test-windows.ps1")',
     );
     expect(workflow).toContain(
+      '-ArtifactsDir (Join-Path $PWD "apps/app/electrobun/artifacts")',
+    );
+    expect(workflow).toContain(
+      '-BuildDir (Join-Path $PWD "apps/app/electrobun/build")',
+    );
+    expect(workflow).toContain(
+      'Add-Content -Path $env:GITHUB_ENV -Value "MILADY_TEST_WINDOWS_LAUNCHER_PATH=$launcherPath"',
+    );
+    expect(workflow).not.toContain(
       'Write-Error "Packaged Windows smoke test exited with code $LASTEXITCODE."',
     );
   });

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -141,8 +141,9 @@ const requiredWorkflowSnippets = [
   "ANTHROPIC_API_KEY: $" + "{{ secrets.ANTHROPIC_API_KEY }}",
   "ELIZAOS_CLOUD_API_KEY: $" + "{{ secrets.ELIZAOS_CLOUD_API_KEY }}",
   "ELIZAOS_CLOUD_BASE_URL: $" + "{{ secrets.ELIZAOS_CLOUD_BASE_URL }}",
-  "bun run test:desktop:packaged:windows",
-  'Write-Error "Packaged Windows smoke test exited with code $LASTEXITCODE."',
+  '& (Join-Path $PWD "apps/app/electrobun/scripts/smoke-test-windows.ps1")',
+  '-ArtifactsDir (Join-Path $PWD "apps/app/electrobun/artifacts")',
+  '-BuildDir (Join-Path $PWD "apps/app/electrobun/build")',
   "bun run test:desktop:playwright",
 ];
 const _requiredPatchedElectrobunCliSnippets = [


### PR DESCRIPTION
## Summary
- run the packaged Windows smoke script directly from the release workflow
- stop wrapping the smoke failure in a generic Write-Error with code -1
- update release workflow contract checks to match the direct invocation

## Testing
- bunx vitest run scripts/electrobun-release-workflow-drift.test.ts
- bun run test:release:contract
- bun run typecheck
- git diff --check