### PR TITLE
milady: align release matrix with direct windows smoke

### DIFF
--- a/scripts/electrobun-release-workflow-drift.test.ts
+++ b/scripts/electrobun-release-workflow-drift.test.ts
@@ -1004,4 +1004,30 @@ describe("Electrobun release workflow drift", () => {
     const serverOnlyIndex = elizaSource.indexOf("serverOnly", catchIndex);
     expect(serverOnlyIndex).toBeGreaterThan(catchIndex);
   });
+
+  it("regression matrix desktop-packaged-windows uses direct pwsh invocation with required path snippets", () => {
+    const REGRESSION_MATRIX_PATH = path.join(ROOT, "test/regression-matrix.json");
+    const matrix = JSON.parse(fs.readFileSync(REGRESSION_MATRIX_PATH, "utf8"));
+    const suite = matrix.suites["desktop-packaged-windows"];
+
+    // Command must use direct & invocation, not bun run wrapper
+    expect(suite.command).toContain(
+      '& (Join-Path $PWD "apps/app/electrobun/scripts/smoke-test-windows.ps1")',
+    );
+
+    // Required snippets must pin both artifact and build dir args
+    expect(suite.requiredSnippets).toContain(
+      "-ArtifactsDir (Join-Path $PWD \"apps/app/electrobun/artifacts\")",
+    );
+    expect(suite.requiredSnippets).toContain(
+      "-BuildDir (Join-Path $PWD \"apps/app/electrobun/build\")",
+    );
+
+    // The workflow must contain the command and all required snippets
+    const workflow = fs.readFileSync(WORKFLOW_PATH, "utf8");
+    expect(workflow).toContain(suite.command);
+    for (const snippet of suite.requiredSnippets) {
+      expect(workflow).toContain(snippet);
+    }
+  });
 });

--- a/scripts/electrobun-release-workflow-drift.test.ts
+++ b/scripts/electrobun-release-workflow-drift.test.ts
@@ -1006,7 +1006,10 @@ describe("Electrobun release workflow drift", () => {
   });
 
   it("regression matrix desktop-packaged-windows uses direct pwsh invocation with required path snippets", () => {
-    const REGRESSION_MATRIX_PATH = path.join(ROOT, "test/regression-matrix.json");
+    const REGRESSION_MATRIX_PATH = path.join(
+      ROOT,
+      "test/regression-matrix.json",
+    );
     const matrix = JSON.parse(fs.readFileSync(REGRESSION_MATRIX_PATH, "utf8"));
     const suite = matrix.suites["desktop-packaged-windows"];
 
@@ -1017,10 +1020,10 @@ describe("Electrobun release workflow drift", () => {
 
     // Required snippets must pin both artifact and build dir args
     expect(suite.requiredSnippets).toContain(
-      "-ArtifactsDir (Join-Path $PWD \"apps/app/electrobun/artifacts\")",
+      '-ArtifactsDir (Join-Path $PWD "apps/app/electrobun/artifacts")',
     );
     expect(suite.requiredSnippets).toContain(
-      "-BuildDir (Join-Path $PWD \"apps/app/electrobun/build\")",
+      '-BuildDir (Join-Path $PWD "apps/app/electrobun/build")',
     );
 
     // The workflow must contain the command and all required snippets

--- a/test/regression-matrix.json
+++ b/test/regression-matrix.json
@@ -98,7 +98,11 @@
     },
     "desktop-packaged-windows": {
       "tier": "heavy",
-      "command": "bun run test:desktop:packaged:windows"
+      "command": "& (Join-Path $PWD \"apps/app/electrobun/scripts/smoke-test-windows.ps1\")",
+      "requiredSnippets": [
+        "-ArtifactsDir (Join-Path $PWD \"apps/app/electrobun/artifacts\")",
+        "-BuildDir (Join-Path $PWD \"apps/app/electrobun/build\")"
+      ]
     },
     "desktop-playwright": {
       "tier": "heavy",


### PR DESCRIPTION
## Summary
- align the release regression matrix contract with the merged direct Windows smoke-script invocation
- stop the release gate from requiring the removed bun wrapper path

## Testing
- bun run test:regression-matrix:release
- bun run test:release:contract
- git diff --check