### PR TITLE
fix: add missing dependencies to app-core package.json

### DIFF
--- a/packages/app-core/package.json
+++ b/packages/app-core/package.json
@@ -79,12 +79,14 @@
     "@capacitor/haptics": "8.0.0",
     "@capacitor/keyboard": "8.0.0",
     "@capacitor/preferences": "^8.0.1",
+    "@elizaos/core": "alpha",
     "@miladyai/agent": "workspace:*",
     "@miladyai/plugin-wechat": "github:milady-ai/plugin-wechat",
     "@lookingglass/webxr": "^0.6.0",
     "@miladyai/ui": "alpha",
     "@miladyai/vrm-utils": "workspace:*",
     "@sparkjsdev/spark": "^0.1.10",
+    "@stwd/sdk": "^0.3.0",
     "lucide-react": "^0.575.0",
     "three": "^0.182.0",
     "zod": "^4.3.6",
@@ -97,6 +99,8 @@
     "directory": "dist"
   },
   "devDependencies": {
+    "@elizaos/plugin-agent-skills": "alpha",
+    "@elizaos/plugin-plugin-manager": "alpha",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19.0.0",


### PR DESCRIPTION
## What

Adds undeclared dependencies to `packages/app-core/package.json` that currently only resolve via hoisting from the root.

## Why

`@elizaos/core` is imported by **117 source files** and `@stwd/sdk` by **8 source files** in `packages/app-core/src/`, but neither is declared in app-core's `package.json`. They resolve at development time because bun/npm hoists them from the root, but standalone consumers of `@miladyai/app-core` (e.g. after `npm publish`) would get `Cannot find module` errors.

AGENTS.md explicitly lists `@elizaos/core` as a "direct import in `src/`" that should be a dependency.

## Changes

**dependencies:**
- `@elizaos/core`: `alpha` — imported by 117 source files
- `@stwd/sdk`: `^0.3.0` — imported by 8 source files (steward bridge, wallet trade routes)

**devDependencies:**
- `@elizaos/plugin-plugin-manager`: `alpha` — imported in `app-manager.test.ts`
- `@elizaos/plugin-agent-skills`: `alpha` — imported in `agent-skills-catalog-fetch.test.ts`

## Testing

- `bun install` — no changes (already hoisted)
- `bun run build` — builds clean
