### PR TITLE
refactor: deduplicate syncMiladyEnvToEliza / syncElizaEnvToMilady

### DIFF
--- a/packages/app-core/src/api/server-security.ts
+++ b/packages/app-core/src/api/server-security.ts
@@ -11,21 +11,7 @@ import {
   resolveTerminalRunRejection as upstreamResolveTerminalRunRejection,
   resolveWebSocketUpgradeRejection as upstreamResolveWebSocketUpgradeRejection,
 } from "@miladyai/agent/api/server";
-import {
-  getBootConfig,
-  syncBrandEnvToEliza,
-  syncElizaEnvToBrand,
-} from "../config/boot-config.js";
-
-function syncMiladyEnvToEliza(): void {
-  const aliases = getBootConfig().envAliases;
-  if (aliases) syncBrandEnvToEliza(aliases);
-}
-
-function syncElizaEnvToMilady(): void {
-  const aliases = getBootConfig().envAliases;
-  if (aliases) syncElizaEnvToBrand(aliases);
-}
+import { syncMiladyEnvToEliza, syncElizaEnvToMilady } from "../utils/env.js";
 
 import {
   normalizeCompatRejection,

--- a/packages/app-core/src/api/server-startup.ts
+++ b/packages/app-core/src/api/server-startup.ts
@@ -8,21 +8,7 @@ import {
   isSafeResetStateDir as upstreamIsSafeResetStateDir,
   resolveCorsOrigin as upstreamResolveCorsOrigin,
 } from "@miladyai/agent/api/server";
-import {
-  getBootConfig,
-  syncBrandEnvToEliza,
-  syncElizaEnvToBrand,
-} from "../config/boot-config.js";
-
-function syncMiladyEnvToEliza(): void {
-  const aliases = getBootConfig().envAliases;
-  if (aliases) syncBrandEnvToEliza(aliases);
-}
-
-function syncElizaEnvToMilady(): void {
-  const aliases = getBootConfig().envAliases;
-  if (aliases) syncElizaEnvToBrand(aliases);
-}
+import { syncMiladyEnvToEliza, syncElizaEnvToMilady } from "../utils/env.js";
 
 const PACKAGE_ROOT_NAMES = new Set(["eliza", "elizaai", "elizaos", "milady"]);
 

--- a/packages/app-core/src/api/server-wallet-trade.ts
+++ b/packages/app-core/src/api/server-wallet-trade.ts
@@ -4,21 +4,7 @@
  */
 import type http from "node:http";
 import { resolveWalletExportRejection as upstreamResolveWalletExportRejection } from "@miladyai/agent/api/server";
-import {
-  getBootConfig,
-  syncBrandEnvToEliza,
-  syncElizaEnvToBrand,
-} from "../config/boot-config.js";
-
-function syncMiladyEnvToEliza(): void {
-  const aliases = getBootConfig().envAliases;
-  if (aliases) syncBrandEnvToEliza(aliases);
-}
-
-function syncElizaEnvToMilady(): void {
-  const aliases = getBootConfig().envAliases;
-  if (aliases) syncElizaEnvToBrand(aliases);
-}
+import { syncMiladyEnvToEliza, syncElizaEnvToMilady } from "../utils/env.js";
 
 import { mirrorCompatHeaders } from "./server-cloud-tts";
 import {

--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -143,21 +143,7 @@ import { resolveDevStackFromEnv } from "./dev-stack";
 
 const require = createRequire(import.meta.url);
 
-import {
-  getBootConfig,
-  syncBrandEnvToEliza,
-  syncElizaEnvToBrand,
-} from "../config/boot-config.js";
-
-function syncMiladyEnvToEliza(): void {
-  const aliases = getBootConfig().envAliases;
-  if (aliases) syncBrandEnvToEliza(aliases);
-}
-
-function syncElizaEnvToMilady(): void {
-  const aliases = getBootConfig().envAliases;
-  if (aliases) syncElizaEnvToBrand(aliases);
-}
+import { syncMiladyEnvToEliza, syncElizaEnvToMilady } from "../utils/env.js";
 
 // Lazy-imported to avoid circular dependency with runtime/eliza.ts
 const lazyEnsureTTS = () =>

--- a/packages/app-core/src/runtime/eliza.ts
+++ b/packages/app-core/src/runtime/eliza.ts
@@ -26,21 +26,7 @@ import {
   resolveServerOnlyPort,
   syncResolvedApiPort,
 } from "@miladyai/shared/runtime-env";
-import {
-  getBootConfig,
-  syncBrandEnvToEliza,
-  syncElizaEnvToBrand,
-} from "../config/boot-config.js";
-
-function syncMiladyEnvToEliza(): void {
-  const aliases = getBootConfig().envAliases;
-  if (aliases) syncBrandEnvToEliza(aliases);
-}
-
-function syncElizaEnvToMilady(): void {
-  const aliases = getBootConfig().envAliases;
-  if (aliases) syncElizaEnvToBrand(aliases);
-}
+import { syncMiladyEnvToEliza, syncElizaEnvToMilady } from "../utils/env.js";
 
 import { loadElizaConfig } from "@miladyai/agent/config/config";
 import {

--- a/packages/app-core/src/utils/env.ts
+++ b/packages/app-core/src/utils/env.ts
@@ -33,3 +33,21 @@ export function isEnvDisabled(value: string | undefined): boolean {
   if (!raw) return false;
   return raw === "0" || raw === "false" || raw === "off" || raw === "no";
 }
+
+/**
+ * Sync Milady brand env vars → elizaOS equivalents.
+ * Extracted from identical copies in runtime/eliza.ts, api/server.ts,
+ * api/server-wallet-trade.ts, api/server-startup.ts, and api/server-security.ts.
+ */
+export { syncBrandEnvToEliza, syncElizaEnvToBrand } from "../config/boot-config.js";
+import { getBootConfig, syncBrandEnvToEliza, syncElizaEnvToBrand } from "../config/boot-config.js";
+
+export function syncMiladyEnvToEliza(): void {
+  const aliases = getBootConfig().envAliases;
+  if (aliases) syncBrandEnvToEliza(aliases);
+}
+
+export function syncElizaEnvToMilady(): void {
+  const aliases = getBootConfig().envAliases;
+  if (aliases) syncElizaEnvToBrand(aliases);
+}


### PR DESCRIPTION
## What

Extracts the `syncMiladyEnvToEliza()` and `syncElizaEnvToMilady()` helpers from 5 independent copy-pasted definitions into a single shared location at `utils/env.ts`.

## Why

The same two functions (identical body, identical imports) were duplicated in:
- `runtime/eliza.ts`
- `api/server.ts`
- `api/server-wallet-trade.ts`
- `api/server-startup.ts`
- `api/server-security.ts`

Any bug fix to the env sync logic had to be applied in 5 places. Now there's one canonical definition.

## Changes

- **`utils/env.ts`** — adds `syncMiladyEnvToEliza()`, `syncElizaEnvToMilady()`, and re-exports `syncBrandEnvToEliza`/`syncElizaEnvToBrand` from boot-config
- **5 source files** — replace inline definitions + boot-config imports with a single import from `utils/env.js`

Net: **+23 / -75 lines** (52 lines removed)

## Testing

- 30 existing tests pass (CORS port allowlist + API token bind)
- `bun run build` succeeds
