### PR TITLE
fix: use LRU eviction for Telegram chat history cache

### DIFF
--- a/packages/app-core/src/runtime/eliza.ts
+++ b/packages/app-core/src/runtime/eliza.ts
@@ -611,13 +611,16 @@ async function ensureTelegramBotPolling(runtime: AgentRuntime): Promise<void> {
           let history = chatHistories.get(chatId);
           if (!history) {
             history = [];
-            chatHistories.set(chatId, history);
-            // Evict oldest chat entry to prevent unbounded memory growth
-            if (chatHistories.size > 500) {
+            // Evict least-recently-used chat to prevent unbounded memory growth
+            if (chatHistories.size >= 500) {
               const oldest = chatHistories.keys().next().value;
               if (oldest !== undefined) chatHistories.delete(oldest);
             }
+          } else {
+            // Move to end of Map iteration order (most-recently-used)
+            chatHistories.delete(chatId);
           }
+          chatHistories.set(chatId, history);
           history.push({ role: "user", content: `@${username}: ${text}` });
           if (history.length > 20) history.splice(0, history.length - 20);
 


### PR DESCRIPTION
## What

Fixes the Telegram chat history eviction to use LRU (least-recently-used) ordering instead of insertion-order.

## Why

The `chatHistories` Map caps at 500 entries. When full, it evicts via `keys().next().value` — which in a JS Map is **insertion order**, not access order. Active long-running chats created early get evicted while dormant chats created later persist. This means frequently-used group chats lose their context while idle DMs keep theirs.

## Fix

On each message, move the accessed chat to the end of Map iteration order:
- **Existing chat:** `delete(chatId)` then `set(chatId, history)` — bumps to end
- **New chat:** `set(chatId, history)` — already at end

The first key in the Map is now always the least-recently-used entry, making eviction correct.

Also changed the size check from `> 500` to `>= 500` so the map never exceeds the intended 500-entry cap.

## Testing

- `bun run build` succeeds
- Logic is straightforward Map reordering, no new dependencies
