### PR TITLE
fix(security): prevent SSRF via Host header injection + shell injection in credential resolver

### DIFF
--- a/packages/app-core/src/api/credential-resolver.ts
+++ b/packages/app-core/src/api/credential-resolver.ts
@@ -11,7 +11,7 @@
  * The OAuth token from Claude Code is an "anthropic-subscription" credential
  * that goes through applySubscriptionCredentials(), not a direct API key.
  */
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -45,9 +45,12 @@ function extractOauthAccessToken(value: unknown): string | null {
 function readKeychainValue(service: string): string | null {
   if (process.platform !== "darwin") return null;
   try {
-    const output = execSync(
-      `security find-generic-password -s "${service}" -w 2>/dev/null`,
-      { encoding: "utf8", timeout: 3000 },
+    // Use execFileSync to avoid shell injection — service is passed as an
+    // argument array element, not interpolated into a shell command string.
+    const output = execFileSync(
+      "security",
+      ["find-generic-password", "-s", service, "-w"],
+      { encoding: "utf8", timeout: 3000, stdio: ["pipe", "pipe", "pipe"] },
     );
     const trimmed = output.trim();
     return trimmed.length > 0 ? trimmed : null;

--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -253,11 +253,37 @@ function resolveCompatPgliteDataDir(config: ElizaConfig): string {
   return path.join(resolveUserPath(workspaceDir), ".eliza", ".elizadb");
 }
 
+/**
+ * Actual port the API server is listening on, set after server.listen()
+ * resolves. Used by loopback calls to target the correct endpoint even
+ * when the server binds to a dynamic port (port: 0 or EADDRINUSE fallback).
+ */
+let _resolvedLoopbackPort: number | null = null;
+
+/** Called from startApiServer after the upstream server resolves. */
+export function setResolvedLoopbackPort(port: number): void {
+  _resolvedLoopbackPort = port;
+}
+
+/**
+ * Build the loopback base URL for internal server-to-self API calls.
+ * Always targets 127.0.0.1 — never trusts the incoming Host header,
+ * which would allow an attacker to redirect loopback fetches (and the
+ * attached API token) to an external server.
+ *
+ * Priority: actual listener port > env vars > default 31337.
+ */
 function resolveCompatLoopbackApiBase(
-  req: Pick<http.IncomingMessage, "headers">,
+  _req: Pick<http.IncomingMessage, "headers">,
 ): string {
-  const host = req.headers.host?.trim() || "127.0.0.1:31337";
-  return `http://${host}`;
+  const port =
+    _resolvedLoopbackPort ??
+    (Number(
+      process.env.MILADY_API_PORT?.trim() ||
+        process.env.ELIZA_PORT?.trim() ||
+        "31337",
+    ) || 31337);
+  return `http://127.0.0.1:${port}`;
 }
 
 function buildCompatLoopbackHeaders(
@@ -1088,6 +1114,14 @@ export async function startApiServer(
     }
 
     const server = await upstreamStartApiServer(...args);
+
+    // Record the actual listener port so loopback calls target the right
+    // endpoint even when the server bound to a dynamic port (port: 0 or
+    // EADDRINUSE fallback).
+    if (typeof server.port === "number" && server.port > 0) {
+      setResolvedLoopbackPort(server.port);
+    }
+
     const originalUpdateRuntime = server.updateRuntime as (
       runtime: AgentRuntime,
     ) => void;


### PR DESCRIPTION
## What

Two security fixes for server-side request forgery and shell injection.

## Finding 1: SSRF via Host Header (HIGH)

`resolveCompatLoopbackApiBase()` trusted the incoming request's `Host` header to construct the base URL for internal loopback API calls:

```typescript
const host = req.headers.host?.trim() || "127.0.0.1:31337";
return `http://${host}`;
```

This URL was then used by `compatLoopbackFetchJson()` and `compatLoopbackRequest()` which **attach the API token** via `Authorization: Bearer` header.

**Exploit:** An attacker sends a request with `Host: attacker.com:8080`. The server makes an internal fetch to `http://attacker.com:8080/api/...` with the valid API token, leaking the master secret.

**Fix:** Never trust the Host header for loopback calls. Always target `127.0.0.1` with the configured `MILADY_API_PORT`.

## Finding 2: Shell Injection in credential-resolver (MEDIUM)

`readKeychainValue()` used `execSync()` with string interpolation:

```typescript
execSync(`security find-generic-password -s "${service}" -w 2>/dev/null`)
```

Currently only called with a hardcoded constant, but the pattern is fragile — any future caller passing user input would have a direct shell injection.

**Fix:** Use `execFileSync()` with an argument array. No shell involved.

## Testing

- `bun run build` succeeds
- CORS port allowlist tests pass (16/16)
