### PR TITLE
fix(security): enforce 600 permissions on config file every write

### DIFF
--- a/packages/agent/src/config/config.ts
+++ b/packages/agent/src/config/config.ts
@@ -161,6 +161,15 @@ export function saveElizaConfig(config: ElizaConfig): void {
     mode: 0o600,
   });
 
+  // Enforce 600 on every write — writeFileSync's mode only applies on
+  // creation, so files created by older versions retain their original
+  // (potentially world-readable) permissions.
+  try {
+    fs.chmodSync(configPath, 0o600);
+  } catch {
+    // chmodSync may fail on some platforms (e.g. Windows). Non-fatal.
+  }
+
   if (!fs.existsSync(configPath)) {
     throw new Error(
       `[eliza-config] Config file missing after write: ${configPath}`,


### PR DESCRIPTION
## What

Adds `chmodSync(0o600)` after every config file write to ensure restrictive permissions regardless of how the file was originally created.

## Why

`writeFileSync` with `mode: 0o600` only applies permissions on **file creation** (`O_CREAT`). If the config file was created by an older version of milady (or manually by the user) with default permissions (644), it remains world-readable forever — even after being overwritten by newer code.

```javascript
// Proof: mode does NOT update existing file permissions
fs.writeFileSync(path, data, { mode: 0o644 });  // creates with 644
fs.writeFileSync(path, data, { mode: 0o600 });  // still 644!
```

The config file (`~/.milady/milady.json`) can contain:
- Cloud API keys (`cloud.apiKey`)
- Plugin credentials (written by `PUT /api/plugins/:id`)
- Wallet-related configuration

## Fix

Explicit `chmodSync(configPath, 0o600)` after every write. Wrapped in try/catch for Windows compatibility (where chmod is a no-op).

## Testing

- `bun run build` succeeds
- Verified behavior on macOS: existing 644 file is correctly tightened to 600 after write
