### PR TITLE
fix(security): redact secrets from log output

### DIFF
--- a/packages/app-core/src/api/auth-pairing-compat-routes.ts
+++ b/packages/app-core/src/api/auth-pairing-compat-routes.ts
@@ -74,8 +74,10 @@ function ensurePairingCode(): string | null {
   if (!pairingCode || now > pairingExpiresAt) {
     pairingCode = generatePairingCode();
     pairingExpiresAt = now + PAIRING_TTL_MS;
+    // Log only the first segment — enough to confirm the code was generated
+    // without exposing the full secret to log aggregators or screen-watchers.
     console.warn(
-      `[milady-api] Pairing code: ${pairingCode} (valid for 10 minutes)`,
+      `[milady-api] Pairing code generated: ${pairingCode.slice(0, 4)}-****-**** (valid for 10 minutes)`,
     );
   }
 

--- a/packages/app-core/src/api/credential-resolver.ts
+++ b/packages/app-core/src/api/credential-resolver.ts
@@ -191,7 +191,7 @@ export function resolveProviderCredential(
     const key = source.resolve();
     if (key) {
       logger.info(
-        `[credential-resolver] Resolved ${source.envVar} for ${providerId} (${key.length} chars, ${source.authType})`,
+        `[credential-resolver] Resolved ${source.envVar} for ${providerId} (${source.authType})`,
       );
       return {
         providerId: source.providerId,


### PR DESCRIPTION
## What

Two log hygiene fixes that prevent secrets from leaking via console output.

## Pairing code logged in full (MEDIUM)

`ensurePairingCode()` logged the full 12-character pairing code to `console.warn`:

```
[milady-api] Pairing code: A1B2-C3D4-E5F6 (valid for 10 minutes)
```

The pairing code can be exchanged for the **master API token** via `POST /api/auth/pair`. Anyone with log access (screen-watchers, log aggregators, crash reporters, terminal history) gets full API access.

**Fix:** Log only the first segment: `A1B2-****-****`

## API key length logged (LOW)

`credential-resolver.ts` logged key length at INFO level:

```
[credential-resolver] Resolved ANTHROPIC_API_KEY for anthropic (47 chars, api-key)
```

Key length narrows brute-force search space and confirms which providers have live credentials.

**Fix:** Remove the length from the log message.

## Testing

- `bun run build` succeeds
