### PR TITLE
fix: use atomic write for config file to prevent corruption on crash

### DIFF
--- a/packages/agent/src/config/config.ts
+++ b/packages/agent/src/config/config.ts
@@ -156,10 +156,22 @@ export function saveElizaConfig(config: ElizaConfig): void {
 
   const content = `${JSON.stringify(sanitized, null, 2)}\n`;
 
-  fs.writeFileSync(configPath, content, {
+  // Atomic write: write to a temp file then rename. If the process crashes
+  // during writeFileSync, only the temp file is corrupted — the original
+  // config remains intact. rename() is atomic on POSIX filesystems when
+  // source and destination are on the same filesystem.
+  //
+  // Resolve symlinks so dotfile-managed setups (symlinked config) update
+  // the target file instead of replacing the symlink with a regular file.
+  const realConfigPath = fs.existsSync(configPath)
+    ? fs.realpathSync(configPath)
+    : configPath;
+  const tmpPath = `${realConfigPath}.tmp.${process.pid}`;
+  fs.writeFileSync(tmpPath, content, {
     encoding: "utf-8",
     mode: 0o600,
   });
+  fs.renameSync(tmpPath, realConfigPath);
 
   if (!fs.existsSync(configPath)) {
     throw new Error(


### PR DESCRIPTION
## What

Makes `saveElizaConfig()` crash-safe by writing to a temp file then renaming.

## Why

The config file (`~/.milady/milady.json`) is written frequently — on every provider change, plugin config update, cloud login, onboarding step, etc. `writeFileSync()` directly to the target path means:

1. Process crash during write → truncated/partial JSON
2. Next launch → `JSON5.parse()` throws on corrupt file
3. App fails to start, user loses their configuration

This is especially dangerous because the config contains wallet credentials, cloud API keys, and plugin state — data that cannot be reconstructed.

## Fix

Write-then-rename (atomic write pattern):

```typescript
const tmpPath = `${configPath}.tmp.${process.pid}`;
fs.writeFileSync(tmpPath, content, { encoding: "utf-8", mode: 0o600 });
fs.renameSync(tmpPath, configPath);
```

`rename()` is atomic on POSIX filesystems when source and destination are on the same mount (always true here — same directory). If the write is interrupted, only the temp file is corrupt. The original config survives.

Same pattern used by SQLite (WAL), editors (vim, nano), and package managers (npm, cargo).

## Testing

- `bun run build` succeeds
