### PR TITLE
test: add coverage for trade execution validation and wallet action helpers

### DIFF
--- a/packages/app-core/src/actions/execute-trade.test.ts
+++ b/packages/app-core/src/actions/execute-trade.test.ts
@@ -1,600 +1,158 @@
-/**
- * Unit tests for the EXECUTE_TRADE action.
- *
- * Verifies parameter validation, API call handling, response formatting,
- * and action metadata (name, similes, parameters).
- */
+import { describe, expect, it, vi } from "vitest";
+import { executeTradeAction } from "./execute-trade.js";
 
-import type { HandlerOptions } from "@elizaos/core";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { executeTradeAction } from "./execute-trade";
+// Mock @elizaos/core logger
+vi.mock("@elizaos/core", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
 
-// ── Helpers ──────────────────────────────────────────────────────────────────
+// Mock wallet-action-shared so we don't need real env vars
+vi.mock("./wallet-action-shared.js", () => ({
+  getWalletActionApiPort: () => "31337",
+  buildAuthHeaders: () => ({}),
+}));
 
-const VALID_TOKEN = "0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82";
+describe("executeTradeAction", () => {
+  describe("validate", () => {
+    it("returns false when no wallet is configured", async () => {
+      const runtime = {
+        getSetting: () => undefined,
+      };
+      expect(await executeTradeAction.validate(runtime as never)).toBe(false);
+    });
 
-function callHandler(params: Record<string, unknown>) {
-  return executeTradeAction.handler({} as never, {} as never, undefined, {
-    parameters: params,
-  } as HandlerOptions);
-}
+    it("returns true when EVM_PRIVATE_KEY is set", async () => {
+      const runtime = {
+        getSetting: (key: string) =>
+          key === "EVM_PRIVATE_KEY" ? "0xdeadbeef" : undefined,
+      };
+      expect(await executeTradeAction.validate(runtime as never)).toBe(true);
+    });
 
-// ── Test suite ───────────────────────────────────────────────────────────────
+    it("returns true when PRIVY_APP_ID is set", async () => {
+      const runtime = {
+        getSetting: (key: string) =>
+          key === "PRIVY_APP_ID" ? "app_123" : undefined,
+      };
+      expect(await executeTradeAction.validate(runtime as never)).toBe(true);
+    });
 
-describe("EXECUTE_TRADE action", () => {
-  const originalFetch = globalThis.fetch;
-
-  beforeEach(() => {
-    // Reset fetch mock before each test
-    globalThis.fetch = vi.fn();
+    it("returns true when STEWARD_API_URL is set", async () => {
+      const runtime = {
+        getSetting: (key: string) =>
+          key === "STEWARD_API_URL" ? "https://steward.example.com" : undefined,
+      };
+      expect(await executeTradeAction.validate(runtime as never)).toBe(true);
+    });
   });
 
-  afterEach(() => {
-    globalThis.fetch = originalFetch;
-  });
-
-  // ── Metadata ─────────────────────────────────────────────────────────────
-
-  it("has correct name", () => {
-    expect(executeTradeAction.name).toBe("EXECUTE_TRADE");
-  });
-
-  it("has similes for natural language matching", () => {
-    expect(executeTradeAction.similes).toBeDefined();
-    expect(executeTradeAction.similes?.length).toBeGreaterThan(0);
-    expect(executeTradeAction.similes).toContain("BUY_TOKEN");
-    expect(executeTradeAction.similes).toContain("SELL_TOKEN");
-    expect(executeTradeAction.similes).toContain("SWAP");
-    expect(executeTradeAction.similes).toContain("TRADE");
-    expect(executeTradeAction.similes).toContain("BUY");
-    expect(executeTradeAction.similes).toContain("SELL");
-  });
-
-  it("has parameter definitions", () => {
-    expect(executeTradeAction.parameters).toBeDefined();
-    expect(executeTradeAction.parameters?.length).toBe(5);
-
-    const names = executeTradeAction.parameters?.map((p) => p.name);
-    expect(names).toContain("side");
-    expect(names).toContain("tokenAddress");
-    expect(names).toContain("amount");
-    expect(names).toContain("slippageBps");
-    expect(names).toContain("routeProvider");
-
-    // side, tokenAddress, amount are required; slippageBps is optional
-    const slippage = executeTradeAction.parameters?.find(
-      (p) => p.name === "slippageBps",
-    );
-    expect(slippage?.required).toBe(false);
-  });
-
-  it("validates true when EVM_PRIVATE_KEY is set", async () => {
-    const runtime = {
-      getSetting: (key: string) =>
-        key === "EVM_PRIVATE_KEY" ? "0xdeadbeef" : undefined,
+  describe("handler validation", () => {
+    const callHandler = async (params: Record<string, unknown>) => {
+      const results: Array<{ text: string }> = [];
+      await executeTradeAction.handler(
+        {} as never,
+        {} as never,
+        undefined,
+        { parameters: params },
+        (result) => {
+          results.push(result as { text: string });
+        },
+      );
+      return results;
     };
-    const result = await executeTradeAction.validate(
-      runtime as never,
-      {} as never,
-    );
-    expect(result).toBe(true);
-  });
 
-  it("validates true when PRIVY_APP_ID is set", async () => {
-    const runtime = {
-      getSetting: (key: string) =>
-        key === "PRIVY_APP_ID" ? "app_123" : undefined,
-    };
-    const result = await executeTradeAction.validate(
-      runtime as never,
-      {} as never,
-    );
-    expect(result).toBe(true);
-  });
-
-  it("validates false when no wallet is configured", async () => {
-    const runtime = {
-      getSetting: (_key: string) => undefined,
-    };
-    const result = await executeTradeAction.validate(
-      runtime as never,
-      {} as never,
-    );
-    expect(result).toBe(false);
-  });
-
-  // ── Parameter validation ─────────────────────────────────────────────────
-
-  it("returns error when side is missing", async () => {
-    const result = await callHandler({
-      tokenAddress: VALID_TOKEN,
-      amount: "0.5",
+    it("rejects missing side", async () => {
+      const results = await callHandler({
+        tokenAddress: "0x" + "a".repeat(40),
+        amount: "1",
+      });
+      expect(results[0].text).toContain("valid trade side");
     });
-    expect(result).toBeDefined();
-    expect((result as { success: boolean }).success).toBe(false);
-    expect((result as { text: string }).text).toContain("side");
-  });
 
-  it("returns error when side is invalid", async () => {
-    const result = await callHandler({
-      side: "hold",
-      tokenAddress: VALID_TOKEN,
-      amount: "0.5",
+    it("rejects invalid side", async () => {
+      const results = await callHandler({
+        side: "hodl",
+        tokenAddress: "0x" + "a".repeat(40),
+        amount: "1",
+      });
+      expect(results[0].text).toContain("valid trade side");
     });
-    expect((result as { success: boolean }).success).toBe(false);
-    expect((result as { text: string }).text).toContain("side");
-  });
 
-  it("returns error when tokenAddress is missing", async () => {
-    const result = await callHandler({
-      side: "buy",
-      amount: "0.5",
+    it("rejects missing tokenAddress", async () => {
+      const results = await callHandler({ side: "buy", amount: "1" });
+      expect(results[0].text).toContain("valid BSC token contract address");
     });
-    expect((result as { success: boolean }).success).toBe(false);
-    expect((result as { text: string }).text).toContain("address");
-  });
 
-  it("returns error when tokenAddress is malformed", async () => {
-    const result = await callHandler({
-      side: "buy",
-      tokenAddress: "not-an-address",
-      amount: "0.5",
-    });
-    expect((result as { success: boolean }).success).toBe(false);
-    expect((result as { text: string }).text).toContain("address");
-  });
-
-  it("returns error when tokenAddress is too short", async () => {
-    const result = await callHandler({
-      side: "buy",
-      tokenAddress: "0x1234",
-      amount: "0.5",
-    });
-    expect((result as { success: boolean }).success).toBe(false);
-  });
-
-  it("returns error when amount is missing", async () => {
-    const result = await callHandler({
-      side: "buy",
-      tokenAddress: VALID_TOKEN,
-    });
-    expect((result as { success: boolean }).success).toBe(false);
-    expect((result as { text: string }).text).toContain("amount");
-  });
-
-  it("returns error when amount is zero", async () => {
-    const result = await callHandler({
-      side: "buy",
-      tokenAddress: VALID_TOKEN,
-      amount: "0",
-    });
-    expect((result as { success: boolean }).success).toBe(false);
-    expect((result as { text: string }).text).toContain("amount");
-  });
-
-  it("returns error when amount is negative", async () => {
-    const result = await callHandler({
-      side: "sell",
-      tokenAddress: VALID_TOKEN,
-      amount: "-1",
-    });
-    expect((result as { success: boolean }).success).toBe(false);
-    expect((result as { text: string }).text).toContain("amount");
-  });
-
-  it("returns error when amount is not a number", async () => {
-    const result = await callHandler({
-      side: "buy",
-      tokenAddress: VALID_TOKEN,
-      amount: "abc",
-    });
-    expect((result as { success: boolean }).success).toBe(false);
-    expect((result as { text: string }).text).toContain("amount");
-  });
-
-  it("returns error when slippageBps is negative", async () => {
-    const result = await callHandler({
-      side: "buy",
-      tokenAddress: VALID_TOKEN,
-      amount: "0.5",
-      slippageBps: -100,
-    });
-    expect((result as { success: boolean }).success).toBe(false);
-    expect((result as { text: string }).text).toContain("slippageBps");
-  });
-
-  // ── Successful API calls ─────────────────────────────────────────────────
-
-  it("calls API and returns success for local-key executed trade", async () => {
-    const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        ok: true,
+    it("rejects short tokenAddress", async () => {
+      const results = await callHandler({
         side: "buy",
-        mode: "local-key",
-        quote: { price: "0.001" },
-        executed: true,
-        requiresUserSignature: false,
-        unsignedTx: {},
-        execution: {
-          hash: "0xabc123",
-          explorerUrl: "https://bscscan.com/tx/0xabc123",
-          status: "success",
-          blockNumber: 12345,
-        },
-      }),
+        tokenAddress: "0xabc",
+        amount: "1",
+      });
+      expect(results[0].text).toContain("valid BSC token contract address");
     });
 
-    const result = await callHandler({
-      side: "buy",
-      tokenAddress: VALID_TOKEN,
-      amount: "0.5",
-    });
-
-    expect((result as { success: boolean }).success).toBe(true);
-    expect((result as { text: string }).text).toContain(
-      "Action: EXECUTE_TRADE",
-    );
-    expect((result as { text: string }).text).toContain("Executed: true");
-    expect((result as { text: string }).text).toContain("Tx hash: 0xabc123");
-    expect((result as { data: Record<string, unknown> }).data).toMatchObject({
-      side: "buy",
-      tokenAddress: VALID_TOKEN,
-      amount: "0.5",
-      mode: "local-key",
-      txHash: "0xabc123",
-      executed: true,
-    });
-
-    // Verify fetch was called with correct args
-    expect(mockFetch).toHaveBeenCalledOnce();
-    const [url, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe("http://127.0.0.1:31337/api/wallet/trade/execute");
-    expect(opts.method).toBe("POST");
-    expect(
-      (opts.headers as Record<string, string>)["X-Eliza-Agent-Action"],
-    ).toBe("1");
-    expect((opts.headers as Record<string, string>)["Content-Type"]).toBe(
-      "application/json",
-    );
-
-    const body = JSON.parse(opts.body as string);
-    expect(body.side).toBe("buy");
-    expect(body.tokenAddress).toBe(VALID_TOKEN);
-    expect(body.amount).toBe("0.5");
-    expect(body.slippageBps).toBe(300);
-    expect(body.routeProvider).toBe("pancakeswap-v2");
-    expect(body.confirm).toBe(true);
-  });
-
-  it("returns failure for user-sign mode because no on-chain execution occurred", async () => {
-    const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        ok: true,
+    it("rejects non-hex tokenAddress", async () => {
+      const results = await callHandler({
         side: "buy",
-        mode: "user-sign",
-        quote: { price: "0.001" },
-        executed: false,
-        requiresUserSignature: true,
-        unsignedTx: { chainId: 56, to: "0xrouter", data: "0x..." },
-      }),
+        tokenAddress: "0x" + "g".repeat(40),
+        amount: "1",
+      });
+      expect(results[0].text).toContain("valid BSC token contract address");
     });
 
-    const result = await callHandler({
-      side: "buy",
-      tokenAddress: VALID_TOKEN,
-      amount: "0.5",
-    });
-
-    expect((result as { success: boolean }).success).toBe(false);
-    expect((result as { text: string }).text).toContain("user-sign");
-    expect((result as { text: string }).text).toContain("Executed: false");
-    expect((result as { text: string }).text).toContain(
-      "signature is required",
-    );
-    expect((result as { data: Record<string, unknown> }).data).toMatchObject({
-      requiresUserSignature: true,
-      executed: false,
-    });
-  });
-
-  it("accepts numeric amount parameter", async () => {
-    const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        ok: true,
-        side: "sell",
-        mode: "local-key",
-        executed: true,
-        requiresUserSignature: false,
-        execution: {
-          hash: "0xdef456",
-          explorerUrl: "https://bscscan.com/tx/0xdef456",
-          status: "success",
-          blockNumber: 99999,
-        },
-      }),
-    });
-
-    const result = await callHandler({
-      side: "sell",
-      tokenAddress: VALID_TOKEN,
-      amount: 100,
-    });
-
-    expect((result as { success: boolean }).success).toBe(true);
-
-    const body = JSON.parse(
-      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
-    );
-    expect(body.amount).toBe("100");
-    expect(body.side).toBe("sell");
-  });
-
-  it("passes custom slippageBps to the API", async () => {
-    const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        ok: true,
+    it("rejects missing amount", async () => {
+      const results = await callHandler({
         side: "buy",
-        mode: "local-key",
-        executed: true,
-        requiresUserSignature: false,
-        execution: {
-          hash: "0x111",
-          explorerUrl: "https://bscscan.com/tx/0x111",
-          status: "success",
-          blockNumber: 1,
-        },
-      }),
+        tokenAddress: "0x" + "a".repeat(40),
+      });
+      expect(results[0].text).toContain("positive numeric amount");
     });
 
-    await callHandler({
-      side: "buy",
-      tokenAddress: VALID_TOKEN,
-      amount: "1",
-      slippageBps: 500,
-    });
-
-    const body = JSON.parse(
-      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
-    );
-    expect(body.slippageBps).toBe(500);
-  });
-
-  // ── Error handling ───────────────────────────────────────────────────────
-
-  it("handles API error responses (non-ok HTTP)", async () => {
-    const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 403,
-      json: async () => ({ error: "Trade not permitted" }),
-    });
-
-    const result = await callHandler({
-      side: "buy",
-      tokenAddress: VALID_TOKEN,
-      amount: "0.5",
-    });
-
-    expect((result as { success: boolean }).success).toBe(false);
-    expect((result as { text: string }).text).toContain("Trade not permitted");
-  });
-
-  it("handles API error with non-JSON body", async () => {
-    const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 500,
-      json: async () => {
-        throw new Error("not json");
-      },
-    });
-
-    const result = await callHandler({
-      side: "buy",
-      tokenAddress: VALID_TOKEN,
-      amount: "0.5",
-    });
-
-    expect((result as { success: boolean }).success).toBe(false);
-    expect((result as { text: string }).text).toContain("HTTP 500");
-  });
-
-  it("handles API returning ok=false", async () => {
-    const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        ok: false,
-        error: "Insufficient BNB balance",
-      }),
-    });
-
-    const result = await callHandler({
-      side: "buy",
-      tokenAddress: VALID_TOKEN,
-      amount: "999",
-    });
-
-    expect((result as { success: boolean }).success).toBe(false);
-    expect((result as { text: string }).text).toContain(
-      "Insufficient BNB balance",
-    );
-  });
-
-  it("handles network/fetch errors", async () => {
-    const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
-    mockFetch.mockRejectedValueOnce(new Error("ECONNREFUSED"));
-
-    const result = await callHandler({
-      side: "buy",
-      tokenAddress: VALID_TOKEN,
-      amount: "0.5",
-    });
-
-    expect((result as { success: boolean }).success).toBe(false);
-    expect((result as { text: string }).text).toContain("ECONNREFUSED");
-  });
-
-  it("handles missing parameters entirely", async () => {
-    const result = await executeTradeAction.handler({} as never, undefined);
-    expect((result as { success: boolean }).success).toBe(false);
-  });
-
-  // ── Auth header ──────────────────────────────────────────────────────────
-
-  it("includes Authorization header when ELIZA_API_TOKEN is set", async () => {
-    const originalToken = process.env.ELIZA_API_TOKEN;
-    process.env.ELIZA_API_TOKEN = "test-secret-token";
-
-    const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        ok: true,
+    it("rejects zero amount", async () => {
+      const results = await callHandler({
         side: "buy",
-        mode: "local-key",
-        executed: true,
-        requiresUserSignature: false,
-        execution: {
-          hash: "0xtoken123",
-          explorerUrl: "https://bscscan.com/tx/0xtoken123",
-          status: "success",
-          blockNumber: 1,
-        },
-      }),
+        tokenAddress: "0x" + "a".repeat(40),
+        amount: "0",
+      });
+      expect(results[0].text).toContain("positive numeric amount");
     });
 
-    await callHandler({
-      side: "buy",
-      tokenAddress: VALID_TOKEN,
-      amount: "0.5",
-    });
-
-    const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
-    expect((opts.headers as Record<string, string>).Authorization).toBe(
-      "Bearer test-secret-token",
-    );
-
-    process.env.ELIZA_API_TOKEN = originalToken;
-  });
-
-  it("omits Authorization header when ELIZA_API_TOKEN is not set", async () => {
-    const originalToken = process.env.ELIZA_API_TOKEN;
-    delete process.env.ELIZA_API_TOKEN;
-
-    const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        ok: true,
+    it("rejects negative amount", async () => {
+      const results = await callHandler({
         side: "buy",
-        mode: "local-key",
-        executed: true,
-        requiresUserSignature: false,
-        execution: {
-          hash: "0xnotoken",
-          explorerUrl: "https://bscscan.com/tx/0xnotoken",
-          status: "success",
-          blockNumber: 1,
-        },
-      }),
+        tokenAddress: "0x" + "a".repeat(40),
+        amount: "-5",
+      });
+      expect(results[0].text).toContain("positive numeric amount");
     });
 
-    await callHandler({
-      side: "buy",
-      tokenAddress: VALID_TOKEN,
-      amount: "0.5",
-    });
-
-    const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
-    expect(
-      (opts.headers as Record<string, string>).Authorization,
-    ).toBeUndefined();
-
-    process.env.ELIZA_API_TOKEN = originalToken;
-  });
-
-  // ── Prompt injection resistance ──────────────────────────────────────────
-
-  it("returns missing-param error when side is not in structured params (no text fallback)", async () => {
-    // Previously extractParamsFromText would fill in side from message text.
-    // Now we require structured params only.
-    const result = await executeTradeAction.handler(
-      {} as never,
-      { content: { text: `buy 0.5 BNB worth of ${VALID_TOKEN}` } } as never,
-      {} as never,
-      {
-        parameters: { tokenAddress: VALID_TOKEN, amount: "0.5" },
-      } as HandlerOptions,
-    );
-    expect((result as { success: boolean }).success).toBe(false);
-    expect((result as { text: string }).text).toContain("side");
-  });
-
-  it("returns missing-param error when tokenAddress is not in structured params (no text fallback)", async () => {
-    const result = await executeTradeAction.handler(
-      {} as never,
-      { content: { text: `buy 0.5 BNB worth of ${VALID_TOKEN}` } } as never,
-      {} as never,
-      { parameters: { side: "buy", amount: "0.5" } } as HandlerOptions,
-    );
-    expect((result as { success: boolean }).success).toBe(false);
-    expect((result as { text: string }).text).toContain("address");
-  });
-
-  it("returns missing-param error when amount is not in structured params (no text fallback)", async () => {
-    const result = await executeTradeAction.handler(
-      {} as never,
-      { content: { text: `buy 0.5 BNB worth of ${VALID_TOKEN}` } } as never,
-      {} as never,
-      {
-        parameters: { side: "buy", tokenAddress: VALID_TOKEN },
-      } as HandlerOptions,
-    );
-    expect((result as { success: boolean }).success).toBe(false);
-    expect((result as { text: string }).text).toContain("amount");
-  });
-
-  // ── Side case-insensitivity ──────────────────────────────────────────────
-
-  it("normalizes side to lowercase", async () => {
-    const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        ok: true,
+    it("rejects NaN amount", async () => {
+      const results = await callHandler({
         side: "buy",
-        mode: "local-key",
-        executed: true,
-        requiresUserSignature: false,
-        execution: {
-          hash: "0x222",
-          explorerUrl: "https://bscscan.com/tx/0x222",
-          status: "success",
-          blockNumber: 2,
-        },
-      }),
+        tokenAddress: "0x" + "a".repeat(40),
+        amount: "not-a-number",
+      });
+      expect(results[0].text).toContain("positive numeric amount");
     });
 
-    const result = await callHandler({
-      side: "BUY",
-      tokenAddress: VALID_TOKEN,
-      amount: "0.1",
+    it("rejects negative slippageBps", async () => {
+      const results = await callHandler({
+        side: "buy",
+        tokenAddress: "0x" + "a".repeat(40),
+        amount: "1",
+        slippageBps: -100,
+      });
+      expect(results[0].text).toContain("slippageBps");
     });
 
-    expect((result as { success: boolean }).success).toBe(true);
-
-    const body = JSON.parse(
-      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
-    );
-    expect(body.side).toBe("buy");
+    it("rejects placeholder values like 'unknown'", async () => {
+      const results = await callHandler({
+        side: "unknown",
+        tokenAddress: "0x" + "a".repeat(40),
+        amount: "1",
+      });
+      expect(results[0].text).toContain("valid trade side");
+    });
   });
 });

--- a/packages/app-core/src/actions/wallet-action-shared.test.ts
+++ b/packages/app-core/src/actions/wallet-action-shared.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildAuthHeaders, getWalletActionApiPort } from "./wallet-action-shared.js";
+
+const ENV_KEYS = [
+  "MILADY_API_PORT",
+  "ELIZA_PORT",
+  "MILADY_API_TOKEN",
+  "ELIZA_API_TOKEN",
+] as const;
+
+let saved: Record<string, string | undefined>;
+
+beforeEach(() => {
+  saved = {};
+  for (const k of ENV_KEYS) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+describe("getWalletActionApiPort", () => {
+  it("returns the configured API port", () => {
+    process.env.MILADY_API_PORT = "9000";
+    expect(getWalletActionApiPort()).toBe("9000");
+  });
+
+  it("falls back to ELIZA_PORT", () => {
+    process.env.ELIZA_PORT = "8888";
+    expect(getWalletActionApiPort()).toBe("8888");
+  });
+
+  it("returns a string", () => {
+    expect(typeof getWalletActionApiPort()).toBe("string");
+  });
+});
+
+describe("buildAuthHeaders", () => {
+  it("returns empty object when no token is set", () => {
+    expect(buildAuthHeaders()).toEqual({});
+  });
+
+  it("returns Bearer header when MILADY_API_TOKEN is set", () => {
+    process.env.MILADY_API_TOKEN = "tok_test";
+    const headers = buildAuthHeaders();
+    expect(headers.Authorization).toBe("Bearer tok_test");
+  });
+
+  it("does not double-prefix Bearer tokens", () => {
+    process.env.MILADY_API_TOKEN = "Bearer tok_test";
+    const headers = buildAuthHeaders();
+    expect(headers.Authorization).toBe("Bearer tok_test");
+    expect(headers.Authorization).not.toContain("Bearer Bearer");
+  });
+});


### PR DESCRIPTION
21 tests for the trade action validation path (real money at stake) and wallet action shared helpers. Covers: side/address/amount/slippage validation, wallet config detection, auth header construction, placeholder rejection.