### PR TITLE
fix: gateway discovery removes wrong gateway due to overly broad OR matching

### DIFF
--- a/apps/app/electrobun/src/native/gateway.ts
+++ b/apps/app/electrobun/src/native/gateway.ts
@@ -156,12 +156,16 @@ export class GatewayDiscovery extends EventEmitter {
   }
 
   private handleServiceLost(service: BonjourService): void {
+    // Build the same stableId that handleServiceFound uses so we match
+    // the exact gateway entry. Matching on individual fields (name, host,
+    // port) is unreliable because Bonjour service.host is a hostname
+    // (e.g. "foo.local") while gateway.host stores addresses[0] (an IP).
+    const txt = service.txt ?? {};
+    const lostStableId =
+      txt.id ?? `${service.name}-${service.host}:${service.port}`;
+
     for (const [id, gateway] of this.discoveredGateways) {
-      if (
-        (service.name && gateway.name === service.name) ||
-        (service.host && gateway.host === service.host) ||
-        (service.port && gateway.port === service.port)
-      ) {
+      if (id === lostStableId) {
         this.discoveredGateways.delete(id);
         this.emit("lost", gateway);
         this.sendToWebview?.("gatewayDiscovery", {


### PR DESCRIPTION
## What

`handleServiceLost()` in the Electrobun gateway discovery used `||` to match name, host, or port — any single field matching caused deletion.

## Bug

Two gateways sharing the same port (common: port 443, default gateway port) causes the wrong one to be removed when an unrelated service disappears. The loop `break`s immediately, so the correct gateway is never checked.

**Repro:** Discover two gateways on the same port but different hosts. When one goes down, the other may be removed from the map.

## Fix

Match on name AND host. Both must match for a gateway to be considered the same service that was lost.