### PR TITLE
fix: add spawn error handler to repo setup to prevent unhandled exception

### DIFF
--- a/scripts/run-repo-setup.mjs
+++ b/scripts/run-repo-setup.mjs
@@ -145,6 +145,9 @@ export async function runRepoSetup(repoRoot = DEFAULT_REPO_ROOT) {
           stdio: "inherit",
         });
 
+        child.on("error", (err) => {
+          reject(new Error(`${step} failed to spawn: ${err.message}`));
+        });
         child.on("exit", (code, signal) => {
           if (signal) {
             reject(new Error(`${step} exited due to signal ${signal}`));


### PR DESCRIPTION
The child process spawned for each setup step only listens for `exit` but not `error`. If a script path doesn't exist (ENOENT), Node emits `error` which becomes an unhandled exception, crashing setup and leaving `.eliza-repo-setup.lock` orphaned — blocking all future installs until manually deleted.

Fix: add `child.on('error', reject)`. 3 lines.