### PR TITLE
fix: prevent double FFmpeg spawn on stream restart (volume/mute change)

### DIFF
--- a/packages/agent/src/services/stream-manager.ts
+++ b/packages/agent/src/services/stream-manager.ts
@@ -160,6 +160,10 @@ class StreamManager {
     const savedStartedAt = this.startedAt;
     const savedFrameCount = this._frameCount;
 
+    // Mark as intentional so the exit handler doesn't trigger autoRestart()
+    // concurrently with our manual restart below.
+    this._intentionalStop = true;
+
     // Detach TTS bridge before stopping FFmpeg
     ttsStreamBridge.detach();
 
@@ -190,6 +194,7 @@ class StreamManager {
       volume: this._volume,
       muted: this._muted,
     };
+    this._intentionalStop = false;
     await this.start(config);
 
     // Restore tracking


### PR DESCRIPTION
## Bug

`restart()` kills FFmpeg and starts a new instance but never sets `_intentionalStop=true` before killing. When FFmpeg's exit event fires asynchronously, the exit handler sees `_running=true` and `_intentionalStop=false`, so it calls `autoRestart()` **concurrently** with the manual restart. Two FFmpeg processes run simultaneously.

## Trigger

Call `setVolume()`, `mute()`, or `unmute()` while streaming.

## Fix

Set `_intentionalStop=true` before killing, reset to `false` before the manual `start()`. The exit handler now correctly skips `autoRestart()` during intentional restarts.