### PR TITLE
fix: SSE stream parser drops multi-line data fields

### DIFF
--- a/packages/agent/src/cloud/bridge-client.ts
+++ b/packages/agent/src/cloud/bridge-client.ts
@@ -197,7 +197,8 @@ export class ElizaCloudClient {
 
         for (const line of part.split("\n")) {
           if (line.startsWith("event: ")) eventType = line.slice(7).trim();
-          else if (line.startsWith("data: ")) eventData = line.slice(6);
+          else if (line.startsWith("data: "))
+            eventData += (eventData ? "\n" : "") + line.slice(6);
         }
 
         if (eventData) {


### PR DESCRIPTION
## Bug

The SSE parser in `sendMessageStream()` overwrites `eventData` on each `data:` line:

```typescript
else if (line.startsWith("data: ")) eventData = line.slice(6); // overwrites!
```

Per the [SSE spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation), multiple `data:` lines in a single event should be concatenated with newlines. This causes silent data loss when Eliza Cloud sends multi-line SSE events.

## Fix

Append instead of overwrite: `eventData += (eventData ? "\n" : "") + line.slice(6)`

One-line change.