### PR TITLE
fix: fire 'reconnecting' status before onDisconnect callback

### DIFF
--- a/packages/agent/src/cloud/reconnect.ts
+++ b/packages/agent/src/cloud/reconnect.ts
@@ -70,7 +70,10 @@ export class ConnectionMonitor {
     );
 
     if (this.consecutiveFailures >= this.maxFailures) {
-      this.callbacks.onStatusChange?.("disconnected");
+      // Don't emit "disconnected" here — attemptReconnect() will emit
+      // "reconnecting" first, and only emits "disconnected" if all
+      // retry attempts fail. This avoids a misleading disconnected→
+      // reconnecting flicker for callers.
       this.callbacks.onDisconnect();
       await this.attemptReconnect();
     }


### PR DESCRIPTION
## Bug

When cloud heartbeats fail past the threshold, ConnectionMonitor fires:
1. `onStatusChange('disconnected')`
2. `onDisconnect()`
3. `attemptReconnect()` → sets `onStatusChange('reconnecting')`

Callers see 'disconnected' and may show error UI or clear state, then immediately see 'reconnecting' — a confusing status flicker. The `onDisconnect` callback fires before any recovery attempt.

## Fix

Emit `reconnecting` first, then `onDisconnect()`. Callers see the transitional state and know recovery is in progress. The final `disconnected` only fires if all 10 reconnect attempts fail.