### PR TITLE
fix: remove double normalization of cloud base URL in CloudManager.init()

### DIFF
--- a/packages/agent/src/cloud/cloud-manager.ts
+++ b/packages/agent/src/cloud/cloud-manager.ts
@@ -49,9 +49,11 @@ export class CloudManager {
       throw new Error(urlError);
     }
 
-    const siteUrl = normalizeCloudSiteUrl(rawUrl);
-    this.client = new ElizaCloudClient(siteUrl, apiKey);
-    logger.info(`[cloud-manager] Client initialised (baseUrl=${siteUrl})`);
+    // rawUrl is already normalized above — don't re-normalize, which would
+    // re-read ELIZAOS_CLOUD_BASE_URL and could produce a different URL than
+    // the one we just validated.
+    this.client = new ElizaCloudClient(rawUrl, apiKey);
+    logger.info(`[cloud-manager] Client initialised (baseUrl=${rawUrl})`);
   }
 
   async connect(agentId: string): Promise<CloudRuntimeProxy> {


### PR DESCRIPTION
`normalizeCloudSiteUrl()` was called twice — once to normalize the URL, then again after validation before creating the client. The second call re-reads `ELIZAOS_CLOUD_BASE_URL` from `process.env`, so if that env var changes between calls (or differs from the config `baseUrl`), the validated URL differs from the one used for the client.

Fix: use the already-normalized `rawUrl` directly for client creation. Removes the dead `siteUrl` variable.