### PR TITLE
fix: vincent oauth completes in external browser via server-side PKCE

### DIFF
--- a/packages/app-core/src/api/client-vincent.ts
+++ b/packages/app-core/src/api/client-vincent.ts
@@ -13,8 +13,15 @@ export interface VincentStatusResponse {
 
 // ── Declaration merging ───────────────────────────────────────────────
 
+export interface VincentStartLoginResponse {
+  authUrl: string;
+  state: string;
+  redirectUri: string;
+}
+
 declare module "./client-base" {
   interface MiladyClient {
+    vincentStartLogin(appName?: string): Promise<VincentStartLoginResponse>;
     vincentRegister(
       appName: string,
       redirectUris: string[],
@@ -30,6 +37,13 @@ declare module "./client-base" {
 }
 
 // ── Implementation ────────────────────────────────────────────────────
+
+MiladyClient.prototype.vincentStartLogin = async function (appName?: string) {
+  return this.fetch("/api/vincent/start-login", {
+    method: "POST",
+    body: JSON.stringify({ appName: appName ?? "Milady" }),
+  });
+};
 
 MiladyClient.prototype.vincentRegister = async function (
   appName: string,

--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -782,8 +782,20 @@ async function handleMiladyCompatRoute(
   }
 
   // ── Vincent OAuth routes ────────────────────────────────────────
-  if (url.pathname.startsWith("/api/vincent/")) {
-    if (!ensureCompatApiAuthorized(req, res)) return true;
+  // /callback/vincent is the OAuth redirect target and is hit by the user's
+  // external system browser — it has no compat API token, so it must bypass
+  // ensureCompatApiAuthorized. The PKCE code_verifier stored server-side
+  // (keyed by the OAuth state param) is what actually authorizes the
+  // token exchange.
+  if (
+    url.pathname.startsWith("/api/vincent/") ||
+    url.pathname === "/callback/vincent"
+  ) {
+    if (
+      url.pathname !== "/callback/vincent" &&
+      !ensureCompatApiAuthorized(req, res)
+    )
+      return true;
     const vincentConfig = loadElizaConfig();
     const handled = await handleVincentRoute(req, res, url.pathname, method, {
       config: vincentConfig,

--- a/packages/app-core/src/api/vincent-routes.test.ts
+++ b/packages/app-core/src/api/vincent-routes.test.ts
@@ -1,0 +1,479 @@
+/**
+ * Route-level tests for vincent-routes.ts — the server-side PKCE flow that
+ * backs Vincent OAuth login.  These are the security-critical gate: state
+ * validation, PKCE-backed token exchange, OAuth error reflection, and token
+ * persistence all live behind GET /callback/vincent.
+ *
+ * What's covered here (per PR #1685 review):
+ *   1. GET /callback/vincent with missing state       → 400 HTML
+ *   2. GET /callback/vincent with unknown state       → 400 HTML ("expired")
+ *   3. GET /callback/vincent with oauth `error` param → 400 HTML, value escaped
+ *   4. Happy path start-login → callback → saveElizaConfig(tokens) + 200 HTML
+ *   5. State is single-use: a replay of a completed callback returns 400
+ *   6. Upstream token exchange failure                → 502 HTML
+ */
+
+import type http from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mocks ───────────────────────────────────────────────────────────────
+
+vi.mock("@elizaos/core", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+
+const saveElizaConfigMock = vi.fn();
+vi.mock("@miladyai/agent/config/config", () => ({
+  saveElizaConfig: (...args: unknown[]) => saveElizaConfigMock(...args),
+}));
+
+// ── Import under test (after mocks) ─────────────────────────────────────
+
+import type { ElizaConfig } from "@miladyai/agent/config/config";
+import { handleVincentRoute } from "./vincent-routes";
+
+// ── Test helpers ────────────────────────────────────────────────────────
+
+interface CapturedResponse {
+  statusCode: number | null;
+  headers: Record<string, string>;
+  body: string;
+  headersSent: boolean;
+}
+
+function fakeReq(
+  method: string,
+  url: string,
+  body?: string,
+): http.IncomingMessage {
+  const listeners: Record<string, Array<(...args: unknown[]) => void>> = {};
+  const req = {
+    method,
+    url,
+    headers: { host: "127.0.0.1:31337" },
+    on(event: string, cb: (...args: unknown[]) => void) {
+      const bucket = listeners[event] ?? [];
+      bucket.push(cb);
+      listeners[event] = bucket;
+      return this;
+    },
+  } as unknown as http.IncomingMessage;
+
+  // If a body was provided, schedule a microtask that feeds it to readBody().
+  if (body !== undefined) {
+    queueMicrotask(() => {
+      for (const cb of listeners.data ?? []) cb(Buffer.from(body));
+      for (const cb of listeners.end ?? []) cb();
+    });
+  } else {
+    queueMicrotask(() => {
+      for (const cb of listeners.end ?? []) cb();
+    });
+  }
+  return req;
+}
+
+function fakeRes(): {
+  res: http.ServerResponse;
+  captured: CapturedResponse;
+} {
+  const captured: CapturedResponse = {
+    statusCode: null,
+    headers: {},
+    body: "",
+    headersSent: false,
+  };
+  const res = {
+    get statusCode() {
+      return captured.statusCode ?? 200;
+    },
+    set statusCode(v: number) {
+      captured.statusCode = v;
+    },
+    get headersSent() {
+      return captured.headersSent;
+    },
+    setHeader(name: string, value: string | number | string[]) {
+      captured.headers[name.toLowerCase()] = String(value);
+    },
+    end(data?: string | Buffer) {
+      if (data !== undefined) captured.body = String(data);
+      captured.headersSent = true;
+    },
+  } as unknown as http.ServerResponse;
+  return { res, captured };
+}
+
+function mockFetchSequence(
+  responses: Array<{
+    ok: boolean;
+    status: number;
+    body: unknown;
+  }>,
+): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn();
+  for (const r of responses) {
+    fetchMock.mockResolvedValueOnce({
+      ok: r.ok,
+      status: r.status,
+      statusText: r.ok ? "OK" : "Error",
+      json: vi.fn().mockResolvedValue(r.body),
+      text: vi
+        .fn()
+        .mockResolvedValue(
+          typeof r.body === "string" ? r.body : JSON.stringify(r.body),
+        ),
+    } as unknown as Response);
+  }
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function makeConfig(): ElizaConfig {
+  return {} as ElizaConfig;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe("vincent-routes — GET /callback/vincent", () => {
+  beforeEach(() => {
+    saveElizaConfigMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns 400 HTML when the callback is missing the code param", async () => {
+    const req = fakeReq("GET", "/callback/vincent");
+    const { res, captured } = fakeRes();
+
+    const handled = await handleVincentRoute(
+      req,
+      res,
+      "/callback/vincent",
+      "GET",
+      { config: makeConfig() },
+    );
+
+    expect(handled).toBe(true);
+    expect(captured.statusCode).toBe(400);
+    expect(captured.headers["content-type"]).toContain("text/html");
+    expect(captured.body).toContain("Vincent login failed");
+    expect(captured.body).toContain("did not include an authorization code");
+    expect(saveElizaConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 HTML when state is missing", async () => {
+    const req = fakeReq("GET", "/callback/vincent?code=abc");
+    const { res, captured } = fakeRes();
+
+    await handleVincentRoute(req, res, "/callback/vincent", "GET", {
+      config: makeConfig(),
+    });
+
+    expect(captured.statusCode).toBe(400);
+    expect(captured.body).toContain("did not include a state parameter");
+    expect(saveElizaConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 HTML when state does not match any pending login", async () => {
+    const req = fakeReq(
+      "GET",
+      "/callback/vincent?code=abc&state=not-a-real-state",
+    );
+    const { res, captured } = fakeRes();
+
+    await handleVincentRoute(req, res, "/callback/vincent", "GET", {
+      config: makeConfig(),
+    });
+
+    expect(captured.statusCode).toBe(400);
+    expect(captured.body).toContain("Vincent login expired");
+    expect(captured.body).toContain("No pending login was found");
+    expect(saveElizaConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 HTML with escaped OAuth error output (XSS guard)", async () => {
+    const req = fakeReq(
+      "GET",
+      "/callback/vincent?error=%3Cscript%3Ealert(1)%3C%2Fscript%3E",
+    );
+    const { res, captured } = fakeRes();
+
+    await handleVincentRoute(req, res, "/callback/vincent", "GET", {
+      config: makeConfig(),
+    });
+
+    expect(captured.statusCode).toBe(400);
+    expect(captured.headers["content-type"]).toContain("text/html");
+    // Escaped output must appear…
+    expect(captured.body).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+    // …and the raw tag must NOT.
+    expect(captured.body).not.toContain("<script>alert(1)</script>");
+    expect(saveElizaConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 502 HTML when Vincent's token endpoint fails", async () => {
+    // 1st fetch = register (success), 2nd fetch = token (failure)
+    mockFetchSequence([
+      { ok: true, status: 200, body: { client_id: "vcl_test" } },
+      { ok: false, status: 400, body: { error: "invalid_request" } },
+    ]);
+
+    const config = makeConfig();
+
+    // Seed a pending login via start-login
+    const startReq = fakeReq(
+      "POST",
+      "/api/vincent/start-login",
+      JSON.stringify({ appName: "Milady" }),
+    );
+    const { res: startRes, captured: startCap } = fakeRes();
+    await handleVincentRoute(
+      startReq,
+      startRes,
+      "/api/vincent/start-login",
+      "POST",
+      { config },
+    );
+    expect(startCap.statusCode).toBe(200);
+    const { state } = JSON.parse(startCap.body) as { state: string };
+    expect(state).toBeTruthy();
+
+    // Hit the callback with a valid state — upstream token exchange fails
+    const cbReq = fakeReq(
+      "GET",
+      `/callback/vincent?code=authcode&state=${state}`,
+    );
+    const { res: cbRes, captured: cbCap } = fakeRes();
+    await handleVincentRoute(cbReq, cbRes, "/callback/vincent", "GET", {
+      config,
+    });
+
+    expect(cbCap.statusCode).toBe(502);
+    expect(cbCap.body).toContain("Token exchange with Vincent failed");
+    expect(saveElizaConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("happy path: start-login → callback persists tokens and returns 200 HTML", async () => {
+    mockFetchSequence([
+      { ok: true, status: 200, body: { client_id: "vcl_happy" } },
+      {
+        ok: true,
+        status: 200,
+        body: {
+          access_token: "tok_access",
+          refresh_token: "tok_refresh",
+        },
+      },
+    ]);
+
+    const config = makeConfig();
+
+    // Seed pending login
+    const startReq = fakeReq(
+      "POST",
+      "/api/vincent/start-login",
+      JSON.stringify({ appName: "Milady" }),
+    );
+    const { res: startRes, captured: startCap } = fakeRes();
+    await handleVincentRoute(
+      startReq,
+      startRes,
+      "/api/vincent/start-login",
+      "POST",
+      { config },
+    );
+    expect(startCap.statusCode).toBe(200);
+    const startBody = JSON.parse(startCap.body) as {
+      authUrl: string;
+      state: string;
+      redirectUri: string;
+    };
+    expect(startBody.authUrl).toContain("heyvincent.ai");
+    expect(startBody.authUrl).toContain(`state=${startBody.state}`);
+    expect(startBody.authUrl).toContain(
+      `redirect_uri=${encodeURIComponent("http://127.0.0.1:31337/callback/vincent")}`,
+    );
+    expect(startBody.redirectUri).toBe(
+      "http://127.0.0.1:31337/callback/vincent",
+    );
+
+    // Now hit the callback with that state
+    const cbReq = fakeReq(
+      "GET",
+      `/callback/vincent?code=live_code&state=${startBody.state}`,
+    );
+    const { res: cbRes, captured: cbCap } = fakeRes();
+    await handleVincentRoute(cbReq, cbRes, "/callback/vincent", "GET", {
+      config,
+    });
+
+    expect(cbCap.statusCode).toBe(200);
+    expect(cbCap.headers["content-type"]).toContain("text/html");
+    expect(cbCap.body).toContain("Vincent connected");
+    expect(cbCap.body).toContain("You can close this window");
+
+    // Tokens must have been persisted via saveElizaConfig with the exact
+    // values returned by the (mocked) token endpoint.
+    expect(saveElizaConfigMock).toHaveBeenCalledTimes(1);
+    const persisted = saveElizaConfigMock.mock.calls[0][0] as {
+      vincent?: {
+        accessToken: string;
+        refreshToken: string | null;
+        clientId: string;
+        connectedAt: number;
+      };
+    };
+    expect(persisted.vincent).toBeDefined();
+    expect(persisted.vincent?.accessToken).toBe("tok_access");
+    expect(persisted.vincent?.refreshToken).toBe("tok_refresh");
+    expect(persisted.vincent?.clientId).toBe("vcl_happy");
+    expect(typeof persisted.vincent?.connectedAt).toBe("number");
+
+    // Verify redirect_uri was included in the token exchange body (RFC 6749
+    // §4.1.3 — Vincent rejects the exchange without it).
+    const fetchMock = (globalThis as { fetch?: ReturnType<typeof vi.fn> })
+      .fetch as ReturnType<typeof vi.fn>;
+    const tokenCall = fetchMock.mock.calls[1];
+    const tokenBody = JSON.parse(
+      (tokenCall[1] as { body: string }).body,
+    ) as Record<string, string>;
+    expect(tokenBody.redirect_uri).toBe(
+      "http://127.0.0.1:31337/callback/vincent",
+    );
+    expect(tokenBody.grant_type).toBe("authorization_code");
+    expect(tokenBody.code).toBe("live_code");
+    expect(tokenBody.client_id).toBe("vcl_happy");
+    expect(tokenBody.code_verifier).toBeTruthy();
+  });
+
+  it("state is single-use: replaying the same state after success returns 400", async () => {
+    // Register + token success for the first callback, then register only
+    // for a would-be second start (not exercised) — we only need two entries.
+    mockFetchSequence([
+      { ok: true, status: 200, body: { client_id: "vcl_replay" } },
+      {
+        ok: true,
+        status: 200,
+        body: { access_token: "tok_r", refresh_token: null },
+      },
+    ]);
+
+    const config = makeConfig();
+
+    // start-login
+    const startReq = fakeReq(
+      "POST",
+      "/api/vincent/start-login",
+      JSON.stringify({}),
+    );
+    const { res: startRes, captured: startCap } = fakeRes();
+    await handleVincentRoute(
+      startReq,
+      startRes,
+      "/api/vincent/start-login",
+      "POST",
+      { config },
+    );
+    const { state } = JSON.parse(startCap.body) as { state: string };
+
+    // First callback succeeds
+    const cb1Req = fakeReq(
+      "GET",
+      `/callback/vincent?code=first&state=${state}`,
+    );
+    const { res: cb1Res, captured: cb1Cap } = fakeRes();
+    await handleVincentRoute(cb1Req, cb1Res, "/callback/vincent", "GET", {
+      config,
+    });
+    expect(cb1Cap.statusCode).toBe(200);
+    expect(saveElizaConfigMock).toHaveBeenCalledTimes(1);
+
+    // Replay with the same state — must be rejected
+    const cb2Req = fakeReq(
+      "GET",
+      `/callback/vincent?code=replay&state=${state}`,
+    );
+    const { res: cb2Res, captured: cb2Cap } = fakeRes();
+    await handleVincentRoute(cb2Req, cb2Res, "/callback/vincent", "GET", {
+      config,
+    });
+    expect(cb2Cap.statusCode).toBe(400);
+    expect(cb2Cap.body).toContain("Vincent login expired");
+    // saveElizaConfig was NOT called a second time.
+    expect(saveElizaConfigMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("vincent-routes — /api/vincent/status and /api/vincent/disconnect", () => {
+  beforeEach(() => {
+    saveElizaConfigMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("GET /api/vincent/status reflects persisted tokens", async () => {
+    const config = {
+      vincent: {
+        accessToken: "tok",
+        refreshToken: null,
+        clientId: "vcl_x",
+        connectedAt: 1_700_000_000,
+      },
+    } as unknown as ElizaConfig;
+
+    const req = fakeReq("GET", "/api/vincent/status");
+    const { res, captured } = fakeRes();
+    await handleVincentRoute(req, res, "/api/vincent/status", "GET", {
+      config,
+    });
+
+    expect(captured.statusCode).toBe(200);
+    const payload = JSON.parse(captured.body) as {
+      connected: boolean;
+      connectedAt: number | null;
+    };
+    expect(payload.connected).toBe(true);
+    expect(payload.connectedAt).toBe(1_700_000_000);
+  });
+
+  it("GET /api/vincent/status reports disconnected when no tokens", async () => {
+    const req = fakeReq("GET", "/api/vincent/status");
+    const { res, captured } = fakeRes();
+    await handleVincentRoute(req, res, "/api/vincent/status", "GET", {
+      config: makeConfig(),
+    });
+
+    expect(captured.statusCode).toBe(200);
+    const payload = JSON.parse(captured.body) as { connected: boolean };
+    expect(payload.connected).toBe(false);
+  });
+
+  it("POST /api/vincent/disconnect clears tokens via saveElizaConfig", async () => {
+    const config = {
+      vincent: {
+        accessToken: "tok",
+        refreshToken: null,
+        clientId: "vcl_x",
+        connectedAt: 1_700_000_000,
+      },
+    } as unknown as ElizaConfig;
+
+    const req = fakeReq("POST", "/api/vincent/disconnect");
+    const { res, captured } = fakeRes();
+    await handleVincentRoute(req, res, "/api/vincent/disconnect", "POST", {
+      config,
+    });
+
+    expect(captured.statusCode).toBe(200);
+    expect(saveElizaConfigMock).toHaveBeenCalledTimes(1);
+    const saved = saveElizaConfigMock.mock.calls[0][0] as {
+      vincent?: unknown;
+    };
+    expect(saved.vincent).toBeUndefined();
+  });
+});

--- a/packages/app-core/src/api/vincent-routes.ts
+++ b/packages/app-core/src/api/vincent-routes.ts
@@ -1,12 +1,20 @@
 /**
  * Vincent OAuth backend routes.
  *
- * POST /api/vincent/register  — Register app with Vincent, get client_id
- * POST /api/vincent/token     — Exchange auth code + verifier for tokens
- * GET  /api/vincent/status    — Check if Vincent is connected
- * POST /api/vincent/disconnect — Clear stored Vincent tokens
+ * POST /api/vincent/start-login — Begin OAuth: register app, generate PKCE, return authUrl
+ * GET  /callback/vincent        — OAuth redirect target: exchange code, persist tokens
+ * POST /api/vincent/register    — (legacy) Register app with Vincent, get client_id
+ * POST /api/vincent/token       — (legacy) Exchange auth code + verifier for tokens
+ * GET  /api/vincent/status      — Check if Vincent is connected
+ * POST /api/vincent/disconnect  — Clear stored Vincent tokens
+ *
+ * The start-login + /callback/vincent pair keeps the PKCE code_verifier on the
+ * server so the OAuth redirect can land in the user's external system browser
+ * (where sessionStorage is not shared with the desktop webview) and still
+ * complete the token exchange.
  */
 
+import crypto from "node:crypto";
 import type http from "node:http";
 import { logger } from "@elizaos/core";
 import type { ElizaConfig } from "@miladyai/agent/config/config";
@@ -14,6 +22,82 @@ import { saveElizaConfig } from "@miladyai/agent/config/config";
 import { sendJson, sendJsonError } from "./response";
 
 const VINCENT_API_BASE = "https://heyvincent.ai";
+
+/** Maximum time a pending PKCE login can sit before it is evicted. */
+const PENDING_LOGIN_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+interface PendingLogin {
+  clientId: string;
+  codeVerifier: string;
+  /**
+   * Must be echoed back to the Vincent token endpoint verbatim. RFC 6749
+   * §4.1.3 requires redirect_uri in the token exchange to exactly match the
+   * one in the authorize request when it was present there — Vincent enforces
+   * this and rejects with "invalid_request: expected string, received
+   * undefined" if the field is missing.
+   */
+  redirectUri: string;
+  createdAt: number;
+}
+
+/**
+ * In-memory store for in-flight OAuth logins, keyed by OAuth `state` param.
+ * Process-local on purpose — Vincent tokens only matter for this runtime.
+ */
+const pendingLogins = new Map<string, PendingLogin>();
+
+function sweepExpiredLogins(): void {
+  const cutoff = Date.now() - PENDING_LOGIN_TTL_MS;
+  for (const [state, entry] of pendingLogins) {
+    if (entry.createdAt < cutoff) pendingLogins.delete(state);
+  }
+}
+
+function base64UrlEncode(buf: Buffer): string {
+  return buf
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function generateCodeVerifier(): string {
+  return base64UrlEncode(crypto.randomBytes(32));
+}
+
+function generateCodeChallenge(verifier: string): string {
+  return base64UrlEncode(crypto.createHash("sha256").update(verifier).digest());
+}
+
+function resolveServerOrigin(req: http.IncomingMessage): string | null {
+  const host = req.headers.host;
+  if (!host) return null;
+  // All Vincent login traffic is loopback — http is fine and matches the
+  // redirect_uri the external browser will actually hit.
+  return `http://${host}`;
+}
+
+interface VincentTokens {
+  accessToken: string;
+  refreshToken: string | null;
+  clientId: string;
+  connectedAt: number;
+}
+
+/**
+ * Read/write the `vincent` field on ElizaConfig. The schema doesn't type this
+ * field yet — keep the unsafe cast isolated in one place.
+ */
+function getVincentTokens(config: ElizaConfig): VincentTokens | undefined {
+  return (config as unknown as { vincent?: VincentTokens }).vincent;
+}
+
+function setVincentTokens(
+  config: ElizaConfig,
+  tokens: VincentTokens | undefined,
+): void {
+  (config as unknown as { vincent?: VincentTokens }).vincent = tokens;
+}
 
 export interface VincentRouteState {
   config: ElizaConfig;
@@ -30,6 +114,212 @@ export async function handleVincentRoute(
   method: string,
   state: VincentRouteState,
 ): Promise<boolean> {
+  // ── POST /api/vincent/start-login ───────────────────────────────
+  // Server-side PKCE: register with Vincent, generate verifier/challenge,
+  // store the verifier keyed by a fresh `state` param, and return the
+  // authorization URL. The browser visits this URL, authenticates, and is
+  // redirected back to GET /callback/vincent on this same origin.
+  if (method === "POST" && pathname === "/api/vincent/start-login") {
+    try {
+      sweepExpiredLogins();
+
+      const origin = resolveServerOrigin(req);
+      if (!origin) {
+        sendJsonError(res, 400, "Missing Host header");
+        return true;
+      }
+      const redirectUri = `${origin}/callback/vincent`;
+
+      const body = await readBody(req).catch(() => "");
+      const parsed = body ? (JSON.parse(body) as { appName?: string }) : {};
+      const appName = parsed.appName?.trim() || "Milady";
+
+      const registerRes = await fetch(
+        `${VINCENT_API_BASE}/api/oauth/public/register`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            client_name: appName,
+            redirect_uris: [redirectUri],
+          }),
+        },
+      );
+      if (!registerRes.ok) {
+        const text = await registerRes.text().catch(() => "");
+        sendJsonError(
+          res,
+          registerRes.status,
+          `Vincent register failed: ${text}`,
+        );
+        return true;
+      }
+      const { client_id } = (await registerRes.json()) as { client_id: string };
+
+      const codeVerifier = generateCodeVerifier();
+      const codeChallenge = generateCodeChallenge(codeVerifier);
+      const stateParam = crypto.randomUUID();
+
+      pendingLogins.set(stateParam, {
+        clientId: client_id,
+        codeVerifier,
+        redirectUri,
+        createdAt: Date.now(),
+      });
+
+      const params = new URLSearchParams({
+        client_id,
+        response_type: "code",
+        redirect_uri: redirectUri,
+        scope: "all",
+        resource: VINCENT_API_BASE,
+        code_challenge: codeChallenge,
+        code_challenge_method: "S256",
+        state: stateParam,
+      });
+      const authUrl = `${VINCENT_API_BASE}/api/oauth/public/authorize?${params.toString()}`;
+
+      sendJson(res, 200, { authUrl, state: stateParam, redirectUri });
+    } catch (err) {
+      logger.error(
+        `[vincent/start-login] ${err instanceof Error ? err.message : String(err)}`,
+      );
+      sendJsonError(res, 500, "Vincent start-login failed");
+    }
+    return true;
+  }
+
+  // ── GET /callback/vincent ───────────────────────────────────────
+  // OAuth redirect target for the Vincent authorization flow.  Loads in the
+  // user's external browser (not the desktop webview), so it returns a small
+  // HTML page that tells the user to close the tab — the desktop app is
+  // polling /api/vincent/status and will flip to connected on its own.
+  if (method === "GET" && pathname === "/callback/vincent") {
+    try {
+      sweepExpiredLogins();
+
+      const url = new URL(req.url ?? "/callback/vincent", "http://localhost");
+      const code = url.searchParams.get("code");
+      const stateParam = url.searchParams.get("state");
+      const oauthError = url.searchParams.get("error");
+
+      if (oauthError) {
+        // `sendCallbackHtml` escapes `message` wholesale — don't escape the
+        // `error` param here or it ends up double-encoded (&amp;lt; instead
+        // of &lt;).
+        sendCallbackHtml(
+          res,
+          400,
+          "Vincent login failed",
+          `Vincent returned an error: ${oauthError}. You may close this window.`,
+        );
+        return true;
+      }
+      if (!code) {
+        sendCallbackHtml(
+          res,
+          400,
+          "Vincent login failed",
+          "The Vincent redirect did not include an authorization code. You may close this window.",
+        );
+        return true;
+      }
+
+      // Require a state param that matches a pending login exactly. This
+      // prevents any local process that can reach loopback from completing a
+      // login flow it did not initiate — only start-login can seed an entry
+      // in pendingLogins, and only the state value we returned from it can
+      // unlock the associated code_verifier. (PKCE already prevents cross-
+      // session token theft via Vincent's challenge/verifier check, but
+      // rejecting unknown state is the cheaper, clearer gate.)
+      if (!stateParam) {
+        sendCallbackHtml(
+          res,
+          400,
+          "Vincent login failed",
+          "The Vincent redirect did not include a state parameter. Please return to Milady and try again.",
+        );
+        return true;
+      }
+      const pending = pendingLogins.get(stateParam);
+      if (!pending) {
+        sendCallbackHtml(
+          res,
+          400,
+          "Vincent login expired",
+          "No pending login was found for this callback. Please return to Milady and try again.",
+        );
+        return true;
+      }
+      pendingLogins.delete(stateParam);
+
+      const tokenRes = await fetch(
+        `${VINCENT_API_BASE}/api/oauth/public/token`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            grant_type: "authorization_code",
+            code,
+            client_id: pending.clientId,
+            code_verifier: pending.codeVerifier,
+            // RFC 6749 §4.1.3: redirect_uri MUST match the one used in the
+            // authorize request. Vincent rejects the exchange with
+            // "invalid_request: expected string, received undefined" without
+            // this field.
+            redirect_uri: pending.redirectUri,
+          }),
+        },
+      );
+      if (!tokenRes.ok) {
+        const text = await tokenRes.text().catch(() => "");
+        logger.error(
+          `[vincent/callback] token exchange failed: ${tokenRes.status} ${text}`,
+        );
+        sendCallbackHtml(
+          res,
+          502,
+          "Vincent login failed",
+          "Token exchange with Vincent failed. Please return to Milady and try again.",
+        );
+        return true;
+      }
+
+      const tokens = (await tokenRes.json()) as {
+        access_token: string;
+        refresh_token?: string;
+      };
+
+      const config = state.config;
+      setVincentTokens(config, {
+        accessToken: tokens.access_token,
+        refreshToken: tokens.refresh_token ?? null,
+        clientId: pending.clientId,
+        connectedAt: Math.floor(Date.now() / 1000),
+      });
+      await saveElizaConfig(config);
+
+      logger.info("[vincent/callback] Vincent connected successfully");
+      sendCallbackHtml(
+        res,
+        200,
+        "Vincent connected",
+        "You're signed in. You can close this window and return to Milady.",
+      );
+    } catch (err) {
+      logger.error(
+        `[vincent/callback] ${err instanceof Error ? err.message : String(err)}`,
+      );
+      sendCallbackHtml(
+        res,
+        500,
+        "Vincent login failed",
+        "An unexpected error occurred completing the Vincent login. You may close this window and try again.",
+      );
+    }
+    return true;
+  }
+
   // ── POST /api/vincent/register ──────────────────────────────────
   if (method === "POST" && pathname === "/api/vincent/register") {
     try {
@@ -107,12 +397,12 @@ export async function handleVincentRoute(
 
       // Persist tokens to config
       const config = state.config;
-      (config as any).vincent = {
+      setVincentTokens(config, {
         accessToken: tokens.access_token,
         refreshToken: tokens.refresh_token ?? null,
         clientId,
         connectedAt: Math.floor(Date.now() / 1000),
-      };
+      });
       await saveElizaConfig(config);
 
       logger.info("[vincent/token] Vincent connected successfully");
@@ -128,7 +418,7 @@ export async function handleVincentRoute(
 
   // ── GET /api/vincent/status ─────────────────────────────────────
   if (method === "GET" && pathname === "/api/vincent/status") {
-    const vincent = (state.config as any).vincent;
+    const vincent = getVincentTokens(state.config);
     const connected = Boolean(vincent?.accessToken);
     sendJson(res, 200, {
       connected,
@@ -141,7 +431,7 @@ export async function handleVincentRoute(
   if (method === "POST" && pathname === "/api/vincent/disconnect") {
     try {
       const config = state.config;
-      (config as any).vincent = undefined;
+      setVincentTokens(config, undefined);
       await saveElizaConfig(config);
       logger.info("[vincent/disconnect] Vincent disconnected");
       sendJson(res, 200, { ok: true });
@@ -166,4 +456,59 @@ function readBody(req: http.IncomingMessage): Promise<string> {
     req.on("end", () => resolve(Buffer.concat(chunks).toString()));
     req.on("error", reject);
   });
+}
+
+function escapeHtml(input: string): string {
+  return input
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function sendCallbackHtml(
+  res: http.ServerResponse,
+  status: number,
+  title: string,
+  message: string,
+): void {
+  if (res.headersSent) return;
+  const safeTitle = escapeHtml(title);
+  const safeMessage = escapeHtml(message);
+  const html = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>${safeTitle} · Milady</title>
+<style>
+  :root { color-scheme: light dark; }
+  html, body { height: 100%; margin: 0; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    display: flex; align-items: center; justify-content: center;
+    background: #0b0b0f; color: #f4f4f5;
+  }
+  .card {
+    max-width: 420px; padding: 32px 36px; border-radius: 16px;
+    background: #17171c; border: 1px solid #2a2a33;
+    box-shadow: 0 20px 60px rgba(0,0,0,0.4);
+    text-align: center;
+  }
+  h1 { margin: 0 0 12px; font-size: 20px; font-weight: 600; }
+  p  { margin: 0; font-size: 14px; line-height: 1.5; color: #b4b4bd; }
+</style>
+</head>
+<body>
+  <main class="card">
+    <h1>${safeTitle}</h1>
+    <p>${safeMessage}</p>
+  </main>
+  <script>setTimeout(() => { try { window.close(); } catch (_) {} }, 1500);</script>
+</body>
+</html>`;
+  res.statusCode = status;
+  res.setHeader("content-type", "text/html; charset=utf-8");
+  res.end(html);
 }

--- a/packages/app-core/src/state/useVincentState.test.ts
+++ b/packages/app-core/src/state/useVincentState.test.ts
@@ -4,37 +4,19 @@ import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockVincentStatus = vi.fn();
-const mockVincentRegister = vi.fn();
-const mockVincentExchangeToken = vi.fn();
+const mockVincentStartLogin = vi.fn();
 const mockVincentDisconnect = vi.fn();
 
 vi.mock("../api", () => ({
   client: {
     vincentStatus: (...args: unknown[]) => mockVincentStatus(...args),
-    vincentRegister: (...args: unknown[]) => mockVincentRegister(...args),
-    vincentExchangeToken: (...args: unknown[]) =>
-      mockVincentExchangeToken(...args),
+    vincentStartLogin: (...args: unknown[]) => mockVincentStartLogin(...args),
     vincentDisconnect: (...args: unknown[]) => mockVincentDisconnect(...args),
   },
 }));
 
-vi.mock("../api/vincent-oauth", () => ({
-  buildVincentAuthUrl: vi.fn().mockResolvedValue({
-    url: "https://heyvincent.ai/auth?client_id=test",
-    codeVerifier: "test-verifier",
-  }),
-  clearCodeVerifier: vi.fn(),
-  getStoredClientId: vi.fn().mockReturnValue(null),
-  getStoredCodeVerifier: vi.fn().mockReturnValue(null),
-  getVincentRedirectUri: vi
-    .fn()
-    .mockReturnValue("http://localhost/callback/vincent"),
-  storeClientId: vi.fn(),
-  storeCodeVerifier: vi.fn(),
-}));
-
 vi.mock("../utils", () => ({
-  openExternalUrl: vi.fn(),
+  openExternalUrl: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { useVincentState } from "./useVincentState";
@@ -46,7 +28,12 @@ describe("useVincentState — handleVincentLogin poll", () => {
       connected: false,
       connectedAt: null,
     });
-    mockVincentRegister.mockResolvedValue({ client_id: "test-client-id" });
+    mockVincentStartLogin.mockResolvedValue({
+      authUrl:
+        "https://heyvincent.ai/api/oauth/public/authorize?client_id=test",
+      state: "test-state",
+      redirectUri: "http://localhost/callback/vincent",
+    });
   });
 
   afterEach(() => {

--- a/packages/app-core/src/state/useVincentState.ts
+++ b/packages/app-core/src/state/useVincentState.ts
@@ -1,23 +1,17 @@
 /**
  * Vincent OAuth state — manages connect/disconnect flow for the wallet UI.
  *
- * Follows the same pattern as useCloudState:
- * - Browser-based OAuth flow (opens Vincent authorize URL)
- * - Polls /api/vincent/status after redirect
- * - Exposes connected/busy/error state for the UI
+ * Flow:
+ * - Call POST /api/vincent/start-login → server generates PKCE and returns authUrl
+ * - Open authUrl in the user's external browser
+ * - Vincent redirects to GET /callback/vincent on the same Milady API origin,
+ *   which exchanges the code server-side and persists tokens
+ * - This hook polls /api/vincent/status and flips to connected when the
+ *   server-side exchange completes
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { client } from "../api";
-import {
-  buildVincentAuthUrl,
-  clearCodeVerifier,
-  getStoredClientId,
-  getStoredCodeVerifier,
-  getVincentRedirectUri,
-  storeClientId,
-  storeCodeVerifier,
-} from "../api/vincent-oauth";
 import { openExternalUrl } from "../utils";
 
 interface VincentStateParams {
@@ -63,47 +57,11 @@ export function useVincentState({ setActionNotice, t }: VincentStateParams) {
     };
   }, [pollVincentStatus]);
 
-  // ── Handle callback (code in URL) ──────────────────────────────
-  useEffect(() => {
-    const url = new URL(window.location.href);
-    const code = url.searchParams.get("code");
-    if (!code || !url.pathname.endsWith("/callback/vincent")) return;
-
-    const codeVerifier = getStoredCodeVerifier();
-    const clientId = getStoredClientId();
-    if (!codeVerifier || !clientId) return;
-
-    // Clean URL
-    url.searchParams.delete("code");
-    window.history.replaceState({}, document.title, url.pathname);
-
-    setVincentLoginBusy(true);
-    client
-      .vincentExchangeToken(code, clientId, codeVerifier)
-      .then((result) => {
-        clearCodeVerifier();
-        if (result.connected) {
-          setVincentConnected(true);
-          setVincentLoginError(null);
-          setActionNotice(
-            t("vincent.connected", { defaultValue: "Vincent connected" }),
-            "success",
-            5000,
-          );
-        }
-      })
-      .catch((err) => {
-        setVincentLoginError(
-          err instanceof Error ? err.message : "Token exchange failed",
-        );
-      })
-      .finally(() => {
-        setVincentLoginBusy(false);
-        busyRef.current = false;
-      });
-  }, [setActionNotice, t]);
-
   // ── Login flow ──────────────────────────────────────────────────
+  // The browser tab that Vincent redirects back to lands on GET
+  // /callback/vincent on the Milady API origin, which does the token
+  // exchange server-side.  All this hook does is kick off that flow and
+  // poll /api/vincent/status until it flips to connected.
   const handleVincentLogin = useCallback(async () => {
     if (vincentConnected || busyRef.current || vincentLoginBusy) return;
     busyRef.current = true;
@@ -111,27 +69,15 @@ export function useVincentState({ setActionNotice, t }: VincentStateParams) {
     setVincentLoginError(null);
 
     try {
-      const redirectUri = getVincentRedirectUri();
+      // Step 1: Ask server to generate PKCE + authUrl
+      const { authUrl } = await client.vincentStartLogin("Milady");
 
-      // Step 1: Register app
-      const { client_id } = await client.vincentRegister("Milady", [
-        redirectUri,
-      ]);
-      storeClientId(client_id);
+      // Step 2: Open the browser on the authUrl
+      await openExternalUrl(authUrl);
 
-      // Step 2: Build PKCE auth URL
-      const { url, codeVerifier } = await buildVincentAuthUrl(
-        client_id,
-        redirectUri,
-      );
-      storeCodeVerifier(codeVerifier);
-
-      // Step 3: Open browser
-      openExternalUrl(url);
-
-      // Poll for connection status — handles desktop apps where the OAuth
-      // callback may be processed server-side instead of via URL redirect.
-      // Also acts as a fallback if the user closes the auth window.
+      // Step 3: Poll /api/vincent/status until the server-side callback
+      // completes the token exchange. Also acts as a fallback if the user
+      // closes the auth window.
       if (loginPollRef.current) clearInterval(loginPollRef.current);
       let pollAttempts = 0;
       const maxPollAttempts = 24; // ~2 minutes at 5s intervals
@@ -183,7 +129,6 @@ export function useVincentState({ setActionNotice, t }: VincentStateParams) {
       setVincentConnected(false);
       setVincentConnectedAt(null);
       setVincentLoginError(null);
-      clearCodeVerifier();
       setActionNotice(
         t("vincent.disconnected", { defaultValue: "Vincent disconnected" }),
         "info",


### PR DESCRIPTION
## Summary

- The Vincent login flow never completed: users authenticated on heyvincent.ai, got redirected back, and were left on a blank tab while the desktop app spun on "connecting". Root cause: the PKCE `code_verifier` was stored in the desktop webview's `sessionStorage`, but the OAuth redirect lands in the user's external system browser (opened via `openExternalUrl` → `desktopOpenExternal` RPC), which has a **separate** `sessionStorage`. The callback effect saw a null verifier, silently bailed, and the desktop poll timed out.
- Move PKCE entirely server-side so the flow works regardless of which browser the redirect lands in.

## What changed

**New routes** (`packages/app-core/src/api/vincent-routes.ts`):

- `POST /api/vincent/start-login` — server registers with Vincent, generates `code_verifier` + `code_challenge` using `node:crypto`, stores a pending entry keyed by a fresh OAuth `state` UUID (10-min TTL, swept on access), and returns `{ authUrl, state, redirectUri }`. `redirect_uri` is built from `req.headers.host` so it matches the actual API origin in dev (`127.0.0.1:31337`) and prod (`127.0.0.1:2138`).
- `GET /callback/vincent` — looks up the pending entry by `state`, exchanges the code with Vincent, persists tokens to `ElizaConfig`, and returns a small self-closing HTML page. **Requires exact `state` match** — rejects requests with a missing or unknown state so no local process can forge a login for a session it didn't initiate. (PKCE already prevents cross-session token theft via Vincent's challenge/verifier check; state validation is the cheaper, clearer gate.)
- Token exchange now includes `redirect_uri` in the request body per **RFC 6749 §4.1.3** — Vincent was rejecting the exchange with `invalid_request: expected string, received undefined` without it, which is what was actually failing after the initial server-side move (found by tailing `[vincent/callback]` logs on dev).

**Routing** (`packages/app-core/src/api/server.ts`):

- `/callback/vincent` is wired through `handleVincentRoute` and **bypasses `ensureCompatApiAuthorized`** — the external browser has no compat token, and the PKCE verifier + state held server-side are the real credentials.

**Client** (`packages/app-core/src/api/client-vincent.ts` + `state/useVincentState.ts`):

- Adds `vincentStartLogin()` on `MiladyClient`.
- `useVincentState.handleVincentLogin` now just calls `vincentStartLogin`, opens the returned `authUrl`, and polls `/api/vincent/status`. The broken sessionStorage callback effect, client-side PKCE helpers, and `clearCodeVerifier()` on disconnect are gone.
- Existing poll-success and poll-timeout tests still pass against the new mock surface.

**Type safety cleanup** (`vincent-routes.ts`):

- Isolated the pre-existing `(config as any).vincent` casts behind typed `getVincentTokens` / `setVincentTokens` helpers. The remaining unsafe cast is now in one place (`as unknown as { vincent?: VincentTokens }`) with a comment explaining that `ElizaConfig` doesn't yet type the field.

## Flow after fix

1. User clicks "Login with Vincent" on the wallet page.
2. Desktop → `POST /api/vincent/start-login` → server returns `authUrl`.
3. Desktop opens `authUrl` in the external system browser via `desktopOpenExternal` RPC.
4. User authenticates on heyvincent.ai.
5. Vincent 302 → `http://127.0.0.1:<api-port>/callback/vincent?code=...&state=...`.
6. API handler validates `state`, exchanges code with Vincent (with matching `redirect_uri`), persists tokens, returns "You can close this window" HTML.
7. Desktop's 5-second status poll flips `vincentConnected` → `true`, UI shows success toast.

## Test plan

- [x] `bunx tsc -p packages/app-core/tsconfig.json --noEmit` — no new errors on Vincent files.
- [x] `bunx vitest run packages/app-core/src/state/useVincentState.test.ts` — 2/2 passing (existing poll-success and poll-timeout cases, updated mocks for the new client surface).
- [x] `bun run pre-review-local` via the milady `pre-review` agent — **APPROVE** (classification: `security`, code quality: pass, security: clear, tests: adequate, decision: APPROVE, exit 0).
- [x] Manual end-to-end smoke on `bun run dev:desktop`:
  - Wallet page → Login with Vincent → external browser opens
  - Auth on heyvincent.ai → redirected to `/callback/vincent` → "You can close this window" page
  - Desktop app flips to Connected; API log: `[vincent/callback] Vincent connected successfully`
  - Disconnect + reconnect round-trip verified: `[vincent/disconnect] Vincent disconnected` followed by a fresh `[vincent/callback] Vincent connected successfully`.

## Notes for reviewers

- The legacy `POST /api/vincent/register` and `POST /api/vincent/token` routes are still present but unused by the client. They can be deleted in a follow-up — left in place here to keep this PR scoped to the fix.
- `packages/app-core/src/api/vincent-oauth.ts` is now dead (client-side PKCE helpers) but left alone for the same reason.
- The desktop app caches dev bundles; reviewers validating locally should `kill` any stale `bun run dev` and restart so the new routes load.