### PR TITLE
Managed Discord runtime flow for Milady agents

### DIFF
--- a/deploy/cloud-agent-shared.test.ts
+++ b/deploy/cloud-agent-shared.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeBridgeMessage } from "./cloud-agent-shared";
+
+describe("normalizeBridgeMessage", () => {
+  test("preserves managed Discord bridge identity and routing metadata", () => {
+    expect(
+      normalizeBridgeMessage({
+        text: "hello there",
+        roomId: "discord-guild:guild-1:channel:channel-1",
+        channelType: "GROUP",
+        source: "discord",
+        sender: {
+          id: "discord-user-1",
+          username: "owner",
+          displayName: "Owner Person",
+          metadata: {
+            discord: {
+              userId: "discord-user-1",
+              username: "owner",
+            },
+          },
+        },
+        metadata: {
+          discord: {
+            guildId: "guild-1",
+            channelId: "channel-1",
+          },
+        },
+      }),
+    ).toEqual({
+      text: "hello there",
+      roomKey: "discord-guild:guild-1:channel:channel-1",
+      mode: "power",
+      channelType: "GROUP",
+      source: "discord",
+      sender: {
+        id: "discord-user-1",
+        username: "owner",
+        displayName: "Owner Person",
+        metadata: {
+          discord: {
+            userId: "discord-user-1",
+            username: "owner",
+          },
+        },
+      },
+      metadata: {
+        discord: {
+          guildId: "guild-1",
+          channelId: "channel-1",
+        },
+      },
+    });
+  });
+
+  test("falls back to safe defaults when bridge params are missing", () => {
+    expect(normalizeBridgeMessage({})).toEqual({
+      text: "",
+      roomKey: "default",
+      mode: "power",
+      channelType: "DM",
+      source: "cloud-bridge",
+    });
+  });
+});

--- a/deploy/cloud-agent-shared.ts
+++ b/deploy/cloud-agent-shared.ts
@@ -15,6 +15,78 @@ export interface BridgeRpcParams {
   text?: string;
   roomId?: string;
   mode?: string;
+  channelType?: string;
+  source?: string;
+  sender?: {
+    id?: string;
+    username?: string;
+    displayName?: string;
+    metadata?: Record<string, unknown>;
+  };
+  metadata?: Record<string, unknown>;
+}
+
+export type NormalizedBridgeMessage = {
+  text: string;
+  roomKey: string;
+  mode: "simple" | "power";
+  channelType: "DM" | "GROUP";
+  source: string;
+  sender?: {
+    id?: string;
+    username?: string;
+    displayName?: string;
+    metadata?: Record<string, unknown>;
+  };
+  metadata?: Record<string, unknown>;
+};
+
+export function normalizeBridgeMessage(
+  params?: BridgeRpcParams,
+): NormalizedBridgeMessage {
+  const trimmedRoomId =
+    typeof params?.roomId === "string" && params.roomId.trim().length > 0
+      ? params.roomId.trim()
+      : "default";
+  const source =
+    typeof params?.source === "string" && params.source.trim().length > 0
+      ? params.source.trim()
+      : "cloud-bridge";
+  const sender =
+    params?.sender && typeof params.sender === "object"
+      ? {
+          ...(typeof params.sender.id === "string" && params.sender.id.trim()
+            ? { id: params.sender.id.trim() }
+            : {}),
+          ...(typeof params.sender.username === "string" &&
+          params.sender.username.trim()
+            ? { username: params.sender.username.trim() }
+            : {}),
+          ...(typeof params.sender.displayName === "string" &&
+          params.sender.displayName.trim()
+            ? { displayName: params.sender.displayName.trim() }
+            : {}),
+          ...(params.sender.metadata &&
+          typeof params.sender.metadata === "object" &&
+          !Array.isArray(params.sender.metadata)
+            ? { metadata: params.sender.metadata }
+            : {}),
+        }
+      : undefined;
+
+  return {
+    text: typeof params?.text === "string" ? params.text : "",
+    roomKey: trimmedRoomId,
+    mode: params?.mode === "simple" ? "simple" : "power",
+    channelType: params?.channelType === "GROUP" ? "GROUP" : "DM",
+    source,
+    ...(sender && Object.keys(sender).length > 0 ? { sender } : {}),
+    ...(params?.metadata &&
+    typeof params.metadata === "object" &&
+    !Array.isArray(params.metadata)
+      ? { metadata: params.metadata }
+      : {}),
+  };
 }
 
 export interface CloudAgentConfig {
@@ -39,15 +111,9 @@ export interface CloudAgentConfig {
 }
 
 interface AgentRuntime {
-  processMessage: (
-    text: string,
-    roomId: string,
-    mode: "simple" | "power",
-  ) => Promise<string>;
+  processMessage: (params: BridgeRpcParams) => Promise<string>;
   processMessageStream: (
-    text: string,
-    roomId: string,
-    mode: "simple" | "power",
+    params: BridgeRpcParams,
     onChunk: (chunk: string) => void,
   ) => Promise<string>;
   getMemories: () => Array<Record<string, unknown>>;
@@ -165,36 +231,145 @@ export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
 
       const runtime = new AgentRuntimeCtor({ character, plugins });
       await runtime.initialize();
+      const runtimeWithBridge = runtime as typeof runtime & {
+        ensureWorldExists?: (world: Record<string, unknown>) => Promise<void>;
+        ensureRoomExists?: (room: Record<string, unknown>) => Promise<void>;
+        ensureParticipantInRoom?: (
+          entityId: ReturnType<typeof stringToUuid>,
+          roomId: ReturnType<typeof stringToUuid>,
+        ) => Promise<void>;
+        getEntityById?: (
+          entityId: ReturnType<typeof stringToUuid>,
+        ) => Promise<Record<string, unknown> | null>;
+        createEntity?: (entity: Record<string, unknown>) => Promise<void>;
+        updateEntity?: (entity: Record<string, unknown>) => Promise<void>;
+      };
 
-      const userId = crypto.randomUUID() as ReturnType<typeof stringToUuid>;
-      const roomId = stringToUuid("cloud-agent-bridge-room");
-      const worldId = stringToUuid("cloud-agent-world");
+      const ensureBridgeContext = async (params: BridgeRpcParams) => {
+        const normalized = normalizeBridgeMessage(params);
+        const worldId = stringToUuid(
+          `${normalized.source}-${normalized.channelType.toLowerCase()}-world`,
+        );
+        const serverId = stringToUuid(`${normalized.source}-bridge-server`);
+        const roomId = stringToUuid(
+          `${normalized.source}-bridge-room-${normalized.roomKey}`,
+        );
+        const entityKey =
+          normalized.sender?.id ??
+          normalized.sender?.username ??
+          `${normalized.source}-bridge-user`;
+        const entityId = stringToUuid(
+          `${normalized.source}-bridge-user-${entityKey}`,
+        );
+        const channelType =
+          normalized.channelType === "GROUP"
+            ? ChannelType.GROUP
+            : ChannelType.DM;
+        const displayName =
+          normalized.sender?.displayName ??
+          normalized.sender?.username ??
+          "BridgeUser";
 
-      await runtime.ensureConnection({
-        entityId: userId,
-        roomId,
-        worldId,
-        userName: "BridgeUser",
-        source: "cloud-bridge",
-        channelId: "cloud-bridge",
-        type: ChannelType.DM,
-      });
+        if (typeof runtimeWithBridge.ensureWorldExists === "function") {
+          await runtimeWithBridge.ensureWorldExists({
+            id: worldId,
+            name:
+              normalized.source === "discord"
+                ? "Discord"
+                : "Cloud Bridge",
+            agentId: runtime.agentId,
+            serverId,
+          });
+        }
+
+        if (typeof runtimeWithBridge.ensureRoomExists === "function") {
+          await runtimeWithBridge.ensureRoomExists({
+            id: roomId,
+            name: normalized.roomKey,
+            type: channelType,
+            channelId: normalized.roomKey,
+            worldId,
+            serverId,
+            agentId: runtime.agentId,
+            source: normalized.source,
+          });
+        }
+
+        const entityMetadata =
+          normalized.sender?.metadata &&
+          typeof normalized.sender.metadata === "object" &&
+          !Array.isArray(normalized.sender.metadata)
+            ? normalized.sender.metadata
+            : undefined;
+        const entityPayload = {
+          id: entityId,
+          agentId: runtime.agentId,
+          names: Array.from(
+            new Set(
+              [displayName, normalized.sender?.username].filter(
+                (value): value is string => Boolean(value),
+              ),
+            ),
+          ),
+          ...(entityMetadata ? { metadata: entityMetadata } : {}),
+        };
+
+        try {
+          if (
+            typeof runtimeWithBridge.getEntityById === "function" &&
+            typeof runtimeWithBridge.updateEntity === "function"
+          ) {
+            const existingEntity = await runtimeWithBridge.getEntityById(
+              entityId,
+            );
+            if (existingEntity) {
+              await runtimeWithBridge.updateEntity({
+                ...existingEntity,
+                ...entityPayload,
+                names:
+                  entityPayload.names.length > 0
+                    ? entityPayload.names
+                    : (existingEntity.names as string[] | undefined) ?? [],
+              });
+            } else if (typeof runtimeWithBridge.createEntity === "function") {
+              await runtimeWithBridge.createEntity(entityPayload);
+            }
+          } else if (typeof runtimeWithBridge.createEntity === "function") {
+            await runtimeWithBridge.createEntity(entityPayload);
+          }
+        } catch {
+          // Best-effort entity sync. The room flow still works if the entity already exists.
+        }
+
+        if (typeof runtimeWithBridge.ensureParticipantInRoom === "function") {
+          await Promise.all([
+            runtimeWithBridge.ensureParticipantInRoom(runtime.agentId, roomId),
+            runtimeWithBridge.ensureParticipantInRoom(entityId, roomId),
+          ]);
+        }
+
+        return { normalized, entityId, roomId, channelType };
+      };
 
       agentRuntime = {
-        processMessage: async (
-          text: string,
-          _roomId: string,
-          mode: "simple" | "power",
-        ): Promise<string> => {
+        processMessage: async (params: BridgeRpcParams): Promise<string> => {
+          const { normalized, entityId, roomId, channelType } =
+            await ensureBridgeContext(params);
           const message = createMessageMemory({
             id: crypto.randomUUID() as ReturnType<typeof stringToUuid>,
-            entityId: userId,
+            entityId,
             roomId,
             content: {
-              text,
-              ...(enableChatMode ? { mode, simple: mode === "simple" } : {}),
-              source: "cloud-bridge",
-              channelType: ChannelType.DM,
+              text: normalized.text,
+              ...(enableChatMode
+                ? {
+                    mode: normalized.mode,
+                    simple: normalized.mode === "simple",
+                  }
+                : {}),
+              source: normalized.source,
+              channelType,
+              ...(normalized.metadata ? { metadata: normalized.metadata } : {}),
             },
           });
 
@@ -209,7 +384,13 @@ export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
           );
 
           state.lastActivityAt = new Date().toISOString();
-          state.memories.push({ role: "user", text, timestamp: Date.now() });
+          state.memories.push({
+            role: "user",
+            text: normalized.text,
+            timestamp: Date.now(),
+            source: normalized.source,
+            roomId: normalized.roomKey,
+          });
           state.memories.push({
             role: "assistant",
             text: responseText,
@@ -220,20 +401,26 @@ export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
           return responseText || "(no response)";
         },
         processMessageStream: async (
-          text: string,
-          _roomId: string,
-          mode: "simple" | "power",
+          params: BridgeRpcParams,
           onChunk: (chunk: string) => void,
         ): Promise<string> => {
+          const { normalized, entityId, roomId, channelType } =
+            await ensureBridgeContext(params);
           const message = createMessageMemory({
             id: crypto.randomUUID() as ReturnType<typeof stringToUuid>,
-            entityId: userId,
+            entityId,
             roomId,
             content: {
-              text,
-              ...(enableChatMode ? { mode, simple: mode === "simple" } : {}),
-              source: "cloud-bridge",
-              channelType: ChannelType.DM,
+              text: normalized.text,
+              ...(enableChatMode
+                ? {
+                    mode: normalized.mode,
+                    simple: normalized.mode === "simple",
+                  }
+                : {}),
+              source: normalized.source,
+              channelType,
+              ...(normalized.metadata ? { metadata: normalized.metadata } : {}),
             },
           });
 
@@ -251,7 +438,13 @@ export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
           );
 
           state.lastActivityAt = new Date().toISOString();
-          state.memories.push({ role: "user", text, timestamp: Date.now() });
+          state.memories.push({
+            role: "user",
+            text: normalized.text,
+            timestamp: Date.now(),
+            source: normalized.source,
+            roomId: normalized.roomKey,
+          });
           state.memories.push({
             role: "assistant",
             text: responseText,
@@ -271,13 +464,16 @@ export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
         "[cloud-agent] @elizaos/core not available, running in echo mode",
       );
       agentRuntime = {
-        processMessage: async (
-          text: string,
-          _roomId: string,
-          _mode: "simple" | "power",
-        ): Promise<string> => {
-          state.memories.push({ role: "user", text, timestamp: Date.now() });
-          const reply = `[echo] ${text}`;
+        processMessage: async (params: BridgeRpcParams): Promise<string> => {
+          const normalized = normalizeBridgeMessage(params);
+          state.memories.push({
+            role: "user",
+            text: normalized.text,
+            timestamp: Date.now(),
+            source: normalized.source,
+            roomId: normalized.roomKey,
+          });
+          const reply = `[echo] ${normalized.text}`;
           state.memories.push({
             role: "assistant",
             text: reply,
@@ -287,13 +483,18 @@ export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
           return reply;
         },
         processMessageStream: async (
-          text: string,
-          _roomId: string,
-          _mode: "simple" | "power",
+          params: BridgeRpcParams,
           onChunk: (chunk: string) => void,
         ): Promise<string> => {
-          state.memories.push({ role: "user", text, timestamp: Date.now() });
-          const reply = `[echo] ${text}`;
+          const normalized = normalizeBridgeMessage(params);
+          state.memories.push({
+            role: "user",
+            text: normalized.text,
+            timestamp: Date.now(),
+            source: normalized.source,
+            roomId: normalized.roomKey,
+          });
+          const reply = `[echo] ${normalized.text}`;
           onChunk(reply);
           state.memories.push({
             role: "assistant",
@@ -451,17 +652,10 @@ export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
         res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
       };
 
-      const text = (rpc.params?.text as string) ?? "";
-      const roomId = (rpc.params?.roomId as string) ?? "default";
-      const mode: "simple" | "power" =
-        rpc.params?.mode === "simple" ? "simple" : "power";
-
       sendEvent("connected", { rpcId: rpc.id, timestamp: Date.now() });
 
       await agentRuntime.processMessageStream(
-        text,
-        roomId,
-        mode,
+        rpc.params ?? {},
         (chunk: string) => {
           sendEvent("chunk", { text: chunk });
         },
@@ -503,15 +697,7 @@ export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
           );
           return;
         }
-        const text = (rpc.params?.text as string) ?? "";
-        const roomId = (rpc.params?.roomId as string) ?? "default";
-        const mode: "simple" | "power" =
-          rpc.params?.mode === "simple" ? "simple" : "power";
-        const responseText = await agentRuntime.processMessage(
-          text,
-          roomId,
-          mode,
-        );
+        const responseText = await agentRuntime.processMessage(rpc.params ?? {});
         res.writeHead(200);
         res.end(
           JSON.stringify({

--- a/packages/agent/test/native-modules.e2e.test.ts
+++ b/packages/agent/test/native-modules.e2e.test.ts
@@ -33,6 +33,10 @@ import { describe, expect, it } from "vitest";
 const testDir = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.resolve(testDir, "..");
 const repoRoot = path.resolve(packageRoot, "..", "..");
+const workspaceRequirePaths = [
+  path.join(packageRoot, "package.json"),
+  path.join(repoRoot, "package.json"),
+];
 
 // ---------------------------------------------------------------------------
 // Helper Functions
@@ -42,125 +46,153 @@ const repoRoot = path.resolve(packageRoot, "..", "..");
  * Finds a package in node_modules, checking both local and hoisted (repo root) locations.
  */
 function findPackagePath(...segments: string[]): string | null {
-	const local = path.join(packageRoot, "node_modules", ...segments);
-	if (fs.existsSync(local)) return local;
-	const hoisted = path.join(repoRoot, "node_modules", ...segments);
-	if (fs.existsSync(hoisted)) return hoisted;
-	return null;
+  const local = path.join(packageRoot, "node_modules", ...segments);
+  if (fs.existsSync(local)) return local;
+  const hoisted = path.join(repoRoot, "node_modules", ...segments);
+  if (fs.existsSync(hoisted)) return hoisted;
+  return null;
 }
 
 /**
  * Attempts to require/import a module and returns success status
  */
 async function canImportModule(
-	moduleName: string,
+  moduleName: string,
 ): Promise<{ success: boolean; error?: string }> {
-	try {
-		await import(moduleName);
-		return { success: true };
-	} catch (err) {
-		return {
-			success: false,
-			error: err instanceof Error ? err.message : String(err),
-		};
-	}
+  try {
+    await import(moduleName);
+    return { success: true };
+  } catch (err) {
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
 }
 
-function runModuleSnippet(
-	source: string,
-): { success: boolean; error?: string; stdout: string; stderr: string } {
-	const result = spawnSync(
-		process.execPath,
-		["--input-type=module", "--eval", source],
-		{
-			cwd: repoRoot,
-			encoding: "utf8",
-			timeout: 30_000,
-		},
-	);
+function runModuleSnippet(source: string): {
+  success: boolean;
+  error?: string;
+  stdout: string;
+  stderr: string;
+} {
+  const module = [
+    'import { createRequire } from "node:module";',
+    'import { pathToFileURL } from "node:url";',
+    `const importFromWorkspace = async (specifier) => {
+			const resolutionErrors = [];
+			for (const requestPath of ${JSON.stringify(workspaceRequirePaths)}) {
+				try {
+					const requireFromWorkspace = createRequire(requestPath);
+					const resolved = requireFromWorkspace.resolve(specifier);
+					return await import(pathToFileURL(resolved).href);
+				} catch (error) {
+					resolutionErrors.push(
+						error instanceof Error ? error.message : String(error),
+					);
+				}
+			}
+			throw new Error(
+				\`Unable to resolve \${specifier} from workspace roots: \${resolutionErrors.join(" | ")}\`,
+			);
+		};`,
+    source,
+  ].join("\n\n");
 
-	if (result.status === 0) {
-		return {
-			success: true,
-			stdout: result.stdout ?? "",
-			stderr: result.stderr ?? "",
-		};
-	}
+  const result = spawnSync(
+    process.execPath,
+    ["--input-type=module", "--eval", module],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      timeout: 30_000,
+    },
+  );
 
-	return {
-		success: false,
-		error:
-			result.error?.message ??
-			result.stderr ??
-			result.stdout ??
-			`process exited with code ${String(result.status)}`,
-		stdout: result.stdout ?? "",
-		stderr: result.stderr ?? "",
-	};
+  if (result.status === 0) {
+    return {
+      success: true,
+      stdout: result.stdout ?? "",
+      stderr: result.stderr ?? "",
+    };
+  }
+
+  return {
+    success: false,
+    error:
+      result.error?.message ??
+      result.stderr ??
+      result.stdout ??
+      `process exited with code ${String(result.status)}`,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
 }
 
 async function canImportModuleInSubprocess(
-	moduleName: string,
+  moduleName: string,
 ): Promise<{ success: boolean; error?: string }> {
-	const result = runModuleSnippet(`await import(${JSON.stringify(moduleName)});`);
-	return result.success
-		? { success: true }
-		: { success: false, error: result.error };
+  const result = runModuleSnippet(
+    `await importFromWorkspace(${JSON.stringify(moduleName)});`,
+  );
+  return result.success
+    ? { success: true }
+    : { success: false, error: result.error };
 }
 
 /**
  * Checks if a native binding file exists for a module
  */
 function hasNativeBinding(modulePath: string, patterns: string[]): boolean {
-	try {
-		const nodeModulesPath =
-			findPackagePath(modulePath) ??
-			path.join(packageRoot, "node_modules", modulePath);
-		if (!fs.existsSync(nodeModulesPath)) return false;
+  try {
+    const nodeModulesPath =
+      findPackagePath(modulePath) ??
+      path.join(packageRoot, "node_modules", modulePath);
+    if (!fs.existsSync(nodeModulesPath)) return false;
 
-		// Recursively search for .node files
-		const findNodeFiles = (dir: string): string[] => {
-			const results: string[] = [];
-			try {
-				const entries = fs.readdirSync(dir, { withFileTypes: true });
-				for (const entry of entries) {
-					const fullPath = path.join(dir, entry.name);
-					if (entry.isDirectory()) {
-						results.push(...findNodeFiles(fullPath));
-					} else if (patterns.some((p) => entry.name.includes(p))) {
-						results.push(fullPath);
-					}
-				}
-			} catch {
-				// Ignore permission errors
-			}
-			return results;
-		};
+    // Recursively search for .node files
+    const findNodeFiles = (dir: string): string[] => {
+      const results: string[] = [];
+      try {
+        const entries = fs.readdirSync(dir, { withFileTypes: true });
+        for (const entry of entries) {
+          const fullPath = path.join(dir, entry.name);
+          if (entry.isDirectory()) {
+            results.push(...findNodeFiles(fullPath));
+          } else if (patterns.some((p) => entry.name.includes(p))) {
+            results.push(fullPath);
+          }
+        }
+      } catch {
+        // Ignore permission errors
+      }
+      return results;
+    };
 
-		const nodeFiles = findNodeFiles(nodeModulesPath);
-		return nodeFiles.length > 0;
-	} catch {
-		return false;
-	}
+    const nodeFiles = findNodeFiles(nodeModulesPath);
+    return nodeFiles.length > 0;
+  } catch {
+    return false;
+  }
 }
 
 /**
  * Reads package.json from both local and repo root, merging all deps.
  */
 function getAllWorkspaceDeps(): Record<string, string> {
-	const localPkg = JSON.parse(
-		fs.readFileSync(path.join(packageRoot, "package.json"), "utf-8"),
-	);
-	const repoRootPkgPath = path.join(repoRoot, "package.json");
-	const repoRootPkg = fs.existsSync(repoRootPkgPath)
-		? JSON.parse(fs.readFileSync(repoRootPkgPath, "utf-8"))
-		: {};
-	return {
-		...(repoRootPkg.dependencies || {}),
-		...(repoRootPkg.devDependencies || {}),
-		...(localPkg.dependencies || {}),
-		...(localPkg.devDependencies || {}),
-	};
+  const localPkg = JSON.parse(
+    fs.readFileSync(path.join(packageRoot, "package.json"), "utf-8"),
+  );
+  const repoRootPkgPath = path.join(repoRoot, "package.json");
+  const repoRootPkg = fs.existsSync(repoRootPkgPath)
+    ? JSON.parse(fs.readFileSync(repoRootPkgPath, "utf-8"))
+    : {};
+  return {
+    ...(repoRootPkg.dependencies || {}),
+    ...(repoRootPkg.devDependencies || {}),
+    ...(localPkg.dependencies || {}),
+    ...(localPkg.devDependencies || {}),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -169,211 +201,167 @@ function getAllWorkspaceDeps(): Record<string, string> {
 
 const hasTfjsNode = !!findPackagePath("@tensorflow", "tfjs-node");
 const hasTfjsNodeBinding = hasNativeBinding("@tensorflow/tfjs-node", [
-	"tfjs_binding.node",
-	".node",
+  "tfjs_binding.node",
+  ".node",
 ]);
 const hasTfjsCore = !!findPackagePath("@tensorflow", "tfjs-core");
 const hasCocoSsd = !!findPackagePath("@tensorflow-models", "coco-ssd");
 const hasMobilenet = !!findPackagePath("@tensorflow-models", "mobilenet");
 const hasPoseDetection = !!findPackagePath(
-	"@tensorflow-models",
-	"pose-detection",
+  "@tensorflow-models",
+  "pose-detection",
 );
 const hasSharp = !!findPackagePath("sharp");
 const hasCanvas = !!findPackagePath("canvas");
-const hasCanvasBinding = hasNativeBinding("canvas", [
-	"canvas.node",
-	".node",
-]);
+const hasCanvasBinding = hasNativeBinding("canvas", ["canvas.node", ".node"]);
 const hasFaceApi = !!findPackagePath("face-api.js");
 const hasTesseract = !!findPackagePath("tesseract.js");
 const hasPluginVision = !!findPackagePath("@elizaos", "plugin-vision");
 const hasNodePty = !!findPackagePath("node-pty");
 const hasLydellNodePty = [
-	path.join(
-		packageRoot,
-		"node_modules",
-		".bun",
-		"@lydell+node-pty@1.1.0",
-	),
-	path.join(packageRoot, "node_modules", "@lydell", "node-pty"),
-	path.join(
-		repoRoot,
-		"node_modules",
-		".bun",
-		"@lydell+node-pty@1.1.0",
-	),
-	path.join(repoRoot, "node_modules", "@lydell", "node-pty"),
+  path.join(packageRoot, "node_modules", ".bun", "@lydell+node-pty@1.1.0"),
+  path.join(packageRoot, "node_modules", "@lydell", "node-pty"),
+  path.join(repoRoot, "node_modules", ".bun", "@lydell+node-pty@1.1.0"),
+  path.join(repoRoot, "node_modules", "@lydell", "node-pty"),
 ].some((p) => fs.existsSync(p));
 const hasPtyManager = !!findPackagePath("pty-manager");
 
 const allDeps = getAllWorkspaceDeps();
 const hasAnyNativeModuleDep = ["sharp", "canvas", "@tensorflow/tfjs-node"].some(
-	(d) => !!allDeps[d],
+  (d) => !!allDeps[d],
 );
 const hasPtyDeps = !!allDeps["node-pty"] || !!allDeps["pty-manager"];
 const hasEmbeddingDeps =
-	!!allDeps["node-llama-cpp"] || !!allDeps["whisper-node"];
+  !!allDeps["node-llama-cpp"] || !!allDeps["whisper-node"];
 
 const electrobunPkgPath = (() => {
-	const localPath = path.join(
-		packageRoot,
-		"apps",
-		"app",
-		"electrobun",
-		"package.json",
-	);
-	const repoPath = path.join(
-		repoRoot,
-		"apps",
-		"app",
-		"electrobun",
-		"package.json",
-	);
-	if (fs.existsSync(localPath)) return localPath;
-	if (fs.existsSync(repoPath)) return repoPath;
-	return null;
+  const localPath = path.join(
+    packageRoot,
+    "apps",
+    "app",
+    "electrobun",
+    "package.json",
+  );
+  const repoPath = path.join(
+    repoRoot,
+    "apps",
+    "app",
+    "electrobun",
+    "package.json",
+  );
+  if (fs.existsSync(localPath)) return localPath;
+  if (fs.existsSync(repoPath)) return repoPath;
+  return null;
 })();
 
-const copyRuntimeScript = [
-	path.join(packageRoot, "scripts", "copy-runtime-node-modules.ts"),
-	path.join(repoRoot, "scripts", "copy-runtime-node-modules.ts"),
-].find((p) => fs.existsSync(p)) ?? null;
+const copyRuntimeScript =
+  [
+    path.join(packageRoot, "scripts", "copy-runtime-node-modules.ts"),
+    path.join(repoRoot, "scripts", "copy-runtime-node-modules.ts"),
+  ].find((p) => fs.existsSync(p)) ?? null;
 
-const releaseWorkflow = [
-	path.join(
-		packageRoot,
-		".github",
-		"workflows",
-		"release-electrobun.yml",
-	),
-	path.join(
-		repoRoot,
-		".github",
-		"workflows",
-		"release-electrobun.yml",
-	),
-].find((p) => fs.existsSync(p)) ?? null;
+const releaseWorkflow =
+  [
+    path.join(packageRoot, ".github", "workflows", "release-electrobun.yml"),
+    path.join(repoRoot, ".github", "workflows", "release-electrobun.yml"),
+  ].find((p) => fs.existsSync(p)) ?? null;
 
 const corePluginsPath = (() => {
-	const candidate = path.join(packageRoot, "src", "runtime", "core-plugins.ts");
-	if (fs.existsSync(candidate)) return candidate;
-	const jsCandidate = path.join(
-		packageRoot,
-		"src",
-		"runtime",
-		"core-plugins.js",
-	);
-	if (fs.existsSync(jsCandidate)) return jsCandidate;
-	return null;
+  const candidate = path.join(packageRoot, "src", "runtime", "core-plugins.ts");
+  if (fs.existsSync(candidate)) return candidate;
+  const jsCandidate = path.join(
+    packageRoot,
+    "src",
+    "runtime",
+    "core-plugins.js",
+  );
+  if (fs.existsSync(jsCandidate)) return jsCandidate;
+  return null;
 })();
 
-const elizaTsPath = [
-	path.join(packageRoot, "src", "runtime", "eliza.ts"),
-	path.join(repoRoot, "src", "runtime", "eliza.ts"),
-	path.join(
-		packageRoot,
-		"packages",
-		"autonomous",
-		"src",
-		"runtime",
-		"eliza.ts",
-	),
-	path.join(
-		repoRoot,
-		"packages",
-		"autonomous",
-		"src",
-		"runtime",
-		"eliza.ts",
-	),
-].find((p) => fs.existsSync(p)) ?? null;
+const elizaTsPath =
+  [
+    path.join(packageRoot, "src", "runtime", "eliza.ts"),
+    path.join(repoRoot, "src", "runtime", "eliza.ts"),
+    path.join(
+      packageRoot,
+      "packages",
+      "autonomous",
+      "src",
+      "runtime",
+      "eliza.ts",
+    ),
+    path.join(repoRoot, "packages", "autonomous", "src", "runtime", "eliza.ts"),
+  ].find((p) => fs.existsSync(p)) ?? null;
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
 describe("Native Module Installation Verification", () => {
-	describe("TensorFlow.js", () => {
-		it.skipIf(!hasTfjsNode)(
-			"@tensorflow/tfjs-node is installed",
-			async () => {
-				const packagePath = findPackagePath("@tensorflow", "tfjs-node");
-				expect(fs.existsSync(packagePath!)).toBe(true);
-			},
-		);
+  describe("TensorFlow.js", () => {
+    it.skipIf(!hasTfjsNode)("@tensorflow/tfjs-node is installed", async () => {
+      const packagePath = findPackagePath("@tensorflow", "tfjs-node");
+      expect(fs.existsSync(packagePath!)).toBe(true);
+    });
 
-		it.skipIf(!hasTfjsNode || !hasTfjsNodeBinding)(
-			"@tensorflow/tfjs-node has native binding",
-			() => {
-				const hasBinding = hasNativeBinding("@tensorflow/tfjs-node", [
-					"tfjs_binding.node",
-					".node",
-				]);
-				expect(hasBinding).toBe(true);
-			},
-		);
+    it.skipIf(!hasTfjsNode || !hasTfjsNodeBinding)(
+      "@tensorflow/tfjs-node has native binding",
+      () => {
+        const hasBinding = hasNativeBinding("@tensorflow/tfjs-node", [
+          "tfjs_binding.node",
+          ".node",
+        ]);
+        expect(hasBinding).toBe(true);
+      },
+    );
 
-		it.skipIf(!hasTfjsCore)(
-			"@tensorflow/tfjs-core is installed",
-			async () => {
-				const packagePath = findPackagePath("@tensorflow", "tfjs-core");
-				expect(fs.existsSync(packagePath!)).toBe(true);
-			},
-		);
-	});
+    it.skipIf(!hasTfjsCore)("@tensorflow/tfjs-core is installed", async () => {
+      const packagePath = findPackagePath("@tensorflow", "tfjs-core");
+      expect(fs.existsSync(packagePath!)).toBe(true);
+    });
+  });
 
-	describe("TensorFlow Models", () => {
-		it.skipIf(!hasCocoSsd)(
-			"@tensorflow-models/coco-ssd is installed",
-			() => {
-				const packagePath = findPackagePath(
-					"@tensorflow-models",
-					"coco-ssd",
-				);
-				expect(fs.existsSync(packagePath!)).toBe(true);
-			},
-		);
+  describe("TensorFlow Models", () => {
+    it.skipIf(!hasCocoSsd)("@tensorflow-models/coco-ssd is installed", () => {
+      const packagePath = findPackagePath("@tensorflow-models", "coco-ssd");
+      expect(fs.existsSync(packagePath!)).toBe(true);
+    });
 
-		it.skipIf(!hasMobilenet)(
-			"@tensorflow-models/mobilenet is installed",
-			() => {
-				const packagePath = findPackagePath(
-					"@tensorflow-models",
-					"mobilenet",
-				);
-				expect(fs.existsSync(packagePath!)).toBe(true);
-			},
-		);
+    it.skipIf(!hasMobilenet)(
+      "@tensorflow-models/mobilenet is installed",
+      () => {
+        const packagePath = findPackagePath("@tensorflow-models", "mobilenet");
+        expect(fs.existsSync(packagePath!)).toBe(true);
+      },
+    );
 
-		it.skipIf(!hasPoseDetection)(
-			"@tensorflow-models/pose-detection is installed",
-			() => {
-				const packagePath = findPackagePath(
-					"@tensorflow-models",
-					"pose-detection",
-				);
-				expect(fs.existsSync(packagePath!)).toBe(true);
-			},
-		);
-	});
+    it.skipIf(!hasPoseDetection)(
+      "@tensorflow-models/pose-detection is installed",
+      () => {
+        const packagePath = findPackagePath(
+          "@tensorflow-models",
+          "pose-detection",
+        );
+        expect(fs.existsSync(packagePath!)).toBe(true);
+      },
+    );
+  });
 
-	describe("Sharp Image Processing", () => {
-		it.skipIf(!hasSharp)("sharp is installed", () => {
-			const packagePath = findPackagePath("sharp");
-			expect(fs.existsSync(packagePath!)).toBe(true);
-		});
+  describe("Sharp Image Processing", () => {
+    it.skipIf(!hasSharp)("sharp is installed", () => {
+      const packagePath = findPackagePath("sharp");
+      expect(fs.existsSync(packagePath!)).toBe(true);
+    });
 
-		it.skipIf(!hasSharp)("sharp can be imported", async () => {
-			const result = await canImportModuleInSubprocess("sharp");
-			expect(result.success).toBe(true);
-		});
+    it.skipIf(!hasSharp)("sharp can be imported", async () => {
+      const result = await canImportModuleInSubprocess("sharp");
+      expect(result.success).toBe(true);
+    });
 
-		it.skipIf(!hasSharp)(
-			"sharp can process an image buffer",
-			async () => {
-				const result = runModuleSnippet(`
-					const sharp = (await import("sharp")).default;
+    it.skipIf(!hasSharp)("sharp can process an image buffer", async () => {
+      const result = runModuleSnippet(`
+					const sharp = (await importFromWorkspace("sharp")).default;
 					const buffer = await sharp({
 						create: {
 							width: 1,
@@ -385,42 +373,30 @@ describe("Native Module Installation Verification", () => {
 					process.stdout.write(String(buffer.length));
 				`);
 
-				expect(result.success, result.error).toBe(true);
-				expect(Number(result.stdout.trim())).toBeGreaterThan(0);
-			},
-		);
-	});
+      expect(result.success, result.error).toBe(true);
+      expect(Number(result.stdout.trim())).toBeGreaterThan(0);
+    });
+  });
 
-	describe("Canvas for Face Recognition", () => {
-		it.skipIf(!hasCanvas)("canvas is installed", () => {
-			const packagePath = findPackagePath("canvas");
-			expect(fs.existsSync(packagePath!)).toBe(true);
-		});
+  describe("Canvas for Face Recognition", () => {
+    it.skipIf(!hasCanvas)("canvas is installed", () => {
+      const packagePath = findPackagePath("canvas");
+      expect(fs.existsSync(packagePath!)).toBe(true);
+    });
 
-		it.skipIf(!hasCanvasBinding)(
-			"canvas has native binding",
-			() => {
-				const hasBinding = hasNativeBinding("canvas", [
-					"canvas.node",
-					".node",
-				]);
-				expect(hasBinding).toBe(true);
-			},
-		);
+    it.skipIf(!hasCanvasBinding)("canvas has native binding", () => {
+      const hasBinding = hasNativeBinding("canvas", ["canvas.node", ".node"]);
+      expect(hasBinding).toBe(true);
+    });
 
-		it.skipIf(!hasCanvasBinding)(
-			"canvas can be imported",
-			async () => {
-				const result = await canImportModuleInSubprocess("canvas");
-				expect(result.success).toBe(true);
-			},
-		);
+    it.skipIf(!hasCanvasBinding)("canvas can be imported", async () => {
+      const result = await canImportModuleInSubprocess("canvas");
+      expect(result.success).toBe(true);
+    });
 
-		it.skipIf(!hasCanvasBinding)(
-			"canvas can create a 2D context",
-			async () => {
-				const result = runModuleSnippet(`
-					const { createCanvas } = await import("canvas");
+    it.skipIf(!hasCanvasBinding)("canvas can create a 2D context", async () => {
+      const result = runModuleSnippet(`
+					const { createCanvas } = await importFromWorkspace("canvas");
 					const canvas = createCanvas(100, 100);
 					const ctx = canvas.getContext("2d");
 					if (!ctx) throw new Error("2D context missing");
@@ -430,169 +406,145 @@ describe("Native Module Installation Verification", () => {
 					process.stdout.write(String(imageData.data[0]));
 				`);
 
-				expect(result.success, result.error).toBe(true);
-				expect(Number(result.stdout.trim())).toBe(255);
-			},
-		);
-	});
+      expect(result.success, result.error).toBe(true);
+      expect(Number(result.stdout.trim())).toBe(255);
+    });
+  });
 
-	describe("Face-API.js", () => {
-		it.skipIf(!hasFaceApi)("face-api.js is installed", () => {
-			const packagePath = findPackagePath("face-api.js");
-			expect(fs.existsSync(packagePath!)).toBe(true);
-		});
+  describe("Face-API.js", () => {
+    it.skipIf(!hasFaceApi)("face-api.js is installed", () => {
+      const packagePath = findPackagePath("face-api.js");
+      expect(fs.existsSync(packagePath!)).toBe(true);
+    });
 
-		it.skipIf(!hasFaceApi)(
-			"face-api.js can be imported",
-			async () => {
-				const result = await canImportModule("face-api.js");
-				expect(result.success).toBe(true);
-			},
-		);
-	});
+    it.skipIf(!hasFaceApi)("face-api.js can be imported", async () => {
+      const result = await canImportModule("face-api.js");
+      expect(result.success).toBe(true);
+    });
+  });
 
-	describe("Tesseract.js OCR", () => {
-		it.skipIf(!hasTesseract)("tesseract.js is installed", () => {
-			const packagePath = findPackagePath("tesseract.js");
-			expect(fs.existsSync(packagePath!)).toBe(true);
-		});
+  describe("Tesseract.js OCR", () => {
+    it.skipIf(!hasTesseract)("tesseract.js is installed", () => {
+      const packagePath = findPackagePath("tesseract.js");
+      expect(fs.existsSync(packagePath!)).toBe(true);
+    });
 
-		it.skipIf(!hasTesseract)(
-			"tesseract.js can be imported",
-			async () => {
-				const result = await canImportModule("tesseract.js");
-				expect(result.success).toBe(true);
-			},
-		);
-	});
+    it.skipIf(!hasTesseract)("tesseract.js can be imported", async () => {
+      const result = await canImportModule("tesseract.js");
+      expect(result.success).toBe(true);
+    });
+  });
 });
 
 describe("Plugin-Vision Availability", () => {
-	it.skipIf(!hasPluginVision)(
-		"@elizaos/plugin-vision is installed",
-		() => {
-			const packagePath = findPackagePath("@elizaos", "plugin-vision");
-			expect(fs.existsSync(packagePath!)).toBe(true);
-		},
-	);
+  it.skipIf(!hasPluginVision)("@elizaos/plugin-vision is installed", () => {
+    const packagePath = findPackagePath("@elizaos", "plugin-vision");
+    expect(fs.existsSync(packagePath!)).toBe(true);
+  });
 
-	it.skipIf(!hasPluginVision)(
-		"@elizaos/plugin-vision can be imported",
-		async () => {
-			const result = await canImportModule("@elizaos/plugin-vision");
-			expect(result.success).toBe(true);
-		},
-	);
+  it.skipIf(!hasPluginVision)(
+    "@elizaos/plugin-vision can be imported",
+    async () => {
+      const result = await canImportModule("@elizaos/plugin-vision");
+      expect(result.success).toBe(true);
+    },
+  );
 
-	it.skipIf(!hasPluginVision)(
-		"plugin-vision has required dependencies",
-		() => {
-			const visionPkgDir = findPackagePath("@elizaos", "plugin-vision");
-			const visionPkgPath = path.join(visionPkgDir!, "package.json");
-			expect(fs.existsSync(visionPkgPath)).toBe(true);
+  it.skipIf(!hasPluginVision)("plugin-vision has required dependencies", () => {
+    const visionPkgDir = findPackagePath("@elizaos", "plugin-vision");
+    const visionPkgPath = path.join(visionPkgDir!, "package.json");
+    expect(fs.existsSync(visionPkgPath)).toBe(true);
 
-			const visionPkgContent = fs.readFileSync(visionPkgPath, "utf-8");
+    const visionPkgContent = fs.readFileSync(visionPkgPath, "utf-8");
 
-			expect(visionPkgContent).toContain('"sharp"');
-			expect(visionPkgContent).toContain('"canvas"');
-			expect(visionPkgContent).toContain('"face-api.js"');
-			expect(visionPkgContent).toContain('"tesseract.js"');
-		},
-	);
+    expect(visionPkgContent).toContain('"sharp"');
+    expect(visionPkgContent).toContain('"canvas"');
+    expect(visionPkgContent).toContain('"face-api.js"');
+    expect(visionPkgContent).toContain('"tesseract.js"');
+  });
 
-	it.skipIf(!hasSharp || !hasTesseract)(
-		"vision dependencies are installed in node_modules",
-		() => {
-			const sharpPath = findPackagePath("sharp");
-			expect(!!sharpPath).toBe(true);
-			const tesseractPath = findPackagePath("tesseract.js");
-			expect(!!tesseractPath).toBe(true);
-		},
-	);
+  it.skipIf(!hasSharp || !hasTesseract)(
+    "vision dependencies are installed in node_modules",
+    () => {
+      const sharpPath = findPackagePath("sharp");
+      expect(!!sharpPath).toBe(true);
+      const tesseractPath = findPackagePath("tesseract.js");
+      expect(!!tesseractPath).toBe(true);
+    },
+  );
 });
 
 describe("Electrobun Native Module Configuration", () => {
-	it.skipIf(!electrobunPkgPath)(
-		"electrobun app package is present and depends on electrobun",
-		() => {
-			const electrobunPkg = JSON.parse(
-				fs.readFileSync(electrobunPkgPath!, "utf-8"),
-			);
-			expect(electrobunPkg.dependencies || {}).toHaveProperty(
-				"electrobun",
-			);
-		},
-	);
+  it.skipIf(!electrobunPkgPath)(
+    "electrobun app package is present and depends on electrobun",
+    () => {
+      const electrobunPkg = JSON.parse(
+        fs.readFileSync(electrobunPkgPath!, "utf-8"),
+      );
+      expect(electrobunPkg.dependencies || {}).toHaveProperty("electrobun");
+    },
+  );
 
-	it.skipIf(!hasAnyNativeModuleDep)(
-		"root runtime declares native module dependencies for desktop packaging",
-		() => {
-			expect(hasAnyNativeModuleDep).toBe(true);
-		},
-	);
+  it.skipIf(!hasAnyNativeModuleDep)(
+    "root runtime declares native module dependencies for desktop packaging",
+    () => {
+      expect(hasAnyNativeModuleDep).toBe(true);
+    },
+  );
 
-	it.skipIf(!copyRuntimeScript || !releaseWorkflow)(
-		"desktop packaging scripts exist for runtime dependency bundling",
-		() => {
-			expect(fs.existsSync(copyRuntimeScript!)).toBe(true);
-			expect(fs.existsSync(releaseWorkflow!)).toBe(true);
-		},
-	);
+  it.skipIf(!copyRuntimeScript || !releaseWorkflow)(
+    "desktop packaging scripts exist for runtime dependency bundling",
+    () => {
+      expect(fs.existsSync(copyRuntimeScript!)).toBe(true);
+      expect(fs.existsSync(releaseWorkflow!)).toBe(true);
+    },
+  );
 });
 
 describe("Core Plugins with Vision Integration", () => {
-	it.skipIf(!corePluginsPath)(
-		"plugin-vision is in OPTIONAL_CORE_PLUGINS",
-		async () => {
-			const { OPTIONAL_CORE_PLUGINS } = await import(
-				"../src/runtime/core-plugins"
-			);
-			expect(OPTIONAL_CORE_PLUGINS).toContain("@elizaos/plugin-vision");
-		},
-	);
+  it.skipIf(!corePluginsPath)(
+    "plugin-vision is in OPTIONAL_CORE_PLUGINS",
+    async () => {
+      const { OPTIONAL_CORE_PLUGINS } = await import(
+        "../src/runtime/core-plugins"
+      );
+      expect(OPTIONAL_CORE_PLUGINS).toContain("@elizaos/plugin-vision");
+    },
+  );
 
-	it.skipIf(!elizaTsPath)(
-		"plugin-vision has static import in eliza.ts",
-		() => {
-			const elizaContent = fs.readFileSync(elizaTsPath!, "utf-8");
-			expect(elizaContent).toContain("plugin-vision");
-		},
-	);
+  it.skipIf(!elizaTsPath)("plugin-vision has static import in eliza.ts", () => {
+    const elizaContent = fs.readFileSync(elizaTsPath!, "utf-8");
+    expect(elizaContent).toContain("plugin-vision");
+  });
 });
 
 describe("PTY Native Modules", () => {
-	it.skipIf(!hasNodePty)("node-pty is installed", () => {
-		const packagePath = findPackagePath("node-pty");
-		expect(fs.existsSync(packagePath!)).toBe(true);
-	});
+  it.skipIf(!hasNodePty)("node-pty is installed", () => {
+    const packagePath = findPackagePath("node-pty");
+    expect(fs.existsSync(packagePath!)).toBe(true);
+  });
 
-	it.skipIf(!hasLydellNodePty)(
-		"@lydell/node-pty is available",
-		() => {
-			expect(hasLydellNodePty).toBe(true);
-		},
-	);
+  it.skipIf(!hasLydellNodePty)("@lydell/node-pty is available", () => {
+    expect(hasLydellNodePty).toBe(true);
+  });
 
-	it.skipIf(!hasPtyManager)("pty-manager is installed", () => {
-		const packagePath = findPackagePath("pty-manager");
-		expect(fs.existsSync(packagePath!)).toBe(true);
-	});
+  it.skipIf(!hasPtyManager)("pty-manager is installed", () => {
+    const packagePath = findPackagePath("pty-manager");
+    expect(fs.existsSync(packagePath!)).toBe(true);
+  });
 
-	it.skipIf(!hasPtyDeps)(
-		"root runtime declares PTY dependencies",
-		() => {
-			expect(!!allDeps["pty-manager"]).toBe(true);
-		},
-	);
+  it.skipIf(!hasPtyDeps)("root runtime declares PTY dependencies", () => {
+    expect(!!allDeps["pty-manager"]).toBe(true);
+  });
 });
 
 describe("Local Embedding Native Modules", () => {
-	it.skipIf(!hasEmbeddingDeps)(
-		"root runtime declares local embedding dependencies",
-		() => {
-			expect(
-				!!allDeps["node-llama-cpp"] || !!allDeps["whisper-node"],
-			).toBe(true);
-		},
-	);
+  it.skipIf(!hasEmbeddingDeps)(
+    "root runtime declares local embedding dependencies",
+    () => {
+      expect(!!allDeps["node-llama-cpp"] || !!allDeps["whisper-node"]).toBe(
+        true,
+      );
+    },
+  );
 });

--- a/packages/app-core/src/api/__tests__/cloud-managed-discord-client.test.ts
+++ b/packages/app-core/src/api/__tests__/cloud-managed-discord-client.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Verifies the managed Discord client helpers target the cloud v1 agent routes.
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(
+  path.resolve(import.meta.dirname, "..", "client-cloud.ts"),
+  "utf-8",
+);
+
+describe("managed cloud Discord client helpers", () => {
+  it("defines a getter for managed Discord agent status", () => {
+    const idx = source.indexOf("prototype.getCloudCompatAgentManagedDiscord");
+    const nearby = source.slice(idx, idx + 260);
+    expect(nearby).toContain("/api/cloud/v1/milady/agents/");
+    expect(nearby).toContain("/discord");
+    expect(nearby).toContain("encodeURIComponent(agentId)");
+  });
+
+  it("defines a POST helper for starting managed Discord OAuth", () => {
+    const idx = source.indexOf(
+      "prototype.createCloudCompatAgentManagedDiscordOauth",
+    );
+    const nearby = source.slice(idx, idx + 360);
+    expect(nearby).toContain('method: "POST"');
+    expect(nearby).toContain("/api/cloud/v1/milady/agents/");
+    expect(nearby).toContain("/discord/oauth");
+  });
+
+  it("defines a DELETE helper for disconnecting managed Discord", () => {
+    const idx = source.indexOf(
+      "prototype.disconnectCloudCompatAgentManagedDiscord",
+    );
+    const nearby = source.slice(idx, idx + 320);
+    expect(nearby).toContain('method: "DELETE"');
+    expect(nearby).toContain("/api/cloud/v1/milady/agents/");
+    expect(nearby).toContain("/discord");
+  });
+});

--- a/packages/app-core/src/api/__tests__/cloud-managed-discord-client.test.ts
+++ b/packages/app-core/src/api/__tests__/cloud-managed-discord-client.test.ts
@@ -1,42 +1,77 @@
 /**
- * Verifies the managed Discord client helpers target the cloud v1 agent routes.
+ * Verifies the managed Discord client helpers call the cloud v1 agent routes.
  */
 
-import { readFileSync } from "node:fs";
-import path from "node:path";
-import { describe, expect, it } from "vitest";
-
-const source = readFileSync(
-  path.resolve(import.meta.dirname, "..", "client-cloud.ts"),
-  "utf-8",
-);
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MiladyClient } from "../client";
 
 describe("managed cloud Discord client helpers", () => {
-  it("defines a getter for managed Discord agent status", () => {
-    const idx = source.indexOf("prototype.getCloudCompatAgentManagedDiscord");
-    const nearby = source.slice(idx, idx + 260);
-    expect(nearby).toContain("/api/cloud/v1/milady/agents/");
-    expect(nearby).toContain("/discord");
-    expect(nearby).toContain("encodeURIComponent(agentId)");
+  const originalFetch = globalThis.fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ success: true, data: {} }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
   });
 
-  it("defines a POST helper for starting managed Discord OAuth", () => {
-    const idx = source.indexOf(
-      "prototype.createCloudCompatAgentManagedDiscordOauth",
-    );
-    const nearby = source.slice(idx, idx + 360);
-    expect(nearby).toContain('method: "POST"');
-    expect(nearby).toContain("/api/cloud/v1/milady/agents/");
-    expect(nearby).toContain("/discord/oauth");
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
   });
 
-  it("defines a DELETE helper for disconnecting managed Discord", () => {
-    const idx = source.indexOf(
-      "prototype.disconnectCloudCompatAgentManagedDiscord",
+  it("calls the managed Discord status endpoint for an agent", async () => {
+    const client = new MiladyClient("http://localhost:2138", "token");
+    await client.getCloudCompatAgentManagedDiscord("agent/with spaces");
+
+    const [url, init] = fetchMock.mock.calls[0] as [
+      RequestInfo | URL,
+      RequestInit,
+    ];
+    expect(String(url)).toBe(
+      "http://localhost:2138/api/cloud/v1/milady/agents/agent%2Fwith%20spaces/discord",
     );
-    const nearby = source.slice(idx, idx + 320);
-    expect(nearby).toContain('method: "DELETE"');
-    expect(nearby).toContain("/api/cloud/v1/milady/agents/");
-    expect(nearby).toContain("/discord");
+    expect(init?.method).toBeUndefined();
+  });
+
+  it("POSTs managed Discord OAuth init requests to the cloud agent route", async () => {
+    const client = new MiladyClient("http://localhost:2138", "token");
+    await client.createCloudCompatAgentManagedDiscordOauth("agent-1", {
+      returnUrl: "/dashboard/settings?tab=agents",
+      botNickname: "Chen",
+    });
+
+    const [url, init] = fetchMock.mock.calls[0] as [
+      RequestInfo | URL,
+      RequestInit,
+    ];
+    expect(String(url)).toBe(
+      "http://localhost:2138/api/cloud/v1/milady/agents/agent-1/discord/oauth",
+    );
+    expect(init?.method).toBe("POST");
+    expect(init?.body).toBe(
+      JSON.stringify({
+        returnUrl: "/dashboard/settings?tab=agents",
+        botNickname: "Chen",
+      }),
+    );
+  });
+
+  it("DELETEs managed Discord connections from the cloud agent route", async () => {
+    const client = new MiladyClient("http://localhost:2138", "token");
+    await client.disconnectCloudCompatAgentManagedDiscord("agent-1");
+
+    const [url, init] = fetchMock.mock.calls[0] as [
+      RequestInfo | URL,
+      RequestInit,
+    ];
+    expect(String(url)).toBe(
+      "http://localhost:2138/api/cloud/v1/milady/agents/agent-1/discord",
+    );
+    expect(init?.method).toBe("DELETE");
   });
 });

--- a/packages/app-core/src/api/client-cloud.ts
+++ b/packages/app-core/src/api/client-cloud.ts
@@ -3,6 +3,7 @@
  * export/import, direct cloud auth, bug reports.
  */
 
+import { MiladyClient } from "./client-base";
 import type {
   CloudBillingCheckoutRequest,
   CloudBillingCheckoutResponse,
@@ -17,6 +18,7 @@ import type {
   CloudCompatAgentStatus,
   CloudCompatJob,
   CloudCompatLaunchResult,
+  CloudCompatManagedDiscordStatus,
   CloudCredits,
   CloudLoginPollResponse,
   CloudLoginResponse,
@@ -28,7 +30,6 @@ import type {
   SandboxStartResponse,
   SandboxWindowInfo,
 } from "./client-types";
-import { MiladyClient } from "./client-base";
 
 // ---------------------------------------------------------------------------
 // Module-level constants
@@ -94,6 +95,27 @@ declare module "./client-base" {
     getCloudCompatAgent(agentId: string): Promise<{
       success: boolean;
       data: CloudCompatAgent;
+    }>;
+    getCloudCompatAgentManagedDiscord(agentId: string): Promise<{
+      success: boolean;
+      data: CloudCompatManagedDiscordStatus;
+    }>;
+    createCloudCompatAgentManagedDiscordOauth(
+      agentId: string,
+      request?: {
+        returnUrl?: string;
+        botNickname?: string;
+      },
+    ): Promise<{
+      success: boolean;
+      data: {
+        authorizeUrl: string;
+        applicationId: string | null;
+      };
+    }>;
+    disconnectCloudCompatAgentManagedDiscord(agentId: string): Promise<{
+      success: boolean;
+      data: CloudCompatManagedDiscordStatus;
     }>;
     deleteCloudCompatAgent(agentId: string): Promise<{
       success: boolean;
@@ -331,6 +353,36 @@ MiladyClient.prototype.getCloudCompatAgent = async function (
 ) {
   return this.fetch(`/api/cloud/compat/agents/${encodeURIComponent(agentId)}`);
 };
+
+MiladyClient.prototype.getCloudCompatAgentManagedDiscord = async function (
+  this: MiladyClient,
+  agentId,
+) {
+  return this.fetch(
+    `/api/cloud/v1/milady/agents/${encodeURIComponent(agentId)}/discord`,
+  );
+};
+
+MiladyClient.prototype.createCloudCompatAgentManagedDiscordOauth =
+  async function (this: MiladyClient, agentId, request = {}) {
+    return this.fetch(
+      `/api/cloud/v1/milady/agents/${encodeURIComponent(agentId)}/discord/oauth`,
+      {
+        method: "POST",
+        body: JSON.stringify(request),
+      },
+    );
+  };
+
+MiladyClient.prototype.disconnectCloudCompatAgentManagedDiscord =
+  async function (this: MiladyClient, agentId) {
+    return this.fetch(
+      `/api/cloud/v1/milady/agents/${encodeURIComponent(agentId)}/discord`,
+      {
+        method: "DELETE",
+      },
+    );
+  };
 
 MiladyClient.prototype.deleteCloudCompatAgent = async function (
   this: MiladyClient,

--- a/packages/app-core/src/api/client-types-cloud.ts
+++ b/packages/app-core/src/api/client-types-cloud.ts
@@ -180,6 +180,22 @@ export interface CloudCompatAgentStatus {
   databaseStatus: string;
 }
 
+export interface CloudCompatManagedDiscordStatus {
+  applicationId: string | null;
+  configured: boolean;
+  connected: boolean;
+  developerPortalUrl: string;
+  guildId: string | null;
+  guildName: string | null;
+  adminDiscordUserId: string | null;
+  adminDiscordUsername: string | null;
+  adminDiscordDisplayName: string | null;
+  adminElizaUserId: string | null;
+  botNickname: string | null;
+  connectedAt: string | null;
+  restarted?: boolean;
+}
+
 export interface CloudCompatJob {
   jobId: string;
   type: string;

--- a/packages/app-core/src/components/pages/ElizaCloudDashboard.tsx
+++ b/packages/app-core/src/components/pages/ElizaCloudDashboard.tsx
@@ -36,6 +36,7 @@ import {
   autoTopUpFormReducer,
   BILLING_PRESET_AMOUNTS,
   buildAutoTopUpFormState,
+  consumeManagedDiscordCallbackUrl,
   CLOUD_ACCENT_CONTROL_TEXT_CLASSNAME,
   CLOUD_INSET_PANEL_CLASSNAME,
   CLOUD_PANEL_CLASSNAME,
@@ -118,6 +119,7 @@ export function CloudDashboard() {
   const [deployAgentName, setDeployAgentName] = useState("");
   const [deploying, setDeploying] = useState(false);
   const mountedRef = useRef(true);
+  const handledManagedDiscordCallbackRef = useRef(false);
   const autoTopUpEnabled = autoTopUpForm.enabled;
   const autoTopUpAmount = autoTopUpForm.amount;
   const autoTopUpThreshold = autoTopUpForm.threshold;
@@ -752,6 +754,58 @@ export function CloudDashboard() {
       void fetchBillingData();
     }
   }, [fetchBillingData, fetchCloudAgents, loadDropStatus, elizaCloudConnected]);
+
+  useEffect(() => {
+    if (handledManagedDiscordCallbackRef.current || typeof window === "undefined") {
+      return;
+    }
+
+    const { callback, cleanedUrl } = consumeManagedDiscordCallbackUrl(
+      window.location.href,
+    );
+    if (!callback) {
+      return;
+    }
+
+    handledManagedDiscordCallbackRef.current = true;
+    setState("cloudDashboardView", "agents");
+    if (callback.agentId) {
+      setSelectedAgentId(callback.agentId);
+    }
+    if (cleanedUrl && cleanedUrl !== window.location.href) {
+      window.history.replaceState({}, document.title, cleanedUrl);
+    }
+
+    if (callback.status === "connected") {
+      setActionNotice(
+        callback.guildName
+          ? t("elizaclouddashboard.ManagedDiscordConnectedNotice", {
+              defaultValue: callback.restarted
+                ? "Managed Discord connected to {{guild}}. The agent restarted and is ready."
+                : "Managed Discord connected to {{guild}}.",
+              guild: callback.guildName,
+            })
+          : t("elizaclouddashboard.ManagedDiscordConnectedNoticeFallback", {
+              defaultValue: callback.restarted
+                ? "Managed Discord connected. The agent restarted and is ready."
+                : "Managed Discord connected.",
+            }),
+        "success",
+        5200,
+      );
+      void fetchCloudAgents();
+      return;
+    }
+
+    setActionNotice(
+      callback.message ||
+        t("elizaclouddashboard.ManagedDiscordConnectFailed", {
+          defaultValue: "Managed Discord setup did not complete.",
+        }),
+      "error",
+      5200,
+    );
+  }, [fetchCloudAgents, setActionNotice, setState, t]);
 
   // Drop cached billing / agents when disconnected so we never show stale balances
   // after context clears credits (local state would otherwise outlive AppContext).

--- a/packages/app-core/src/components/pages/ElizaCloudDashboard.tsx
+++ b/packages/app-core/src/components/pages/ElizaCloudDashboard.tsx
@@ -756,7 +756,10 @@ export function CloudDashboard() {
   }, [fetchBillingData, fetchCloudAgents, loadDropStatus, elizaCloudConnected]);
 
   useEffect(() => {
-    if (handledManagedDiscordCallbackRef.current || typeof window === "undefined") {
+    if (
+      handledManagedDiscordCallbackRef.current ||
+      typeof window === "undefined"
+    ) {
       return;
     }
 

--- a/packages/app-core/src/components/pages/cloud-dashboard-utils.test.ts
+++ b/packages/app-core/src/components/pages/cloud-dashboard-utils.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { consumeManagedDiscordCallbackUrl } from "./cloud-dashboard-utils";
+
+describe("consumeManagedDiscordCallbackUrl", () => {
+  it("extracts managed Discord callback state and removes transient params", () => {
+    const { callback, cleanedUrl } = consumeManagedDiscordCallbackUrl(
+      "http://localhost:4173/dashboard/settings?tab=agents&discord=connected&managed=1&agentId=agent-1&guildId=guild-1&guildName=Milady%20HQ&restarted=1",
+    );
+
+    expect(callback).toEqual({
+      status: "connected",
+      managed: true,
+      agentId: "agent-1",
+      guildId: "guild-1",
+      guildName: "Milady HQ",
+      message: null,
+      restarted: true,
+    });
+    expect(cleanedUrl).toBe(
+      "http://localhost:4173/dashboard/settings?tab=agents",
+    );
+  });
+
+  it("ignores non-managed Discord callback params", () => {
+    const { callback, cleanedUrl } = consumeManagedDiscordCallbackUrl(
+      "http://localhost:4173/dashboard/settings?tab=agents&discord=connected",
+    );
+
+    expect(callback).toBeNull();
+    expect(cleanedUrl).toBeNull();
+  });
+});

--- a/packages/app-core/src/components/pages/cloud-dashboard-utils.ts
+++ b/packages/app-core/src/components/pages/cloud-dashboard-utils.ts
@@ -109,6 +109,63 @@ export function readBoolean(value: unknown): boolean | undefined {
   return typeof value === "boolean" ? value : undefined;
 }
 
+export interface ManagedDiscordCallbackState {
+  status: "connected" | "error";
+  agentId: string | null;
+  guildId: string | null;
+  guildName: string | null;
+  managed: boolean;
+  message: string | null;
+  restarted: boolean;
+}
+
+const MANAGED_DISCORD_CALLBACK_QUERY_KEYS = [
+  "discord",
+  "managed",
+  "agentId",
+  "guildId",
+  "guildName",
+  "restarted",
+  "message",
+] as const;
+
+export function consumeManagedDiscordCallbackUrl(rawUrl: string): {
+  callback: ManagedDiscordCallbackState | null;
+  cleanedUrl: string | null;
+} {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return { callback: null, cleanedUrl: null };
+  }
+
+  const status = url.searchParams.get("discord");
+  const managed = url.searchParams.get("managed") === "1";
+  if ((status !== "connected" && status !== "error") || !managed) {
+    return { callback: null, cleanedUrl: null };
+  }
+
+  const callback: ManagedDiscordCallbackState = {
+    status,
+    managed,
+    agentId: readString(url.searchParams.get("agentId")) ?? null,
+    guildId: readString(url.searchParams.get("guildId")) ?? null,
+    guildName: readString(url.searchParams.get("guildName")) ?? null,
+    message: readString(url.searchParams.get("message")) ?? null,
+    restarted: url.searchParams.get("restarted") === "1",
+  };
+
+  for (const key of MANAGED_DISCORD_CALLBACK_QUERY_KEYS) {
+    url.searchParams.delete(key);
+  }
+
+  return {
+    callback,
+    cleanedUrl: url.toString(),
+  };
+}
+
 export function normalizeBillingSummary(
   raw: CloudBillingSummary,
 ): CloudBillingSummary {

--- a/packages/plugin-roles/src/action.ts
+++ b/packages/plugin-roles/src/action.ts
@@ -20,8 +20,8 @@ import {
 import type { RoleName, RolesWorldMetadata } from "./types";
 import {
   canModifyRole,
-  getEntityRole,
   normalizeRole,
+  resolveEntityRole,
   resolveWorldForMessage,
 } from "./utils";
 
@@ -206,7 +206,12 @@ export const updateRoleAction: Action = {
     const { world, metadata } = resolved;
 
     // Check requester's role
-    const requesterRole = getEntityRole(metadata, message.entityId);
+    const requesterRole = await resolveEntityRole(
+      runtime,
+      world,
+      metadata,
+      message.entityId,
+    );
     if (requesterRole !== "OWNER" && requesterRole !== "ADMIN") {
       await callback?.({
         text: "You don't have permission to manage roles. Only OWNERs and ADMINs can assign roles.",
@@ -236,7 +241,12 @@ export const updateRoleAction: Action = {
     }
 
     // Permission check
-    const targetCurrentRole = getEntityRole(metadata, targetEntityId);
+    const targetCurrentRole = await resolveEntityRole(
+      runtime,
+      world,
+      metadata,
+      targetEntityId,
+    );
 
     // Prevent the last OWNER from demoting themselves
     if (

--- a/packages/plugin-roles/src/index.ts
+++ b/packages/plugin-roles/src/index.ts
@@ -22,7 +22,11 @@ import {
 import { rolesProvider } from "./provider";
 import { updateRoleAction } from "./action";
 import type { RolesPluginConfig, RolesWorldMetadata } from "./types";
-import { normalizeRole } from "./utils";
+import {
+  matchEntityToConnectorAdminWhitelist,
+  normalizeRole,
+  setConnectorAdminWhitelist,
+} from "./utils";
 
 export { rolesProvider } from "./provider";
 export { updateRoleAction } from "./action";
@@ -59,11 +63,26 @@ async function updateWorldMetadata(
   await runtime.updateWorld(world as Parameters<IAgentRuntime["updateWorld"]>[0]);
 }
 
+function scheduleBootstrapRetry(
+  label: string,
+  task: () => Promise<boolean>,
+): void {
+  setTimeout(() => {
+    void task().then((ok) => {
+      if (!ok) {
+        logger.info(
+          `[roles] ${label} retry skipped because runtime state is still unavailable`,
+        );
+      }
+    });
+  }, 1500);
+}
+
 /**
  * Ensure the world owner has OWNER role in metadata.
  * Called on plugin init — guarantees the app-local user is always OWNER.
  */
-async function ensureOwnerRole(runtime: IAgentRuntime): Promise<void> {
+async function ensureOwnerRole(runtime: IAgentRuntime): Promise<boolean> {
   try {
     const worlds = await runtime.getAllWorlds();
 
@@ -85,8 +104,12 @@ async function ensureOwnerRole(runtime: IAgentRuntime): Promise<void> {
         return true;
       });
     }
+    return true;
   } catch (err) {
-    logger.warn(`[roles] Failed to bootstrap owner roles: ${err}`);
+    logger.info(
+      `[roles] Deferring owner role bootstrap until worlds are available: ${err}`,
+    );
+    return false;
   }
 }
 
@@ -97,9 +120,9 @@ async function ensureOwnerRole(runtime: IAgentRuntime): Promise<void> {
 async function applyConnectorAdminWhitelists(
   runtime: IAgentRuntime,
   whitelist: Record<string, string[]>,
-): Promise<void> {
+): Promise<boolean> {
   const hasWhitelist = Object.values(whitelist).some((ids) => ids.length > 0);
-  if (!hasWhitelist) return;
+  if (!hasWhitelist) return true;
 
   try {
     const worlds = await runtime.getAllWorlds();
@@ -122,28 +145,11 @@ async function applyConnectorAdminWhitelists(
 
             if (metadata.roles[entityId]) continue;
 
-            if (!entity.metadata) continue;
-
-            const platformMetadata = entity.metadata as Record<
-              string,
-              Record<string, unknown> | undefined
-            >;
-            let matched = false;
-
-            for (const [connector, platformIds] of Object.entries(whitelist)) {
-              const connectorMeta = platformMetadata[connector];
-              if (!connectorMeta || typeof connectorMeta !== "object") continue;
-
-              for (const field of ["userId", "id", "username", "userName"]) {
-                const value = connectorMeta[field];
-                if (typeof value === "string" && platformIds.includes(value)) {
-                  matched = true;
-                  break;
-                }
-              }
-
-              if (matched) break;
-            }
+            const matched = matchEntityToConnectorAdminWhitelist(
+              (entity.metadata as Record<string, unknown> | undefined) ??
+                undefined,
+              whitelist,
+            );
 
             if (matched) {
               metadata.roles[entityId] = "ADMIN";
@@ -158,10 +164,12 @@ async function applyConnectorAdminWhitelists(
         return updated;
       });
     }
+    return true;
   } catch (err) {
-    logger.warn(
-      `[roles] Failed to apply connector admin whitelists: ${String(err)}`,
+    logger.info(
+      `[roles] Deferring connector admin bootstrap until worlds are available: ${String(err)}`,
     );
+    return false;
   }
 }
 
@@ -176,14 +184,28 @@ const rolesPlugin: Plugin = {
 
   async init(pluginConfig: Record<string, unknown>, runtime: IAgentRuntime) {
     logger.info("[roles] Initializing plugin-roles");
+    const config = pluginConfig as RolesPluginConfig | undefined;
+    setConnectorAdminWhitelist(runtime, config?.connectorAdmins);
 
     // Step 1: Ensure world owners have OWNER role
-    await ensureOwnerRole(runtime);
+    const ownerBootstrapOk = await ensureOwnerRole(runtime);
+    if (!ownerBootstrapOk) {
+      scheduleBootstrapRetry("Owner role bootstrap", () =>
+        ensureOwnerRole(runtime),
+      );
+    }
 
     // Step 2: Apply connector admin whitelists if configured
-    const config = pluginConfig as RolesPluginConfig | undefined;
     if (config?.connectorAdmins) {
-      await applyConnectorAdminWhitelists(runtime, config.connectorAdmins);
+      const adminBootstrapOk = await applyConnectorAdminWhitelists(
+        runtime,
+        config.connectorAdmins,
+      );
+      if (!adminBootstrapOk) {
+        scheduleBootstrapRetry("Connector admin bootstrap", () =>
+          applyConnectorAdminWhitelists(runtime, config.connectorAdmins),
+        );
+      }
     }
 
     logger.info("[roles] Plugin-roles initialized");

--- a/packages/plugin-roles/src/index.ts
+++ b/packages/plugin-roles/src/index.ts
@@ -231,15 +231,16 @@ const rolesPlugin: Plugin = {
     }
 
     // Step 2: Apply connector admin whitelists if configured
-    if (config?.connectorAdmins) {
-      setConnectorAdminWhitelist(runtime, config.connectorAdmins);
+    const connectorAdmins = config?.connectorAdmins;
+    if (connectorAdmins) {
+      setConnectorAdminWhitelist(runtime, connectorAdmins);
       const adminBootstrapOk = await applyConnectorAdminWhitelists(
         runtime,
-        config.connectorAdmins,
+        connectorAdmins,
       );
       if (!adminBootstrapOk) {
         scheduleBootstrapRetry(runtime, "Connector admin bootstrap", () =>
-          applyConnectorAdminWhitelists(runtime, config.connectorAdmins),
+          applyConnectorAdminWhitelists(runtime, connectorAdmins),
         );
       }
     } else {

--- a/packages/plugin-roles/src/index.ts
+++ b/packages/plugin-roles/src/index.ts
@@ -14,13 +14,9 @@
  *   }
  */
 
-import {
-  logger,
-  type IAgentRuntime,
-  type Plugin,
-} from "@elizaos/core";
-import { rolesProvider } from "./provider";
+import { type IAgentRuntime, logger, type Plugin } from "@elizaos/core";
 import { updateRoleAction } from "./action";
+import { rolesProvider } from "./provider";
 import type { RolesPluginConfig, RolesWorldMetadata } from "./types";
 import {
   matchEntityToConnectorAdminWhitelist,
@@ -28,16 +24,17 @@ import {
   setConnectorAdminWhitelist,
 } from "./utils";
 
-export { rolesProvider } from "./provider";
+const BOOTSTRAP_RETRY_TIMERS_KEY = Symbol.for(
+  "@miladyai/plugin-roles.bootstrapRetries",
+);
+const BOOTSTRAP_RETRY_LIMIT = 3;
+
+type RuntimeWithBootstrapRetries = IAgentRuntime & {
+  [BOOTSTRAP_RETRY_TIMERS_KEY]?: Map<string, ReturnType<typeof setTimeout>>;
+};
+
 export { updateRoleAction } from "./action";
-export {
-  canModifyRole,
-  checkSenderRole,
-  getEntityRole,
-  normalizeRole,
-  resolveWorldForMessage,
-  setEntityRole,
-} from "./utils";
+export { rolesProvider } from "./provider";
 export type {
   ConnectorAdminWhitelist,
   RoleCheckResult,
@@ -46,6 +43,14 @@ export type {
   RolesWorldMetadata,
 } from "./types";
 export { ROLE_RANK } from "./types";
+export {
+  canModifyRole,
+  checkSenderRole,
+  getEntityRole,
+  normalizeRole,
+  resolveWorldForMessage,
+  setEntityRole,
+} from "./utils";
 
 async function updateWorldMetadata(
   runtime: IAgentRuntime,
@@ -60,22 +65,53 @@ async function updateWorldMetadata(
   if (!changed) return;
 
   (world as { metadata: RolesWorldMetadata }).metadata = metadata;
-  await runtime.updateWorld(world as Parameters<IAgentRuntime["updateWorld"]>[0]);
+  await runtime.updateWorld(
+    world as Parameters<IAgentRuntime["updateWorld"]>[0],
+  );
+}
+
+function getBootstrapRetryTimers(
+  runtime: IAgentRuntime,
+): Map<string, ReturnType<typeof setTimeout>> {
+  const runtimeWithBootstrapRetries = runtime as RuntimeWithBootstrapRetries;
+  runtimeWithBootstrapRetries[BOOTSTRAP_RETRY_TIMERS_KEY] ??= new Map();
+  return runtimeWithBootstrapRetries[BOOTSTRAP_RETRY_TIMERS_KEY];
 }
 
 function scheduleBootstrapRetry(
+  runtime: IAgentRuntime,
   label: string,
   task: () => Promise<boolean>,
+  attempt = 1,
 ): void {
-  setTimeout(() => {
+  const timers = getBootstrapRetryTimers(runtime);
+  const existingTimer = timers.get(label);
+  if (existingTimer) {
+    clearTimeout(existingTimer);
+  }
+
+  const delayMs = Math.min(1500 * attempt, 5000);
+  const timer = setTimeout(() => {
+    timers.delete(label);
     void task().then((ok) => {
-      if (!ok) {
-        logger.info(
-          `[roles] ${label} retry skipped because runtime state is still unavailable`,
-        );
+      if (ok) {
+        return;
       }
+
+      if (attempt >= BOOTSTRAP_RETRY_LIMIT) {
+        logger.warn(
+          `[roles] ${label} retries exhausted because runtime state is still unavailable`,
+        );
+        return;
+      }
+
+      logger.info(
+        `[roles] ${label} retry ${attempt} skipped because runtime state is still unavailable`,
+      );
+      scheduleBootstrapRetry(runtime, label, task, attempt + 1);
     });
-  }, 1500);
+  }, delayMs);
+  timers.set(label, timer);
 }
 
 /**
@@ -185,27 +221,29 @@ const rolesPlugin: Plugin = {
   async init(pluginConfig: Record<string, unknown>, runtime: IAgentRuntime) {
     logger.info("[roles] Initializing plugin-roles");
     const config = pluginConfig as RolesPluginConfig | undefined;
-    setConnectorAdminWhitelist(runtime, config?.connectorAdmins);
 
     // Step 1: Ensure world owners have OWNER role
     const ownerBootstrapOk = await ensureOwnerRole(runtime);
     if (!ownerBootstrapOk) {
-      scheduleBootstrapRetry("Owner role bootstrap", () =>
+      scheduleBootstrapRetry(runtime, "Owner role bootstrap", () =>
         ensureOwnerRole(runtime),
       );
     }
 
     // Step 2: Apply connector admin whitelists if configured
     if (config?.connectorAdmins) {
+      setConnectorAdminWhitelist(runtime, config.connectorAdmins);
       const adminBootstrapOk = await applyConnectorAdminWhitelists(
         runtime,
         config.connectorAdmins,
       );
       if (!adminBootstrapOk) {
-        scheduleBootstrapRetry("Connector admin bootstrap", () =>
+        scheduleBootstrapRetry(runtime, "Connector admin bootstrap", () =>
           applyConnectorAdminWhitelists(runtime, config.connectorAdmins),
         );
       }
+    } else {
+      setConnectorAdminWhitelist(runtime, undefined);
     }
 
     logger.info("[roles] Plugin-roles initialized");

--- a/packages/plugin-roles/src/provider.ts
+++ b/packages/plugin-roles/src/provider.ts
@@ -13,7 +13,7 @@ import {
   type UUID,
 } from "@elizaos/core";
 import { type RoleName, type RolesWorldMetadata } from "./types";
-import { getEntityRole, normalizeRole } from "./utils";
+import { normalizeRole, resolveEntityRole } from "./utils";
 
 export const rolesProvider: Provider = {
   name: "roles",
@@ -43,8 +43,13 @@ export const rolesProvider: Provider = {
     }
 
     const metadata = (world.metadata ?? {}) as RolesWorldMetadata;
+    const speakerRole = await resolveEntityRole(
+      runtime,
+      world,
+      metadata,
+      message.entityId,
+    );
     const roles = metadata.roles ?? {};
-    const speakerRole = getEntityRole(metadata, message.entityId);
 
     // Build a compact role summary for the agent context.
     const owners: string[] = [];

--- a/packages/plugin-roles/src/provider.ts
+++ b/packages/plugin-roles/src/provider.ts
@@ -4,15 +4,15 @@
  */
 
 import {
-  logger,
   type IAgentRuntime,
+  logger,
   type Memory,
   type Provider,
   type ProviderResult,
   type State,
   type UUID,
 } from "@elizaos/core";
-import { type RoleName, type RolesWorldMetadata } from "./types";
+import type { RoleName, RolesWorldMetadata } from "./types";
 import { normalizeRole, resolveEntityRole } from "./utils";
 
 export const rolesProvider: Provider = {
@@ -49,7 +49,10 @@ export const rolesProvider: Provider = {
       metadata,
       message.entityId,
     );
-    const roles = metadata.roles ?? {};
+    const roles = { ...(metadata.roles ?? {}) };
+    if (!roles[message.entityId] && speakerRole !== "GUEST") {
+      roles[message.entityId] = speakerRole;
+    }
 
     // Build a compact role summary for the agent context.
     const owners: string[] = [];
@@ -72,8 +75,11 @@ export const rolesProvider: Provider = {
           const entity = await runtime.getEntityById(id as UUID);
           const name =
             entity?.names?.[0] ??
-            (entity?.metadata as Record<string, Record<string, string>> | undefined)
-              ?.default?.name ??
+            (
+              entity?.metadata as
+                | Record<string, Record<string, string>>
+                | undefined
+            )?.default?.name ??
             id.slice(0, 8);
           results.push(name);
         } catch {

--- a/packages/plugin-roles/src/utils.ts
+++ b/packages/plugin-roles/src/utils.ts
@@ -3,7 +3,85 @@
  */
 
 import type { IAgentRuntime, Memory, UUID } from "@elizaos/core";
-import { type RoleName, type RolesWorldMetadata, ROLE_RANK } from "./types";
+import {
+  type ConnectorAdminWhitelist,
+  type RoleName,
+  type RolesWorldMetadata,
+  ROLE_RANK,
+} from "./types";
+
+const CONNECTOR_ADMIN_WHITELIST_KEY = Symbol.for(
+  "@miladyai/plugin-roles.connectorAdmins",
+);
+const CONNECTOR_ID_FIELDS = ["userId", "id", "username", "userName"] as const;
+
+type RuntimeWithConnectorAdmins = IAgentRuntime & {
+  [CONNECTOR_ADMIN_WHITELIST_KEY]?: ConnectorAdminWhitelist;
+};
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((entry): entry is string => typeof entry === "string")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function normalizeConnectorAdminWhitelist(
+  whitelist: ConnectorAdminWhitelist | Record<string, unknown> | undefined,
+): ConnectorAdminWhitelist {
+  if (!whitelist || typeof whitelist !== "object") return {};
+
+  return Object.fromEntries(
+    Object.entries(whitelist)
+      .map(([connector, values]) => [connector, asStringArray(values)])
+      .filter(([, values]) => values.length > 0),
+  );
+}
+
+export function setConnectorAdminWhitelist(
+  runtime: IAgentRuntime,
+  whitelist: ConnectorAdminWhitelist | Record<string, unknown> | undefined,
+): void {
+  (runtime as RuntimeWithConnectorAdmins)[CONNECTOR_ADMIN_WHITELIST_KEY] =
+    normalizeConnectorAdminWhitelist(whitelist);
+}
+
+export function getConnectorAdminWhitelist(
+  runtime: IAgentRuntime,
+): ConnectorAdminWhitelist {
+  return (
+    (runtime as RuntimeWithConnectorAdmins)[CONNECTOR_ADMIN_WHITELIST_KEY] ?? {}
+  );
+}
+
+export function matchEntityToConnectorAdminWhitelist(
+  entityMetadata: Record<string, unknown> | null | undefined,
+  whitelist: ConnectorAdminWhitelist | Record<string, unknown> | undefined,
+): { connector: string; matchedValue: string } | null {
+  if (!entityMetadata || typeof entityMetadata !== "object") return null;
+
+  const normalizedWhitelist = normalizeConnectorAdminWhitelist(whitelist);
+  for (const [connector, platformIds] of Object.entries(normalizedWhitelist)) {
+    const connectorMeta = entityMetadata[connector];
+    if (
+      !connectorMeta ||
+      typeof connectorMeta !== "object" ||
+      Array.isArray(connectorMeta)
+    ) {
+      continue;
+    }
+
+    for (const field of CONNECTOR_ID_FIELDS) {
+      const value = connectorMeta[field];
+      if (typeof value === "string" && platformIds.includes(value)) {
+        return { connector, matchedValue: value };
+      }
+    }
+  }
+
+  return null;
+}
 
 /**
  * Normalise a role string to a valid RoleName. Unknown values become "GUEST".
@@ -23,6 +101,65 @@ export function getEntityRole(
 ): RoleName {
   if (!metadata?.roles) return "GUEST";
   return normalizeRole(metadata.roles[entityId]);
+}
+
+/**
+ * Resolve an entity's effective role, including connector-admin whitelist
+ * matches for users that first appear after plugin bootstrap.
+ */
+export async function resolveEntityRole(
+  runtime: IAgentRuntime,
+  world: Awaited<ReturnType<IAgentRuntime["getWorld"]>>,
+  metadata: RolesWorldMetadata | undefined,
+  entityId: string,
+): Promise<RoleName> {
+  const explicitRole = getEntityRole(metadata, entityId);
+  if (explicitRole !== "GUEST") {
+    return explicitRole;
+  }
+
+  const whitelist = getConnectorAdminWhitelist(runtime);
+  if (Object.keys(whitelist).length === 0) {
+    return explicitRole;
+  }
+
+  if (typeof runtime.getEntityById !== "function") {
+    return explicitRole;
+  }
+
+  let entity: Awaited<ReturnType<IAgentRuntime["getEntityById"]>> | null = null;
+  try {
+    entity = await runtime.getEntityById(entityId as UUID);
+  } catch {
+    return explicitRole;
+  }
+
+  const matched = matchEntityToConnectorAdminWhitelist(
+    (entity?.metadata as Record<string, unknown> | undefined) ?? undefined,
+    whitelist,
+  );
+  if (!matched) {
+    return explicitRole;
+  }
+
+  if (!metadata?.roles) {
+    metadata = { ...(metadata ?? {}), roles: {} };
+  }
+  metadata.roles ??= {};
+  metadata.roles[entityId] = "ADMIN";
+
+  if (world) {
+    try {
+      (world as { metadata: RolesWorldMetadata }).metadata = metadata;
+      await runtime.updateWorld(
+        world as Parameters<IAgentRuntime["updateWorld"]>[0],
+      );
+    } catch {
+      // Best-effort persistence. The effective role still resolves to ADMIN.
+    }
+  }
+
+  return "ADMIN";
 }
 
 /**
@@ -86,9 +223,9 @@ export async function checkSenderRole(
 } | null> {
   const resolved = await resolveWorldForMessage(runtime, message);
   if (!resolved) return null;
-  const { metadata } = resolved;
+  const { world, metadata } = resolved;
   const entityId = message.entityId as UUID;
-  const role = getEntityRole(metadata, entityId);
+  const role = await resolveEntityRole(runtime, world, metadata, entityId);
   return {
     entityId,
     role,

--- a/packages/plugin-roles/src/utils.ts
+++ b/packages/plugin-roles/src/utils.ts
@@ -84,8 +84,9 @@ export function matchEntityToConnectorAdminWhitelist(
       continue;
     }
 
+    const connectorMetaRecord = connectorMeta as Record<string, unknown>;
     for (const field of CONNECTOR_ID_FIELDS) {
-      const value = connectorMeta[field];
+      const value = connectorMetaRecord[field];
       if (typeof value === "string" && platformIds.includes(value)) {
         return { connector, matchedValue: value };
       }

--- a/packages/plugin-roles/src/utils.ts
+++ b/packages/plugin-roles/src/utils.ts
@@ -5,18 +5,22 @@
 import type { IAgentRuntime, Memory, UUID } from "@elizaos/core";
 import {
   type ConnectorAdminWhitelist,
+  ROLE_RANK,
   type RoleName,
   type RolesWorldMetadata,
-  ROLE_RANK,
 } from "./types";
 
 const CONNECTOR_ADMIN_WHITELIST_KEY = Symbol.for(
   "@miladyai/plugin-roles.connectorAdmins",
 );
+const CONNECTOR_ADMIN_CACHE_KEY = Symbol.for(
+  "@miladyai/plugin-roles.connectorAdmins.cache",
+);
 const CONNECTOR_ID_FIELDS = ["userId", "id", "username", "userName"] as const;
 
 type RuntimeWithConnectorAdmins = IAgentRuntime & {
   [CONNECTOR_ADMIN_WHITELIST_KEY]?: ConnectorAdminWhitelist;
+  [CONNECTOR_ADMIN_CACHE_KEY]?: Set<string>;
 };
 
 function asStringArray(value: unknown): string[] {
@@ -43,8 +47,10 @@ export function setConnectorAdminWhitelist(
   runtime: IAgentRuntime,
   whitelist: ConnectorAdminWhitelist | Record<string, unknown> | undefined,
 ): void {
-  (runtime as RuntimeWithConnectorAdmins)[CONNECTOR_ADMIN_WHITELIST_KEY] =
+  const runtimeWithConnectorAdmins = runtime as RuntimeWithConnectorAdmins;
+  runtimeWithConnectorAdmins[CONNECTOR_ADMIN_WHITELIST_KEY] =
     normalizeConnectorAdminWhitelist(whitelist);
+  runtimeWithConnectorAdmins[CONNECTOR_ADMIN_CACHE_KEY]?.clear();
 }
 
 export function getConnectorAdminWhitelist(
@@ -53,6 +59,12 @@ export function getConnectorAdminWhitelist(
   return (
     (runtime as RuntimeWithConnectorAdmins)[CONNECTOR_ADMIN_WHITELIST_KEY] ?? {}
   );
+}
+
+function getConnectorAdminCache(runtime: IAgentRuntime): Set<string> {
+  const runtimeWithConnectorAdmins = runtime as RuntimeWithConnectorAdmins;
+  runtimeWithConnectorAdmins[CONNECTOR_ADMIN_CACHE_KEY] ??= new Set<string>();
+  return runtimeWithConnectorAdmins[CONNECTOR_ADMIN_CACHE_KEY];
 }
 
 export function matchEntityToConnectorAdminWhitelist(
@@ -109,7 +121,7 @@ export function getEntityRole(
  */
 export async function resolveEntityRole(
   runtime: IAgentRuntime,
-  world: Awaited<ReturnType<IAgentRuntime["getWorld"]>>,
+  _world: Awaited<ReturnType<IAgentRuntime["getWorld"]>>,
   metadata: RolesWorldMetadata | undefined,
   entityId: string,
 ): Promise<RoleName> {
@@ -121,6 +133,11 @@ export async function resolveEntityRole(
   const whitelist = getConnectorAdminWhitelist(runtime);
   if (Object.keys(whitelist).length === 0) {
     return explicitRole;
+  }
+
+  const connectorAdminCache = getConnectorAdminCache(runtime);
+  if (connectorAdminCache.has(entityId)) {
+    return "ADMIN";
   }
 
   if (typeof runtime.getEntityById !== "function") {
@@ -142,23 +159,7 @@ export async function resolveEntityRole(
     return explicitRole;
   }
 
-  if (!metadata?.roles) {
-    metadata = { ...(metadata ?? {}), roles: {} };
-  }
-  metadata.roles ??= {};
-  metadata.roles[entityId] = "ADMIN";
-
-  if (world) {
-    try {
-      (world as { metadata: RolesWorldMetadata }).metadata = metadata;
-      await runtime.updateWorld(
-        world as Parameters<IAgentRuntime["updateWorld"]>[0],
-      );
-    } catch {
-      // Best-effort persistence. The effective role still resolves to ADMIN.
-    }
-  }
-
+  connectorAdminCache.add(entityId);
   return "ADMIN";
 }
 
@@ -251,6 +252,8 @@ export async function setEntityRole(
   if (!metadata.roles) metadata.roles = {};
   metadata.roles[targetEntityId] = newRole;
   (world as { metadata: RolesWorldMetadata }).metadata = metadata;
-  await runtime.updateWorld(world as Parameters<IAgentRuntime["updateWorld"]>[0]);
+  await runtime.updateWorld(
+    world as Parameters<IAgentRuntime["updateWorld"]>[0],
+  );
   return { ...metadata.roles };
 }

--- a/packages/plugin-roles/test/provider.test.ts
+++ b/packages/plugin-roles/test/provider.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { rolesProvider } from "../src/provider";
+import { setConnectorAdminWhitelist } from "../src/utils";
 import type { RoleName, RolesWorldMetadata } from "../src/types";
 import type { IAgentRuntime, Memory, State, UUID } from "@elizaos/core";
 
@@ -7,6 +8,7 @@ function mockRuntime(opts: {
   room?: { worldId: string | null } | null;
   worldMeta?: RolesWorldMetadata | null;
   entities?: Record<string, { names: string[]; metadata?: Record<string, unknown> }>;
+  updateWorld?: ReturnType<typeof vi.fn>;
 }): IAgentRuntime {
   return {
     getRoom: vi.fn().mockResolvedValue(opts.room ?? null),
@@ -15,6 +17,7 @@ function mockRuntime(opts: {
         ? { id: "world-1", metadata: opts.worldMeta }
         : opts.worldMeta === null ? null : undefined,
     ),
+    updateWorld: opts.updateWorld ?? vi.fn().mockResolvedValue(undefined),
     getEntityById: vi.fn().mockImplementation(async (id: string) => {
       const e = opts.entities?.[id];
       if (!e) return null;
@@ -75,6 +78,31 @@ describe("rolesProvider", () => {
     const result = await rolesProvider.get(runtime, msg("nobody"), emptyState);
     expect(result.values?.speakerRole).toBe("GUEST");
     expect(result.values?.canManageRoles).toBe(false);
+  });
+
+  it("promotes a connector-whitelisted Discord speaker to ADMIN on first contact", async () => {
+    const updateWorld = vi.fn().mockResolvedValue(undefined);
+    const worldMeta: RolesWorldMetadata = { roles: { o1: "OWNER" } };
+    const runtime = mockRuntime({
+      room: { worldId: "w1" },
+      worldMeta,
+      updateWorld,
+      entities: {
+        o1: { names: ["Shaw"] },
+        discordAdmin: {
+          names: ["Owner Person"],
+          metadata: { discord: { userId: "123456789", username: "owner" } },
+        },
+      },
+    });
+    setConnectorAdminWhitelist(runtime, { discord: ["123456789"] });
+
+    const result = await rolesProvider.get(runtime, msg("discordAdmin"), emptyState);
+    expect(result.values?.speakerRole).toBe("ADMIN");
+    expect(result.values?.canManageRoles).toBe(true);
+    expect(result.data?.admins).toContain("discordAdmin");
+    expect(worldMeta.roles?.discordAdmin).toBe("ADMIN");
+    expect(updateWorld).toHaveBeenCalledTimes(1);
   });
 
   it("returns empty when no room found", async () => {

--- a/packages/plugin-roles/test/provider.test.ts
+++ b/packages/plugin-roles/test/provider.test.ts
@@ -1,22 +1,29 @@
+import type { IAgentRuntime, Memory, State, UUID } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { rolesProvider } from "../src/provider";
-import { setConnectorAdminWhitelist } from "../src/utils";
 import type { RoleName, RolesWorldMetadata } from "../src/types";
-import type { IAgentRuntime, Memory, State, UUID } from "@elizaos/core";
+import { setConnectorAdminWhitelist } from "../src/utils";
 
 function mockRuntime(opts: {
   room?: { worldId: string | null } | null;
   worldMeta?: RolesWorldMetadata | null;
-  entities?: Record<string, { names: string[]; metadata?: Record<string, unknown> }>;
+  entities?: Record<
+    string,
+    { names: string[]; metadata?: Record<string, unknown> }
+  >;
   updateWorld?: ReturnType<typeof vi.fn>;
 }): IAgentRuntime {
   return {
     getRoom: vi.fn().mockResolvedValue(opts.room ?? null),
-    getWorld: vi.fn().mockResolvedValue(
-      opts.worldMeta !== undefined && opts.worldMeta !== null
-        ? { id: "world-1", metadata: opts.worldMeta }
-        : opts.worldMeta === null ? null : undefined,
-    ),
+    getWorld: vi
+      .fn()
+      .mockResolvedValue(
+        opts.worldMeta !== undefined && opts.worldMeta !== null
+          ? { id: "world-1", metadata: opts.worldMeta }
+          : opts.worldMeta === null
+            ? null
+            : undefined,
+      ),
     updateWorld: opts.updateWorld ?? vi.fn().mockResolvedValue(undefined),
     getEntityById: vi.fn().mockImplementation(async (id: string) => {
       const e = opts.entities?.[id];
@@ -27,7 +34,11 @@ function mockRuntime(opts: {
 }
 
 function msg(entityId: string): Memory {
-  return { entityId: entityId as UUID, roomId: "room-1" as UUID, content: { text: "" } } as Memory;
+  return {
+    entityId: entityId as UUID,
+    roomId: "room-1" as UUID,
+    content: { text: "" },
+  } as Memory;
 }
 
 const emptyState = {} as State;
@@ -41,8 +52,15 @@ describe("rolesProvider", () => {
   it("returns OWNER speaker with hierarchy", async () => {
     const runtime = mockRuntime({
       room: { worldId: "w1" },
-      worldMeta: { roles: { o1: "OWNER", a1: "ADMIN", u1: "USER", g1: "GUEST" } },
-      entities: { o1: { names: ["Shaw"] }, a1: { names: ["Alice"] }, u1: { names: ["Bob"] }, g1: { names: ["Eve"] } },
+      worldMeta: {
+        roles: { o1: "OWNER", a1: "ADMIN", u1: "USER", g1: "GUEST" },
+      },
+      entities: {
+        o1: { names: ["Shaw"] },
+        a1: { names: ["Alice"] },
+        u1: { names: ["Bob"] },
+        g1: { names: ["Eve"] },
+      },
     });
     const result = await rolesProvider.get(runtime, msg("o1"), emptyState);
     expect(result.values?.speakerRole).toBe("OWNER");
@@ -81,12 +99,10 @@ describe("rolesProvider", () => {
   });
 
   it("promotes a connector-whitelisted Discord speaker to ADMIN on first contact", async () => {
-    const updateWorld = vi.fn().mockResolvedValue(undefined);
     const worldMeta: RolesWorldMetadata = { roles: { o1: "OWNER" } };
     const runtime = mockRuntime({
       room: { worldId: "w1" },
       worldMeta,
-      updateWorld,
       entities: {
         o1: { names: ["Shaw"] },
         discordAdmin: {
@@ -97,27 +113,42 @@ describe("rolesProvider", () => {
     });
     setConnectorAdminWhitelist(runtime, { discord: ["123456789"] });
 
-    const result = await rolesProvider.get(runtime, msg("discordAdmin"), emptyState);
+    const result = await rolesProvider.get(
+      runtime,
+      msg("discordAdmin"),
+      emptyState,
+    );
     expect(result.values?.speakerRole).toBe("ADMIN");
     expect(result.values?.canManageRoles).toBe(true);
     expect(result.data?.admins).toContain("discordAdmin");
-    expect(worldMeta.roles?.discordAdmin).toBe("ADMIN");
-    expect(updateWorld).toHaveBeenCalledTimes(1);
+    expect(worldMeta.roles?.discordAdmin).toBeUndefined();
   });
 
   it("returns empty when no room found", async () => {
-    const result = await rolesProvider.get(mockRuntime({ room: null }), msg("e1"), emptyState);
+    const result = await rolesProvider.get(
+      mockRuntime({ room: null }),
+      msg("e1"),
+      emptyState,
+    );
     expect(result.values?.speakerRole).toBe("GUEST");
     expect(result.text).toBe("");
   });
 
   it("returns empty when room has no worldId", async () => {
-    const result = await rolesProvider.get(mockRuntime({ room: { worldId: null } }), msg("e1"), emptyState);
+    const result = await rolesProvider.get(
+      mockRuntime({ room: { worldId: null } }),
+      msg("e1"),
+      emptyState,
+    );
     expect(result.values?.speakerRole).toBe("GUEST");
   });
 
   it("returns empty when world not found", async () => {
-    const result = await rolesProvider.get(mockRuntime({ room: { worldId: "w1" }, worldMeta: null }), msg("e1"), emptyState);
+    const result = await rolesProvider.get(
+      mockRuntime({ room: { worldId: "w1" }, worldMeta: null }),
+      msg("e1"),
+      emptyState,
+    );
     expect(result.values?.speakerRole).toBe("GUEST");
   });
 
@@ -143,7 +174,9 @@ describe("rolesProvider", () => {
   it("survives getEntityById throwing", async () => {
     const runtime = {
       getRoom: vi.fn().mockResolvedValue({ worldId: "w1" }),
-      getWorld: vi.fn().mockResolvedValue({ id: "w1", metadata: { roles: { e1: "OWNER" } } }),
+      getWorld: vi
+        .fn()
+        .mockResolvedValue({ id: "w1", metadata: { roles: { e1: "OWNER" } } }),
       getEntityById: vi.fn().mockRejectedValue(new Error("DB gone")),
     } as unknown as IAgentRuntime;
     const result = await rolesProvider.get(runtime, msg("e1"), emptyState);
@@ -163,18 +196,30 @@ describe("rolesProvider", () => {
   });
 
   it("data.roles mirrors the world metadata", async () => {
-    const roles = { o1: "OWNER" as RoleName, a1: "ADMIN" as RoleName, u1: "USER" as RoleName };
+    const roles = {
+      o1: "OWNER" as RoleName,
+      a1: "ADMIN" as RoleName,
+      u1: "USER" as RoleName,
+    };
     const runtime = mockRuntime({
       room: { worldId: "w1" },
       worldMeta: { roles },
-      entities: { o1: { names: ["O"] }, a1: { names: ["A"] }, u1: { names: ["U"] } },
+      entities: {
+        o1: { names: ["O"] },
+        a1: { names: ["A"] },
+        u1: { names: ["U"] },
+      },
     });
     const result = await rolesProvider.get(runtime, msg("o1"), emptyState);
     expect(result.data?.roles).toEqual(roles);
   });
 
   it("always returns consistent data shape (even when empty)", async () => {
-    const result = await rolesProvider.get(mockRuntime({ room: null }), msg("e1"), emptyState);
+    const result = await rolesProvider.get(
+      mockRuntime({ room: null }),
+      msg("e1"),
+      emptyState,
+    );
     expect(result.data?.roles).toEqual({});
     expect(result.data?.owners).toEqual([]);
     expect(result.data?.admins).toEqual([]);

--- a/packages/plugin-roles/test/utils.test.ts
+++ b/packages/plugin-roles/test/utils.test.ts
@@ -3,8 +3,11 @@ import {
   canModifyRole,
   checkSenderRole,
   getEntityRole,
+  matchEntityToConnectorAdminWhitelist,
   normalizeRole,
+  resolveEntityRole,
   resolveWorldForMessage,
+  setConnectorAdminWhitelist,
   setEntityRole,
 } from "../src/utils";
 import type { RoleName, RolesWorldMetadata } from "../src/types";
@@ -19,11 +22,21 @@ function mockRuntime(opts: {
   room?: { worldId: string | null } | null;
   world?: { id: string; metadata: RolesWorldMetadata } | null;
   updateWorld?: ReturnType<typeof vi.fn>;
+  entities?: Record<string, { names?: string[]; metadata?: Record<string, unknown> }>;
 }): IAgentRuntime {
   return {
     getRoom: vi.fn().mockResolvedValue(opts.room ?? null),
     getWorld: vi.fn().mockResolvedValue(opts.world ?? null),
     updateWorld: opts.updateWorld ?? vi.fn().mockResolvedValue(undefined),
+    getEntityById: vi.fn().mockImplementation(async (id: string) => {
+      const entity = opts.entities?.[id];
+      if (!entity) return null;
+      return {
+        id,
+        names: entity.names ?? [],
+        metadata: entity.metadata ?? {},
+      };
+    }),
   } as unknown as IAgentRuntime;
 }
 
@@ -134,6 +147,29 @@ describe("getEntityRole", () => {
   it("normalizes stored role values", () => {
     const meta = { roles: { e1: "owner" as RoleName } };
     expect(getEntityRole(meta, "e1")).toBe("OWNER");
+  });
+});
+
+describe("matchEntityToConnectorAdminWhitelist", () => {
+  it("matches Discord user ids from entity metadata", () => {
+    expect(
+      matchEntityToConnectorAdminWhitelist(
+        { discord: { userId: "123456789" } },
+        { discord: ["123456789"] },
+      ),
+    ).toEqual({
+      connector: "discord",
+      matchedValue: "123456789",
+    });
+  });
+
+  it("returns null when the connector does not match", () => {
+    expect(
+      matchEntityToConnectorAdminWhitelist(
+        { discord: { userId: "123456789" } },
+        { telegram: ["123456789"] },
+      ),
+    ).toBeNull();
   });
 });
 
@@ -266,6 +302,29 @@ describe("resolveWorldForMessage", () => {
   });
 });
 
+describe("resolveEntityRole", () => {
+  it("promotes a connector-whitelisted Discord entity to ADMIN", async () => {
+    const updateWorld = vi.fn().mockResolvedValue(undefined);
+    const world = { id: "w1", metadata: { roles: {} } as RolesWorldMetadata };
+    const runtime = mockRuntime({
+      room: { worldId: "w1" },
+      world,
+      updateWorld,
+      entities: {
+        speaker: {
+          metadata: { discord: { userId: "discord-admin-1", username: "owner" } },
+        },
+      },
+    });
+    setConnectorAdminWhitelist(runtime, { discord: ["discord-admin-1"] });
+
+    const role = await resolveEntityRole(runtime, world, world.metadata, "speaker");
+    expect(role).toBe("ADMIN");
+    expect(world.metadata.roles?.speaker).toBe("ADMIN");
+    expect(updateWorld).toHaveBeenCalledTimes(1);
+  });
+});
+
 // ═══════════════════════════════════════════════════════════════════════════
 // checkSenderRole
 // ═══════════════════════════════════════════════════════════════════════════
@@ -308,6 +367,27 @@ describe("checkSenderRole", () => {
     });
     expect(await checkSenderRole(runtime, msg("unknown"))).toEqual({
       entityId: "unknown", role: "GUEST", isOwner: false, isAdmin: false, canManageRoles: false,
+    });
+  });
+
+  it("returns ADMIN for a connector-whitelisted Discord sender", async () => {
+    const runtime = mockRuntime({
+      room: { worldId: "w1" },
+      world: { id: "w1", metadata: { roles: {} } },
+      entities: {
+        unknown: {
+          metadata: { discord: { userId: "discord-admin-2", username: "owner" } },
+        },
+      },
+    });
+    setConnectorAdminWhitelist(runtime, { discord: ["discord-admin-2"] });
+
+    expect(await checkSenderRole(runtime, msg("unknown"))).toEqual({
+      entityId: "unknown",
+      role: "ADMIN",
+      isOwner: false,
+      isAdmin: true,
+      canManageRoles: true,
     });
   });
 

--- a/packages/plugin-roles/test/utils.test.ts
+++ b/packages/plugin-roles/test/utils.test.ts
@@ -1,4 +1,7 @@
+import type { IAgentRuntime, Memory, UUID } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
+import type { RoleName, RolesWorldMetadata } from "../src/types";
+import { ROLE_RANK } from "../src/types";
 import {
   canModifyRole,
   checkSenderRole,
@@ -10,9 +13,6 @@ import {
   setConnectorAdminWhitelist,
   setEntityRole,
 } from "../src/utils";
-import type { RoleName, RolesWorldMetadata } from "../src/types";
-import { ROLE_RANK } from "../src/types";
-import type { IAgentRuntime, Memory, UUID } from "@elizaos/core";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -20,9 +20,12 @@ import type { IAgentRuntime, Memory, UUID } from "@elizaos/core";
 
 function mockRuntime(opts: {
   room?: { worldId: string | null } | null;
-  world?: { id: string; metadata: RolesWorldMetadata } | null;
+  world?: { id: string; metadata: RolesWorldMetadata | null } | null;
   updateWorld?: ReturnType<typeof vi.fn>;
-  entities?: Record<string, { names?: string[]; metadata?: Record<string, unknown> }>;
+  entities?: Record<
+    string,
+    { names?: string[]; metadata?: Record<string, unknown> }
+  >;
 }): IAgentRuntime {
   return {
     getRoom: vi.fn().mockResolvedValue(opts.room ?? null),
@@ -72,8 +75,17 @@ describe("normalizeRole", () => {
 
   it("returns GUEST for anything else", () => {
     for (const val of [
-      "GUEST", "guest", "MEMBER", "moderator", "NONE", "none",
-      "UNKNOWN", "", " ", "  ADMIN  ", "root",
+      "GUEST",
+      "guest",
+      "MEMBER",
+      "moderator",
+      "NONE",
+      "none",
+      "UNKNOWN",
+      "",
+      " ",
+      "  ADMIN  ",
+      "root",
     ]) {
       expect(normalizeRole(val)).toBe("GUEST");
     }
@@ -85,7 +97,8 @@ describe("normalizeRole", () => {
   });
 
   it("fuzz: never returns invalid role names", () => {
-    const chars = "abcdefghijklmnopqrstuvwxyzADMINOWNERUSERGUEST0123456789!@#$%^&*() ";
+    const chars =
+      "abcdefghijklmnopqrstuvwxyzADMINOWNERUSERGUEST0123456789!@#$%^&*() ";
     for (let i = 0; i < 500; i++) {
       const len = Math.floor(Math.random() * 20);
       let s = "";
@@ -274,36 +287,51 @@ describe("canModifyRole", () => {
 
 describe("resolveWorldForMessage", () => {
   it("returns world + metadata for a valid room→world chain", async () => {
-    const world = { id: "w1", metadata: { roles: { e1: "OWNER" as RoleName } } };
+    const world = {
+      id: "w1",
+      metadata: { roles: { e1: "OWNER" as RoleName } },
+    };
     const runtime = mockRuntime({ room: { worldId: "w1" }, world });
     const result = await resolveWorldForMessage(runtime, msg("e1"));
     expect(result).not.toBeNull();
-    expect(result!.world).toBe(world);
+    expect(result?.world).toBe(world);
   });
 
   it("returns null when room not found", async () => {
-    expect(await resolveWorldForMessage(mockRuntime({ room: null }), msg("e1"))).toBeNull();
+    expect(
+      await resolveWorldForMessage(mockRuntime({ room: null }), msg("e1")),
+    ).toBeNull();
   });
 
   it("returns null when room has no worldId", async () => {
-    expect(await resolveWorldForMessage(mockRuntime({ room: { worldId: null } }), msg("e1"))).toBeNull();
+    expect(
+      await resolveWorldForMessage(
+        mockRuntime({ room: { worldId: null } }),
+        msg("e1"),
+      ),
+    ).toBeNull();
   });
 
   it("returns null when world not found", async () => {
-    expect(await resolveWorldForMessage(mockRuntime({ room: { worldId: "w1" }, world: null }), msg("e1"))).toBeNull();
+    expect(
+      await resolveWorldForMessage(
+        mockRuntime({ room: { worldId: "w1" }, world: null }),
+        msg("e1"),
+      ),
+    ).toBeNull();
   });
 
   it("returns empty metadata when world has null metadata", async () => {
-    const world = { id: "w1", metadata: null } as unknown;
-    const runtime = mockRuntime({ room: { worldId: "w1" }, world: world as any });
+    const world = { id: "w1", metadata: null };
+    const runtime = mockRuntime({ room: { worldId: "w1" }, world });
     const result = await resolveWorldForMessage(runtime, msg("e1"));
     expect(result).not.toBeNull();
-    expect(result!.metadata).toEqual({});
+    expect(result?.metadata).toEqual({});
   });
 });
 
 describe("resolveEntityRole", () => {
-  it("promotes a connector-whitelisted Discord entity to ADMIN", async () => {
+  it("resolves a connector-whitelisted Discord entity to ADMIN without mutating world metadata", async () => {
     const updateWorld = vi.fn().mockResolvedValue(undefined);
     const world = { id: "w1", metadata: { roles: {} } as RolesWorldMetadata };
     const runtime = mockRuntime({
@@ -312,16 +340,51 @@ describe("resolveEntityRole", () => {
       updateWorld,
       entities: {
         speaker: {
-          metadata: { discord: { userId: "discord-admin-1", username: "owner" } },
+          metadata: {
+            discord: { userId: "discord-admin-1", username: "owner" },
+          },
         },
       },
     });
     setConnectorAdminWhitelist(runtime, { discord: ["discord-admin-1"] });
 
-    const role = await resolveEntityRole(runtime, world, world.metadata, "speaker");
+    const role = await resolveEntityRole(
+      runtime,
+      world,
+      world.metadata,
+      "speaker",
+    );
     expect(role).toBe("ADMIN");
-    expect(world.metadata.roles?.speaker).toBe("ADMIN");
-    expect(updateWorld).toHaveBeenCalledTimes(1);
+    expect(world.metadata.roles?.speaker).toBeUndefined();
+    expect(updateWorld).not.toHaveBeenCalled();
+  });
+
+  it("caches connector-admin matches after the first lookup", async () => {
+    const runtime = mockRuntime({
+      room: { worldId: "w1" },
+      world: { id: "w1", metadata: { roles: {} } },
+      entities: {
+        speaker: {
+          metadata: { discord: { userId: "discord-admin-1" } },
+        },
+      },
+    });
+    setConnectorAdminWhitelist(runtime, { discord: ["discord-admin-1"] });
+
+    await resolveEntityRole(
+      runtime,
+      { id: "w1", metadata: { roles: {} } },
+      { roles: {} },
+      "speaker",
+    );
+    await resolveEntityRole(
+      runtime,
+      { id: "w1", metadata: { roles: {} } },
+      { roles: {} },
+      "speaker",
+    );
+
+    expect(runtime.getEntityById).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -336,7 +399,11 @@ describe("checkSenderRole", () => {
       world: { id: "w1", metadata: { roles: { e1: "OWNER" } } },
     });
     expect(await checkSenderRole(runtime, msg("e1"))).toEqual({
-      entityId: "e1", role: "OWNER", isOwner: true, isAdmin: true, canManageRoles: true,
+      entityId: "e1",
+      role: "OWNER",
+      isOwner: true,
+      isAdmin: true,
+      canManageRoles: true,
     });
   });
 
@@ -346,7 +413,11 @@ describe("checkSenderRole", () => {
       world: { id: "w1", metadata: { roles: { a1: "ADMIN" } } },
     });
     expect(await checkSenderRole(runtime, msg("a1"))).toEqual({
-      entityId: "a1", role: "ADMIN", isOwner: false, isAdmin: true, canManageRoles: true,
+      entityId: "a1",
+      role: "ADMIN",
+      isOwner: false,
+      isAdmin: true,
+      canManageRoles: true,
     });
   });
 
@@ -356,7 +427,11 @@ describe("checkSenderRole", () => {
       world: { id: "w1", metadata: { roles: { u1: "USER" } } },
     });
     expect(await checkSenderRole(runtime, msg("u1"))).toEqual({
-      entityId: "u1", role: "USER", isOwner: false, isAdmin: false, canManageRoles: false,
+      entityId: "u1",
+      role: "USER",
+      isOwner: false,
+      isAdmin: false,
+      canManageRoles: false,
     });
   });
 
@@ -366,7 +441,11 @@ describe("checkSenderRole", () => {
       world: { id: "w1", metadata: { roles: {} } },
     });
     expect(await checkSenderRole(runtime, msg("unknown"))).toEqual({
-      entityId: "unknown", role: "GUEST", isOwner: false, isAdmin: false, canManageRoles: false,
+      entityId: "unknown",
+      role: "GUEST",
+      isOwner: false,
+      isAdmin: false,
+      canManageRoles: false,
     });
   });
 
@@ -376,7 +455,9 @@ describe("checkSenderRole", () => {
       world: { id: "w1", metadata: { roles: {} } },
       entities: {
         unknown: {
-          metadata: { discord: { userId: "discord-admin-2", username: "owner" } },
+          metadata: {
+            discord: { userId: "discord-admin-2", username: "owner" },
+          },
         },
       },
     });
@@ -392,7 +473,9 @@ describe("checkSenderRole", () => {
   });
 
   it("returns null when world can't be resolved", async () => {
-    expect(await checkSenderRole(mockRuntime({ room: null }), msg("e1"))).toBeNull();
+    expect(
+      await checkSenderRole(mockRuntime({ room: null }), msg("e1")),
+    ).toBeNull();
   });
 });
 
@@ -403,8 +486,15 @@ describe("checkSenderRole", () => {
 describe("setEntityRole", () => {
   it("sets a new role and persists", async () => {
     const updateWorld = vi.fn().mockResolvedValue(undefined);
-    const worldObj = { id: "w1", metadata: { roles: { e1: "OWNER" as RoleName } } };
-    const runtime = mockRuntime({ room: { worldId: "w1" }, world: worldObj, updateWorld });
+    const worldObj = {
+      id: "w1",
+      metadata: { roles: { e1: "OWNER" as RoleName } },
+    };
+    const runtime = mockRuntime({
+      room: { worldId: "w1" },
+      world: worldObj,
+      updateWorld,
+    });
     const result = await setEntityRole(runtime, msg("e1"), "e2", "ADMIN");
     expect(result).toEqual({ e1: "OWNER", e2: "ADMIN" });
     expect(updateWorld).toHaveBeenCalledTimes(1);
@@ -412,8 +502,15 @@ describe("setEntityRole", () => {
 
   it("sets GUEST role (stays in map unlike old NONE behavior)", async () => {
     const updateWorld = vi.fn().mockResolvedValue(undefined);
-    const worldObj = { id: "w1", metadata: { roles: { e1: "OWNER" as RoleName, e2: "ADMIN" as RoleName } } };
-    const runtime = mockRuntime({ room: { worldId: "w1" }, world: worldObj, updateWorld });
+    const worldObj = {
+      id: "w1",
+      metadata: { roles: { e1: "OWNER" as RoleName, e2: "ADMIN" as RoleName } },
+    };
+    const runtime = mockRuntime({
+      room: { worldId: "w1" },
+      world: worldObj,
+      updateWorld,
+    });
     const result = await setEntityRole(runtime, msg("e1"), "e2", "GUEST");
     expect(result).toEqual({ e1: "OWNER", e2: "GUEST" });
   });
@@ -427,7 +524,11 @@ describe("setEntityRole", () => {
   it("initializes roles map when missing", async () => {
     const updateWorld = vi.fn().mockResolvedValue(undefined);
     const worldObj = { id: "w1", metadata: {} as RolesWorldMetadata };
-    const runtime = mockRuntime({ room: { worldId: "w1" }, world: worldObj, updateWorld });
+    const runtime = mockRuntime({
+      room: { worldId: "w1" },
+      world: worldObj,
+      updateWorld,
+    });
     const result = await setEntityRole(runtime, msg("e1"), "e2", "USER");
     expect(result).toEqual({ e2: "USER" });
   });


### PR DESCRIPTION
## Summary
- preserve managed Discord sender identity through the cloud bridge
- consume managed Discord callback state in the Eliza Cloud dashboard
- dynamically grant connector-admin access to the linked Discord account on first contact

## Testing
- bun test packages/plugin-roles/test/init.test.ts packages/plugin-roles/test/provider.test.ts packages/plugin-roles/test/utils.test.ts
- bunx vitest run packages/app-core/src/api/__tests__/cloud-managed-discord-client.test.ts packages/app-core/src/components/pages/cloud-dashboard-utils.test.ts
- bun test deploy/cloud-agent-shared.test.ts