### PR TITLE
docs(web): explain stable vs canary vs source on install page

### DIFF
--- a/apps/web/src/docs/content/beginner/install.mdx
+++ b/apps/web/src/docs/content/beginner/install.mdx
@@ -4,6 +4,26 @@ Milady ships as a desktop app for macOS, Windows, and Linux. There's also a CLI 
 
 **Time needed:** about five minutes on a fresh machine, plus a few minutes for the first-run setup.
 
+## Which version should I download?
+
+Milady is published in two release channels, plus the source code on GitHub. Pick the one that matches how much risk you're comfortable with — you can switch later.
+
+| Channel | Who it's for | Link |
+| --- | --- | --- |
+| **Stable** | Everyone, by default. Tested, notarized, and safe to leave running day to day. | [Latest stable release](https://github.com/milady-ai/milady/releases/latest) |
+| **Canary** | Early adopters who want new features the day they land and don't mind the occasional rough edge. | [All releases (look for the *Pre-release* badge)](https://github.com/milady-ai/milady/releases) |
+| **Source (GitHub)** | Developers who want to read the code, file issues, or build from `main` themselves. | [github.com/milady-ai/milady](https://github.com/milady-ai/milady) |
+
+**Stable** is what the big "Download" buttons on [milady.ai](https://milady.ai) point to. Release tags look like `v1.4.0` — no suffix. Bug fixes and security patches land here first.
+
+**Canary** is tagged with `alpha`, `beta`, `rc`, or `nightly` (e.g. `v1.5.0-beta.2`). New connectors, UI experiments, and plugin system changes show up here days or weeks before they promote to stable. If you hit a bug on canary, the fastest way to get it fixed is to [file an issue](https://github.com/milady-ai/milady/issues) with the exact tag — canary users are how we catch regressions before stable ships. Canary installs live alongside stable on macOS as `Milady-canary.app`, so you can run both side-by-side without blowing away your stable config.
+
+**Source (GitHub)** isn't a build — it's the full codebase. Use it if you want to read how something works, contribute a fix, or build Milady yourself from a branch. The README has build instructions. Everything else in these docs applies whether you installed from stable, canary, or a source build.
+
+<Callout kind="tip">
+Not sure? Pick **stable**. You can always switch to canary later by downloading it from the releases page; the two channels share the same `~/.milady/` config directory, so your characters, keys, and conversations come with you.
+</Callout>
+
 ## Desktop app (recommended)
 
 The desktop app is the friendliest way to get started. It bundles the runtime, the dashboard, and the companion UI into one installable package with auto-updates.


### PR DESCRIPTION
## Summary

- Users downloading Milady couldn't tell the difference between stable, canary, and the GitHub source — they'd grab whatever release they hit first and get confused when behavior didn't match the docs. Add a "Which version should I download?" section to `apps/web/src/docs/content/beginner/install.mdx` with a three-row table, one-sentence descriptions, direct links, and a default-stable recommendation.

## What's in it

A single table + three short paragraphs + a tip callout on the install page:

| Channel | Who it's for | Link |
| --- | --- | --- |
| **Stable** | Everyone, by default. | Latest stable release |
| **Canary** | Early adopters. | All releases, look for *Pre-release* |
| **Source (GitHub)** | Devs reading/building the code. | Repo root |

The prose explains:
- Stable = untagged/semver releases (e.g. `v1.4.0`). Tested, notarized, safe to leave running. The big "Download" buttons on milady.ai point here.
- Canary = tagged `alpha`, `beta`, `rc`, or `nightly` (e.g. `v1.5.0-beta.2`) — this matches the exact regex in `.github/workflows/release-electrobun.yml:90` that sets `BUILD_ENV=canary`. Canary builds install side-by-side as `Milady-canary.app` on macOS (matching `scripts/sync-desktop-renderer.mjs:29`).
- Source = the repo itself, not a build. For contributors.
- Default recommendation: pick stable. Switching is free because both channels share `~/.milady/`.

## Test plan

- [x] Visual check: rendered locally at /docs/beginner/install under the Vite dev server. Table + callout render correctly against the existing docs shell.
- [x] `Callout kind="tip"` component is already in use elsewhere in the docs tree (`voice-and-tts.mdx`, `memory-and-knowledge.mdx`), so no new MDX components needed.
- [x] Links verified against existing references in the repo (same URLs as `troubleshooting.mdx`, `install.mdx`, and `scripts/write-homepage-release-data.mjs`).

## Why now

Related to #1685 discussions where the difference between release channels became relevant for testing the Vincent OAuth fix on canary vs stable builds. Not blocked by it — ships independently.