### PR TITLE
fix(ci): resolve canvas via absolute path to bypass bun workspace symlink issue

### DIFF
--- a/packages/agent/test/native-modules.e2e.test.ts
+++ b/packages/agent/test/native-modules.e2e.test.ts
@@ -70,7 +70,10 @@ async function canImportModule(
   }
 }
 
-function runModuleSnippet(source: string): {
+function runModuleSnippet(
+  source: string,
+  absolutePathOverrides: Record<string, string> = {},
+): {
   success: boolean;
   error?: string;
   stdout: string;
@@ -79,7 +82,16 @@ function runModuleSnippet(source: string): {
   const module = [
     'import { createRequire } from "node:module";',
     'import { pathToFileURL } from "node:url";',
+    // Map of specifier → absolute on-disk entry file. When present, the
+    // subprocess imports the file:// URL directly and skips bare-specifier
+    // resolution entirely. Used for modules that bun places under a
+    // per-workspace node_modules symlink unreachable via
+    // `createRequire(workspacePackageJson).resolve(specifier)` in CI.
+    `const __absolutePathOverrides = ${JSON.stringify(absolutePathOverrides)};`,
     `const importFromWorkspace = async (specifier) => {
+			if (Object.prototype.hasOwnProperty.call(__absolutePathOverrides, specifier)) {
+				return await import(pathToFileURL(__absolutePathOverrides[specifier]).href);
+			}
 			const resolutionErrors = [];
 			for (const requestPath of ${JSON.stringify(workspaceRequirePaths)}) {
 				try {
@@ -131,13 +143,54 @@ function runModuleSnippet(source: string): {
 
 async function canImportModuleInSubprocess(
   moduleName: string,
+  absolutePathOverrides: Record<string, string> = {},
 ): Promise<{ success: boolean; error?: string }> {
   const result = runModuleSnippet(
     `await importFromWorkspace(${JSON.stringify(moduleName)});`,
+    absolutePathOverrides,
   );
   return result.success
     ? { success: true }
     : { success: false, error: result.error };
+}
+
+/**
+ * Resolves a package's main entry file using the outer process, where
+ * `findPackagePath` has working filesystem access to bun's per-workspace
+ * symlinks. Returns an absolute file path or null.
+ *
+ * This exists because the `importFromWorkspace` helper inside
+ * `runModuleSnippet` relies on bare-specifier resolution via
+ * `createRequire(workspacePackageJson).resolve(specifier)`. That works for
+ * packages with a root-level `node_modules/<pkg>` symlink (created when the
+ * package is declared in the root `package.json`, e.g. sharp) but fails in
+ * CI for packages only declared in a leaf workspace (e.g. canvas, which is
+ * a dep of `packages/agent` only). Bun places those under
+ * `node_modules/.bun/<pkg>@<ver>/` and links them into the leaf's
+ * `node_modules`, but Node's bare-specifier resolver in the spawned
+ * subprocess can't always reach them from the workspace package.json alone.
+ * Resolving to an absolute on-disk path in the outer process and passing the
+ * file:// URL into the subprocess sidesteps bare-specifier resolution.
+ */
+function findPackageMainFile(moduleName: string): string | null {
+  const pkgDir = findPackagePath(moduleName);
+  if (!pkgDir) return null;
+  const pkgJsonPath = path.join(pkgDir, "package.json");
+  if (!fs.existsSync(pkgJsonPath)) return null;
+  try {
+    const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8"));
+    const main =
+      typeof pkg.main === "string" && pkg.main.length > 0
+        ? pkg.main
+        : "index.js";
+    const mainPath = path.resolve(pkgDir, main);
+    if (fs.existsSync(mainPath)) return mainPath;
+    const fallback = path.join(pkgDir, "index.js");
+    if (fs.existsSync(fallback)) return fallback;
+    return null;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -390,12 +443,24 @@ describe("Native Module Installation Verification", () => {
     });
 
     it.skipIf(!hasCanvasBinding)("canvas can be imported", async () => {
-      const result = await canImportModuleInSubprocess("canvas");
-      expect(result.success).toBe(true);
+      // Pre-resolve canvas's main entry file in the outer process. Bun places
+      // canvas under `node_modules/.bun/canvas@<ver>/node_modules/canvas/`
+      // and only links it into `packages/agent/node_modules/canvas`, which
+      // bare-specifier resolution in the spawned subprocess can't reliably
+      // reach in CI. Passing the absolute path sidesteps that entirely.
+      const canvasMainFile = findPackageMainFile("canvas");
+      expect(canvasMainFile, "canvas main file not resolvable").toBeTruthy();
+      const result = await canImportModuleInSubprocess("canvas", {
+        canvas: canvasMainFile!,
+      });
+      expect(result.success, result.error).toBe(true);
     });
 
     it.skipIf(!hasCanvasBinding)("canvas can create a 2D context", async () => {
-      const result = runModuleSnippet(`
+      const canvasMainFile = findPackageMainFile("canvas");
+      expect(canvasMainFile, "canvas main file not resolvable").toBeTruthy();
+      const result = runModuleSnippet(
+        `
 					const { createCanvas } = await importFromWorkspace("canvas");
 					const canvas = createCanvas(100, 100);
 					const ctx = canvas.getContext("2d");
@@ -404,7 +469,9 @@ describe("Native Module Installation Verification", () => {
 					ctx.fillRect(0, 0, 50, 50);
 					const imageData = ctx.getImageData(0, 0, 1, 1);
 					process.stdout.write(String(imageData.data[0]));
-				`);
+				`,
+        { canvas: canvasMainFile! },
+      );
 
       expect(result.success, result.error).toBe(true);
       expect(Number(result.stdout.trim())).toBe(255);


### PR DESCRIPTION
## Summary

- Every open PR against develop has been failing E2E Tests (Vitest) for ~13 hours on `packages/agent/test/native-modules.e2e.test.ts > Canvas for Face Recognition > canvas can be imported` and `canvas can create a 2D context`. Confirmed pre-existing on develop by checking the last 10+ develop Tests runs — last green was `2026-04-04 13:55` ("fix: wallet key generation..."), first red was `cbe145319 lifeops: add service routes` at `2026-04-04 15:20`.
- Fixes both tests without changing what's being tested.

## Root cause

Sharp passes through the same `runModuleSnippet` infrastructure. Canvas fails through it. The difference:

- **sharp** is declared in `package.json` (root, `^0.34.5`) AND `packages/agent/package.json` (`^0.33.5`), so bun creates a root-level `node_modules/sharp` symlink.
- **canvas** is only declared in `packages/agent/package.json` (`^3.0.1`). Bun puts it under `node_modules/.bun/canvas@3.2.3/node_modules/canvas/` with a symlink only at `packages/agent/node_modules/canvas`.

`createRequire(packages/agent/package.json).resolve("canvas")` walks up from the leaf and finds the per-workspace symlink locally, so the test passes on developer machines. In CI — under `bun install` with scripts enabled and the `actions/cache` restore for `~/.bun/install/cache` — Node's bare-specifier resolver in the spawned subprocess can't reliably reach canvas from that path. Stack shows Node's internal `package_json_reader:314` and `packageResolve`, erroring with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'canvas' imported from /home/runner/_work/milady/milady/[eval1]
```

The `hasCanvas` / `hasCanvasBinding` checks in the outer test process (which use `findPackagePath` and filesystem `existsSync` rather than bare-specifier resolution) both succeed, which is why the tests run instead of skipping — the binding file is present on disk in CI, it's just unreachable to the subprocess's ESM loader.

## Fix

Pre-resolve canvas's main entry file in the outer test process (using the existing `findPackagePath` helper that already gates `hasCanvas`) and pass the absolute on-disk path into the subprocess through a new `absolutePathOverrides` parameter on `runModuleSnippet`. The subprocess then does `await import(pathToFileURL(absolutePath).href)` directly, skipping bare-specifier resolution entirely.

- `runModuleSnippet(source, absolutePathOverrides?)` — new optional map param. Strictly additive: if not provided, behaves exactly as before.
- `canImportModuleInSubprocess(moduleName, absolutePathOverrides?)` — same.
- New helper `findPackageMainFile(moduleName)` — reads `package.json.main` from the package dir (which `findPackagePath` already locates) and returns an absolute on-disk path.
- Only the two failing canvas tests opt in. Sharp, tfjs, tesseract, face-api.js, plugin-vision all keep the existing workspace-resolution path and continue to work.

## Test plan

- [x] `bunx vitest run -c vitest.e2e.config.ts packages/agent/test/native-modules.e2e.test.ts` locally — **17/17 passed, 14 skipped** (same pass count as develop). Canvas tests specifically pass under the new absolute-path path.
- [x] Diagnostic: ran the exact subprocess code (`node --input-type=module --eval ...` using `createRequire` + `import(fileURL)`) locally — canvas resolves and loads successfully. Confirms the local environment is fine and the CI failure is environmental, not a bug in canvas or the test logic.
- [x] Biome lint clean on the touched file (the 1 pre-existing organize-imports warning is outside CI's `BIOME_ROOTS` scope — `scripts/run-biome-check.mjs:14` only scans `src`, `scripts`, `apps`; `packages/` is excluded).
- [x] Typecheck clean on the touched file.
- [ ] CI will confirm once this PR's workflow runs. Expect the full E2E job to go green, which will unblock every open PR currently stuck on the same cascade (E2E fail → All Tests Passed fail → Auto-merge blocked).

## Blast radius

- Unblocks: every currently-open PR against develop (at minimum #1685 and #1688).
- Doesn't touch any production code — `packages/agent/test/native-modules.e2e.test.ts` is test-only.
- Doesn't change what's being verified — canvas still has to exist on disk with a valid native binding, still has to import, and still has to create a working 2D context.
- No new deps, no build system changes, no lockfile changes.