### PR TITLE
fix(app): keep native onboarding out of cloud-only mode

### DIFF
--- a/apps/app/src/cloud-only.ts
+++ b/apps/app/src/cloud-only.ts
@@ -5,9 +5,9 @@ export function shouldUseCloudOnlyBranding(options: {
 }): boolean {
   if (options.isDev) return false;
 
-  // Mobile (iOS/Android) is always cloud-only — no local runtime available.
-  // Users must connect to ElizaCloud or a remote instance.
-  if (options.isNativePlatform) return true;
+  // Native mobile apps need both gateway discovery and cloud connection
+  // options in onboarding, so they are not cloud-only.
+  if (options.isNativePlatform) return false;
 
   // Desktop shells inject an explicit backend before React boots. When that
   // happens, the renderer should follow the host backend's capabilities rather

--- a/apps/app/test/cloud-only.test.ts
+++ b/apps/app/test/cloud-only.test.ts
@@ -32,23 +32,23 @@ describe("shouldUseCloudOnlyBranding", () => {
     ).toBe(true);
   });
 
-  it("returns true for native platforms even without an injected backend", () => {
+  it("returns false for native platforms even without an injected backend", () => {
     expect(
       shouldUseCloudOnlyBranding({
         isDev: false,
         injectedApiBase: undefined,
         isNativePlatform: true,
       }),
-    ).toBe(true);
+    ).toBe(false);
   });
 
-  it("returns true for native platforms in production", () => {
+  it("returns false for native platforms in production", () => {
     expect(
       shouldUseCloudOnlyBranding({
         isDev: false,
         injectedApiBase: "   ",
         isNativePlatform: true,
       }),
-    ).toBe(true);
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
Maintainer-practice slice from PR #1700.\n\nScope:\n- native platforms are not forced cloud-only\n- test expectations updated\n\nPurpose:\n- run full GitHub workflow checks on a minimal, reviewable fix.