### PR TITLE
fix cross-channel provider context bleed

### DIFF
--- a/packages/agent/src/providers/activity-profile.ts
+++ b/packages/agent/src/providers/activity-profile.ts
@@ -80,7 +80,12 @@ export const activityProfileProvider: Provider = {
           profile.screenContextFocus !== "idle" &&
           profile.screenContextFocus !== "unknown";
 
-        if (!hasActiveScreen && profile.lastSeenPlatform && profile.lastSeenAt > 0) {
+        // Only include platform context when the message isn't from the
+        // web chat — otherwise the agent assumes the conversation is
+        // happening on that platform (e.g. "active on imessage" in a
+        // normal web chat makes it think it's an iMessage conversation).
+        const isDirectChat = source === "client_chat";
+        if (!hasActiveScreen && profile.lastSeenPlatform && profile.lastSeenAt > 0 && !isDirectChat) {
           const ago = formatAgo(now.getTime() - profile.lastSeenAt);
           parts.push(
             profile.isCurrentlyActive

--- a/packages/agent/src/providers/admin-panel.ts
+++ b/packages/agent/src/providers/admin-panel.ts
@@ -136,6 +136,16 @@ export function createAdminPanelProvider(): Provider {
         return empty;
       }
 
+      // Only inject web-chat history when the agent is responding within the
+      // web chat itself.  Surfacing it in connector channels (iMessage,
+      // Telegram, etc.) causes the agent to confuse which channel the current
+      // conversation is on.
+      const source = (message.content as Record<string, unknown> | undefined)
+        ?.source;
+      if (source && source !== "client_chat") {
+        return empty;
+      }
+
       const adminEntityId = await resolveOwnerEntityId(runtime, message);
       if (!adminEntityId) {
         return empty;


### PR DESCRIPTION
## Summary
- **activity-profile provider**: no longer injects `"active on imessage"` (or other platform tags) into web chat context — suppressed when `source === "client_chat"`
- **admin-panel provider**: no longer injects recent web chat history into connector channel contexts (iMessage, Telegram, etc.) — only surfaces `# Recent Owner Conversation` when the agent is actually responding in the web chat

Both providers were unconditionally injecting cross-channel context, causing the agent to confuse which channel the current conversation was on (e.g. treating normal web chat as iMessage).

## Test plan
- [ ] Send a message in web chat — verify agent does not reference iMessage or other connector platforms
- [ ] Send a message via iMessage — verify agent responds in iMessage context without web chat history bleeding in
- [ ] Verify proactive planner still reads `lastSeenPlatform` from task metadata (unaffected — it reads directly, not via provider output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)