### PR TITLE
fix: browser page full height + vite optimizeDeps crash

### DIFF
--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -830,6 +830,7 @@ export default defineConfig({
     // Remap node: builtins to npm polyfills during dep optimization so
     // esbuild doesn't externalize them as "browser-external:node:*".
     esbuildOptions: {
+      target: "es2022",
       plugins: [
         {
           name: "node-builtins-polyfill",

--- a/packages/app-core/src/App.tsx
+++ b/packages/app-core/src/App.tsx
@@ -93,7 +93,7 @@ function TabScrollView({
 
 function TabContentView({ children }: { children: ReactNode }) {
   return (
-    <div className="flex-1 min-h-0 min-w-0 w-full overflow-hidden">
+    <div className="flex flex-col flex-1 min-h-0 min-w-0 w-full overflow-hidden">
       {children}
     </div>
   );


### PR DESCRIPTION
## Summary
- **TabContentView** was missing `flex flex-col`, so child views (Browser, Connectors, etc.) couldn't stretch to full viewport height via `flex-1`
- **Vite optimizeDeps** esbuild phase used default browser targets (`chrome87`, `safari14`) which choke on destructuring in `@capacitor/core` — set `target: "es2022"` to match the rest of the build config, fixing 1083-error crash in `dev:desktop:watch`

## Test plan
- [x] `bun run dev:desktop:watch` starts without Vite crash
- [ ] Browser tab page fills full viewport height (no dead space below)
- [ ] Other TabContentView pages (Connectors, Advanced, etc.) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)