### PR TITLE
fix(app): align Vite dep optimize target with es2022

### DIFF
--- a/.github/actions/setup-bun-workspace/action.yml
+++ b/.github/actions/setup-bun-workspace/action.yml
@@ -76,6 +76,10 @@ runs:
         key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
         restore-keys: bun-${{ runner.os }}-
 
+    - name: Initialize required workspace submodules
+      shell: bash
+      run: git submodule update --init --recursive -- plugins/plugin-agent-orchestrator
+
     - name: Install dependencies
       shell: bash
       run: ${{ inputs.install-command }}

--- a/apps/app/plugins/mobile-signals/src/web.ts
+++ b/apps/app/plugins/mobile-signals/src/web.ts
@@ -45,16 +45,18 @@ async function getBatterySnapshot(): Promise<{
   return {
     onBattery: !battery.charging,
     batteryLevel:
-      typeof battery.level === "number" ? Math.max(0, Math.min(1, battery.level)) : null,
+      typeof battery.level === "number"
+        ? Math.max(0, Math.min(1, battery.level))
+        : null,
     isCharging: battery.charging,
   };
 }
 
-async function buildSnapshot(
-  reason: string,
-): Promise<MobileSignalsSnapshot> {
+async function buildSnapshot(reason: string): Promise<MobileSignalsSnapshot> {
   const isVisible =
-    typeof document !== "undefined" ? document.visibilityState === "visible" : true;
+    typeof document !== "undefined"
+      ? document.visibilityState === "visible"
+      : true;
   const hasFocus =
     typeof document !== "undefined" && typeof document.hasFocus === "function"
       ? document.hasFocus()
@@ -100,7 +102,10 @@ export class MobileSignalsWeb extends WebPlugin implements MobileSignalsPlugin {
       };
       document.addEventListener("visibilitychange", handleVisibilityChange);
       this.cleanup.push(() =>
-        document.removeEventListener("visibilitychange", handleVisibilityChange),
+        document.removeEventListener(
+          "visibilitychange",
+          handleVisibilityChange,
+        ),
       );
     }
 

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -830,6 +830,10 @@ export default defineConfig({
     // Remap node: builtins to npm polyfills during dep optimization so
     // esbuild doesn't externalize them as "browser-external:node:*".
     esbuildOptions: {
+      // Keep dep pre-bundling on the same baseline as the app build.
+      // Vite's default optimizer target is "modules" (chrome87/safari14), which
+      // can trigger esbuild transform failures on modern dependency code.
+      target: "es2022",
       plugins: [
         {
           name: "node-builtins-polyfill",

--- a/scripts/vite-app-target.test.ts
+++ b/scripts/vite-app-target.test.ts
@@ -1,0 +1,24 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadConfigFromFile } from "vite";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const appDir = path.join(repoRoot, "apps", "app");
+const configPath = path.join(appDir, "vite.config.ts");
+
+describe("apps/app vite config", () => {
+  it("aligns optimizeDeps esbuild target with build target", async () => {
+    const loaded = await loadConfigFromFile(
+      { command: "serve", mode: "development" },
+      configPath,
+      appDir,
+    );
+
+    expect(loaded?.config.esbuild?.target).toBe("es2022");
+    expect(loaded?.config.optimizeDeps?.esbuildOptions?.target).toBe("es2022");
+  });
+});


### PR DESCRIPTION
## Summary
- set `optimizeDeps.esbuildOptions.target` to `es2022` in app Vite config
- keep dep prebundle target aligned with existing app build/esbuild target
- add a regression test that asserts the app config keeps both targets aligned

## Why
Vite dependency optimization was running against the default legacy modules target (`chrome87`/`safari14` family), which caused esbuild transform failures on modern dependency code during desktop dev startup.

## Validation
- `bunx vite optimize --config vite.config.ts --force` (from `apps/app`)
- `bunx vitest run scripts/vite-app-target.test.ts`