### PR TITLE
fix: 5 browser workspace bugs (stale state, leaks, auth, contract calls)

### DIFF
--- a/apps/app/electrobun/src/browser-workspace-bridge-server.ts
+++ b/apps/app/electrobun/src/browser-workspace-bridge-server.ts
@@ -57,7 +57,9 @@ async function readJsonBody<T>(req: http.IncomingMessage): Promise<T | null> {
 }
 
 function isAuthorized(req: http.IncomingMessage, token: string): boolean {
-  if (!token) return true;
+  // Always require a non-empty token. The caller generates a random token at
+  // startup, so an empty token here indicates a misconfiguration — reject.
+  if (!token) return false;
   return req.headers.authorization === `Bearer ${token}`;
 }
 

--- a/apps/app/electrobun/src/native/browser-workspace.ts
+++ b/apps/app/electrobun/src/native/browser-workspace.ts
@@ -281,6 +281,16 @@ $bmp.Dispose()`;
       return buf.length > 100 ? { data: buf.toString("base64") } : null;
     } catch {
       return null;
+    } finally {
+      // Clean up tmp file if it was created but not yet deleted (e.g. crash
+      // between screencapture write and unlinkSync above).
+      try {
+        if (fs.existsSync(tmpPath)) {
+          fs.unlinkSync(tmpPath);
+        }
+      } catch {
+        // best-effort cleanup
+      }
     }
   }
 

--- a/apps/app/electrobun/src/native/browser-workspace.ts
+++ b/apps/app/electrobun/src/native/browser-workspace.ts
@@ -218,13 +218,14 @@ export class BrowserWorkspaceManager {
       return null;
     }
 
+    let tmpPath: string | undefined;
     try {
       const size = tab.window.getSize();
       const x = position.x ?? 0;
       const y = position.y ?? 0;
       const width = size.width;
       const height = size.height;
-      const tmpPath = path.join(
+      tmpPath = path.join(
         os.tmpdir(),
         `milady-browser-workspace-${options.id}-${Date.now()}.png`,
       );
@@ -285,7 +286,7 @@ $bmp.Dispose()`;
       // Clean up tmp file if it was created but not yet deleted (e.g. crash
       // between screencapture write and unlinkSync above).
       try {
-        if (fs.existsSync(tmpPath)) {
+        if (tmpPath && fs.existsSync(tmpPath)) {
           fs.unlinkSync(tmpPath);
         }
       } catch {

--- a/packages/app-core/src/components/pages/BrowserWorkspaceView.test.ts
+++ b/packages/app-core/src/components/pages/BrowserWorkspaceView.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { resolveBrowserWorkspaceMessageOrigin } from "./BrowserWorkspaceView";
+import {
+  normalizeBrowserWorkspaceTxRequest,
+  resolveBrowserWorkspaceMessageOrigin,
+} from "./BrowserWorkspaceView";
 
 describe("resolveBrowserWorkspaceMessageOrigin", () => {
   it("returns the origin when it is a valid non-null string", () => {
@@ -21,5 +24,49 @@ describe("resolveBrowserWorkspaceMessageOrigin", () => {
     // result in "*" targetOrigin — wallet addresses would leak.
     expect(resolveBrowserWorkspaceMessageOrigin("")).not.toBe("*");
     expect(resolveBrowserWorkspaceMessageOrigin("null")).not.toBe("*");
+  });
+});
+
+describe("normalizeBrowserWorkspaceTxRequest", () => {
+  it("parses a standard eth_sendTransaction request", () => {
+    const result = normalizeBrowserWorkspaceTxRequest(
+      [{ to: "0xabc", value: "0x1", chainId: "0x1" }],
+      1,
+    );
+    expect(result).toEqual({
+      broadcast: true,
+      chainId: 1,
+      to: "0xabc",
+      value: "0x1",
+    });
+  });
+
+  it("defaults value to 0x0 when omitted (ERC-20 contract calls)", () => {
+    const result = normalizeBrowserWorkspaceTxRequest(
+      [{ to: "0xabc", data: "0x1234" }],
+      1,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.value).toBe("0x0");
+    expect(result!.data).toBe("0x1234");
+  });
+
+  it("returns null when 'to' is missing", () => {
+    expect(
+      normalizeBrowserWorkspaceTxRequest([{ value: "0x1" }], 1),
+    ).toBeNull();
+  });
+
+  it("returns null for non-object params", () => {
+    expect(normalizeBrowserWorkspaceTxRequest(null, 1)).toBeNull();
+    expect(normalizeBrowserWorkspaceTxRequest("bad", 1)).toBeNull();
+  });
+
+  it("uses fallback chainId when not specified", () => {
+    const result = normalizeBrowserWorkspaceTxRequest(
+      [{ to: "0xabc", value: "1" }],
+      42,
+    );
+    expect(result!.chainId).toBe(42);
   });
 });

--- a/packages/app-core/src/components/pages/BrowserWorkspaceView.tsx
+++ b/packages/app-core/src/components/pages/BrowserWorkspaceView.tsx
@@ -212,13 +212,15 @@ function normalizeBrowserWorkspaceTxRequest(
   const chainId =
     parseBrowserWorkspaceChainId(value.chainId) ?? fallbackChainId;
   const to = typeof value.to === "string" ? value.to.trim() : "";
+  // value is optional — ERC-20 and other contract calls legitimately omit it.
+  // Default to "0x0" when absent so these calls aren't silently rejected.
   const amount =
     typeof value.value === "string"
       ? value.value.trim()
       : typeof value.value === "number"
         ? String(value.value)
-        : "";
-  if (!to || !amount || !chainId) {
+        : "0x0";
+  if (!to || !chainId) {
     return null;
   }
   return {
@@ -461,16 +463,16 @@ export function BrowserWorkspaceView(): JSX.Element {
     if (!selectedTabId) {
       return;
     }
-    const remainingTabs = workspace.tabs.filter(
-      (tab) => tab.id !== selectedTabId,
-    );
-    const nextTabId = remainingTabs[0]?.id ?? null;
     await client.closeBrowserWorkspaceTab(selectedTabId);
+    // Fetch fresh tab list after closing — avoids stale closure refs that
+    // could pick a tab the server no longer knows about.
+    const snapshot = await client.getBrowserWorkspace();
+    const nextTabId = snapshot.tabs[0]?.id ?? null;
     if (nextTabId) {
       await client.showBrowserWorkspaceTab(nextTabId);
     }
     await loadWorkspace({ preferTabId: nextTabId, silent: true });
-  }, [loadWorkspace, selectedTabId, workspace.tabs]);
+  }, [loadWorkspace, selectedTabId]);
 
   const registerBrowserWorkspaceIframe = useCallback(
     (tabId: string, iframe: HTMLIFrameElement | null) => {
@@ -788,7 +790,9 @@ export function BrowserWorkspaceView(): JSX.Element {
           }
 
           browserWalletChainIdByTabRef.current.set(sourceTab.id, nextChainId);
-          postBrowserWalletReady(sourceTab, currentWalletState);
+          // Use the ref (not the stale closure snapshot) so the dApp receives
+          // the most up-to-date wallet state after the chain switch.
+          postBrowserWalletReady(sourceTab, browserWalletStateRef.current);
           respond({
             type: BROWSER_WALLET_RESPONSE_TYPE,
             requestId: request.requestId,

--- a/packages/app-core/src/components/pages/BrowserWorkspaceView.tsx
+++ b/packages/app-core/src/components/pages/BrowserWorkspaceView.tsx
@@ -193,7 +193,8 @@ function resolveBrowserWorkspaceWalletAccounts(
   return state.evmAddress ? [state.evmAddress] : [];
 }
 
-function normalizeBrowserWorkspaceTxRequest(
+/** @internal Exported for testing only. */
+export function normalizeBrowserWorkspaceTxRequest(
   params: unknown,
   fallbackChainId: number,
 ): {


### PR DESCRIPTION
## Summary
Fixes the remaining 5 issues from the browser workspace code review (3 HIGH + 2 MEDIUM):

- **Stale tab list after close** — `closeSelectedBrowserWorkspaceTab` fetches fresh snapshot after close instead of using stale closure refs
- **Tmp screenshot files leak** — `snapshotTab` now cleans up tmp PNGs in a `finally` block
- **Missing value rejects contract calls** — `normalizeBrowserWorkspaceTxRequest` defaults to `"0x0"` when `value` is omitted, unblocking ERC-20 calls
- **Empty token bypasses bridge auth** — `isAuthorized` now rejects empty tokens instead of skipping auth
- **Chain switch sends stale wallet state** — uses live ref instead of closure snapshot in `wallet_switchEthereumChain`

Companion to #1714 (critical fixes).

## Test plan
- [ ] Close a tab while agent opens another concurrently — next tab selection works
- [ ] ERC-20 transfer via embedded dApp completes (no silent rejection)
- [ ] `wallet_switchEthereumChain` → dApp receives updated chain in ready message
- [ ] Bridge server rejects requests when token is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)