### PR TITLE
fix: vite dev server resilience and remote HMR support

### DIFF
--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -1060,8 +1060,9 @@ export default defineConfig({
     strictPort: true,
     // WKWebView (Electrobun) can build broken HMR / source-map URLs when the
     // client advertises 0.0.0.0; pin the HMR endpoint to loopback.
+    // On VPS, override with MILADY_HMR_HOST to allow remote access.
     hmr: {
-      host: "127.0.0.1",
+      host: process.env.MILADY_HMR_HOST || "127.0.0.1",
       port: uiPort,
     },
     cors: {

--- a/scripts/dev-ui.mjs
+++ b/scripts/dev-ui.mjs
@@ -1238,8 +1238,7 @@ function startVite() {
   viteProcess.on("exit", (code) => {
     if (shuttingDown) return;
     if (code !== 0) {
-      console.error(`${green(logPrefix)} vite exited with code ${code}`);
-      cleanup(code ?? 1);
+      console.error(`${green(logPrefix)} vite exited with code ${code} — API server continues without UI`);
     }
   });
 }


### PR DESCRIPTION
This PR will be reviewed by an AI agent. Provide clear context to help it assess your changes.

Aesthetic/UI changes that don't improve agent capability are out of scope and will be rejected.

## Category
- [x] Bug fix
- [ ] Security fix
- [ ] Performance improvement
- [ ] New feature
- [ ] Documentation
- [ ] Test coverage
- [ ] Other

## What
two fixes for running the dev server on a remote vps. vite HMR host is now configurable via MILADY_HMR_HOST env, and vite crashing no longer kills the API server.

## Why
was setting up milady on a vps and ran into both. the HMR client was hardcoded to 127.0.0.1 so remote browsers couldnt connect to the hot reload websocket, and when vite hit a build error the whole orchestrator died which took the agent down with it. agent should stay up even if the ui build is broken.

## How
vite.config.ts, the hmr host now reads from process.env.MILADY_HMR_HOST and falls back to 127.0.0.1 so existing electrobun behavior is unchanged.

scripts/dev-ui.mjs, the vite exit handler logs the failure but no longer calls cleanup, so the api server stays running independently.

## Testing
verified on a vps, set MILADY_HMR_HOST to the public ip, opened the dashboard from a remote browser, hot reload works. forced a vite build error and confirmed the api server keeps running and discord stays connected.
