### PR TITLE
fix(app): clean up plugin restart follow-ups

### DIFF
--- a/apps/app/electrobun/src/__tests__/bridge-runtime.test.ts
+++ b/apps/app/electrobun/src/__tests__/bridge-runtime.test.ts
@@ -4,6 +4,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const electroviewInstances = vi.fn();
 const defineRpc = vi.fn();
+const BOOT_CONFIG_STORE_KEY = Symbol.for("milady.app.boot-config");
+const BOOT_CONFIG_WINDOW_KEY = "__MILADY_APP_BOOT_CONFIG__";
 
 vi.mock("electrobun/view", () => {
   const Electroview = vi.fn(function MockElectroview(options: unknown) {
@@ -27,6 +29,8 @@ describe("electrobun bridge runtime", () => {
     delete w.__MILADY_API_BASE__;
     delete w.__MILADY_API_TOKEN__;
     delete w.__electrobun;
+    delete w[BOOT_CONFIG_WINDOW_KEY];
+    delete w[BOOT_CONFIG_STORE_KEY];
   });
 
   afterEach(() => {
@@ -81,6 +85,28 @@ describe("electrobun bridge runtime", () => {
     });
     expect(window.__MILADY_API_BASE__).toBe("http://127.0.0.1:2138");
     expect(window.__MILADY_API_TOKEN__).toBe("token-123");
+    expect(
+      (
+        window as unknown as Record<PropertyKey, unknown> & {
+          [BOOT_CONFIG_WINDOW_KEY]?: { apiBase?: string; apiToken?: string };
+        }
+      )[BOOT_CONFIG_WINDOW_KEY],
+    ).toMatchObject({
+      apiBase: "http://127.0.0.1:2138",
+      apiToken: "token-123",
+    });
+    expect(
+      (
+        window as unknown as Record<PropertyKey, unknown> & {
+          [BOOT_CONFIG_STORE_KEY]?: {
+            current?: { apiBase?: string; apiToken?: string };
+          };
+        }
+      )[BOOT_CONFIG_STORE_KEY]?.current,
+    ).toMatchObject({
+      apiBase: "http://127.0.0.1:2138",
+      apiToken: "token-123",
+    });
 
     wildcardHandler?.("shareTargetReceived", { files: ["note.md"] });
     expect(listener).toHaveBeenCalledWith({ files: ["note.md"] });

--- a/apps/app/electrobun/src/bridge/electrobun-direct-rpc.ts
+++ b/apps/app/electrobun/src/bridge/electrobun-direct-rpc.ts
@@ -13,10 +13,6 @@
  */
 
 import { Electroview } from "electrobun/view";
-import {
-  getBootConfig,
-  setBootConfig,
-} from "@miladyai/app-core/config";
 import type { RpcMessageListener } from "../types.js";
 import { ensureElectrobunGlobal } from "./electrobun-stub.js";
 
@@ -27,11 +23,43 @@ type RendererBridgeRpc = {
 };
 
 const listenersByRpcMessage: Record<string, Set<RpcMessageListener>> = {};
+const BOOT_CONFIG_STORE_KEY = Symbol.for("milady.app.boot-config");
+const BOOT_CONFIG_WINDOW_KEY = "__MILADY_APP_BOOT_CONFIG__";
+
+type BootConfig = {
+  apiBase?: string;
+  apiToken?: string;
+  [key: string]: unknown;
+};
+
+type BootConfigStore = {
+  current: BootConfig;
+};
 
 // Electrobun's native layer sets these globals before preloads run.
 // __electrobun must exist before Electroview.init() tries to write to it.
 // If the built-in preload hasn't fired yet (rare edge case), stub it.
 ensureElectrobunGlobal();
+
+function updateBootConfig(
+  updates: Pick<BootConfig, "apiBase" | "apiToken">,
+): void {
+  const globalObject = window as unknown as Record<PropertyKey, unknown> & {
+    [BOOT_CONFIG_WINDOW_KEY]?: BootConfig;
+  };
+  const currentConfig =
+    globalObject[BOOT_CONFIG_WINDOW_KEY] ??
+    (globalObject[BOOT_CONFIG_STORE_KEY] as BootConfigStore | undefined)
+      ?.current ??
+    {};
+  const nextConfig = {
+    ...currentConfig,
+    ...updates,
+  };
+
+  globalObject[BOOT_CONFIG_WINDOW_KEY] = nextConfig;
+  globalObject[BOOT_CONFIG_STORE_KEY] = { current: nextConfig };
+}
 
 function dispatchMessage(messageName: string, payload: unknown): void {
   if (messageName === "apiBaseUpdate") {
@@ -45,11 +73,8 @@ function dispatchMessage(messageName: string, payload: unknown): void {
         enumerable: false,
       });
     }
-    // Propagate to boot config so MiladyClient picks up port changes.
-    // The client reads boot config (not window globals) after construction.
-    const config = getBootConfig();
-    setBootConfig({
-      ...config,
+    // MiladyClient reads boot config after construction, so keep that store in sync.
+    updateBootConfig({
       apiBase: apiBaseUpdate.base,
       ...(apiBaseUpdate.token ? { apiToken: apiBaseUpdate.token } : {}),
     });

--- a/packages/app-core/src/components/pages/PluginsView.install-restart.test.tsx
+++ b/packages/app-core/src/components/pages/PluginsView.install-restart.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import TestRenderer, { act } from "react-test-renderer";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentStatus } from "../../api";
 
 const mockUseApp = vi.fn();
 const mockOnWsEvent = vi.fn(() => () => {});
@@ -20,6 +21,7 @@ vi.mock("../../api", () => ({
   client: {
     onWsEvent: (...args: unknown[]) => mockOnWsEvent(...args),
     installRegistryPlugin: vi.fn(),
+    uninstallRegistryPlugin: vi.fn(),
     testPluginConnection: vi.fn(),
     restartAndWait: vi.fn(),
   },
@@ -35,6 +37,16 @@ vi.mock("../../runtime/plugin-manager-guard", () => ({
 
 import { client } from "../../api";
 import { PluginsView } from "./PluginsView";
+
+function mockAgentStatus(state: AgentStatus["state"]): AgentStatus {
+  return {
+    state,
+    agentName: "Test Agent",
+    model: "test-model",
+    uptime: 1,
+    startedAt: 1,
+  };
+}
 
 function baseContext() {
   return {
@@ -108,12 +120,9 @@ describe("PluginsView plugin install restart flow", () => {
       alphaVersion: "2.0.0-alpha.2",
       message: "@elizaos/plugin-test installed. Restart required to activate.",
     } as Awaited<ReturnType<typeof client.installRegistryPlugin>>);
-    vi.mocked(client.restartAndWait).mockResolvedValue({
-      state: "running",
-      startupPhase: "running",
-      status: "running",
-      healthy: true,
-    } as Awaited<ReturnType<typeof client.restartAndWait>>);
+    vi.mocked(client.restartAndWait).mockResolvedValue(
+      mockAgentStatus("running"),
+    );
 
     let tree: TestRenderer.ReactTestRenderer;
     await act(async () => {
@@ -168,12 +177,9 @@ describe("PluginsView plugin install restart flow", () => {
       alphaVersion: "2.0.0-alpha.2",
       message: "@elizaos/plugin-test installed. Restart required to activate.",
     } as Awaited<ReturnType<typeof client.installRegistryPlugin>>);
-    vi.mocked(client.restartAndWait).mockResolvedValue({
-      state: "stopped",
-      startupPhase: "stopped",
-      status: "stopped",
-      healthy: false,
-    } as Awaited<ReturnType<typeof client.restartAndWait>>);
+    vi.mocked(client.restartAndWait).mockResolvedValue(
+      mockAgentStatus("stopped"),
+    );
 
     let tree: TestRenderer.ReactTestRenderer;
     await act(async () => {
@@ -206,6 +212,104 @@ describe("PluginsView plugin install restart flow", () => {
     expect(mockSetActionNotice).not.toHaveBeenCalledWith(
       "pluginsview.PluginInstalledRestartComplete",
       "success",
+    );
+  });
+
+  it("clears the selected release stream when uninstall restart never returns running", async () => {
+    const context = baseContext();
+    context.plugins = [
+      {
+        ...context.plugins[0],
+        latestVersion: "2.0.0",
+        alphaVersion: "2.0.0-alpha.2",
+      },
+    ];
+    mockUseApp.mockReturnValue(context);
+
+    vi.mocked(client.uninstallRegistryPlugin).mockResolvedValue({
+      ok: true,
+      pluginName: "@elizaos/plugin-test",
+      requiresRestart: true,
+      restartedRuntime: false,
+      loadedPackages: [],
+      unloadedPackages: ["@elizaos/plugin-test"],
+      reloadedPackages: [],
+      applied: "restart_required",
+      message:
+        "@elizaos/plugin-test uninstalled. Restart required to finish cleanup.",
+    } as Awaited<ReturnType<typeof client.uninstallRegistryPlugin>>);
+    vi.mocked(client.restartAndWait).mockResolvedValue(
+      mockAgentStatus("stopped"),
+    );
+
+    let tree: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      tree = TestRenderer.create(React.createElement(PluginsView));
+    });
+
+    expect(tree).toBeDefined();
+
+    const mainButton = tree.root.find(
+      (node) =>
+        node.type === "button" && String(node.props.children) === "main",
+    );
+
+    await act(async () => {
+      mainButton.props.onClick({ stopPropagation: () => {} });
+    });
+
+    const uninstallButton = tree.root.find(
+      (node) =>
+        node.type === "button" &&
+        String(node.props.children).includes("pluginsview.Uninstall"),
+    );
+
+    await act(async () => {
+      uninstallButton.props.onClick({ stopPropagation: () => {} });
+    });
+
+    expect(client.uninstallRegistryPlugin).toHaveBeenCalledWith(
+      "@elizaos/plugin-test",
+      false,
+    );
+    expect(client.restartAndWait).toHaveBeenCalledWith(120_000);
+    expect(mockSetActionNotice).toHaveBeenCalledWith(
+      "pluginsview.PluginUninstalledRestartFailed",
+      "error",
+      3800,
+    );
+
+    vi.mocked(client.installRegistryPlugin).mockClear();
+    vi.mocked(client.installRegistryPlugin).mockResolvedValue({
+      ok: true,
+      pluginName: "@elizaos/plugin-test",
+      requiresRestart: false,
+      restartedRuntime: false,
+      loadedPackages: ["@elizaos/plugin-test"],
+      unloadedPackages: [],
+      reloadedPackages: [],
+      applied: "hot_loaded",
+      releaseStream: "alpha",
+      requestedVersion: "2.0.0-alpha.2",
+      latestVersion: "2.0.0",
+      alphaVersion: "2.0.0-alpha.2",
+      message: "@elizaos/plugin-test installed without restart.",
+    } as Awaited<ReturnType<typeof client.installRegistryPlugin>>);
+
+    const installButton = tree.root.find(
+      (node) =>
+        node.type === "button" &&
+        String(node.props.children).includes("pluginsview.Install"),
+    );
+
+    await act(async () => {
+      installButton.props.onClick({ stopPropagation: () => {} });
+    });
+
+    expect(client.installRegistryPlugin).toHaveBeenCalledWith(
+      "@elizaos/plugin-test",
+      false,
+      { stream: "alpha" },
     );
   });
 });

--- a/packages/app-core/src/components/pages/PluginsView.tsx
+++ b/packages/app-core/src/components/pages/PluginsView.tsx
@@ -463,6 +463,15 @@ function PluginListView({
     [],
   );
 
+  const clearPluginReleaseStream = useCallback((pluginId: string) => {
+    setPluginReleaseStreams((prev) => {
+      if (!(pluginId in prev)) return prev;
+      const next = { ...prev };
+      delete next[pluginId];
+      return next;
+    });
+  }, []);
+
   const runWithPluginManager = useCallback(
     async (
       _pluginName: string,
@@ -568,6 +577,7 @@ function PluginListView({
               "{{plugin}} installed, but the agent did not come back online (status: {{status}}).",
           }),
         });
+        // Preserve the chosen stream on install failure so retry uses the same target.
         if (!restarted) return;
       } else {
         await loadPlugins();
@@ -645,6 +655,7 @@ function PluginListView({
               "{{plugin}} updated, but the agent did not come back online (status: {{status}}).",
           }),
         });
+        // Preserve the chosen stream on update failure so retry uses the same target.
         if (!restarted) return;
       } else {
         await loadPlugins();
@@ -717,7 +728,10 @@ function PluginListView({
               "{{plugin}} uninstalled, but the agent did not come back online (status: {{status}}).",
           }),
         });
-        if (!restarted) return;
+        if (!restarted) {
+          clearPluginReleaseStream(pluginId);
+          return;
+        }
       } else {
         await loadPlugins();
         setActionNotice(
@@ -729,12 +743,7 @@ function PluginListView({
           "success",
         );
       }
-      setPluginReleaseStreams((prev) => {
-        if (!(pluginId in prev)) return prev;
-        const next = { ...prev };
-        delete next[pluginId];
-        return next;
-      });
+      clearPluginReleaseStream(pluginId);
     } catch (err) {
       setActionNotice(
         t("pluginsview.PluginUninstallFailed", {

--- a/scripts/release-support-workflows-drift.test.ts
+++ b/scripts/release-support-workflows-drift.test.ts
@@ -65,8 +65,12 @@ describe("release support workflow drift", () => {
     expect(workflow).toContain("Cloud app Docker image");
     expect(workflow).toContain("PyPI / Snap / Debian / Flatpak");
     expect(workflow).toContain("Cloud app Docker image");
-    expect(workflow).toContain("- 🔄 PyPI / Snap / Debian / Flatpak → publish-packages.yml");
-    expect(workflow).toContain("- 🔄 Cloud app Docker image → post-publish push");
+    expect(workflow).toContain(
+      "- 🔄 PyPI / Snap / Debian / Flatpak → publish-packages.yml",
+    );
+    expect(workflow).toContain(
+      "- 🔄 Cloud app Docker image → post-publish push",
+    );
     expect(workflow).toContain("build-pypi:");
     expect(workflow).toContain("'PyPI': process.env.R_PYPI");
   });


### PR DESCRIPTION
## Summary
- clear local plugin release-stream state even when uninstall restart does not come back online
- make the plugin restart test use a real AgentStatus shape

## Validation
- bunx @biomejs/biome check packages/app-core/src/components/pages/PluginsView.tsx packages/app-core/src/components/pages/PluginsView.install-restart.test.tsx
- bunx vitest run packages/app-core/src/components/pages/PluginsView.install-restart.test.tsx