### PR TITLE
fix: skip broken plugin-openrouter submodule init until upstream is fixed

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -558,8 +558,8 @@ jobs:
             const multilineDecisionPattern = /(?:^|\n)\s*(?:#{1,4}\s+)?(?:\d+\.\s*)?(?:\*{0,2})Decision(?:\*{0,2})?\s*:?\s*\n+\s*(?:\*{0,2})(APPROVE|REQUEST CHANGES|CLOSE)\b/i;
             const boldVerdictPattern = /\*{1,3}(APPROVE|REQUEST CHANGES|CLOSE)\b\*{1,3}/i;
             const bareLineVerdictPattern = /(?:^|\n)\s*(APPROVE|REQUEST CHANGES|CLOSE)\b/i;
-            const maxAttempts = 5; // Increased for fallback comment posting
-            const pollIntervalMs = 3_000;
+            const maxAttempts = 12;
+            const pollIntervalMs = 5_000;
 
             const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -577,10 +577,10 @@ jobs:
               return '';
             };
 
-            const findLatest = (items) => {
+            const findLatest = (items, { requireRunMarker = true } = {}) => {
               const filtered = items.filter((c) => {
                 if (!c?.body) return false;
-                if (!runMarker || !c.body.includes(runMarker)) return false;
+                if (requireRunMarker && runMarker && !c.body.includes(runMarker)) return false;
                 return Boolean(extractDecision(c.body));
               });
               return filtered.sort((a, b) =>
@@ -614,7 +614,7 @@ jobs:
                 ...comments.filter((c) => c.user?.type === 'Bot'),
                 ...normalizedReviews.filter((r) => r.user?.type === 'Bot'),
               ];
-              latest = findLatest(allBotEntries);
+              latest = findLatest(allBotEntries, { requireRunMarker: true });
 
               if (latest) {
                 break;
@@ -629,6 +629,32 @@ jobs:
             let verdict = 'reject';
             let decision = 'REQUEST CHANGES';
             let decisionCommentUrl = '';
+
+            if (!latest) {
+              const [comments, reviews] = await Promise.all([
+                github.paginate(github.rest.issues.listComments, {
+                  owner, repo, issue_number, per_page: 100,
+                }),
+                github.paginate(github.rest.pulls.listReviews, {
+                  owner, repo, pull_number: issue_number, per_page: 100,
+                }),
+              ]);
+
+              const normalizedReviews = reviews.map(r => ({
+                ...r,
+                created_at: r.submitted_at || r.created_at,
+              }));
+
+              const allBotEntries = [
+                ...comments.filter((c) => c.user?.type === 'Bot'),
+                ...normalizedReviews.filter((r) => r.user?.type === 'Bot'),
+              ];
+
+              latest = findLatest(allBotEntries, { requireRunMarker: false });
+              if (latest) {
+                core.warning('Falling back to latest parseable bot review because the exact run-marker comment was not visible before timeout.');
+              }
+            }
 
             if (latest) {
               const normalized = extractDecision(latest.body);

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -589,6 +589,7 @@ jobs:
             };
 
             let latest = null;
+            let usedFallbackReview = false;
             let attemptUsed = 1;
 
             for (let attempt = 1; attempt <= maxAttempts; attempt++) {
@@ -650,9 +651,14 @@ jobs:
                 ...normalizedReviews.filter((r) => r.user?.type === 'Bot'),
               ];
 
-              latest = findLatest(allBotEntries, { requireRunMarker: false });
-              if (latest) {
-                core.warning('Falling back to latest parseable bot review because the exact run-marker comment was not visible before timeout.');
+              const fallbackLatest = findLatest(allBotEntries, { requireRunMarker: false });
+              const fallbackDecision = extractDecision(fallbackLatest?.body || '');
+              if (fallbackLatest && fallbackDecision && fallbackDecision !== 'APPROVE') {
+                latest = fallbackLatest;
+                usedFallbackReview = true;
+                core.warning(`Falling back to latest parseable bot review with non-approve decision (${fallbackDecision}) because the exact run-marker comment was not visible before timeout.`);
+              } else if (fallbackLatest && fallbackDecision === 'APPROVE') {
+                core.warning('Ignoring stale fallback APPROVE review because it does not carry the current run marker.');
               }
             }
 
@@ -670,6 +676,10 @@ jobs:
               }
             } else {
               core.warning(`No structured review decision comment found for current run marker after ${attemptUsed} attempts. Treating as reject.`);
+            }
+
+            if (usedFallbackReview) {
+              core.notice(`Using fallback non-approve decision from ${decisionCommentUrl || 'a bot review comment'} after run-marker timeout.`);
             }
 
             core.setOutput('verdict', verdict);

--- a/scripts/electrobun-release-workflow-drift.test.ts
+++ b/scripts/electrobun-release-workflow-drift.test.ts
@@ -711,7 +711,7 @@ describe("Electrobun release workflow drift", () => {
       "$stopProtectedProcessIds = [System.Collections.Generic.HashSet[int]]::new()",
     );
     expect(smokeScript).toContain(
-      'Get-CimInstance Win32_Process -Filter "ProcessId = $PID"',
+      'Get-CimInstance Win32_Process -Filter "ProcessId = $currentPid"',
     );
     expect(smokeScript).toContain(
       "-not $stopProtectedProcessIds.Contains([int]$_.Id)",

--- a/scripts/init-submodules.mjs
+++ b/scripts/init-submodules.mjs
@@ -28,9 +28,10 @@ const SUBMODULE_READINESS_MARKERS = {
 // typescript/ that Windows git rejects as invalid filenames. Skip checkout
 // until elizaos-plugins/plugin-openrouter#25 is merged; the package is
 // available via npm in the meantime.
+// TODO: remove once elizaos-plugins/plugin-openrouter#25 is merged.
 const SKIP_SUBMODULES = new Set(["plugins/plugin-openrouter"]);
 
-export function getSubmoduleSkipReason(
+function getSubmoduleSkipReason(
   submodulePath,
   { skipLocal = skipLocalUpstreams } = {},
 ) {

--- a/scripts/init-submodules.mjs
+++ b/scripts/init-submodules.mjs
@@ -30,12 +30,24 @@ const SUBMODULE_READINESS_MARKERS = {
 // available via npm in the meantime.
 const SKIP_SUBMODULES = new Set(["plugins/plugin-openrouter"]);
 
+export function getSubmoduleSkipReason(
+  submodulePath,
+  { skipLocal = skipLocalUpstreams } = {},
+) {
+  if (SKIP_SUBMODULES.has(submodulePath)) {
+    return "it is in the explicit skip list";
+  }
+  if (skipLocal && submodulePath === "eliza") {
+    return "local upstreams are disabled";
+  }
+  return null;
+}
+
 export function shouldSkipSubmoduleInit(
   submodulePath,
   { skipLocal = skipLocalUpstreams } = {},
 ) {
-  if (SKIP_SUBMODULES.has(submodulePath)) return true;
-  return skipLocal && submodulePath === "eliza";
+  return getSubmoduleSkipReason(submodulePath, { skipLocal }) !== null;
 }
 
 export function parseTrackedSubmodules(configOutput) {
@@ -123,9 +135,10 @@ export function runInitSubmodules({
   let failed = 0;
 
   for (const submodule of submodules) {
+    const skipReason = getSubmoduleSkipReason(submodule.path);
     if (shouldSkipSubmodule(submodule.path)) {
       log(
-        `[init-submodules] Skipping ${submodule.name} (${submodule.path}) because local upstreams are disabled`,
+        `[init-submodules] Skipping ${submodule.name} (${submodule.path}) because ${skipReason ?? "local upstreams are disabled"}`,
       );
       continue;
     }

--- a/scripts/init-submodules.mjs
+++ b/scripts/init-submodules.mjs
@@ -24,10 +24,17 @@ const SUBMODULE_READINESS_MARKERS = {
   "steward-fi": ["package.json", "packages/api/package.json"],
 };
 
+// plugin-openrouter contains PGlite :memory:<UUID> paths committed under
+// typescript/ that Windows git rejects as invalid filenames. Skip checkout
+// until elizaos-plugins/plugin-openrouter#25 is merged; the package is
+// available via npm in the meantime.
+const SKIP_SUBMODULES = new Set(["plugins/plugin-openrouter"]);
+
 export function shouldSkipSubmoduleInit(
   submodulePath,
   { skipLocal = skipLocalUpstreams } = {},
 ) {
+  if (SKIP_SUBMODULES.has(submodulePath)) return true;
   return skipLocal && submodulePath === "eliza";
 }
 

--- a/scripts/init-submodules.test.ts
+++ b/scripts/init-submodules.test.ts
@@ -25,6 +25,14 @@ describe("parseTrackedSubmodules", () => {
 });
 
 describe("shouldSkipSubmoduleInit", () => {
+  it("skips plugin-openrouter until the upstream Windows-invalid paths are fixed", () => {
+    expect(
+      shouldSkipSubmoduleInit("plugins/plugin-openrouter", {
+        skipLocal: false,
+      }),
+    ).toBe(true);
+  });
+
   it("skips the repo-local eliza checkout when local upstreams are disabled", () => {
     expect(shouldSkipSubmoduleInit("eliza", { skipLocal: true })).toBe(true);
     expect(

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -838,7 +838,7 @@ function assertWindowsSmokeScriptHasLeadingParamBlock() {
     '$startupBootstrapFile = Join-Path $startupBundleRoot "startup-session.json"',
     "Write-StartupBootstrap",
     "$stopProtectedProcessIds = [System.Collections.Generic.HashSet[int]]::new()",
-    'Get-CimInstance Win32_Process -Filter "ProcessId = $PID"',
+    'Get-CimInstance Win32_Process -Filter "ProcessId = $currentPid"',
     "-not $stopProtectedProcessIds.Contains([int]$_.Id)",
     "[int]::TryParse([string]$state.port, [ref]$observedPort)",
     "if ($state.session_id -ne $startupSessionId)",


### PR DESCRIPTION
## Summary

- temporarily skip `plugins/plugin-openrouter` during repo-local submodule init on Windows-safe setup paths
- sync the Windows release contract check with the current smoke script variable name (`$currentPid`)
- make `agent-review.yml` wait longer for the current run marker and only fall back to stale non-approve verdicts

## Root Cause

`elizaos-plugins/plugin-openrouter` committed PGlite `typescript/:memory:<UUID>/` paths. Windows git rejects those filenames because `:` is invalid in checkout paths, so `git submodule update --init --recursive plugins/plugin-openrouter` fails.

Separately, the release contract checker had drifted from the current Windows smoke script (`$PID` vs `$currentPid`), and the agent-review verdict parser could time out before the current run's review comment became visible.

## This PR

This does not redirect the submodule or change `.gitmodules`.

Instead, it:
- adds a temporary skip in `scripts/init-submodules.mjs` so Milady's managed submodule-init flow does not attempt to check out `plugins/plugin-openrouter` until the upstream repository is fixed
- updates `scripts/release-check.ts` so the release contract matches the current Windows smoke script
- updates `.github/workflows/agent-review.yml` to poll longer for the current run marker and preserve only stale blocking verdicts on timeout; stale approvals are ignored

The package remains available from npm in the meantime.

Upstream fix: elizaos-plugins/plugin-openrouter#25

## Revert Plan

- remove the `SKIP_SUBMODULES` entry for `plugins/plugin-openrouter`
- remove the temporary agent-review timeout fallback once the current-run marker is reliably visible without it
- let normal submodule init resume once the upstream branch no longer contains the invalid paths
