### PR TITLE
fix: handle clipboard write failure in CopyButton, remove duplicate catch

### DIFF
--- a/packages/app-core/src/state/useDataLoaders.ts
+++ b/packages/app-core/src/state/useDataLoaders.ts
@@ -423,7 +423,6 @@ export function useDataLoaders(deps: DataLoadersDeps) {
           setOwnerNameState(persisted);
         }
       })
-      .catch(() => {})
       .catch(() => {});
 
     return () => {

--- a/packages/ui/src/components/ui/copy-button.tsx
+++ b/packages/ui/src/components/ui/copy-button.tsx
@@ -28,11 +28,28 @@ export const CopyButton = React.forwardRef<HTMLButtonElement, CopyButtonProps>(
     ref,
   ) => {
     const [copied, setCopied] = React.useState(false);
+    const timerRef = React.useRef<ReturnType<typeof setTimeout>>(null);
+
+    React.useEffect(() => {
+      return () => {
+        if (timerRef.current) clearTimeout(timerRef.current);
+      };
+    }, []);
 
     const handleCopy = React.useCallback(() => {
-      void navigator.clipboard.writeText(value);
-      setCopied(true);
-      setTimeout(() => setCopied(false), feedbackDuration);
+      navigator.clipboard.writeText(value).then(
+        () => {
+          setCopied(true);
+          if (timerRef.current) clearTimeout(timerRef.current);
+          timerRef.current = setTimeout(
+            () => setCopied(false),
+            feedbackDuration,
+          );
+        },
+        () => {
+          /* clipboard write failed — don't show false "copied" feedback */
+        },
+      );
     }, [value, feedbackDuration]);
 
     return (


### PR DESCRIPTION
## Summary
- **CopyButton** (`packages/ui/src/components/ui/copy-button.tsx`): Previously used `void navigator.clipboard.writeText(value)` which fires-and-forgets the clipboard write, then immediately shows the "copied" checkmark — even when the write fails (permission denied, insecure context, etc.). Now the component awaits the promise and only shows success feedback on actual success.
- **CopyButton timer leak**: The `setTimeout` that resets the copied state was never cleaned up on unmount, which could call `setCopied` on an unmounted component. Added a `useRef` + cleanup `useEffect` to clear the timer.
- **useDataLoaders** (`packages/app-core/src/state/useDataLoaders.ts`): Removed a duplicate `.catch(() => {})` that was chained after an identical `.catch(() => {})` — the second handler is unreachable dead code (a caught promise resolves to `undefined`, so the second catch never fires).

## Test plan
- [ ] Click the copy button in the chat UI — verify checkmark appears and text is in clipboard
- [ ] Revoke clipboard permission (or test in an insecure context like HTTP) — verify the button does NOT show the checkmark
- [ ] Rapidly click copy, then navigate away — verify no React warnings about setState on unmounted component
- [ ] Verify owner name loading in data loaders still works (no behavioral change from removing the duplicate catch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)