### PR TITLE
fix: add missing error handlers and abort cleanup in async effects

### DIFF
--- a/packages/app-core/src/components/coding/CodingAgentSettingsSection.tsx
+++ b/packages/app-core/src/components/coding/CodingAgentSettingsSection.tsx
@@ -41,6 +41,7 @@ export function CodingAgentSettingsSection() {
   const [authResult, setAuthResult] = useState<AuthResult | null>(null);
 
   useEffect(() => {
+    const controller = new AbortController();
     void (async () => {
       setLoading(true);
       try {
@@ -50,10 +51,14 @@ export function CodingAgentSettingsSection() {
             client.fetchModels("anthropic", false).catch(() => null),
             client.fetchModels("google-genai", false).catch(() => null),
             client.fetchModels("openai", false).catch(() => null),
-            fetch("/api/coding-agents/preflight")
+            fetch("/api/coding-agents/preflight", {
+              signal: controller.signal,
+            })
               .then((response) => (response.ok ? response.json() : null))
               .catch(() => null),
           ]);
+
+        if (controller.signal.aborted) return;
 
         const env = (cfg.env ?? {}) as Record<string, string>;
         const cloud = (cfg.cloud ?? {}) as Record<string, string>;
@@ -140,8 +145,9 @@ export function CodingAgentSettingsSection() {
       } catch {
         // Fall back to built-in defaults when config or model fetches fail.
       }
-      setLoading(false);
+      if (!controller.signal.aborted) setLoading(false);
     })();
+    return () => controller.abort();
   }, []);
 
   const llmProvider = (prefs.PARALLAX_LLM_PROVIDER ||

--- a/packages/app-core/src/components/pages/ChatView.tsx
+++ b/packages/app-core/src/components/pages/ChatView.tsx
@@ -127,7 +127,8 @@ export function ChatView({
   // ── Coding agent preflight ──────────────────────────────────────
   const [codingAgentsAvailable, setCodingAgentsAvailable] = useState(false);
   useEffect(() => {
-    fetch("/api/coding-agents/preflight")
+    const controller = new AbortController();
+    fetch("/api/coding-agents/preflight", { signal: controller.signal })
       .then((r) => r.json())
       .then((data: { installed?: unknown[]; available?: boolean }) => {
         setCodingAgentsAvailable(
@@ -136,8 +137,9 @@ export function ChatView({
         );
       })
       .catch(() => {
-        /* preflight unavailable — hide code button */
+        /* preflight unavailable or aborted — hide code button */
       });
+    return () => controller.abort();
   }, []);
 
   const handleCreateTask = useCallback(
@@ -324,7 +326,7 @@ export function ChatView({
 
       const readers = imageFiles.map(
         (file) =>
-          new Promise<ImageAttachment>((resolve) => {
+          new Promise<ImageAttachment>((resolve, reject) => {
             const reader = new FileReader();
             reader.onload = () => {
               const result = reader.result as string;
@@ -333,18 +335,25 @@ export function ChatView({
               const data = commaIdx >= 0 ? result.slice(commaIdx + 1) : result;
               resolve({ data, mimeType: file.type, name: file.name });
             };
+            reader.onerror = () =>
+              reject(reader.error ?? new Error("Failed to read file"));
+            reader.onabort = () => reject(new Error("File read aborted"));
             reader.readAsDataURL(file);
           }),
       );
 
-      void Promise.all(readers).then((attachments) => {
-        setChatPendingImages((prev) => {
-          const combined = [...prev, ...attachments];
-          // Mirror the server-side MAX_CHAT_IMAGES=4 limit so the user gets
-          // immediate feedback rather than a 400 after upload.
-          return combined.slice(0, 4);
+      void Promise.all(readers)
+        .then((attachments) => {
+          setChatPendingImages((prev) => {
+            const combined = [...prev, ...attachments];
+            // Mirror the server-side MAX_CHAT_IMAGES=4 limit so the user gets
+            // immediate feedback rather than a 400 after upload.
+            return combined.slice(0, 4);
+          });
+        })
+        .catch((err) => {
+          console.warn("Failed to load image attachments:", err);
         });
-      });
     },
     [setChatPendingImages],
   );


### PR DESCRIPTION
## Summary
- **ChatView `addImageFiles`**: `FileReader` promises lacked `onerror`/`onabort` handlers, causing promises that never settle on read failure (e.g. permission errors, corrupt files). Added `.catch()` on `Promise.all` to prevent unhandled rejections.
- **ChatView preflight fetch**: Added `AbortController` so the coding-agents preflight request is cancelled on unmount, preventing state updates on unmounted components.
- **CodingAgentSettingsSection**: Added `AbortController` for the preflight fetch and abort guards before state updates, preventing post-unmount state writes when navigating away during the 5-fetch initialization.

## Test plan
- [ ] Open chat view, attach an image — verify it still previews correctly
- [ ] Quickly navigate away from chat view while preflight fetch is in-flight — verify no console warnings about state updates on unmounted component
- [ ] Open coding agent settings then navigate away quickly — verify no console warnings
- [ ] Attempt to attach a file that fails to read (e.g. revoke permissions mid-read) — verify console warning instead of unhandled rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)