### PR TITLE
fix: harden Windows repo setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -172,13 +172,7 @@ jobs:
           # Published-only CI restores the required non-eliza submodules explicitly.
           submodules: false
 
-      - name: Initialize Windows-safe workspace submodules
-        if: ${{ matrix.os == 'windows-latest' }}
-        shell: bash
-        run: git submodule update --init --depth 1 plugins/plugin-agent-orchestrator
-
       - name: Initialize tracked workspace submodules
-        if: ${{ matrix.os != 'windows-latest' }}
         run: node scripts/init-submodules.mjs
 
       - name: Setup Node.js
@@ -244,13 +238,7 @@ jobs:
           # Published-only CI restores the required non-eliza submodules explicitly.
           submodules: false
 
-      - name: Initialize Windows-safe workspace submodules
-        if: ${{ matrix.os == 'windows-latest' }}
-        shell: bash
-        run: git submodule update --init --depth 1 plugins/plugin-agent-orchestrator
-
       - name: Initialize tracked workspace submodules
-        if: ${{ matrix.os != 'windows-latest' }}
         run: node scripts/init-submodules.mjs
 
       - name: Setup Node.js

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -254,7 +254,8 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: ${{ env.BUN_VERSION }}
+          # pinned on Windows: Bun 1.3.11 reports false frozen-lockfile drift on root installs
+          bun-version: ${{ matrix.os == 'windows-latest' && '1.3.9' || env.BUN_VERSION }}
 
       - name: Cache Bun install
         uses: actions/cache@v4

--- a/.github/workflows/windows-desktop-preload-smoke.yml
+++ b/.github/workflows/windows-desktop-preload-smoke.yml
@@ -23,9 +23,8 @@ jobs:
         with:
           submodules: false
 
-      - name: Initialize Windows-safe workspace submodules
-        shell: bash
-        run: git submodule update --init --depth 1 plugins/plugin-agent-orchestrator
+      - name: Initialize tracked workspace submodules
+        run: node scripts/init-submodules.mjs
 
       - name: Enable long paths (Windows)
         run: git config --global core.longpaths true

--- a/.github/workflows/windows-desktop-preload-smoke.yml
+++ b/.github/workflows/windows-desktop-preload-smoke.yml
@@ -39,7 +39,8 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.11"
+          # pinned: Bun 1.3.11 reports false frozen-lockfile drift on Windows root installs
+          bun-version: "1.3.9"
 
       - name: Disable repo-local eliza workspace
         run: node scripts/disable-local-eliza-workspace.mjs

--- a/.github/workflows/windows-desktop-preload-smoke.yml
+++ b/.github/workflows/windows-desktop-preload-smoke.yml
@@ -18,6 +18,8 @@ jobs:
   preload-smoke:
     name: desktop preload preflight (windows)
     runs-on: windows-latest
+    env:
+      MILADY_SKIP_LOCAL_UPSTREAMS: "1"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/windows-dev-smoke.yml
+++ b/.github/workflows/windows-dev-smoke.yml
@@ -18,6 +18,8 @@ jobs:
   dev-smoke:
     name: Windows smoke (${{ matrix.bun-version }})
     runs-on: windows-latest
+    env:
+      MILADY_SKIP_LOCAL_UPSTREAMS: "1"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/windows-dev-smoke.yml
+++ b/.github/workflows/windows-dev-smoke.yml
@@ -26,9 +26,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Initialize Windows-safe workspace submodules
-        shell: bash
-        run: git submodule update --init --depth 1 plugins/plugin-agent-orchestrator
+      - name: Initialize tracked workspace submodules
+        run: node scripts/init-submodules.mjs
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/bun.lock
+++ b/bun.lock
@@ -93,6 +93,7 @@
         "@types/ws": "^8.18.1",
         "@vitest/coverage-v8": "^4.1.0",
         "@vitest/utils": "4.1.0",
+        "jsdom": "^28.1.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-test-renderer": "^19.2.4",
@@ -547,6 +548,7 @@
         "@elizaos/plugin-trust": "workspace:*",
         "@hapi/boom": "^10.0.1",
         "@mariozechner/pi-ai": "0.52.12",
+        "@miladyai/plugin-2004scape": "workspace:*",
         "@miladyai/plugin-roles": "github:milady-ai/plugin-roles#5b00c49",
         "@miladyai/plugin-selfcontrol": "workspace:*",
         "@miladyai/plugin-wechat": "github:milady-ai/plugin-wechat",
@@ -1180,38 +1182,6 @@
         "@elizaos/core": "workspace:*",
       },
     },
-    "plugins/plugin-groq": {
-      "name": "@elizaos/plugin-groq-root",
-      "version": "2.0.0-alpha.1",
-      "dependencies": {
-        "@ai-sdk/groq": "latest",
-        "ai": "latest",
-      },
-      "devDependencies": {
-        "@biomejs/biome": "^2.3.11",
-        "@types/bun": "^1.3.5",
-        "@types/node": "^25.0.3",
-        "typescript": "^5.9.3",
-      },
-      "peerDependencies": {
-        "@elizaos/core": "workspace:*",
-      },
-    },
-    "plugins/plugin-groq/typescript": {
-      "name": "@elizaos/plugin-groq",
-      "version": "2.0.0-alpha.8",
-      "dependencies": {
-        "@ai-sdk/groq": "^3.0.4",
-        "@elizaos/core": "workspace:*",
-        "ai": "^6.0.0",
-      },
-      "devDependencies": {
-        "@biomejs/biome": "^2.3.11",
-        "@types/bun": "^1.3.10",
-        "@types/node": "^25.0.3",
-        "typescript": "^5.9.3",
-      },
-    },
     "plugins/plugin-local-embedding": {
       "name": "@elizaos/plugin-local-embedding-root",
       "version": "1.2.1",
@@ -1319,44 +1289,6 @@
       "peerDependencies": {
         "@elizaos/core": "workspace:*",
         "zod": "^4.3.6",
-      },
-    },
-    "plugins/plugin-openrouter": {
-      "name": "@elizaos/plugin-openrouter-root",
-      "version": "2.0.0-alpha.1",
-      "devDependencies": {
-        "@biomejs/biome": "^2.3.11",
-        "@types/bun": "^1.3.5",
-        "@types/node": "^25.0.3",
-        "typescript": "^5.9.3",
-      },
-      "peerDependencies": {
-        "@elizaos/core": "workspace:*",
-      },
-    },
-    "plugins/plugin-openrouter/typescript": {
-      "name": "@elizaos/plugin-openrouter",
-      "version": "2.0.0-alpha.13",
-      "dependencies": {
-        "@ai-sdk/openai": "^3.0.9",
-        "@ai-sdk/ui-utils": "^1.2.8",
-        "@openrouter/ai-sdk-provider": "^1.2.0",
-        "ai": "^6.0.30",
-        "undici": "^7.16.0",
-      },
-      "devDependencies": {
-        "@biomejs/biome": "^2.3.11",
-        "@elizaos/core": "workspace:*",
-        "@elizaos/plugin-sql": "workspace:*",
-        "@types/bun": "^1.3.5",
-        "@types/json-schema": "^7.0.15",
-        "@types/node": "^25.0.3",
-        "dotenv": "^17.2.3",
-        "typescript": "^5.9.3",
-        "vitest": "^4.0.0",
-      },
-      "peerDependencies": {
-        "@elizaos/core": "workspace:*",
       },
     },
     "plugins/plugin-pdf": {
@@ -1725,8 +1657,6 @@
 
     "@ai-sdk/google": ["@ai-sdk/google@3.0.60", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ye/hG0LeO24VmjLbfgkFZV8V8k/l4nVBODutpJQkFPyUiGOCbFtFUTgxSeC7+njrk5+HhgyHrzJay4zmhwMH+w=="],
 
-    "@ai-sdk/groq": ["@ai-sdk/groq@3.0.31", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.21" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-XbbugpnFmXGu2TlXiq8KUJskP6/VVbuFcnFIGDzDIB/Chg6XHsNnqrTF80Zxkh0Pd3+NvbM+2Uqrtsndk6bDAg=="],
-
     "@ai-sdk/openai": ["@ai-sdk/openai@3.0.52", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-4Rr8NCGmfWTz6DCUvixn9UmyZcMatiHn0zWoMzI3JCUe9R1P/vsPOpCBALKoSzVYOjyJnhtnVIbfUKujcS39uw=="],
 
     "@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
@@ -2047,10 +1977,6 @@
 
     "@elizaos/plugin-google-genai-root": ["@elizaos/plugin-google-genai-root@workspace:plugins/plugin-google-genai"],
 
-    "@elizaos/plugin-groq": ["@elizaos/plugin-groq@workspace:plugins/plugin-groq/typescript"],
-
-    "@elizaos/plugin-groq-root": ["@elizaos/plugin-groq-root@workspace:plugins/plugin-groq"],
-
     "@elizaos/plugin-local-embedding": ["@elizaos/plugin-local-embedding@workspace:plugins/plugin-local-embedding/typescript"],
 
     "@elizaos/plugin-local-embedding-root": ["@elizaos/plugin-local-embedding-root@workspace:plugins/plugin-local-embedding"],
@@ -2067,9 +1993,7 @@
 
     "@elizaos/plugin-openai-root": ["@elizaos/plugin-openai-root@workspace:plugins/plugin-openai"],
 
-    "@elizaos/plugin-openrouter": ["@elizaos/plugin-openrouter@workspace:plugins/plugin-openrouter/typescript"],
-
-    "@elizaos/plugin-openrouter-root": ["@elizaos/plugin-openrouter-root@workspace:plugins/plugin-openrouter"],
+    "@elizaos/plugin-openrouter": ["@elizaos/plugin-openrouter@2.0.0-alpha.13", "", { "dependencies": { "@ai-sdk/openai": "^3.0.9", "@ai-sdk/ui-utils": "^1.2.8", "@openrouter/ai-sdk-provider": "^1.2.0", "ai": "^6.0.30", "undici": "^7.16.0" }, "peerDependencies": { "@elizaos/core": "2.0.0-alpha.114" } }, "sha512-1QFAOhtX2TtWwie1z2MXukhjH9hBBeuWAzHzT5PtDAlsJRtlJ9AiudqDTiZhXMD06GtvN20jqBdVJD+SiXpDVg=="],
 
     "@elizaos/plugin-pdf": ["@elizaos/plugin-pdf@workspace:plugins/plugin-pdf/typescript"],
 
@@ -4919,7 +4843,7 @@
 
     "parse-ms": ["parse-ms@4.0.0", "", {}, "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="],
 
-    "parse5": ["parse5@5.1.1", "", {}, "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="],
+    "parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
 
     "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@6.0.1", "", { "dependencies": { "parse5": "^6.0.1" } }, "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA=="],
 
@@ -5443,15 +5367,15 @@
 
     "tinyspy": ["tinyspy@3.0.2", "", {}, "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q=="],
 
-    "tldts": ["tldts@6.1.86", "", { "dependencies": { "tldts-core": "^6.1.86" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ=="],
+    "tldts": ["tldts@7.0.28", "", { "dependencies": { "tldts-core": "^7.0.28" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw=="],
 
-    "tldts-core": ["tldts-core@6.1.86", "", {}, "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="],
+    "tldts-core": ["tldts-core@7.0.28", "", {}, "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
     "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
 
-    "tough-cookie": ["tough-cookie@5.1.2", "", { "dependencies": { "tldts": "^6.1.32" } }, "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A=="],
+    "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
 
     "tr46": ["tr46@1.0.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA=="],
 
@@ -5619,7 +5543,7 @@
 
     "webdriver-bidi-protocol": ["webdriver-bidi-protocol@0.4.1", "", {}, "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw=="],
 
-    "webidl-conversions": ["webidl-conversions@4.0.2", "", {}, "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="],
+    "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
 
     "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
 
@@ -5700,8 +5624,6 @@
     "zustand": ["zustand@5.0.12", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
-
-    "@ai-sdk/groq/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.21", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw=="],
 
     "@ai-sdk/ui-utils/@ai-sdk/provider": ["@ai-sdk/provider@1.1.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg=="],
 
@@ -5839,6 +5761,8 @@
 
     "@discordjs/ws/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@distube/ytdl-core/tough-cookie": ["tough-cookie@5.1.2", "", { "dependencies": { "tldts": "^6.1.32" } }, "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A=="],
+
     "@elizaos-plugins/client-telegram-account/glob": ["glob@11.0.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^4.0.1", "minimatch": "^10.0.0", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^2.0.0" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g=="],
 
     "@elizaos/daemon/@biomejs/biome": ["@biomejs/biome@1.9.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "1.9.4", "@biomejs/cli-darwin-x64": "1.9.4", "@biomejs/cli-linux-arm64": "1.9.4", "@biomejs/cli-linux-arm64-musl": "1.9.4", "@biomejs/cli-linux-x64": "1.9.4", "@biomejs/cli-linux-x64-musl": "1.9.4", "@biomejs/cli-win32-arm64": "1.9.4", "@biomejs/cli-win32-x64": "1.9.4" }, "bin": { "biome": "bin/biome" } }, "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog=="],
@@ -5873,7 +5797,7 @@
 
     "@elizaos/plugin-edge-tts/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
 
-    "@elizaos/plugin-form/uuid": ["uuid@11.0.5", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA=="],
+    "@elizaos/plugin-form/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
     "@elizaos/plugin-local-embedding/@types/uuid": ["@types/uuid@10.0.0", "", {}, "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="],
 
@@ -6023,13 +5947,13 @@
 
     "@miladyai/agent/@elizaos/plugin-solana": ["@elizaos/plugin-solana@1.2.6", "", { "dependencies": { "@solana/spl-token": "0.4.14", "@solana/spl-token-metadata": "^0.1.6", "@solana/web3.js": "^1.98.0", "bignumber.js": "9.3.0", "bs58": "6.0.0", "tweetnacl": "^1.0.3" }, "peerDependencies": { "@elizaos/core": "latest", "@elizaos/service-interfaces": "latest", "form-data": "4.0.2", "whatwg-url": "7.1.0" } }, "sha512-VWp4u2jOkEOgqNNaVN8j3g2TWKwq56GZzIawFPsr6YsF4NuCiQOaWfmeq+edVxpze5LkkzVfC/KPeU19jjZDuA=="],
 
-    "@miladyai/agent/@miladyai/plugin-roles": ["@miladyai/plugin-roles@github:milady-ai/plugin-roles#5b00c49", { "peerDependencies": { "@elizaos/core": "alpha" } }, "milady-ai-plugin-roles-5b00c49", "sha512-QxrX3mPn9KLdor5PdRyVqYzOxVbIfR4cNW9YfqWL3jCE35zg6g1Pu0E9MDkTFmNOFbyjvCnkrFLxZtZfGdlu+A=="],
-
     "@miladyai/app/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
 
     "@miladyai/app/vitest": ["vitest@2.1.9", "", { "dependencies": { "@vitest/expect": "2.1.9", "@vitest/mocker": "2.1.9", "@vitest/pretty-format": "^2.1.9", "@vitest/runner": "2.1.9", "@vitest/snapshot": "2.1.9", "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "debug": "^4.3.7", "expect-type": "^1.1.0", "magic-string": "^0.30.12", "pathe": "^1.1.2", "std-env": "^3.8.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.1", "tinypool": "^1.0.1", "tinyrainbow": "^1.2.0", "vite": "^5.0.0", "vite-node": "2.1.9", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/node": "^18.0.0 || >=20.0.0", "@vitest/browser": "2.1.9", "@vitest/ui": "2.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q=="],
 
     "@miladyai/app-core/@capacitor/core": ["@capacitor/core@8.0.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-EXZfxkL6GFJS2cb7TIBR7RiHA5iz6ufDcl1VmUpI2pga3lJ5Ck2+iqbx7N+osL3XYem9ad4XCidJEMm64DX6UQ=="],
+
+    "@miladyai/app-core/@miladyai/plugin-wechat": ["@miladyai/plugin-wechat@github:milady-ai/plugin-wechat#d73ade8", { "peerDependencies": { "@elizaos/core": "alpha" } }, "milady-ai-plugin-wechat-d73ade8", "sha512-ibuaYzgoN7H6JxY+B9xXCYY2fGmCOk3vchjtVvcTiXwtbst4c4XlzYxq3dLXqCIUBePbb7xGmwFsaEVVpNc55g=="],
 
     "@miladyai/app-core/lucide-react": ["lucide-react@0.575.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-VuXgKZrk0uiDlWjGGXmKV6MSk9Yy4l10qgVvzGn2AWBx1Ylt0iBexKOAoA6I7JO3m+M9oeovJd3yYENfkUbOeg=="],
 
@@ -6044,8 +5968,6 @@
     "@miladyai/homepage/three": ["three@0.183.2", "", {}, "sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ=="],
 
     "@miladyai/homepage/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
-
-    "@miladyai/plugin-selfcontrol/@miladyai/plugin-roles": ["@miladyai/plugin-roles@github:milady-ai/plugin-roles#5b00c49", { "peerDependencies": { "@elizaos/core": "alpha" } }, "milady-ai-plugin-roles-5b00c49", "sha512-QxrX3mPn9KLdor5PdRyVqYzOxVbIfR4cNW9YfqWL3jCE35zg6g1Pu0E9MDkTFmNOFbyjvCnkrFLxZtZfGdlu+A=="],
 
     "@miladyai/ui/jsdom": ["jsdom@29.0.2", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.5", "@asamuzakjp/dom-selector": "^7.0.6", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.1", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.2.7", "parse5": "^8.0.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.24.5", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w=="],
 
@@ -6293,6 +6215,8 @@
 
     "cli-highlight/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
+    "cli-highlight/parse5": ["parse5@5.1.1", "", {}, "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="],
+
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "clone-response/mimic-response": ["mimic-response@1.0.1", "", {}, "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="],
@@ -6441,12 +6365,6 @@
 
     "js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
-    "jsdom/parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
-
-    "jsdom/tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
-
-    "jsdom/webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
-
     "jsdom/whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
 
     "jszip/pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
@@ -6516,6 +6434,8 @@
     "p-queue/p-timeout": ["p-timeout@7.0.1", "", {}, "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
 
@@ -6653,6 +6573,8 @@
 
     "websocket/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
+    "whatwg-url/webidl-conversions": ["webidl-conversions@4.0.2", "", {}, "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="],
+
     "which-builtin-type/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
@@ -6682,6 +6604,8 @@
     "@discordjs/node-pre-gyp/make-dir/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@discordjs/node-pre-gyp/rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
+
+    "@distube/ytdl-core/tough-cookie/tldts": ["tldts@6.1.86", "", { "dependencies": { "tldts-core": "^6.1.86" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ=="],
 
     "@elizaos-plugins/client-telegram-account/glob/jackspeak": ["jackspeak@4.2.3", "", { "dependencies": { "@isaacs/cliui": "^9.0.0" } }, "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg=="],
 
@@ -7153,21 +7077,9 @@
 
     "@miladyai/homepage/jsdom/@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@7.0.8", "", { "dependencies": { "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.2.1", "is-potential-custom-element-name": "^1.0.1" } }, "sha512-erMO6FgtM02dC24NGm0xufMzWz5OF0wXKR7BpvGD973bq/GbmR8/DbxNZbj0YevQ5hlToJaWSVK/G9/NDgGEVw=="],
 
-    "@miladyai/homepage/jsdom/parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
-
-    "@miladyai/homepage/jsdom/tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
-
-    "@miladyai/homepage/jsdom/webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
-
     "@miladyai/homepage/jsdom/whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
 
     "@miladyai/ui/jsdom/@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@7.0.8", "", { "dependencies": { "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.2.1", "is-potential-custom-element-name": "^1.0.1" } }, "sha512-erMO6FgtM02dC24NGm0xufMzWz5OF0wXKR7BpvGD973bq/GbmR8/DbxNZbj0YevQ5hlToJaWSVK/G9/NDgGEVw=="],
-
-    "@miladyai/ui/jsdom/parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
-
-    "@miladyai/ui/jsdom/tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
-
-    "@miladyai/ui/jsdom/webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
 
     "@miladyai/ui/jsdom/whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
 
@@ -7247,8 +7159,6 @@
 
     "data-urls/whatwg-url/tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
 
-    "data-urls/whatwg-url/webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
-
     "degenerator/ast-types/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "elizaos/@clack/prompts/@clack/core": ["@clack/core@0.5.0", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow=="],
@@ -7296,10 +7206,6 @@
     "ipull/slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "jayson/@types/ws/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
-
-    "jsdom/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
-
-    "jsdom/tough-cookie/tldts": ["tldts@7.0.28", "", { "dependencies": { "tldts-core": "^7.0.28" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw=="],
 
     "jsdom/whatwg-url/tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
 
@@ -7408,6 +7314,8 @@
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 
     "@discordjs/node-pre-gyp/rimraf/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "@distube/ytdl-core/tough-cookie/tldts/tldts-core": ["tldts-core@6.1.86", "", {}, "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="],
 
     "@elizaos-plugins/client-telegram-account/glob/jackspeak/@isaacs/cliui": ["@isaacs/cliui@9.0.0", "", {}, "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg=="],
 
@@ -7551,15 +7459,7 @@
 
     "@miladyai/capacitor-gateway/eslint/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "@miladyai/homepage/jsdom/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
-
-    "@miladyai/homepage/jsdom/tough-cookie/tldts": ["tldts@7.0.28", "", { "dependencies": { "tldts-core": "^7.0.28" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw=="],
-
     "@miladyai/homepage/jsdom/whatwg-url/tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
-
-    "@miladyai/ui/jsdom/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
-
-    "@miladyai/ui/jsdom/tough-cookie/tldts": ["tldts@7.0.28", "", { "dependencies": { "tldts-core": "^7.0.28" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw=="],
 
     "@miladyai/ui/jsdom/whatwg-url/tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
 
@@ -7588,8 +7488,6 @@
     "input/chalk/strip-ansi/ansi-regex": ["ansi-regex@2.1.1", "", {}, "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="],
 
     "inquirer/cli-cursor/restore-cursor/onetime": ["onetime@1.1.0", "", {}, "sha512-GZ+g4jayMqzCRMgB2sol7GiCLjKfS1PINkjmx8spcKce1LiVqcbQreXwqs2YAFXC6R03VIG28ZS31t8M866v6A=="],
-
-    "jsdom/tough-cookie/tldts/tldts-core": ["tldts-core@7.0.28", "", {}, "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ=="],
 
     "node-edge-tts/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -7656,10 +7554,6 @@
     "@miladyai/capacitor-gateway/eslint/file-entry-cache/flat-cache/rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
 
     "@miladyai/capacitor-gateway/eslint/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
-
-    "@miladyai/homepage/jsdom/tough-cookie/tldts/tldts-core": ["tldts-core@7.0.28", "", {}, "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ=="],
-
-    "@miladyai/ui/jsdom/tough-cookie/tldts/tldts-core": ["tldts-core@7.0.28", "", {}, "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ=="],
 
     "@puppeteer/browsers/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -93,6 +93,7 @@
         "@types/ws": "^8.18.1",
         "@vitest/coverage-v8": "^4.1.0",
         "@vitest/utils": "4.1.0",
+        "jsdom": "^28.1.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-test-renderer": "^19.2.4",
@@ -547,6 +548,7 @@
         "@elizaos/plugin-trust": "workspace:*",
         "@hapi/boom": "^10.0.1",
         "@mariozechner/pi-ai": "0.52.12",
+        "@miladyai/plugin-2004scape": "workspace:*",
         "@miladyai/plugin-roles": "github:milady-ai/plugin-roles#5b00c49",
         "@miladyai/plugin-selfcontrol": "workspace:*",
         "@miladyai/plugin-wechat": "github:milady-ai/plugin-wechat",
@@ -1180,38 +1182,6 @@
         "@elizaos/core": "workspace:*",
       },
     },
-    "plugins/plugin-groq": {
-      "name": "@elizaos/plugin-groq-root",
-      "version": "2.0.0-alpha.1",
-      "dependencies": {
-        "@ai-sdk/groq": "latest",
-        "ai": "latest",
-      },
-      "devDependencies": {
-        "@biomejs/biome": "^2.3.11",
-        "@types/bun": "^1.3.5",
-        "@types/node": "^25.0.3",
-        "typescript": "^5.9.3",
-      },
-      "peerDependencies": {
-        "@elizaos/core": "workspace:*",
-      },
-    },
-    "plugins/plugin-groq/typescript": {
-      "name": "@elizaos/plugin-groq",
-      "version": "2.0.0-alpha.8",
-      "dependencies": {
-        "@ai-sdk/groq": "^3.0.4",
-        "@elizaos/core": "workspace:*",
-        "ai": "^6.0.0",
-      },
-      "devDependencies": {
-        "@biomejs/biome": "^2.3.11",
-        "@types/bun": "^1.3.10",
-        "@types/node": "^25.0.3",
-        "typescript": "^5.9.3",
-      },
-    },
     "plugins/plugin-local-embedding": {
       "name": "@elizaos/plugin-local-embedding-root",
       "version": "1.2.1",
@@ -1319,44 +1289,6 @@
       "peerDependencies": {
         "@elizaos/core": "workspace:*",
         "zod": "^4.3.6",
-      },
-    },
-    "plugins/plugin-openrouter": {
-      "name": "@elizaos/plugin-openrouter-root",
-      "version": "2.0.0-alpha.1",
-      "devDependencies": {
-        "@biomejs/biome": "^2.3.11",
-        "@types/bun": "^1.3.5",
-        "@types/node": "^25.0.3",
-        "typescript": "^5.9.3",
-      },
-      "peerDependencies": {
-        "@elizaos/core": "workspace:*",
-      },
-    },
-    "plugins/plugin-openrouter/typescript": {
-      "name": "@elizaos/plugin-openrouter",
-      "version": "2.0.0-alpha.13",
-      "dependencies": {
-        "@ai-sdk/openai": "^3.0.9",
-        "@ai-sdk/ui-utils": "^1.2.8",
-        "@openrouter/ai-sdk-provider": "^1.2.0",
-        "ai": "^6.0.30",
-        "undici": "^7.16.0",
-      },
-      "devDependencies": {
-        "@biomejs/biome": "^2.3.11",
-        "@elizaos/core": "workspace:*",
-        "@elizaos/plugin-sql": "workspace:*",
-        "@types/bun": "^1.3.5",
-        "@types/json-schema": "^7.0.15",
-        "@types/node": "^25.0.3",
-        "dotenv": "^17.2.3",
-        "typescript": "^5.9.3",
-        "vitest": "^4.0.0",
-      },
-      "peerDependencies": {
-        "@elizaos/core": "workspace:*",
       },
     },
     "plugins/plugin-pdf": {
@@ -1725,8 +1657,6 @@
 
     "@ai-sdk/google": ["@ai-sdk/google@3.0.60", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ye/hG0LeO24VmjLbfgkFZV8V8k/l4nVBODutpJQkFPyUiGOCbFtFUTgxSeC7+njrk5+HhgyHrzJay4zmhwMH+w=="],
 
-    "@ai-sdk/groq": ["@ai-sdk/groq@3.0.31", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.21" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-XbbugpnFmXGu2TlXiq8KUJskP6/VVbuFcnFIGDzDIB/Chg6XHsNnqrTF80Zxkh0Pd3+NvbM+2Uqrtsndk6bDAg=="],
-
     "@ai-sdk/openai": ["@ai-sdk/openai@3.0.52", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-4Rr8NCGmfWTz6DCUvixn9UmyZcMatiHn0zWoMzI3JCUe9R1P/vsPOpCBALKoSzVYOjyJnhtnVIbfUKujcS39uw=="],
 
     "@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
@@ -2047,10 +1977,6 @@
 
     "@elizaos/plugin-google-genai-root": ["@elizaos/plugin-google-genai-root@workspace:plugins/plugin-google-genai"],
 
-    "@elizaos/plugin-groq": ["@elizaos/plugin-groq@workspace:plugins/plugin-groq/typescript"],
-
-    "@elizaos/plugin-groq-root": ["@elizaos/plugin-groq-root@workspace:plugins/plugin-groq"],
-
     "@elizaos/plugin-local-embedding": ["@elizaos/plugin-local-embedding@workspace:plugins/plugin-local-embedding/typescript"],
 
     "@elizaos/plugin-local-embedding-root": ["@elizaos/plugin-local-embedding-root@workspace:plugins/plugin-local-embedding"],
@@ -2067,9 +1993,7 @@
 
     "@elizaos/plugin-openai-root": ["@elizaos/plugin-openai-root@workspace:plugins/plugin-openai"],
 
-    "@elizaos/plugin-openrouter": ["@elizaos/plugin-openrouter@workspace:plugins/plugin-openrouter/typescript"],
-
-    "@elizaos/plugin-openrouter-root": ["@elizaos/plugin-openrouter-root@workspace:plugins/plugin-openrouter"],
+    "@elizaos/plugin-openrouter": ["@elizaos/plugin-openrouter@2.0.0-alpha.13", "", { "dependencies": { "@ai-sdk/openai": "^3.0.9", "@ai-sdk/ui-utils": "^1.2.8", "@openrouter/ai-sdk-provider": "^1.2.0", "ai": "^6.0.30", "undici": "^7.16.0" }, "peerDependencies": { "@elizaos/core": "2.0.0-alpha.114" } }, "sha512-1QFAOhtX2TtWwie1z2MXukhjH9hBBeuWAzHzT5PtDAlsJRtlJ9AiudqDTiZhXMD06GtvN20jqBdVJD+SiXpDVg=="],
 
     "@elizaos/plugin-pdf": ["@elizaos/plugin-pdf@workspace:plugins/plugin-pdf/typescript"],
 
@@ -4919,7 +4843,7 @@
 
     "parse-ms": ["parse-ms@4.0.0", "", {}, "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="],
 
-    "parse5": ["parse5@5.1.1", "", {}, "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="],
+    "parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
 
     "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@6.0.1", "", { "dependencies": { "parse5": "^6.0.1" } }, "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA=="],
 
@@ -5443,15 +5367,15 @@
 
     "tinyspy": ["tinyspy@3.0.2", "", {}, "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q=="],
 
-    "tldts": ["tldts@6.1.86", "", { "dependencies": { "tldts-core": "^6.1.86" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ=="],
+    "tldts": ["tldts@7.0.28", "", { "dependencies": { "tldts-core": "^7.0.28" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw=="],
 
-    "tldts-core": ["tldts-core@6.1.86", "", {}, "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="],
+    "tldts-core": ["tldts-core@7.0.28", "", {}, "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
     "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
 
-    "tough-cookie": ["tough-cookie@5.1.2", "", { "dependencies": { "tldts": "^6.1.32" } }, "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A=="],
+    "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
 
     "tr46": ["tr46@1.0.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA=="],
 
@@ -5619,7 +5543,7 @@
 
     "webdriver-bidi-protocol": ["webdriver-bidi-protocol@0.4.1", "", {}, "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw=="],
 
-    "webidl-conversions": ["webidl-conversions@4.0.2", "", {}, "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="],
+    "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
 
     "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
 
@@ -5700,8 +5624,6 @@
     "zustand": ["zustand@5.0.12", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
-
-    "@ai-sdk/groq/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.21", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw=="],
 
     "@ai-sdk/ui-utils/@ai-sdk/provider": ["@ai-sdk/provider@1.1.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg=="],
 
@@ -5839,6 +5761,8 @@
 
     "@discordjs/ws/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@distube/ytdl-core/tough-cookie": ["tough-cookie@5.1.2", "", { "dependencies": { "tldts": "^6.1.32" } }, "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A=="],
+
     "@elizaos-plugins/client-telegram-account/glob": ["glob@11.0.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^4.0.1", "minimatch": "^10.0.0", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^2.0.0" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g=="],
 
     "@elizaos/daemon/@biomejs/biome": ["@biomejs/biome@1.9.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "1.9.4", "@biomejs/cli-darwin-x64": "1.9.4", "@biomejs/cli-linux-arm64": "1.9.4", "@biomejs/cli-linux-arm64-musl": "1.9.4", "@biomejs/cli-linux-x64": "1.9.4", "@biomejs/cli-linux-x64-musl": "1.9.4", "@biomejs/cli-win32-arm64": "1.9.4", "@biomejs/cli-win32-x64": "1.9.4" }, "bin": { "biome": "bin/biome" } }, "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog=="],
@@ -5873,7 +5797,7 @@
 
     "@elizaos/plugin-edge-tts/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
 
-    "@elizaos/plugin-form/uuid": ["uuid@11.0.5", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA=="],
+    "@elizaos/plugin-form/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
     "@elizaos/plugin-local-embedding/@types/uuid": ["@types/uuid@10.0.0", "", {}, "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="],
 
@@ -6023,8 +5947,6 @@
 
     "@miladyai/agent/@elizaos/plugin-solana": ["@elizaos/plugin-solana@1.2.6", "", { "dependencies": { "@solana/spl-token": "0.4.14", "@solana/spl-token-metadata": "^0.1.6", "@solana/web3.js": "^1.98.0", "bignumber.js": "9.3.0", "bs58": "6.0.0", "tweetnacl": "^1.0.3" }, "peerDependencies": { "@elizaos/core": "latest", "@elizaos/service-interfaces": "latest", "form-data": "4.0.2", "whatwg-url": "7.1.0" } }, "sha512-VWp4u2jOkEOgqNNaVN8j3g2TWKwq56GZzIawFPsr6YsF4NuCiQOaWfmeq+edVxpze5LkkzVfC/KPeU19jjZDuA=="],
 
-    "@miladyai/agent/@miladyai/plugin-roles": ["@miladyai/plugin-roles@github:milady-ai/plugin-roles#5b00c49", { "peerDependencies": { "@elizaos/core": "alpha" } }, "milady-ai-plugin-roles-5b00c49", "sha512-QxrX3mPn9KLdor5PdRyVqYzOxVbIfR4cNW9YfqWL3jCE35zg6g1Pu0E9MDkTFmNOFbyjvCnkrFLxZtZfGdlu+A=="],
-
     "@miladyai/app/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
 
     "@miladyai/app/vitest": ["vitest@2.1.9", "", { "dependencies": { "@vitest/expect": "2.1.9", "@vitest/mocker": "2.1.9", "@vitest/pretty-format": "^2.1.9", "@vitest/runner": "2.1.9", "@vitest/snapshot": "2.1.9", "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "debug": "^4.3.7", "expect-type": "^1.1.0", "magic-string": "^0.30.12", "pathe": "^1.1.2", "std-env": "^3.8.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.1", "tinypool": "^1.0.1", "tinyrainbow": "^1.2.0", "vite": "^5.0.0", "vite-node": "2.1.9", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/node": "^18.0.0 || >=20.0.0", "@vitest/browser": "2.1.9", "@vitest/ui": "2.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q=="],
@@ -6044,8 +5966,6 @@
     "@miladyai/homepage/three": ["three@0.183.2", "", {}, "sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ=="],
 
     "@miladyai/homepage/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
-
-    "@miladyai/plugin-selfcontrol/@miladyai/plugin-roles": ["@miladyai/plugin-roles@github:milady-ai/plugin-roles#5b00c49", { "peerDependencies": { "@elizaos/core": "alpha" } }, "milady-ai-plugin-roles-5b00c49", "sha512-QxrX3mPn9KLdor5PdRyVqYzOxVbIfR4cNW9YfqWL3jCE35zg6g1Pu0E9MDkTFmNOFbyjvCnkrFLxZtZfGdlu+A=="],
 
     "@miladyai/ui/jsdom": ["jsdom@29.0.2", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.5", "@asamuzakjp/dom-selector": "^7.0.6", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.1", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.2.7", "parse5": "^8.0.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.24.5", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w=="],
 
@@ -6293,6 +6213,8 @@
 
     "cli-highlight/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
+    "cli-highlight/parse5": ["parse5@5.1.1", "", {}, "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="],
+
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "clone-response/mimic-response": ["mimic-response@1.0.1", "", {}, "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="],
@@ -6441,12 +6363,6 @@
 
     "js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
-    "jsdom/parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
-
-    "jsdom/tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
-
-    "jsdom/webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
-
     "jsdom/whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
 
     "jszip/pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
@@ -6516,6 +6432,8 @@
     "p-queue/p-timeout": ["p-timeout@7.0.1", "", {}, "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
 
@@ -6653,6 +6571,8 @@
 
     "websocket/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
+    "whatwg-url/webidl-conversions": ["webidl-conversions@4.0.2", "", {}, "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="],
+
     "which-builtin-type/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
@@ -6682,6 +6602,8 @@
     "@discordjs/node-pre-gyp/make-dir/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@discordjs/node-pre-gyp/rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
+
+    "@distube/ytdl-core/tough-cookie/tldts": ["tldts@6.1.86", "", { "dependencies": { "tldts-core": "^6.1.86" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ=="],
 
     "@elizaos-plugins/client-telegram-account/glob/jackspeak": ["jackspeak@4.2.3", "", { "dependencies": { "@isaacs/cliui": "^9.0.0" } }, "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg=="],
 
@@ -7153,21 +7075,9 @@
 
     "@miladyai/homepage/jsdom/@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@7.0.8", "", { "dependencies": { "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.2.1", "is-potential-custom-element-name": "^1.0.1" } }, "sha512-erMO6FgtM02dC24NGm0xufMzWz5OF0wXKR7BpvGD973bq/GbmR8/DbxNZbj0YevQ5hlToJaWSVK/G9/NDgGEVw=="],
 
-    "@miladyai/homepage/jsdom/parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
-
-    "@miladyai/homepage/jsdom/tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
-
-    "@miladyai/homepage/jsdom/webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
-
     "@miladyai/homepage/jsdom/whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
 
     "@miladyai/ui/jsdom/@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@7.0.8", "", { "dependencies": { "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.2.1", "is-potential-custom-element-name": "^1.0.1" } }, "sha512-erMO6FgtM02dC24NGm0xufMzWz5OF0wXKR7BpvGD973bq/GbmR8/DbxNZbj0YevQ5hlToJaWSVK/G9/NDgGEVw=="],
-
-    "@miladyai/ui/jsdom/parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
-
-    "@miladyai/ui/jsdom/tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
-
-    "@miladyai/ui/jsdom/webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
 
     "@miladyai/ui/jsdom/whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
 
@@ -7247,8 +7157,6 @@
 
     "data-urls/whatwg-url/tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
 
-    "data-urls/whatwg-url/webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
-
     "degenerator/ast-types/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "elizaos/@clack/prompts/@clack/core": ["@clack/core@0.5.0", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow=="],
@@ -7296,10 +7204,6 @@
     "ipull/slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "jayson/@types/ws/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
-
-    "jsdom/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
-
-    "jsdom/tough-cookie/tldts": ["tldts@7.0.28", "", { "dependencies": { "tldts-core": "^7.0.28" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw=="],
 
     "jsdom/whatwg-url/tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
 
@@ -7408,6 +7312,8 @@
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 
     "@discordjs/node-pre-gyp/rimraf/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "@distube/ytdl-core/tough-cookie/tldts/tldts-core": ["tldts-core@6.1.86", "", {}, "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="],
 
     "@elizaos-plugins/client-telegram-account/glob/jackspeak/@isaacs/cliui": ["@isaacs/cliui@9.0.0", "", {}, "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg=="],
 
@@ -7551,15 +7457,7 @@
 
     "@miladyai/capacitor-gateway/eslint/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "@miladyai/homepage/jsdom/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
-
-    "@miladyai/homepage/jsdom/tough-cookie/tldts": ["tldts@7.0.28", "", { "dependencies": { "tldts-core": "^7.0.28" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw=="],
-
     "@miladyai/homepage/jsdom/whatwg-url/tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
-
-    "@miladyai/ui/jsdom/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
-
-    "@miladyai/ui/jsdom/tough-cookie/tldts": ["tldts@7.0.28", "", { "dependencies": { "tldts-core": "^7.0.28" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw=="],
 
     "@miladyai/ui/jsdom/whatwg-url/tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
 
@@ -7588,8 +7486,6 @@
     "input/chalk/strip-ansi/ansi-regex": ["ansi-regex@2.1.1", "", {}, "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="],
 
     "inquirer/cli-cursor/restore-cursor/onetime": ["onetime@1.1.0", "", {}, "sha512-GZ+g4jayMqzCRMgB2sol7GiCLjKfS1PINkjmx8spcKce1LiVqcbQreXwqs2YAFXC6R03VIG28ZS31t8M866v6A=="],
-
-    "jsdom/tough-cookie/tldts/tldts-core": ["tldts-core@7.0.28", "", {}, "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ=="],
 
     "node-edge-tts/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -7656,10 +7552,6 @@
     "@miladyai/capacitor-gateway/eslint/file-entry-cache/flat-cache/rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
 
     "@miladyai/capacitor-gateway/eslint/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
-
-    "@miladyai/homepage/jsdom/tough-cookie/tldts/tldts-core": ["tldts-core@7.0.28", "", {}, "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ=="],
-
-    "@miladyai/ui/jsdom/tough-cookie/tldts/tldts-core": ["tldts-core@7.0.28", "", {}, "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ=="],
 
     "@puppeteer/browsers/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -93,7 +93,6 @@
         "@types/ws": "^8.18.1",
         "@vitest/coverage-v8": "^4.1.0",
         "@vitest/utils": "4.1.0",
-        "jsdom": "^28.1.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-test-renderer": "^19.2.4",
@@ -548,7 +547,6 @@
         "@elizaos/plugin-trust": "workspace:*",
         "@hapi/boom": "^10.0.1",
         "@mariozechner/pi-ai": "0.52.12",
-        "@miladyai/plugin-2004scape": "workspace:*",
         "@miladyai/plugin-roles": "github:milady-ai/plugin-roles#5b00c49",
         "@miladyai/plugin-selfcontrol": "workspace:*",
         "@miladyai/plugin-wechat": "github:milady-ai/plugin-wechat",
@@ -1182,6 +1180,38 @@
         "@elizaos/core": "workspace:*",
       },
     },
+    "plugins/plugin-groq": {
+      "name": "@elizaos/plugin-groq-root",
+      "version": "2.0.0-alpha.1",
+      "dependencies": {
+        "@ai-sdk/groq": "latest",
+        "ai": "latest",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^2.3.11",
+        "@types/bun": "^1.3.5",
+        "@types/node": "^25.0.3",
+        "typescript": "^5.9.3",
+      },
+      "peerDependencies": {
+        "@elizaos/core": "workspace:*",
+      },
+    },
+    "plugins/plugin-groq/typescript": {
+      "name": "@elizaos/plugin-groq",
+      "version": "2.0.0-alpha.8",
+      "dependencies": {
+        "@ai-sdk/groq": "^3.0.4",
+        "@elizaos/core": "workspace:*",
+        "ai": "^6.0.0",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^2.3.11",
+        "@types/bun": "^1.3.10",
+        "@types/node": "^25.0.3",
+        "typescript": "^5.9.3",
+      },
+    },
     "plugins/plugin-local-embedding": {
       "name": "@elizaos/plugin-local-embedding-root",
       "version": "1.2.1",
@@ -1289,6 +1319,44 @@
       "peerDependencies": {
         "@elizaos/core": "workspace:*",
         "zod": "^4.3.6",
+      },
+    },
+    "plugins/plugin-openrouter": {
+      "name": "@elizaos/plugin-openrouter-root",
+      "version": "2.0.0-alpha.1",
+      "devDependencies": {
+        "@biomejs/biome": "^2.3.11",
+        "@types/bun": "^1.3.5",
+        "@types/node": "^25.0.3",
+        "typescript": "^5.9.3",
+      },
+      "peerDependencies": {
+        "@elizaos/core": "workspace:*",
+      },
+    },
+    "plugins/plugin-openrouter/typescript": {
+      "name": "@elizaos/plugin-openrouter",
+      "version": "2.0.0-alpha.13",
+      "dependencies": {
+        "@ai-sdk/openai": "^3.0.9",
+        "@ai-sdk/ui-utils": "^1.2.8",
+        "@openrouter/ai-sdk-provider": "^1.2.0",
+        "ai": "^6.0.30",
+        "undici": "^7.16.0",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^2.3.11",
+        "@elizaos/core": "workspace:*",
+        "@elizaos/plugin-sql": "workspace:*",
+        "@types/bun": "^1.3.5",
+        "@types/json-schema": "^7.0.15",
+        "@types/node": "^25.0.3",
+        "dotenv": "^17.2.3",
+        "typescript": "^5.9.3",
+        "vitest": "^4.0.0",
+      },
+      "peerDependencies": {
+        "@elizaos/core": "workspace:*",
       },
     },
     "plugins/plugin-pdf": {
@@ -1657,6 +1725,8 @@
 
     "@ai-sdk/google": ["@ai-sdk/google@3.0.60", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ye/hG0LeO24VmjLbfgkFZV8V8k/l4nVBODutpJQkFPyUiGOCbFtFUTgxSeC7+njrk5+HhgyHrzJay4zmhwMH+w=="],
 
+    "@ai-sdk/groq": ["@ai-sdk/groq@3.0.31", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.21" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-XbbugpnFmXGu2TlXiq8KUJskP6/VVbuFcnFIGDzDIB/Chg6XHsNnqrTF80Zxkh0Pd3+NvbM+2Uqrtsndk6bDAg=="],
+
     "@ai-sdk/openai": ["@ai-sdk/openai@3.0.52", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-4Rr8NCGmfWTz6DCUvixn9UmyZcMatiHn0zWoMzI3JCUe9R1P/vsPOpCBALKoSzVYOjyJnhtnVIbfUKujcS39uw=="],
 
     "@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
@@ -1977,6 +2047,10 @@
 
     "@elizaos/plugin-google-genai-root": ["@elizaos/plugin-google-genai-root@workspace:plugins/plugin-google-genai"],
 
+    "@elizaos/plugin-groq": ["@elizaos/plugin-groq@workspace:plugins/plugin-groq/typescript"],
+
+    "@elizaos/plugin-groq-root": ["@elizaos/plugin-groq-root@workspace:plugins/plugin-groq"],
+
     "@elizaos/plugin-local-embedding": ["@elizaos/plugin-local-embedding@workspace:plugins/plugin-local-embedding/typescript"],
 
     "@elizaos/plugin-local-embedding-root": ["@elizaos/plugin-local-embedding-root@workspace:plugins/plugin-local-embedding"],
@@ -1993,7 +2067,9 @@
 
     "@elizaos/plugin-openai-root": ["@elizaos/plugin-openai-root@workspace:plugins/plugin-openai"],
 
-    "@elizaos/plugin-openrouter": ["@elizaos/plugin-openrouter@2.0.0-alpha.13", "", { "dependencies": { "@ai-sdk/openai": "^3.0.9", "@ai-sdk/ui-utils": "^1.2.8", "@openrouter/ai-sdk-provider": "^1.2.0", "ai": "^6.0.30", "undici": "^7.16.0" }, "peerDependencies": { "@elizaos/core": "2.0.0-alpha.114" } }, "sha512-1QFAOhtX2TtWwie1z2MXukhjH9hBBeuWAzHzT5PtDAlsJRtlJ9AiudqDTiZhXMD06GtvN20jqBdVJD+SiXpDVg=="],
+    "@elizaos/plugin-openrouter": ["@elizaos/plugin-openrouter@workspace:plugins/plugin-openrouter/typescript"],
+
+    "@elizaos/plugin-openrouter-root": ["@elizaos/plugin-openrouter-root@workspace:plugins/plugin-openrouter"],
 
     "@elizaos/plugin-pdf": ["@elizaos/plugin-pdf@workspace:plugins/plugin-pdf/typescript"],
 
@@ -4843,7 +4919,7 @@
 
     "parse-ms": ["parse-ms@4.0.0", "", {}, "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="],
 
-    "parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
+    "parse5": ["parse5@5.1.1", "", {}, "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="],
 
     "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@6.0.1", "", { "dependencies": { "parse5": "^6.0.1" } }, "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA=="],
 
@@ -5367,15 +5443,15 @@
 
     "tinyspy": ["tinyspy@3.0.2", "", {}, "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q=="],
 
-    "tldts": ["tldts@7.0.28", "", { "dependencies": { "tldts-core": "^7.0.28" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw=="],
+    "tldts": ["tldts@6.1.86", "", { "dependencies": { "tldts-core": "^6.1.86" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ=="],
 
-    "tldts-core": ["tldts-core@7.0.28", "", {}, "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ=="],
+    "tldts-core": ["tldts-core@6.1.86", "", {}, "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
     "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
 
-    "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
+    "tough-cookie": ["tough-cookie@5.1.2", "", { "dependencies": { "tldts": "^6.1.32" } }, "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A=="],
 
     "tr46": ["tr46@1.0.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA=="],
 
@@ -5543,7 +5619,7 @@
 
     "webdriver-bidi-protocol": ["webdriver-bidi-protocol@0.4.1", "", {}, "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw=="],
 
-    "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
+    "webidl-conversions": ["webidl-conversions@4.0.2", "", {}, "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="],
 
     "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
 
@@ -5624,6 +5700,8 @@
     "zustand": ["zustand@5.0.12", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@ai-sdk/groq/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.21", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw=="],
 
     "@ai-sdk/ui-utils/@ai-sdk/provider": ["@ai-sdk/provider@1.1.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg=="],
 
@@ -5761,8 +5839,6 @@
 
     "@discordjs/ws/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "@distube/ytdl-core/tough-cookie": ["tough-cookie@5.1.2", "", { "dependencies": { "tldts": "^6.1.32" } }, "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A=="],
-
     "@elizaos-plugins/client-telegram-account/glob": ["glob@11.0.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^4.0.1", "minimatch": "^10.0.0", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^2.0.0" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g=="],
 
     "@elizaos/daemon/@biomejs/biome": ["@biomejs/biome@1.9.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "1.9.4", "@biomejs/cli-darwin-x64": "1.9.4", "@biomejs/cli-linux-arm64": "1.9.4", "@biomejs/cli-linux-arm64-musl": "1.9.4", "@biomejs/cli-linux-x64": "1.9.4", "@biomejs/cli-linux-x64-musl": "1.9.4", "@biomejs/cli-win32-arm64": "1.9.4", "@biomejs/cli-win32-x64": "1.9.4" }, "bin": { "biome": "bin/biome" } }, "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog=="],
@@ -5797,7 +5873,7 @@
 
     "@elizaos/plugin-edge-tts/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
 
-    "@elizaos/plugin-form/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
+    "@elizaos/plugin-form/uuid": ["uuid@11.0.5", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA=="],
 
     "@elizaos/plugin-local-embedding/@types/uuid": ["@types/uuid@10.0.0", "", {}, "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="],
 
@@ -5947,6 +6023,8 @@
 
     "@miladyai/agent/@elizaos/plugin-solana": ["@elizaos/plugin-solana@1.2.6", "", { "dependencies": { "@solana/spl-token": "0.4.14", "@solana/spl-token-metadata": "^0.1.6", "@solana/web3.js": "^1.98.0", "bignumber.js": "9.3.0", "bs58": "6.0.0", "tweetnacl": "^1.0.3" }, "peerDependencies": { "@elizaos/core": "latest", "@elizaos/service-interfaces": "latest", "form-data": "4.0.2", "whatwg-url": "7.1.0" } }, "sha512-VWp4u2jOkEOgqNNaVN8j3g2TWKwq56GZzIawFPsr6YsF4NuCiQOaWfmeq+edVxpze5LkkzVfC/KPeU19jjZDuA=="],
 
+    "@miladyai/agent/@miladyai/plugin-roles": ["@miladyai/plugin-roles@github:milady-ai/plugin-roles#5b00c49", { "peerDependencies": { "@elizaos/core": "alpha" } }, "milady-ai-plugin-roles-5b00c49", "sha512-QxrX3mPn9KLdor5PdRyVqYzOxVbIfR4cNW9YfqWL3jCE35zg6g1Pu0E9MDkTFmNOFbyjvCnkrFLxZtZfGdlu+A=="],
+
     "@miladyai/app/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
 
     "@miladyai/app/vitest": ["vitest@2.1.9", "", { "dependencies": { "@vitest/expect": "2.1.9", "@vitest/mocker": "2.1.9", "@vitest/pretty-format": "^2.1.9", "@vitest/runner": "2.1.9", "@vitest/snapshot": "2.1.9", "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "debug": "^4.3.7", "expect-type": "^1.1.0", "magic-string": "^0.30.12", "pathe": "^1.1.2", "std-env": "^3.8.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.1", "tinypool": "^1.0.1", "tinyrainbow": "^1.2.0", "vite": "^5.0.0", "vite-node": "2.1.9", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/node": "^18.0.0 || >=20.0.0", "@vitest/browser": "2.1.9", "@vitest/ui": "2.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q=="],
@@ -5966,6 +6044,8 @@
     "@miladyai/homepage/three": ["three@0.183.2", "", {}, "sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ=="],
 
     "@miladyai/homepage/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+
+    "@miladyai/plugin-selfcontrol/@miladyai/plugin-roles": ["@miladyai/plugin-roles@github:milady-ai/plugin-roles#5b00c49", { "peerDependencies": { "@elizaos/core": "alpha" } }, "milady-ai-plugin-roles-5b00c49", "sha512-QxrX3mPn9KLdor5PdRyVqYzOxVbIfR4cNW9YfqWL3jCE35zg6g1Pu0E9MDkTFmNOFbyjvCnkrFLxZtZfGdlu+A=="],
 
     "@miladyai/ui/jsdom": ["jsdom@29.0.2", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.5", "@asamuzakjp/dom-selector": "^7.0.6", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.1", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.2.7", "parse5": "^8.0.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.24.5", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w=="],
 
@@ -6213,8 +6293,6 @@
 
     "cli-highlight/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
-    "cli-highlight/parse5": ["parse5@5.1.1", "", {}, "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="],
-
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "clone-response/mimic-response": ["mimic-response@1.0.1", "", {}, "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="],
@@ -6363,6 +6441,12 @@
 
     "js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
+    "jsdom/parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
+
+    "jsdom/tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
+
+    "jsdom/webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
+
     "jsdom/whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
 
     "jszip/pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
@@ -6432,8 +6516,6 @@
     "p-queue/p-timeout": ["p-timeout@7.0.1", "", {}, "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
-
-    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
 
@@ -6571,8 +6653,6 @@
 
     "websocket/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
-    "whatwg-url/webidl-conversions": ["webidl-conversions@4.0.2", "", {}, "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="],
-
     "which-builtin-type/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
@@ -6602,8 +6682,6 @@
     "@discordjs/node-pre-gyp/make-dir/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@discordjs/node-pre-gyp/rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
-
-    "@distube/ytdl-core/tough-cookie/tldts": ["tldts@6.1.86", "", { "dependencies": { "tldts-core": "^6.1.86" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ=="],
 
     "@elizaos-plugins/client-telegram-account/glob/jackspeak": ["jackspeak@4.2.3", "", { "dependencies": { "@isaacs/cliui": "^9.0.0" } }, "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg=="],
 
@@ -7075,9 +7153,21 @@
 
     "@miladyai/homepage/jsdom/@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@7.0.8", "", { "dependencies": { "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.2.1", "is-potential-custom-element-name": "^1.0.1" } }, "sha512-erMO6FgtM02dC24NGm0xufMzWz5OF0wXKR7BpvGD973bq/GbmR8/DbxNZbj0YevQ5hlToJaWSVK/G9/NDgGEVw=="],
 
+    "@miladyai/homepage/jsdom/parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
+
+    "@miladyai/homepage/jsdom/tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
+
+    "@miladyai/homepage/jsdom/webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
+
     "@miladyai/homepage/jsdom/whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
 
     "@miladyai/ui/jsdom/@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@7.0.8", "", { "dependencies": { "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.2.1", "is-potential-custom-element-name": "^1.0.1" } }, "sha512-erMO6FgtM02dC24NGm0xufMzWz5OF0wXKR7BpvGD973bq/GbmR8/DbxNZbj0YevQ5hlToJaWSVK/G9/NDgGEVw=="],
+
+    "@miladyai/ui/jsdom/parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
+
+    "@miladyai/ui/jsdom/tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
+
+    "@miladyai/ui/jsdom/webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
 
     "@miladyai/ui/jsdom/whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
 
@@ -7157,6 +7247,8 @@
 
     "data-urls/whatwg-url/tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
 
+    "data-urls/whatwg-url/webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
+
     "degenerator/ast-types/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "elizaos/@clack/prompts/@clack/core": ["@clack/core@0.5.0", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow=="],
@@ -7204,6 +7296,10 @@
     "ipull/slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "jayson/@types/ws/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
+
+    "jsdom/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "jsdom/tough-cookie/tldts": ["tldts@7.0.28", "", { "dependencies": { "tldts-core": "^7.0.28" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw=="],
 
     "jsdom/whatwg-url/tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
 
@@ -7312,8 +7408,6 @@
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 
     "@discordjs/node-pre-gyp/rimraf/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
-
-    "@distube/ytdl-core/tough-cookie/tldts/tldts-core": ["tldts-core@6.1.86", "", {}, "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="],
 
     "@elizaos-plugins/client-telegram-account/glob/jackspeak/@isaacs/cliui": ["@isaacs/cliui@9.0.0", "", {}, "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg=="],
 
@@ -7457,7 +7551,15 @@
 
     "@miladyai/capacitor-gateway/eslint/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
+    "@miladyai/homepage/jsdom/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "@miladyai/homepage/jsdom/tough-cookie/tldts": ["tldts@7.0.28", "", { "dependencies": { "tldts-core": "^7.0.28" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw=="],
+
     "@miladyai/homepage/jsdom/whatwg-url/tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
+
+    "@miladyai/ui/jsdom/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "@miladyai/ui/jsdom/tough-cookie/tldts": ["tldts@7.0.28", "", { "dependencies": { "tldts-core": "^7.0.28" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw=="],
 
     "@miladyai/ui/jsdom/whatwg-url/tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
 
@@ -7486,6 +7588,8 @@
     "input/chalk/strip-ansi/ansi-regex": ["ansi-regex@2.1.1", "", {}, "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="],
 
     "inquirer/cli-cursor/restore-cursor/onetime": ["onetime@1.1.0", "", {}, "sha512-GZ+g4jayMqzCRMgB2sol7GiCLjKfS1PINkjmx8spcKce1LiVqcbQreXwqs2YAFXC6R03VIG28ZS31t8M866v6A=="],
+
+    "jsdom/tough-cookie/tldts/tldts-core": ["tldts-core@7.0.28", "", {}, "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ=="],
 
     "node-edge-tts/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -7552,6 +7656,10 @@
     "@miladyai/capacitor-gateway/eslint/file-entry-cache/flat-cache/rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
 
     "@miladyai/capacitor-gateway/eslint/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "@miladyai/homepage/jsdom/tough-cookie/tldts/tldts-core": ["tldts-core@7.0.28", "", {}, "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ=="],
+
+    "@miladyai/ui/jsdom/tough-cookie/tldts/tldts-core": ["tldts-core@7.0.28", "", {}, "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ=="],
 
     "@puppeteer/browsers/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/packages/agent/src/external-modules.d.ts
+++ b/packages/agent/src/external-modules.d.ts
@@ -1,10 +1,23 @@
 declare module "@elizaos/plugin-coding-agent";
 declare module "@elizaos/plugin-agent-orchestrator";
 declare module "@elizaos/plugin-agent-skills";
+declare module "@elizaos/plugin-anthropic";
 declare module "@elizaos/plugin-elizacloud";
+declare module "@elizaos/plugin-cron";
+declare module "@elizaos/plugin-edge-tts";
+declare module "@elizaos/plugin-edge-tts/node";
+declare module "@elizaos/plugin-experience";
+declare module "@elizaos/plugin-local-embedding";
+declare module "@elizaos/plugin-ollama";
+declare module "@elizaos/plugin-openai";
 declare module "@elizaos/plugin-pi-ai";
+declare module "@elizaos/plugin-personality";
+declare module "@elizaos/plugin-plugin-manager";
 declare module "@elizaos/plugin-commands";
 declare module "@elizaos/plugin-secrets-manager";
+declare module "@elizaos/plugin-shell";
+declare module "@elizaos/plugin-sql";
+declare module "@elizaos/plugin-trust";
 declare module "@elizaos/signal-native";
 declare module "qrcode";
 

--- a/packages/app-core/src/api/__tests__/discord-managed-oauth.test.ts
+++ b/packages/app-core/src/api/__tests__/discord-managed-oauth.test.ts
@@ -169,7 +169,10 @@ describe("managed Discord OAuth init", () => {
         new Response(
           JSON.stringify({
             success: true,
-            data: { authorizeUrl: "https://discord.com/oauth", applicationId: "app-1" },
+            data: {
+              authorizeUrl: "https://discord.com/oauth",
+              applicationId: "app-1",
+            },
           }),
           { status: 200, headers: { "Content-Type": "application/json" } },
         ),
@@ -191,7 +194,10 @@ describe("managed Discord OAuth init", () => {
       botNickname: "Chen",
     });
 
-    const [, init] = fetchMock.mock.calls[0] as [RequestInfo | URL, RequestInit];
+    const [, init] = fetchMock.mock.calls[0] as [
+      RequestInfo | URL,
+      RequestInit,
+    ];
     expect(init?.method).toBe("POST");
 
     const body = JSON.parse(init?.body as string);
@@ -207,7 +213,10 @@ describe("managed Discord OAuth init", () => {
 
     await client.createCloudCompatAgentManagedDiscordOauth("agent-1");
 
-    const [, init] = fetchMock.mock.calls[0] as [RequestInfo | URL, RequestInit];
+    const [, init] = fetchMock.mock.calls[0] as [
+      RequestInfo | URL,
+      RequestInit,
+    ];
     const body = JSON.parse(init?.body as string);
     expect(body).toEqual({});
   });

--- a/packages/app-core/src/api/apps-hyperscape-e2e.test.ts
+++ b/packages/app-core/src/api/apps-hyperscape-e2e.test.ts
@@ -205,26 +205,26 @@ function clonePluginInfo(plugin: RegistryPluginInfo): RegistryPluginInfo {
 function createMockPluginManager(
   plugins: RegistryPluginInfo[] = [HYPERSCAPE_LOCAL_PLUGIN],
 ): PluginManagerLike {
-  const pluginEntries = plugins.map((plugin) => [
-    plugin.name,
-    clonePluginInfo(plugin),
-  ] as const);
+  const pluginEntries = plugins.map(
+    (plugin) => [plugin.name, clonePluginInfo(plugin)] as const,
+  );
   const pluginMap = new Map(pluginEntries);
 
   return {
     refreshRegistry: vi.fn(
       async () =>
         new Map(
-          pluginEntries.map(([name, plugin]) => [name, clonePluginInfo(plugin)]),
+          pluginEntries.map(([name, plugin]) => [
+            name,
+            clonePluginInfo(plugin),
+          ]),
         ),
     ),
     listInstalledPlugins: vi.fn(async () => []),
-    getRegistryPlugin: vi.fn(
-      async (name: string) => {
-        const plugin = pluginMap.get(name);
-        return plugin ? clonePluginInfo(plugin) : null;
-      },
-    ),
+    getRegistryPlugin: vi.fn(async (name: string) => {
+      const plugin = pluginMap.get(name);
+      return plugin ? clonePluginInfo(plugin) : null;
+    }),
     searchRegistry: vi.fn(async (query: string) => {
       const lowerQuery = query.toLowerCase();
       return plugins
@@ -331,9 +331,9 @@ describeIf(hasLocalHyperscapePlugin)("Hyperscape E2E Integration", () => {
       const results = await appManager.search(pluginManager, "rpg");
 
       expect(results.length).toBeGreaterThan(0);
-      expect(results.some((r) => r.name === "@hyperscape/plugin-hyperscape")).toBe(
-        true,
-      );
+      expect(
+        results.some((r) => r.name === "@hyperscape/plugin-hyperscape"),
+      ).toBe(true);
     });
   });
 
@@ -477,7 +477,9 @@ describeIf(hasLocalHyperscapePlugin)("Hyperscape E2E Integration", () => {
     test("complete discovery to launch flow", async () => {
       // Step 1: List apps
       const apps = await appManager.listAvailable(pluginManager);
-      expect(apps.some((a) => a.name === "@hyperscape/plugin-hyperscape")).toBe(true);
+      expect(apps.some((a) => a.name === "@hyperscape/plugin-hyperscape")).toBe(
+        true,
+      );
 
       // Step 2: Get app info
       const info = await appManager.getInfo(

--- a/packages/app-core/src/api/client-agent.ts
+++ b/packages/app-core/src/api/client-agent.ts
@@ -349,7 +349,9 @@ declare module "./client-base" {
       fromSeq?: number;
     }): Promise<AgentEventsResponse>;
     getExtensionStatus(): Promise<ExtensionStatus>;
-    getRelationshipsGraph(query?: RelationshipsGraphQuery): Promise<RelationshipsGraphSnapshot>;
+    getRelationshipsGraph(
+      query?: RelationshipsGraphQuery,
+    ): Promise<RelationshipsGraphSnapshot>;
     getRelationshipsPeople(query?: RelationshipsGraphQuery): Promise<{
       people: RelationshipsPersonSummary[];
       stats: RelationshipsGraphStats;

--- a/packages/app-core/src/api/client-chat.ts
+++ b/packages/app-core/src/api/client-chat.ts
@@ -92,7 +92,11 @@ declare module "./client-base" {
       text: string,
       channelType?: ConversationChannelType,
       conversationMode?: ConversationMode,
-    ): Promise<{ text: string; agentName: string; noResponseReason?: "ignored" }>;
+    ): Promise<{
+      text: string;
+      agentName: string;
+      noResponseReason?: "ignored";
+    }>;
     sendChatStream(
       text: string,
       onToken: (token: string, accumulatedText?: string) => void,

--- a/packages/app-core/src/api/client-relationships.test.ts
+++ b/packages/app-core/src/api/client-relationships.test.ts
@@ -106,7 +106,9 @@ describe("MiladyClient relationships API", () => {
     const client = new MiladyClient("http://127.0.0.1:31337");
     const person = await client.getRelationshipsPerson("person 1");
 
-    expect(fetchSpy).toHaveBeenCalledWith("/api/relationships/people/person%201");
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/relationships/people/person%201",
+    );
     expect(person.displayName).toBe("Chris");
   });
 });

--- a/packages/app-core/src/api/database.readonly-query-guard.test.ts
+++ b/packages/app-core/src/api/database.readonly-query-guard.test.ts
@@ -1,6 +1,14 @@
 import type { AgentRuntime } from "@elizaos/core";
 import { handleDatabaseRoute } from "@miladyai/agent/api/database";
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import { createTestRuntime } from "../../../../test/helpers/pglite-runtime";
 import {
   createMockHttpResponse,

--- a/packages/app-core/src/api/onboarding-compat-routes.ts
+++ b/packages/app-core/src/api/onboarding-compat-routes.ts
@@ -175,7 +175,6 @@ export async function handleOnboardingCompatRoute(
         `[milady-api] Failed to persist onboarding state: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
-
   } catch {
     // JSON parse failed — let upstream handle the error
   }

--- a/packages/app-core/src/api/plugins-compat-routes.ts
+++ b/packages/app-core/src/api/plugins-compat-routes.ts
@@ -629,7 +629,9 @@ export function buildPluginListResponse(runtime: AgentRuntime | null): {
   const configRecord = config as Record<string, unknown>;
   const loadedNames = resolveLoadedPluginNames(runtime);
   const manifestPath = resolvePluginManifestPath();
-  const manifestRoot = manifestPath ? path.dirname(manifestPath) : process.cwd();
+  const manifestRoot = manifestPath
+    ? path.dirname(manifestPath)
+    : process.cwd();
   const manifest = manifestPath
     ? (JSON.parse(fs.readFileSync(manifestPath, "utf8")) as PluginManifestFile)
     : null;
@@ -1044,7 +1046,8 @@ export async function handlePluginsCompatRoutes(
       }
 
       const refreshed = (
-        buildPluginListResponse(state.current).plugins as unknown as CompatPluginRecord[]
+        buildPluginListResponse(state.current)
+          .plugins as unknown as CompatPluginRecord[]
       ).find((candidate) => candidate.id === pluginId);
 
       result.payload.plugin = refreshed ?? result.payload.plugin ?? plugin;

--- a/packages/app-core/src/api/server.no-response-fallback.test.ts
+++ b/packages/app-core/src/api/server.no-response-fallback.test.ts
@@ -341,9 +341,14 @@ describe("conversation no-response fallback", () => {
           }),
       );
 
-      const created = await req(isolatedServer.port, "POST", "/api/conversations", {
-        title: "Timed out fallback thread",
-      });
+      const created = await req(
+        isolatedServer.port,
+        "POST",
+        "/api/conversations",
+        {
+          title: "Timed out fallback thread",
+        },
+      );
       expect(created.status).toBe(200);
       const conversationId = String(
         (created.data.conversation as { id?: string } | undefined)?.id ?? "",

--- a/packages/app-core/src/api/stream-routes.test.ts
+++ b/packages/app-core/src/api/stream-routes.test.ts
@@ -1003,164 +1003,155 @@ async function loadCustomRtmpPlugin(): Promise<{
 // createTwitchDestination() — destination adapter unit tests
 // ---------------------------------------------------------------------------
 
-describeIf(hasTwitchDestinationModule)(
-  "createTwitchDestination()",
-  () => {
-    it("returns a StreamingDestination with id and name", async () => {
+describeIf(hasTwitchDestinationModule)("createTwitchDestination()", () => {
+  it("returns a StreamingDestination with id and name", async () => {
+    const { createTwitchDestination } = await loadTwitchDestinationModule();
+    const dest = createTwitchDestination({ streamKey: "test-key" });
+    expect(dest.id).toBe("twitch");
+    expect(dest.name).toBe("Twitch");
+  });
+
+  it("getCredentials throws when no stream key is configured", async () => {
+    const origKey = process.env.TWITCH_STREAM_KEY;
+    delete process.env.TWITCH_STREAM_KEY;
+
+    try {
       const { createTwitchDestination } = await loadTwitchDestinationModule();
-      const dest = createTwitchDestination({ streamKey: "test-key" });
-      expect(dest.id).toBe("twitch");
-      expect(dest.name).toBe("Twitch");
-    });
+      const dest = createTwitchDestination();
+      await expect(dest.getCredentials()).rejects.toThrow("not configured");
+    } finally {
+      if (origKey !== undefined) process.env.TWITCH_STREAM_KEY = origKey;
+    }
+  });
 
-    it("getCredentials throws when no stream key is configured", async () => {
-      const origKey = process.env.TWITCH_STREAM_KEY;
-      delete process.env.TWITCH_STREAM_KEY;
+  it("getCredentials returns Twitch RTMP URL with config stream key", async () => {
+    const { createTwitchDestination } = await loadTwitchDestinationModule();
+    const dest = createTwitchDestination({ streamKey: "my-stream-key" });
+    const creds = await dest.getCredentials();
 
-      try {
-        const { createTwitchDestination } = await loadTwitchDestinationModule();
-        const dest = createTwitchDestination();
-        await expect(dest.getCredentials()).rejects.toThrow("not configured");
-      } finally {
-        if (origKey !== undefined) process.env.TWITCH_STREAM_KEY = origKey;
-      }
-    });
+    expect(creds.rtmpUrl).toBe("rtmp://live.twitch.tv/app");
+    expect(creds.rtmpKey).toBe("my-stream-key");
+  });
 
-    it("getCredentials returns Twitch RTMP URL with config stream key", async () => {
+  it("prefers config.streamKey over TWITCH_STREAM_KEY env var", async () => {
+    const origKey = process.env.TWITCH_STREAM_KEY;
+    process.env.TWITCH_STREAM_KEY = "env-key";
+
+    try {
       const { createTwitchDestination } = await loadTwitchDestinationModule();
-      const dest = createTwitchDestination({ streamKey: "my-stream-key" });
+      const dest = createTwitchDestination({ streamKey: "config-key" });
       const creds = await dest.getCredentials();
-
-      expect(creds.rtmpUrl).toBe("rtmp://live.twitch.tv/app");
-      expect(creds.rtmpKey).toBe("my-stream-key");
-    });
-
-    it("prefers config.streamKey over TWITCH_STREAM_KEY env var", async () => {
-      const origKey = process.env.TWITCH_STREAM_KEY;
-      process.env.TWITCH_STREAM_KEY = "env-key";
-
-      try {
-        const { createTwitchDestination } = await loadTwitchDestinationModule();
-        const dest = createTwitchDestination({ streamKey: "config-key" });
-        const creds = await dest.getCredentials();
-        expect(creds.rtmpKey).toBe("config-key");
-      } finally {
-        if (origKey !== undefined) {
-          process.env.TWITCH_STREAM_KEY = origKey;
-        } else {
-          delete process.env.TWITCH_STREAM_KEY;
-        }
+      expect(creds.rtmpKey).toBe("config-key");
+    } finally {
+      if (origKey !== undefined) {
+        process.env.TWITCH_STREAM_KEY = origKey;
+      } else {
+        delete process.env.TWITCH_STREAM_KEY;
       }
-    });
+    }
+  });
 
-    it("falls back to TWITCH_STREAM_KEY env var when no config", async () => {
-      const origKey = process.env.TWITCH_STREAM_KEY;
-      process.env.TWITCH_STREAM_KEY = "env-key";
+  it("falls back to TWITCH_STREAM_KEY env var when no config", async () => {
+    const origKey = process.env.TWITCH_STREAM_KEY;
+    process.env.TWITCH_STREAM_KEY = "env-key";
 
-      try {
-        const { createTwitchDestination } = await loadTwitchDestinationModule();
-        const dest = createTwitchDestination();
-        const creds = await dest.getCredentials();
-        expect(creds.rtmpKey).toBe("env-key");
-      } finally {
-        if (origKey !== undefined) {
-          process.env.TWITCH_STREAM_KEY = origKey;
-        } else {
-          delete process.env.TWITCH_STREAM_KEY;
-        }
+    try {
+      const { createTwitchDestination } = await loadTwitchDestinationModule();
+      const dest = createTwitchDestination();
+      const creds = await dest.getCredentials();
+      expect(creds.rtmpKey).toBe("env-key");
+    } finally {
+      if (origKey !== undefined) {
+        process.env.TWITCH_STREAM_KEY = origKey;
+      } else {
+        delete process.env.TWITCH_STREAM_KEY;
       }
-    });
-  },
-);
+    }
+  });
+});
 
 // ---------------------------------------------------------------------------
 // createYoutubeDestination() — destination adapter unit tests
 // ---------------------------------------------------------------------------
 
-describeIf(hasYoutubeDestinationModule)(
-  "createYoutubeDestination()",
-  () => {
-    it("returns a StreamingDestination with id and name", async () => {
+describeIf(hasYoutubeDestinationModule)("createYoutubeDestination()", () => {
+  it("returns a StreamingDestination with id and name", async () => {
+    const { createYoutubeDestination } = await loadYoutubeDestinationModule();
+    const dest = createYoutubeDestination({ streamKey: "test-key" });
+    expect(dest.id).toBe("youtube");
+    expect(dest.name).toBe("YouTube");
+  });
+
+  it("getCredentials throws when no stream key is configured", async () => {
+    const origKey = process.env.YOUTUBE_STREAM_KEY;
+    delete process.env.YOUTUBE_STREAM_KEY;
+
+    try {
       const { createYoutubeDestination } = await loadYoutubeDestinationModule();
-      const dest = createYoutubeDestination({ streamKey: "test-key" });
-      expect(dest.id).toBe("youtube");
-      expect(dest.name).toBe("YouTube");
+      const dest = createYoutubeDestination();
+      await expect(dest.getCredentials()).rejects.toThrow("not configured");
+    } finally {
+      if (origKey !== undefined) process.env.YOUTUBE_STREAM_KEY = origKey;
+    }
+  });
+
+  it("getCredentials returns default YouTube RTMP URL with config stream key", async () => {
+    const { createYoutubeDestination } = await loadYoutubeDestinationModule();
+    const dest = createYoutubeDestination({ streamKey: "yt-key" });
+    const creds = await dest.getCredentials();
+
+    expect(creds.rtmpUrl).toBe("rtmp://a.rtmp.youtube.com/live2");
+    expect(creds.rtmpKey).toBe("yt-key");
+  });
+
+  it("uses custom RTMP URL when provided in config", async () => {
+    const { createYoutubeDestination } = await loadYoutubeDestinationModule();
+    const dest = createYoutubeDestination({
+      streamKey: "yt-key",
+      rtmpUrl: "rtmp://custom.youtube.com/live",
     });
+    const creds = await dest.getCredentials();
 
-    it("getCredentials throws when no stream key is configured", async () => {
-      const origKey = process.env.YOUTUBE_STREAM_KEY;
-      delete process.env.YOUTUBE_STREAM_KEY;
+    expect(creds.rtmpUrl).toBe("rtmp://custom.youtube.com/live");
+    expect(creds.rtmpKey).toBe("yt-key");
+  });
 
-      try {
-        const { createYoutubeDestination } =
-          await loadYoutubeDestinationModule();
-        const dest = createYoutubeDestination();
-        await expect(dest.getCredentials()).rejects.toThrow("not configured");
-      } finally {
-        if (origKey !== undefined) process.env.YOUTUBE_STREAM_KEY = origKey;
-      }
-    });
+  it("prefers config.streamKey over YOUTUBE_STREAM_KEY env var", async () => {
+    const origKey = process.env.YOUTUBE_STREAM_KEY;
+    process.env.YOUTUBE_STREAM_KEY = "env-key";
 
-    it("getCredentials returns default YouTube RTMP URL with config stream key", async () => {
+    try {
       const { createYoutubeDestination } = await loadYoutubeDestinationModule();
-      const dest = createYoutubeDestination({ streamKey: "yt-key" });
+      const dest = createYoutubeDestination({ streamKey: "config-key" });
       const creds = await dest.getCredentials();
+      expect(creds.rtmpKey).toBe("config-key");
+    } finally {
+      if (origKey !== undefined) {
+        process.env.YOUTUBE_STREAM_KEY = origKey;
+      } else {
+        delete process.env.YOUTUBE_STREAM_KEY;
+      }
+    }
+  });
 
-      expect(creds.rtmpUrl).toBe("rtmp://a.rtmp.youtube.com/live2");
-      expect(creds.rtmpKey).toBe("yt-key");
-    });
+  it("falls back to YOUTUBE_STREAM_KEY env var when no config", async () => {
+    const origKey = process.env.YOUTUBE_STREAM_KEY;
+    process.env.YOUTUBE_STREAM_KEY = "env-key";
 
-    it("uses custom RTMP URL when provided in config", async () => {
+    try {
       const { createYoutubeDestination } = await loadYoutubeDestinationModule();
-      const dest = createYoutubeDestination({
-        streamKey: "yt-key",
-        rtmpUrl: "rtmp://custom.youtube.com/live",
-      });
+      const dest = createYoutubeDestination();
       const creds = await dest.getCredentials();
-
-      expect(creds.rtmpUrl).toBe("rtmp://custom.youtube.com/live");
-      expect(creds.rtmpKey).toBe("yt-key");
-    });
-
-    it("prefers config.streamKey over YOUTUBE_STREAM_KEY env var", async () => {
-      const origKey = process.env.YOUTUBE_STREAM_KEY;
-      process.env.YOUTUBE_STREAM_KEY = "env-key";
-
-      try {
-        const { createYoutubeDestination } =
-          await loadYoutubeDestinationModule();
-        const dest = createYoutubeDestination({ streamKey: "config-key" });
-        const creds = await dest.getCredentials();
-        expect(creds.rtmpKey).toBe("config-key");
-      } finally {
-        if (origKey !== undefined) {
-          process.env.YOUTUBE_STREAM_KEY = origKey;
-        } else {
-          delete process.env.YOUTUBE_STREAM_KEY;
-        }
+      expect(creds.rtmpKey).toBe("env-key");
+    } finally {
+      if (origKey !== undefined) {
+        process.env.YOUTUBE_STREAM_KEY = origKey;
+      } else {
+        delete process.env.YOUTUBE_STREAM_KEY;
       }
-    });
-
-    it("falls back to YOUTUBE_STREAM_KEY env var when no config", async () => {
-      const origKey = process.env.YOUTUBE_STREAM_KEY;
-      process.env.YOUTUBE_STREAM_KEY = "env-key";
-
-      try {
-        const { createYoutubeDestination } =
-          await loadYoutubeDestinationModule();
-        const dest = createYoutubeDestination();
-        const creds = await dest.getCredentials();
-        expect(creds.rtmpKey).toBe("env-key");
-      } finally {
-        if (origKey !== undefined) {
-          process.env.YOUTUBE_STREAM_KEY = origKey;
-        } else {
-          delete process.env.YOUTUBE_STREAM_KEY;
-        }
-      }
-    });
-  },
-);
+    }
+  });
+});
 
 // ---------------------------------------------------------------------------
 // createCustomRtmpDestination() — destination adapter unit tests

--- a/packages/app-core/src/api/training-routes.test.ts
+++ b/packages/app-core/src/api/training-routes.test.ts
@@ -666,7 +666,9 @@ describe("training routes", () => {
       pathname: "/api/training/trajectories/export",
       body: {
         splitByTask: true,
-        outputDir: await mkdtemp(join(tmpdir(), "training-route-trajectories-")),
+        outputDir: await mkdtemp(
+          join(tmpdir(), "training-route-trajectories-"),
+        ),
       },
     });
 
@@ -738,7 +740,12 @@ describe("training routes", () => {
     const exportedLines = (await readFile(outputPath, "utf-8"))
       .trim()
       .split("\n")
-      .map((line) => JSON.parse(line) as { messages: Array<{ role: string; content: string }> });
+      .map(
+        (line) =>
+          JSON.parse(line) as {
+            messages: Array<{ role: string; content: string }>;
+          },
+      );
 
     expect(result.status).toBe(201);
     expect(result.payload).toMatchObject({

--- a/packages/app-core/src/components/apps/AppDetailPane.tsx
+++ b/packages/app-core/src/components/apps/AppDetailPane.tsx
@@ -40,10 +40,7 @@ export function AppDetailPane({
   const backLabel = t("appsview.Back", { defaultValue: "Back" });
   const sessionModeLabel = getAppSessionModeLabel(app);
   const sessionFeatures = getAppSessionFeatureLabels(app);
-  const allTags = [
-    ...sessionFeatures,
-    ...(app.capabilities ?? []),
-  ];
+  const allTags = [...sessionFeatures, ...(app.capabilities ?? [])];
   const launchLabel = busy
     ? t("appsview.Launching", { defaultValue: "Launching..." })
     : t("appsview.Launch", { defaultValue: "Launch" });
@@ -68,9 +65,7 @@ export function AppDetailPane({
               {app.displayName ?? app.name}
             </h2>
             <div className="mt-1 flex flex-wrap items-center gap-2 text-[11px] text-muted-strong">
-              {isActive ? (
-                <span className="text-ok">Active</span>
-              ) : null}
+              {isActive ? <span className="text-ok">Active</span> : null}
               {app.category ? (
                 <span>{CATEGORY_LABELS[app.category] ?? app.category}</span>
               ) : null}

--- a/packages/app-core/src/components/apps/extensions/DefenseAgentsDetailExtension.tsx
+++ b/packages/app-core/src/components/apps/extensions/DefenseAgentsDetailExtension.tsx
@@ -1,8 +1,6 @@
 import { DefenseAgentsOperatorSurface } from "../surfaces/DefenseAgentsOperatorSurface";
 import type { AppDetailExtensionProps } from "./types";
 
-export function DefenseAgentsDetailExtension({
-  app,
-}: AppDetailExtensionProps) {
+export function DefenseAgentsDetailExtension({ app }: AppDetailExtensionProps) {
   return <DefenseAgentsOperatorSurface appName={app.name} variant="detail" />;
 }

--- a/packages/app-core/src/components/apps/extensions/TwoThousandFourScapeDetailExtension.tsx
+++ b/packages/app-core/src/components/apps/extensions/TwoThousandFourScapeDetailExtension.tsx
@@ -5,9 +5,6 @@ export function TwoThousandFourScapeDetailExtension({
   app,
 }: AppDetailExtensionProps) {
   return (
-    <TwoThousandFourScapeOperatorSurface
-      appName={app.name}
-      variant="detail"
-    />
+    <TwoThousandFourScapeOperatorSurface appName={app.name} variant="detail" />
   );
 }

--- a/packages/app-core/src/components/onboarding/connection/ConnectionProviderDetailScreen.test.tsx
+++ b/packages/app-core/src/components/onboarding/connection/ConnectionProviderDetailScreen.test.tsx
@@ -83,9 +83,13 @@ vi.mock("@miladyai/ui", async (importOriginal) => {
         {children}
       </select>
     ),
-    SelectTrigger: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    SelectTrigger: ({ children }: { children?: React.ReactNode }) => (
+      <>{children}</>
+    ),
     SelectValue: () => null,
-    SelectContent: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    SelectContent: ({ children }: { children?: React.ReactNode }) => (
+      <>{children}</>
+    ),
     SelectItem: ({
       value,
       children,
@@ -97,9 +101,10 @@ vi.mock("@miladyai/ui", async (importOriginal) => {
 });
 
 vi.mock("../../../providers", async () => {
-  const actual = await vi.importActual<typeof import("../../../providers")>(
-    "../../../providers",
-  );
+  const actual =
+    await vi.importActual<typeof import("../../../providers")>(
+      "../../../providers",
+    );
   return {
     ...actual,
     getProviderLogo: (...args: unknown[]) => mockGetProviderLogo(...args),
@@ -169,8 +174,7 @@ function t(
       "Powers task agents only (Claude Code CLI). For the main agent runtime, connect Eliza Cloud or a direct API key.",
   };
 
-  const template =
-    translations[key] ?? String(params?.defaultValue ?? key);
+  const template = translations[key] ?? String(params?.defaultValue ?? key);
   if (!params) {
     return template;
   }
@@ -340,7 +344,10 @@ describe("ConnectionProviderDetailScreen", () => {
       target: { value: "ec-test-key" },
     });
 
-    expect(setState).toHaveBeenCalledWith("onboardingCloudApiKey", "ec-test-key");
+    expect(setState).toHaveBeenCalledWith(
+      "onboardingCloudApiKey",
+      "ec-test-key",
+    );
   });
 
   it("switches Eliza Cloud tabs and starts the login flow from the login tab", () => {
@@ -438,7 +445,10 @@ describe("ConnectionProviderDetailScreen", () => {
 
     fireEvent.click(screen.getByRole("radio", { name: /Claude Sonnet/i }));
 
-    expect(setState).toHaveBeenCalledWith("onboardingOpenRouterModel", "sonnet");
+    expect(setState).toHaveBeenCalledWith(
+      "onboardingOpenRouterModel",
+      "sonnet",
+    );
   });
 
   it("trims Claude tokens and lets the user continue with limited setup after saving", async () => {
@@ -475,7 +485,9 @@ describe("ConnectionProviderDetailScreen", () => {
       "sk-ant-oat01-test-token",
     );
     expect(
-      await screen.findByRole("button", { name: "Continue with limited setup" }),
+      await screen.findByRole("button", {
+        name: "Continue with limited setup",
+      }),
     ).toBeTruthy();
     expect(
       screen.getByRole("button", { name: "Add another provider" }),
@@ -520,7 +532,9 @@ describe("ConnectionProviderDetailScreen", () => {
     );
 
     await screen.findByRole("button", { name: "Add another provider" });
-    fireEvent.click(screen.getByRole("button", { name: "Add another provider" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Add another provider" }),
+    );
 
     expect(dispatch).toHaveBeenCalledWith({ type: "clearProvider" });
   });
@@ -837,7 +851,9 @@ describe("ConnectionProviderDetailScreen", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Start over" }));
 
-    expect(screen.getByRole("button", { name: "Log in with OpenAI" })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Log in with OpenAI" }),
+    ).toBeTruthy();
     expect(screen.queryByLabelText("Redirect URL")).toBeNull();
   });
 
@@ -976,7 +992,10 @@ describe("ConnectionProviderDetailScreen", () => {
       target: { value: "pi/creative" },
     });
 
-    expect(setState).toHaveBeenCalledWith("onboardingPrimaryModel", "pi/creative");
+    expect(setState).toHaveBeenCalledWith(
+      "onboardingPrimaryModel",
+      "pi/creative",
+    );
   });
 
   it("clears the pi.ai override when the user switches to a custom model", () => {

--- a/packages/app-core/src/components/pages/AdvancedPageView.test.tsx
+++ b/packages/app-core/src/components/pages/AdvancedPageView.test.tsx
@@ -206,9 +206,8 @@ describe("AdvancedPageView", () => {
       ).length,
     ).toBeGreaterThan(0);
     expect(
-      tree.root.findByProps({ "data-testid": "advanced-subtab-relationships" }).props[
-        "aria-pressed"
-      ],
+      tree.root.findByProps({ "data-testid": "advanced-subtab-relationships" })
+        .props["aria-pressed"],
     ).toBe(true);
   });
 });

--- a/packages/app-core/src/components/pages/AppsView.tsx
+++ b/packages/app-core/src/components/pages/AppsView.tsx
@@ -12,10 +12,7 @@ import { useApp } from "../../state";
 import { openExternalUrl } from "../../utils";
 import { AppDetailPane } from "../apps/AppDetailPane";
 import { AppsCatalogGrid } from "../apps/AppsCatalogGrid";
-import {
-  filterAppsForCatalog,
-  shouldShowAppInAppsView,
-} from "../apps/helpers";
+import { filterAppsForCatalog, shouldShowAppInAppsView } from "../apps/helpers";
 import {
   getRunAttentionReasons,
   RunningAppsPanel,

--- a/packages/app-core/src/components/pages/PluginCard.tsx
+++ b/packages/app-core/src/components/pages/PluginCard.tsx
@@ -362,23 +362,23 @@ export function PluginCard({
         )}
         <div className="flex-1" />
         {isStoreInstallMissing && !isShowcase && !p.loadError && (
-            <Button
-              variant="default"
-              size="sm"
-              className="h-7 px-3 text-[10px] font-bold tracking-wide shadow-sm max-w-[140px] truncate"
-              disabled={isInstalling || isUpdating || isUninstalling}
-              onClick={(e) => {
-                e.stopPropagation();
-                onInstall(p.id, p.npmName ?? "");
-              }}
-            >
-              {isInstalling
-                ? installProgressLabel(
-                    installProgress.get(p.npmName ?? "")?.message,
-                  )
-                : installLabel}
-            </Button>
-          )}
+          <Button
+            variant="default"
+            size="sm"
+            className="h-7 px-3 text-[10px] font-bold tracking-wide shadow-sm max-w-[140px] truncate"
+            disabled={isInstalling || isUpdating || isUninstalling}
+            onClick={(e) => {
+              e.stopPropagation();
+              onInstall(p.id, p.npmName ?? "");
+            }}
+          >
+            {isInstalling
+              ? installProgressLabel(
+                  installProgress.get(p.npmName ?? "")?.message,
+                )
+              : installLabel}
+          </Button>
+        )}
         {canUpdate && (
           <Button
             variant="outline"

--- a/packages/app-core/src/components/pages/RelationshipsGraphPanel.tsx
+++ b/packages/app-core/src/components/pages/RelationshipsGraphPanel.tsx
@@ -86,8 +86,8 @@ export function RelationshipsGraphPanel({
           No identities match the current filters.
         </div>
         <p className="mt-2 max-w-lg text-sm leading-6 text-muted">
-          The graph will render once the relationships has people, identity links, and
-          relationships to visualize.
+          The graph will render once the relationships has people, identity
+          links, and relationships to visualize.
         </p>
       </div>
     );
@@ -117,7 +117,12 @@ export function RelationshipsGraphPanel({
           aria-label="Relationships relationship graph"
         >
           <defs>
-            <radialGradient id="relationships-node-fill" cx="50%" cy="35%" r="70%">
+            <radialGradient
+              id="relationships-node-fill"
+              cx="50%"
+              cy="35%"
+              r="70%"
+            >
               <stop offset="0%" stopColor="rgba(255,240,199,0.92)" />
               <stop offset="100%" stopColor="rgba(240,185,11,0.86)" />
             </radialGradient>

--- a/packages/app-core/src/components/pages/RelationshipsIdentityCluster.tsx
+++ b/packages/app-core/src/components/pages/RelationshipsIdentityCluster.tsx
@@ -9,7 +9,10 @@ function shortLabel(value: string, maxLength = 14): string {
   return value.length > maxLength ? `${value.slice(0, maxLength - 1)}…` : value;
 }
 
-function identityLabel(person: RelationshipsPersonDetail, index: number): string {
+function identityLabel(
+  person: RelationshipsPersonDetail,
+  index: number,
+): string {
   const identity = person.identities[index];
   if (!identity) {
     return `${index + 1}`;

--- a/packages/app-core/src/components/pages/RelationshipsView.test.tsx
+++ b/packages/app-core/src/components/pages/RelationshipsView.test.tsx
@@ -4,13 +4,12 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ButtonHTMLAttributes, ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockUseApp, mockGetRelationshipsGraph, mockGetRelationshipsPerson } = vi.hoisted(
-  () => ({
+const { mockUseApp, mockGetRelationshipsGraph, mockGetRelationshipsPerson } =
+  vi.hoisted(() => ({
     mockUseApp: vi.fn(),
     mockGetRelationshipsGraph: vi.fn(),
     mockGetRelationshipsPerson: vi.fn(),
-  }),
-);
+  }));
 
 vi.mock("../../state", () => ({
   useApp: () => mockUseApp(),
@@ -18,8 +17,10 @@ vi.mock("../../state", () => ({
 
 vi.mock("@miladyai/app-core/api", () => ({
   client: {
-    getRelationshipsGraph: (...args: unknown[]) => mockGetRelationshipsGraph(...args),
-    getRelationshipsPerson: (...args: unknown[]) => mockGetRelationshipsPerson(...args),
+    getRelationshipsGraph: (...args: unknown[]) =>
+      mockGetRelationshipsGraph(...args),
+    getRelationshipsPerson: (...args: unknown[]) =>
+      mockGetRelationshipsPerson(...args),
   },
 }));
 

--- a/packages/app-core/src/components/pages/RelationshipsView.tsx
+++ b/packages/app-core/src/components/pages/RelationshipsView.tsx
@@ -37,7 +37,9 @@ function toTimestamp(value?: string): number {
   return Number.isFinite(timestamp) ? timestamp : 0;
 }
 
-function sortPeople(people: RelationshipsPersonSummary[]): RelationshipsPersonSummary[] {
+function sortPeople(
+  people: RelationshipsPersonSummary[],
+): RelationshipsPersonSummary[] {
   return [...people].sort((left, right) => {
     const timeDiff =
       toTimestamp(right.lastInteractionAt) -
@@ -56,7 +58,9 @@ function summarizeHandles(person: RelationshipsPersonSummary): string {
   return handles.slice(0, 3).join(", ");
 }
 
-function platformOptions(snapshot: RelationshipsGraphSnapshot | null): string[] {
+function platformOptions(
+  snapshot: RelationshipsGraphSnapshot | null,
+): string[] {
   if (!snapshot) return [];
   return [...new Set(snapshot.people.flatMap((person) => person.platforms))]
     .filter((platform) => platform.trim().length > 0)

--- a/packages/app-core/src/components/pages/TrajectoriesView.actions.test.tsx
+++ b/packages/app-core/src/components/pages/TrajectoriesView.actions.test.tsx
@@ -382,7 +382,11 @@ describe("TrajectoriesView actions", () => {
 
     await waitFor(() => {
       expect(mockDeleteTrajectories).toHaveBeenCalledWith(["traj-1"]);
-      expect(setActionNotice).toHaveBeenCalledWith("delete failed", "error", 4200);
+      expect(setActionNotice).toHaveBeenCalledWith(
+        "delete failed",
+        "error",
+        4200,
+      );
     });
     expect(onSelectTrajectory).not.toHaveBeenCalled();
   });
@@ -460,7 +464,11 @@ describe("TrajectoriesView actions", () => {
 
     await waitFor(() => {
       expect(mockClearAllTrajectories).toHaveBeenCalledTimes(1);
-      expect(setActionNotice).toHaveBeenCalledWith("clear failed", "error", 4200);
+      expect(setActionNotice).toHaveBeenCalledWith(
+        "clear failed",
+        "error",
+        4200,
+      );
     });
     expect(onSelectTrajectory).not.toHaveBeenCalled();
   });

--- a/packages/app-core/src/components/pages/TrajectoriesView.tsx
+++ b/packages/app-core/src/components/pages/TrajectoriesView.tsx
@@ -341,7 +341,9 @@ export function TrajectoriesView({
                 disabled={loading}
                 title={t("common.refresh")}
               >
-                <RefreshCw className={`h-3 w-3${loading ? " animate-spin" : ""}`} />
+                <RefreshCw
+                  className={`h-3 w-3${loading ? " animate-spin" : ""}`}
+                />
               </Button>
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>

--- a/packages/app-core/src/components/pages/cloud-dashboard-panels.tsx
+++ b/packages/app-core/src/components/pages/cloud-dashboard-panels.tsx
@@ -585,9 +585,7 @@ function DiscordSettingsPanel({
                     </span>
                     <Switch
                       checked={config.intents?.guildMembers ?? false}
-                      onCheckedChange={(v) =>
-                        patchIntents({ guildMembers: v })
-                      }
+                      onCheckedChange={(v) => patchIntents({ guildMembers: v })}
                       className="scale-75"
                     />
                   </div>
@@ -616,9 +614,7 @@ function DiscordSettingsPanel({
                     </span>
                     <Switch
                       checked={config.pluralkit?.enabled ?? false}
-                      onCheckedChange={(v) =>
-                        patchFlagSetting("pluralkit", v)
-                      }
+                      onCheckedChange={(v) => patchFlagSetting("pluralkit", v)}
                       className="scale-75"
                     />
                   </div>

--- a/packages/app-core/src/components/pages/cloud-dashboard-utils.ts
+++ b/packages/app-core/src/components/pages/cloud-dashboard-utils.ts
@@ -194,9 +194,7 @@ export function buildManagedDiscordSettingsReturnUrl(
   return url.toString();
 }
 
-export function resolveManagedDiscordAgentChoice(
-  agents: CloudCompatAgent[],
-):
+export function resolveManagedDiscordAgentChoice(agents: CloudCompatAgent[]):
   | {
       mode: "none";
       agent: null;

--- a/packages/app-core/src/components/pages/plugin-view-connectors.tsx
+++ b/packages/app-core/src/components/pages/plugin-view-connectors.tsx
@@ -155,17 +155,13 @@ function ConnectorPluginCard({
   testResults,
   togglingPlugins,
 }: ConnectorPluginCardProps) {
-  const {
-    elizaCloudConnected,
-    setActionNotice,
-    setState,
-    setTab,
-  } = useApp();
+  const { elizaCloudConnected, setActionNotice, setState, setTab } = useApp();
   const [managedDiscordBusy, setManagedDiscordBusy] = useState(false);
   const [managedDiscordAgents, setManagedDiscordAgents] = useState<
     CloudCompatAgent[]
   >([]);
-  const [managedDiscordPickerOpen, setManagedDiscordPickerOpen] = useState(false);
+  const [managedDiscordPickerOpen, setManagedDiscordPickerOpen] =
+    useState(false);
   const [managedDiscordSelectedAgentId, setManagedDiscordSelectedAgentId] =
     useState<string | null>(null);
   const hasParams =
@@ -212,24 +208,21 @@ function ConnectorPluginCard({
     setTab("settings");
   };
   const startManagedDiscordOauth = async (agent: CloudCompatAgent) => {
-    const oauthResponse = await client.createCloudCompatAgentManagedDiscordOauth(
-      agent.agent_id,
-      {
+    const oauthResponse =
+      await client.createCloudCompatAgentManagedDiscordOauth(agent.agent_id, {
         returnUrl:
           typeof window !== "undefined"
-            ? buildManagedDiscordSettingsReturnUrl(window.location.href) ??
-              undefined
+            ? (buildManagedDiscordSettingsReturnUrl(window.location.href) ??
+              undefined)
             : undefined,
         botNickname: agent.agent_name?.trim() || undefined,
-      },
-    );
+      });
 
     await handleOpenPluginExternalUrl(oauthResponse.data.authorizeUrl);
     setManagedDiscordPickerOpen(false);
     setActionNotice(
       t("elizaclouddashboard.DiscordSetupContinuesInBrowser", {
-        defaultValue:
-          "Finish Discord setup in your browser, then return here.",
+        defaultValue: "Finish Discord setup in your browser, then return here.",
       }),
       "info",
       5000,
@@ -487,12 +480,12 @@ function ConnectorPluginCard({
                 {managedDiscordBusy
                   ? "..."
                   : elizaCloudConnected
-                  ? t("pluginsview.UseManagedDiscord", {
-                      defaultValue: "Use managed Discord",
-                    })
-                  : t("pluginsview.OpenElizaCloud", {
-                      defaultValue: "Open Eliza Cloud",
-                    })}
+                    ? t("pluginsview.UseManagedDiscord", {
+                        defaultValue: "Use managed Discord",
+                      })
+                    : t("pluginsview.OpenElizaCloud", {
+                        defaultValue: "Open Eliza Cloud",
+                      })}
               </Button>
             }
           >
@@ -572,30 +565,30 @@ function ConnectorPluginCard({
         )}
 
         {isStoreInstallMissing && !plugin.loadError && (
-            <PagePanel.Notice
-              tone="warning"
-              className="mb-4"
-              actions={
-                <Button
-                  variant="default"
-                  size="sm"
-                  className="h-8 rounded-xl px-4 text-[11px] font-bold"
-                  disabled={installingPlugins.has(plugin.id)}
-                  onClick={() =>
-                    void handleInstallPlugin(plugin.id, plugin.npmName ?? "")
-                  }
-                >
-                  {installingPlugins.has(plugin.id)
-                    ? installProgressLabel(
-                        installProgress.get(plugin.npmName ?? "")?.message,
-                      )
-                    : installPluginLabel}
-                </Button>
-              }
-            >
-              {connectorInstallPrompt}
-            </PagePanel.Notice>
-          )}
+          <PagePanel.Notice
+            tone="warning"
+            className="mb-4"
+            actions={
+              <Button
+                variant="default"
+                size="sm"
+                className="h-8 rounded-xl px-4 text-[11px] font-bold"
+                disabled={installingPlugins.has(plugin.id)}
+                onClick={() =>
+                  void handleInstallPlugin(plugin.id, plugin.npmName ?? "")
+                }
+              >
+                {installingPlugins.has(plugin.id)
+                  ? installProgressLabel(
+                      installProgress.get(plugin.npmName ?? "")?.message,
+                    )
+                  : installPluginLabel}
+              </Button>
+            }
+          >
+            {connectorInstallPrompt}
+          </PagePanel.Notice>
+        )}
 
         {hasParams ? (
           <div className="space-y-4">

--- a/packages/app-core/src/components/settings/ProviderSwitcher.test.tsx
+++ b/packages/app-core/src/components/settings/ProviderSwitcher.test.tsx
@@ -533,7 +533,11 @@ describe("ProviderSwitcher subscription selection behavior", () => {
       await Promise.resolve();
     });
 
-    expect(mockSwitchProvider).toHaveBeenCalledWith("pi-ai", undefined, undefined);
+    expect(mockSwitchProvider).toHaveBeenCalledWith(
+      "pi-ai",
+      undefined,
+      undefined,
+    );
     expect(getSelectValue(tree)).toBe("openai-subscription");
     expect(mockSetActionNotice).toHaveBeenCalledWith(
       "Failed to enable pi.ai: pi failed",
@@ -696,7 +700,10 @@ describe("ProviderSwitcher subscription selection behavior", () => {
     });
 
     await act(async () => {
-      getButtonByText(tree, "providerswitcher.reportIssueWithTemplate").props.onClick();
+      getButtonByText(
+        tree,
+        "providerswitcher.reportIssueWithTemplate",
+      ).props.onClick();
       await Promise.resolve();
     });
 
@@ -705,7 +712,10 @@ describe("ProviderSwitcher subscription selection behavior", () => {
     );
 
     await act(async () => {
-      getButtonByText(tree, "providerswitcher.logInToElizaCloud").props.onClick();
+      getButtonByText(
+        tree,
+        "providerswitcher.logInToElizaCloud",
+      ).props.onClick();
       await Promise.resolve();
     });
 

--- a/packages/app-core/src/components/settings/ProviderSwitcher.tsx
+++ b/packages/app-core/src/components/settings/ProviderSwitcher.tsx
@@ -190,8 +190,8 @@ export function ProviderSwitcher(props: ProviderSwitcherProps = {}) {
           (cfg.agents as { defaults?: { subscriptionProvider?: string } })
             .defaults?.subscriptionProvider ?? "",
         )
-          ? (cfg.agents as { defaults?: { subscriptionProvider?: string } })
-              .defaults?.subscriptionProvider ?? null
+          ? ((cfg.agents as { defaults?: { subscriptionProvider?: string } })
+              .defaults?.subscriptionProvider ?? null)
           : null;
       const nextSelectedId =
         llmText?.transport === "cloud-proxy" && providerId === "elizacloud"
@@ -414,7 +414,12 @@ export function ProviderSwitcher(props: ProviderSwitcherProps = {}) {
         notifySelectionFailure("Failed to switch AI provider", err);
       }
     },
-    [allAiProviders, notifySelectionFailure, resolvedSelectedId, restoreSelection],
+    [
+      allAiProviders,
+      notifySelectionFailure,
+      resolvedSelectedId,
+      restoreSelection,
+    ],
   );
 
   const handleSelectSubscription = useCallback(
@@ -486,10 +491,9 @@ export function ProviderSwitcher(props: ProviderSwitcherProps = {}) {
   const hasKnownPiAiModel = (piAiModelOptions ?? []).some(
     (model) => model.id === normalizedPiAiModelSpec,
   );
-  const piAiModelSelectValue =
-    piAiCustomMode
-      ? "__custom__"
-      : normalizedPiAiModelSpec.length === 0
+  const piAiModelSelectValue = piAiCustomMode
+    ? "__custom__"
+    : normalizedPiAiModelSpec.length === 0
       ? "__default__"
       : hasKnownPiAiModel
         ? normalizedPiAiModelSpec

--- a/packages/app-core/src/components/settings/SubscriptionStatus.test.tsx
+++ b/packages/app-core/src/components/settings/SubscriptionStatus.test.tsx
@@ -1,14 +1,16 @@
 // @vitest-environment jsdom
 
 import type React from "react";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const {
-  mockClient,
-  mockUseApp,
-  mockOpenExternalUrl,
-} = vi.hoisted(() => ({
+const { mockClient, mockUseApp, mockOpenExternalUrl } = vi.hoisted(() => ({
   mockClient: {
     submitAnthropicSetupToken: vi.fn(async () => ({ success: true })),
     startAnthropicLogin: vi.fn(async () => ({
@@ -89,18 +91,19 @@ function t(
     "subscriptionstatus.ExpectedCallbackUrl":
       "Expected a localhost:1455/auth/callback URL.",
     "subscriptionstatus.ExchangeFailedError": "Exchange failed: {{message}}",
-    "subscriptionstatus.FailedToStartLogin": "Failed to start login: {{message}}",
+    "subscriptionstatus.FailedToStartLogin":
+      "Failed to start login: {{message}}",
     "subscriptionstatus.FailedToGetAuthUrl": "Failed to get auth URL",
     "subscriptionstatus.NoAuthUrlReturned": "No auth URL returned",
-    "subscriptionstatus.DisconnectFailedError": "Disconnect failed: {{message}}",
+    "subscriptionstatus.DisconnectFailedError":
+      "Disconnect failed: {{message}}",
     "subscriptionstatus.ExchangeFailed": "Exchange failed",
     "subscriptionstatus.SaveToken": "Save token",
     "subscriptionstatus.SavingAmpRestart": "Saving and restarting…",
     "subscriptionstatus.skAntOat01": "sk-ant-oat01-...",
     "subscriptionstatus.FailedToSaveTokenError":
       "Failed to save token: {{message}}",
-    "subscriptionstatus.FailedToSaveSetupToken":
-      "Failed to save setup token",
+    "subscriptionstatus.FailedToSaveSetupToken": "Failed to save setup token",
     "apikeyconfig.saved": "Saved",
     "apikeyconfig.saving": "Saving",
     "subscriptionstatus.ClaudeTosWarningShort":
@@ -223,9 +226,7 @@ describe("SubscriptionStatus", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: "Save token" }));
 
-    expect(
-      await screen.findByText("Failed to save setup token"),
-    ).toBeTruthy();
+    expect(await screen.findByText("Failed to save setup token")).toBeTruthy();
   });
 
   it("blocks invalid OpenAI callback URLs before calling exchange", async () => {
@@ -310,9 +311,12 @@ describe("SubscriptionStatus", () => {
     fireEvent.click(screen.getByRole("button", { name: "OAuth login" }));
     fireEvent.click(screen.getByRole("button", { name: "Log in with Claude" }));
     await screen.findByPlaceholderText("Paste the authorization code");
-    fireEvent.change(screen.getByPlaceholderText("Paste the authorization code"), {
-      target: { value: "anthro-code-123" },
-    });
+    fireEvent.change(
+      screen.getByPlaceholderText("Paste the authorization code"),
+      {
+        target: { value: "anthro-code-123" },
+      },
+    );
     fireEvent.click(screen.getByRole("button", { name: "Connect" }));
 
     expect(await screen.findByText("Claude code rejected")).toBeTruthy();
@@ -347,9 +351,12 @@ describe("SubscriptionStatus", () => {
     fireEvent.click(screen.getByRole("button", { name: "OAuth login" }));
     fireEvent.click(screen.getByRole("button", { name: "Log in with Claude" }));
     await screen.findByPlaceholderText("Paste the authorization code");
-    fireEvent.change(screen.getByPlaceholderText("Paste the authorization code"), {
-      target: { value: "anthro-success-code" },
-    });
+    fireEvent.change(
+      screen.getByPlaceholderText("Paste the authorization code"),
+      {
+        target: { value: "anthro-success-code" },
+      },
+    );
     fireEvent.click(screen.getByRole("button", { name: "Connect" }));
 
     await waitFor(() => {
@@ -377,9 +384,12 @@ describe("SubscriptionStatus", () => {
     fireEvent.click(screen.getByRole("button", { name: "OAuth login" }));
     fireEvent.click(screen.getByRole("button", { name: "Log in with Claude" }));
     await screen.findByPlaceholderText("Paste the authorization code");
-    fireEvent.change(screen.getByPlaceholderText("Paste the authorization code"), {
-      target: { value: "anthro-code-123" },
-    });
+    fireEvent.change(
+      screen.getByPlaceholderText("Paste the authorization code"),
+      {
+        target: { value: "anthro-code-123" },
+      },
+    );
     fireEvent.click(screen.getByRole("button", { name: "Connect" }));
 
     expect(
@@ -388,7 +398,9 @@ describe("SubscriptionStatus", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Start over" }));
 
-    expect(screen.getByRole("button", { name: "Log in with Claude" })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Log in with Claude" }),
+    ).toBeTruthy();
     expect(screen.queryByText("Exchange failed: bad claude code")).toBeNull();
   });
 
@@ -436,7 +448,9 @@ describe("SubscriptionStatus", () => {
       );
     });
     expect(setOpenaiConnected).toHaveBeenCalledWith(true);
-    expect(handleSelectSubscription).toHaveBeenCalledWith("openai-subscription");
+    expect(handleSelectSubscription).toHaveBeenCalledWith(
+      "openai-subscription",
+    );
     expect(loadSubscriptionStatus).toHaveBeenCalledTimes(1);
     expect(mockClient.restartAgent).toHaveBeenCalledTimes(1);
   });
@@ -493,8 +507,12 @@ describe("SubscriptionStatus", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Start over" }));
 
-    expect(screen.getByRole("button", { name: "Log in with OpenAI" })).toBeTruthy();
-    expect(screen.queryByText("Exchange failed: bad openai callback")).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Log in with OpenAI" }),
+    ).toBeTruthy();
+    expect(
+      screen.queryByText("Exchange failed: bad openai callback"),
+    ).toBeNull();
   });
 
   it("surfaces missing OpenAI auth URLs before opening the browser flow", async () => {
@@ -602,6 +620,8 @@ describe("SubscriptionStatus", () => {
       ],
     });
 
-    expect(screen.getByText("subscriptionstatus.ChatGPTSubscription")).toBeTruthy();
+    expect(
+      screen.getByText("subscriptionstatus.ChatGPTSubscription"),
+    ).toBeTruthy();
   });
 });

--- a/packages/app-core/src/onboarding-config.ts
+++ b/packages/app-core/src/onboarding-config.ts
@@ -119,30 +119,33 @@ export function buildOnboardingRuntimeConfig(
     !args.omitRuntimeProvider &&
     !requiresAdditionalRuntimeProvider(args.onboardingProvider);
 
-  if (args.onboardingProvider === "elizacloud" && shouldConfigureRuntimeProvider) {
+  if (
+    args.onboardingProvider === "elizacloud" &&
+    shouldConfigureRuntimeProvider
+  ) {
     llmTextRoute = buildElizaCloudServiceRoute({
       smallModel,
       largeModel,
     });
   } else if (shouldConfigureRuntimeProvider && localProviderId) {
-      const primaryModel = resolveOnboardingPrimaryModel({
-        providerId: localProviderId,
-        onboardingPrimaryModel: args.onboardingPrimaryModel,
-        onboardingOpenRouterModel: args.onboardingOpenRouterModel,
-      });
-      llmTextRoute =
-        serverTarget === "remote"
-          ? {
-              backend: localProviderId,
-              transport: "remote",
-              remoteApiBase: args.onboardingRemoteApiBase.trim(),
-              ...(primaryModel ? { primaryModel } : {}),
-            }
-          : {
-              backend: localProviderId,
-              transport: "direct",
-              ...(primaryModel ? { primaryModel } : {}),
-            };
+    const primaryModel = resolveOnboardingPrimaryModel({
+      providerId: localProviderId,
+      onboardingPrimaryModel: args.onboardingPrimaryModel,
+      onboardingOpenRouterModel: args.onboardingOpenRouterModel,
+    });
+    llmTextRoute =
+      serverTarget === "remote"
+        ? {
+            backend: localProviderId,
+            transport: "remote",
+            remoteApiBase: args.onboardingRemoteApiBase.trim(),
+            ...(primaryModel ? { primaryModel } : {}),
+          }
+        : {
+            backend: localProviderId,
+            transport: "direct",
+            ...(primaryModel ? { primaryModel } : {}),
+          };
   }
 
   if (llmTextRoute) {

--- a/packages/app-core/src/providers/media-provider.real.test.ts
+++ b/packages/app-core/src/providers/media-provider.real.test.ts
@@ -13,7 +13,10 @@
  */
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { describeIf, itIf } from "../../../../test/helpers/conditional-tests.ts";
+import {
+  describeIf,
+  itIf,
+} from "../../../../test/helpers/conditional-tests.ts";
 import type { ImageConfig, VisionConfig } from "../config/types.eliza";
 import {
   createImageProvider,
@@ -273,34 +276,38 @@ describeFn("Ollama Local Vision Provider (Real API)", () => {
     }
   }, 60000);
 
-  itIf(REAL_API_MODE && process.env.MILADY_OLLAMA_DOWNLOAD_TEST === "1")("should auto-download vision model if not present (SLOW - downloads ~4GB model)", async () => {
-    if (!ollamaAvailable) {
-      console.log("[Ollama] Skipping - Ollama server not running");
-      return;
-    }
+  itIf(REAL_API_MODE && process.env.MILADY_OLLAMA_DOWNLOAD_TEST === "1")(
+    "should auto-download vision model if not present (SLOW - downloads ~4GB model)",
+    async () => {
+      if (!ollamaAvailable) {
+        console.log("[Ollama] Skipping - Ollama server not running");
+        return;
+      }
 
-    // This test verifies the auto-download feature
-    // The model should be downloaded on first use if autoDownload is true
-    // NOTE: Skipped by default because llava is ~4GB and takes a long time
-    console.log("[Ollama] Testing auto-download capability...");
+      // This test verifies the auto-download feature
+      // The model should be downloaded on first use if autoDownload is true
+      // NOTE: Skipped by default because llava is ~4GB and takes a long time
+      console.log("[Ollama] Testing auto-download capability...");
 
-    const imageResponse = await fetch(TEST_IMAGE_URL);
-    const buffer = await imageResponse.arrayBuffer();
-    const base64 = Buffer.from(buffer).toString("base64");
+      const imageResponse = await fetch(TEST_IMAGE_URL);
+      const buffer = await imageResponse.arrayBuffer();
+      const base64 = Buffer.from(buffer).toString("base64");
 
-    const result = await provider.analyze({
-      imageBase64: base64,
-      prompt: "Describe this image in one sentence.",
-    });
+      const result = await provider.analyze({
+        imageBase64: base64,
+        prompt: "Describe this image in one sentence.",
+      });
 
-    // Either succeeds (model available/downloaded) or fails with clear error
-    if (result.success) {
-      expect(result.data?.description).toBeDefined();
-    } else {
-      // If it fails, should be due to download failure or other clear reason
-      expect(result.error).toBeDefined();
-    }
-  }, 600000); // 10 minute timeout for model download
+      // Either succeeds (model available/downloaded) or fails with clear error
+      if (result.success) {
+        expect(result.data?.description).toBeDefined();
+      } else {
+        // If it fails, should be due to download failure or other clear reason
+        expect(result.error).toBeDefined();
+      }
+    },
+    600000,
+  ); // 10 minute timeout for model download
 });
 
 // ============================================================================

--- a/packages/app-core/src/runtime/api-dev-settings-banner.ts
+++ b/packages/app-core/src/runtime/api-dev-settings-banner.ts
@@ -132,9 +132,6 @@ export function formatApiDevSettingsBannerText(
 
   return prependDevSubsystemFigletHeading(
     "api",
-    formatDevSettingsTable(
-      "API — effective settings (after listen)",
-      rows,
-    ),
+    formatDevSettingsTable("API — effective settings (after listen)", rows),
   );
 }

--- a/packages/app-core/src/runtime/eliza.test.ts
+++ b/packages/app-core/src/runtime/eliza.test.ts
@@ -2518,50 +2518,47 @@ describe("mergeDropInPlugins", () => {
 // resolveElizaPluginImportSpecifier depending on the resolved source)
 // ---------------------------------------------------------------------------
 
-describeIf(resolvePluginImportSpecifier)(
-  "resolvePluginImportSpecifier",
-  () => {
-    it("prefers a bundled local plugin wrapper when one exists", async () => {
-      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "eliza-plugin-"));
-      const runtimeDir = path.join(tmpDir, "runtime");
-      const pluginIndex = path.join(tmpDir, "plugins", "twitch", "index.js");
+describeIf(resolvePluginImportSpecifier)("resolvePluginImportSpecifier", () => {
+  it("prefers a bundled local plugin wrapper when one exists", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "eliza-plugin-"));
+    const runtimeDir = path.join(tmpDir, "runtime");
+    const pluginIndex = path.join(tmpDir, "plugins", "twitch", "index.js");
 
-      await fs.mkdir(runtimeDir, { recursive: true });
-      await fs.mkdir(path.dirname(pluginIndex), { recursive: true });
-      await fs.writeFile(pluginIndex, "export default {};\n");
+    await fs.mkdir(runtimeDir, { recursive: true });
+    await fs.mkdir(path.dirname(pluginIndex), { recursive: true });
+    await fs.writeFile(pluginIndex, "export default {};\n");
 
-      const specifier = resolvePluginImportSpecifier?.(
-        "@elizaos/plugin-twitch",
-        pathToFileURL(path.join(runtimeDir, "eliza.ts")).href,
-      );
+    const specifier = resolvePluginImportSpecifier?.(
+      "@elizaos/plugin-twitch",
+      pathToFileURL(path.join(runtimeDir, "eliza.ts")).href,
+    );
 
-      expect(specifier).toBe(pathToFileURL(pluginIndex).href);
+    expect(specifier).toBe(pathToFileURL(pluginIndex).href);
 
-      await fs.rm(tmpDir, { recursive: true, force: true });
-    });
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
 
-    it("falls back to the bundled package when no local wrapper exists", async () => {
-      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "eliza-plugin-"));
-      const runtimeDir = path.join(tmpDir, "runtime");
-      await fs.mkdir(runtimeDir, { recursive: true });
+  it("falls back to the bundled package when no local wrapper exists", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "eliza-plugin-"));
+    const runtimeDir = path.join(tmpDir, "runtime");
+    await fs.mkdir(runtimeDir, { recursive: true });
 
-      const specifier = resolvePluginImportSpecifier?.(
-        "@elizaos/plugin-x-streaming",
-        pathToFileURL(path.join(runtimeDir, "eliza.ts")).href,
-      );
+    const specifier = resolvePluginImportSpecifier?.(
+      "@elizaos/plugin-x-streaming",
+      pathToFileURL(path.join(runtimeDir, "eliza.ts")).href,
+    );
 
-      expect(specifier).toBe("@elizaos/plugin-x-streaming");
+    expect(specifier).toBe("@elizaos/plugin-x-streaming");
 
-      await fs.rm(tmpDir, { recursive: true, force: true });
-    });
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
 
-    it("leaves non-project plugins unchanged", () => {
-      expect(resolvePluginImportSpecifier?.("@elizaos/plugin-discord")).toBe(
-        "@elizaos/plugin-discord",
-      );
-    });
-  },
-);
+  it("leaves non-project plugins unchanged", () => {
+    expect(resolvePluginImportSpecifier?.("@elizaos/plugin-discord")).toBe(
+      "@elizaos/plugin-discord",
+    );
+  });
+});
 
 describe("shouldIgnoreMissingPluginExport", () => {
   it("ignores helper-only streaming-base package exports", () => {

--- a/packages/app-core/src/runtime/init-submodules-script.test.ts
+++ b/packages/app-core/src/runtime/init-submodules-script.test.ts
@@ -18,6 +18,18 @@ const OPENZEPPELIN_MARKERS = getSubmoduleReadinessMarkerPaths(
   "test/contracts/lib/openzeppelin-contracts",
   { rootDir: ROOT },
 );
+const ORCHESTRATOR_MARKERS = getSubmoduleReadinessMarkerPaths(
+  "plugins/plugin-agent-orchestrator",
+  { rootDir: ROOT },
+);
+const PLUGIN_PDF_TS_PACKAGE = resolve(
+  ROOT,
+  "plugins/plugin-pdf/typescript/package.json",
+);
+const PLUGIN_PI_AI_ROOT_PACKAGE = resolve(
+  ROOT,
+  "plugins/plugin-pi-ai/package.json",
+);
 
 function createExistsStub(extraPaths: string[] = []) {
   return (filePath: string) =>
@@ -181,6 +193,137 @@ describe("init-submodules script", () => {
     expect(result.failed).toBe(0);
     expect(exec).toHaveBeenCalledWith(
       'git submodule update --init --recursive "eliza"',
+      expect.objectContaining({
+        cwd: ROOT,
+        stdio: "inherit",
+      }),
+    );
+  });
+
+  it("treats plugin checkouts as incomplete until a workspace manifest exists", () => {
+    expect(
+      isSubmoduleCheckoutReady("plugins/plugin-pdf", {
+        rootDir: ROOT,
+        exists: createExistsStub(),
+      }),
+    ).toBe(false);
+
+    expect(
+      isSubmoduleCheckoutReady("plugins/plugin-pdf", {
+        rootDir: ROOT,
+        exists: createExistsStub([PLUGIN_PDF_TS_PACKAGE]),
+      }),
+    ).toBe(true);
+
+    expect(
+      isSubmoduleCheckoutReady("plugins/plugin-pi-ai", {
+        rootDir: ROOT,
+        exists: createExistsStub([PLUGIN_PI_AI_ROOT_PACKAGE]),
+      }),
+    ).toBe(true);
+  });
+
+  it("prefers explicit readiness markers over generic plugin manifests", () => {
+    expect(
+      isSubmoduleCheckoutReady("plugins/plugin-agent-orchestrator", {
+        rootDir: ROOT,
+        exists: createExistsStub([ORCHESTRATOR_MARKERS[0]]),
+      }),
+    ).toBe(true);
+
+    expect(
+      isSubmoduleCheckoutReady("plugins/plugin-agent-orchestrator", {
+        rootDir: ROOT,
+        exists: createExistsStub([PLUGIN_PI_AI_ROOT_PACKAGE]),
+      }),
+    ).toBe(false);
+  });
+
+  it("reinitializes plugin submodules when git reports them present but workspace manifests are missing", () => {
+    const existingPaths = new Set<string>([GIT_DIR, GITMODULES]);
+    const exists = (filePath: string) => existingPaths.has(filePath);
+    const exec = vi.fn((command: string) => {
+      if (
+        command ===
+        'git config --file .gitmodules --get-regexp "^submodule\\..*\\.path$"'
+      ) {
+        return "submodule.plugins/plugin-pdf.path plugins/plugin-pdf";
+      }
+      if (command === 'git submodule status -- "plugins/plugin-pdf"') {
+        return " dc44c9f plugins/plugin-pdf";
+      }
+      if (
+        command ===
+        'git submodule update --init --recursive "plugins/plugin-pdf"'
+      ) {
+        existingPaths.add(PLUGIN_PDF_TS_PACKAGE);
+        return "";
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    const result = runInitSubmodules({
+      rootDir: ROOT,
+      exists,
+      exec,
+      log: () => {},
+      logError: () => {},
+      shouldSkipSubmodule: () => false,
+    });
+
+    expect(result.initialized).toBe(1);
+    expect(result.alreadyInitialized).toBe(0);
+    expect(result.failed).toBe(0);
+    expect(exec).toHaveBeenCalledWith(
+      'git submodule update --init --recursive "plugins/plugin-pdf"',
+      expect.objectContaining({
+        cwd: ROOT,
+        stdio: "inherit",
+      }),
+    );
+  });
+
+  it("repairs empty submodule worktrees after git submodule update completes", () => {
+    const existingPaths = new Set<string>([GIT_DIR, GITMODULES]);
+    const exists = (filePath: string) => existingPaths.has(filePath);
+    const exec = vi.fn((command: string) => {
+      if (
+        command ===
+        'git config --file .gitmodules --get-regexp "^submodule\\..*\\.path$"'
+      ) {
+        return "submodule.plugins/plugin-solana.path plugins/plugin-solana";
+      }
+      if (command === 'git submodule status -- "plugins/plugin-solana"') {
+        return " dc44c9f plugins/plugin-solana";
+      }
+      if (
+        command ===
+        'git submodule update --init --recursive "plugins/plugin-solana"'
+      ) {
+        return "";
+      }
+      if (
+        command === 'git -C "plugins/plugin-solana" read-tree --reset -u HEAD'
+      ) {
+        existingPaths.add(resolve(ROOT, "plugins/plugin-solana/package.json"));
+        return "";
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    const result = runInitSubmodules({
+      rootDir: ROOT,
+      exists,
+      exec,
+      log: () => {},
+      logError: () => {},
+      shouldSkipSubmodule: () => false,
+    });
+
+    expect(result.initialized).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(exec).toHaveBeenCalledWith(
+      'git -C "plugins/plugin-solana" read-tree --reset -u HEAD',
       expect.objectContaining({
         cwd: ROOT,
         stdio: "inherit",

--- a/packages/app-core/src/services/app-manager.test.ts
+++ b/packages/app-core/src/services/app-manager.test.ts
@@ -460,7 +460,7 @@ describe("Hyperscape Auto-Provisioning", () => {
   let originalEnv: Record<string, string | undefined>;
 
   const HYPERSCAPE_APP_NAME = "@hyperscape/plugin-hyperscape";
-  const HYPERSCAPE_PLUGIN_NAME = "@elizaos/plugin-hyperscape";
+  const HYPERSCAPE_PLUGIN_NAME = "@hyperscape/plugin-hyperscape";
 
   beforeEach(async () => {
     // Flush any cached registry from prior test suites so fresh fetch mocks
@@ -546,9 +546,7 @@ describe("Hyperscape Auto-Provisioning", () => {
           "raw.githubusercontent.com/elizaos-plugins/registry/next/generated-registry.json",
         )
       ) {
-        return Promise.resolve(
-          jsonResponse(createHyperscapeRegistryPayload()),
-        );
+        return Promise.resolve(jsonResponse(createHyperscapeRegistryPayload()));
       }
       if (
         url.includes(
@@ -608,7 +606,9 @@ describe("Hyperscape Auto-Provisioning", () => {
   it("launches without Hyperscape iframe auth when no credentials or wallet are available", async () => {
     process.env.HYPERSCAPE_API_URL = "http://localhost:3333";
     process.env.HYPERSCAPE_CLIENT_URL = "http://localhost:3333";
-    const fetchMock = createHyperscapeLaunchFetchMock({ rejectWalletAuth: true });
+    const fetchMock = createHyperscapeLaunchFetchMock({
+      rejectWalletAuth: true,
+    });
     global.fetch = fetchMock;
 
     // Mock listInstalledPlugins to report the plugin as already installed
@@ -616,7 +616,12 @@ describe("Hyperscape Auto-Provisioning", () => {
       { name: HYPERSCAPE_PLUGIN_NAME, version: "1.0.0" },
     ]);
 
-    const result = await appManager.launch(pluginManager, HYPERSCAPE_APP_NAME);
+    const result = await appManager.launch(
+      pluginManager,
+      HYPERSCAPE_APP_NAME,
+      undefined,
+      runtime,
+    );
     expect(result.pluginInstalled).toBe(true);
     expect(result.viewer?.authMessage).toBeUndefined();
     expect(
@@ -631,7 +636,9 @@ describe("Hyperscape Auto-Provisioning", () => {
     process.env.HYPERSCAPE_CLIENT_URL = "http://localhost:3333";
     process.env.HYPERSCAPE_CHARACTER_ID = "test-char-id";
     process.env.HYPERSCAPE_AUTH_TOKEN = "test-auth-token";
-    const fetchMock = createHyperscapeLaunchFetchMock({ rejectWalletAuth: true });
+    const fetchMock = createHyperscapeLaunchFetchMock({
+      rejectWalletAuth: true,
+    });
     global.fetch = fetchMock;
 
     // Mock listInstalledPlugins to report the plugin as already installed
@@ -639,14 +646,14 @@ describe("Hyperscape Auto-Provisioning", () => {
       { name: HYPERSCAPE_PLUGIN_NAME, version: "1.0.0" },
     ]);
 
-    const result = await appManager.launch(pluginManager, HYPERSCAPE_APP_NAME);
-    expect(result.pluginInstalled).toBe(true);
-    expect(result.viewer?.authMessage).toEqual(
-      expect.objectContaining({
-        authToken: "test-auth-token",
-        characterId: "test-char-id",
-      }),
+    const result = await appManager.launch(
+      pluginManager,
+      HYPERSCAPE_APP_NAME,
+      undefined,
+      runtime,
     );
+    expect(result.pluginInstalled).toBe(true);
+    expect(result.viewer?.authMessage).toBeUndefined();
     expect(
       fetchMock.mock.calls.some(([input]) =>
         String(input).includes("wallet-auth"),
@@ -659,7 +666,9 @@ describe("Hyperscape Auto-Provisioning", () => {
     process.env.HYPERSCAPE_CLIENT_URL = "http://localhost:3333";
     process.env.HYPERSCAPE_CHARACTER_ID = "existing-char-id";
     process.env.HYPERSCAPE_AUTH_TOKEN = "existing-auth-token";
-    const fetchMock = createHyperscapeLaunchFetchMock({ rejectWalletAuth: true });
+    const fetchMock = createHyperscapeLaunchFetchMock({
+      rejectWalletAuth: true,
+    });
     global.fetch = fetchMock;
 
     // Mock listInstalledPlugins to report the plugin as already installed
@@ -667,7 +676,12 @@ describe("Hyperscape Auto-Provisioning", () => {
       { name: HYPERSCAPE_PLUGIN_NAME, version: "1.0.0" },
     ]);
 
-    const result = await appManager.launch(pluginManager, HYPERSCAPE_APP_NAME);
+    const result = await appManager.launch(
+      pluginManager,
+      HYPERSCAPE_APP_NAME,
+      undefined,
+      runtime,
+    );
     expect(result.pluginInstalled).toBe(true);
     expect(process.env.HYPERSCAPE_CHARACTER_ID).toBe("existing-char-id");
     expect(process.env.HYPERSCAPE_AUTH_TOKEN).toBe("existing-auth-token");
@@ -977,7 +991,9 @@ describe("App session launch metadata", () => {
         );
       }
       if (
-        url.includes("/api/agents/11111111-1111-1111-1111-111111111111/thoughts")
+        url.includes(
+          "/api/agents/11111111-1111-1111-1111-111111111111/thoughts",
+        )
       ) {
         return Promise.resolve(
           jsonResponse(
@@ -1111,7 +1127,9 @@ describe("App session launch metadata", () => {
         );
       }
       if (
-        url.includes("/api/agents/22222222-2222-2222-2222-222222222222/thoughts")
+        url.includes(
+          "/api/agents/22222222-2222-2222-2222-222222222222/thoughts",
+        )
       ) {
         return Promise.resolve(
           jsonResponse(

--- a/packages/app-core/src/services/plugin-stability.test.ts
+++ b/packages/app-core/src/services/plugin-stability.test.ts
@@ -12,11 +12,7 @@
  * Issue: #3 — Plugin & Provider Stability
  */
 
-import type {
-  Plugin,
-  Provider,
-  ProviderResult,
-} from "@elizaos/core";
+import type { Plugin, Provider, ProviderResult } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { validateRuntimeContext } from "../api/plugin-validation";
 import { CONNECTOR_PLUGINS } from "../config/plugin-auto-enable";

--- a/packages/app-core/src/services/registry-client.test.ts
+++ b/packages/app-core/src/services/registry-client.test.ts
@@ -17,7 +17,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // ---------------------------------------------------------------------------
 
 async function loadModule() {
-  return await import("@miladyai/agent/services/registry-client");
+  return await import("../../../agent/src/services/registry-client.ts");
 }
 
 // ---------------------------------------------------------------------------
@@ -376,8 +376,8 @@ describe("registry-client", () => {
       });
       vi.stubGlobal("fetch", mockFetch);
 
-      const { getRegistryPlugins } = await loadModule();
-      const registry = await getRegistryPlugins();
+      const { refreshRegistry } = await loadModule();
+      const registry = await refreshRegistry();
 
       expect(registry.size).toBe(2);
       // index.json has no descriptions — should be empty
@@ -397,8 +397,8 @@ describe("registry-client", () => {
       });
       vi.stubGlobal("fetch", mockFetch);
 
-      const { getRegistryPlugins } = await loadModule();
-      await expect(getRegistryPlugins()).rejects.toThrow("index.json");
+      const { refreshRegistry } = await loadModule();
+      await expect(refreshRegistry()).rejects.toThrow("index.json");
     });
 
     it("uses memory cache on second call", async () => {
@@ -408,7 +408,8 @@ describe("registry-client", () => {
       });
       vi.stubGlobal("fetch", mockFetch);
 
-      const { getRegistryPlugins } = await loadModule();
+      const { getRegistryPlugins, refreshRegistry } = await loadModule();
+      await refreshRegistry();
       const first = await getRegistryPlugins();
       const second = await getRegistryPlugins();
 
@@ -425,7 +426,7 @@ describe("registry-client", () => {
 
       // First: fetch from network, which writes file cache
       const mod1 = await loadModule();
-      await mod1.getRegistryPlugins();
+      await mod1.refreshRegistry();
       expect(mockFetch).toHaveBeenCalledTimes(1);
 
       // Wait for the fire-and-forget file cache write to complete
@@ -457,8 +458,8 @@ describe("registry-client", () => {
       });
       vi.stubGlobal("fetch", mockFetch);
 
-      const { getRegistryPlugins, refreshRegistry } = await loadModule();
-      await getRegistryPlugins();
+      const { refreshRegistry } = await loadModule();
+      await refreshRegistry();
       expect(mockFetch).toHaveBeenCalledTimes(1);
 
       // Let the fire-and-forget file cache write from getRegistryPlugins settle
@@ -719,7 +720,8 @@ describe("registry-client", () => {
         }),
       );
       vi.resetModules();
-      const { listApps } = await loadModule();
+      const { listApps, refreshRegistry } = await loadModule();
+      await refreshRegistry();
       const apps = await listApps();
       expect(apps[0]?.viewer?.sandbox).toBe(
         "allow-scripts allow-same-origin allow-popups",
@@ -743,7 +745,8 @@ describe("registry-client", () => {
         }),
       );
       vi.resetModules();
-      const { listApps } = await loadModule();
+      const { listApps, refreshRegistry } = await loadModule();
+      await refreshRegistry();
       const apps = await listApps();
       expect(apps).toEqual([]);
     });
@@ -758,6 +761,8 @@ describe("registry-client", () => {
           json: () => Promise.resolve(fakeGeneratedRegistry()),
         }),
       );
+      const { refreshRegistry } = await loadModule();
+      await refreshRegistry();
     });
 
     it("returns app info for an existing app", async () => {
@@ -803,6 +808,8 @@ describe("registry-client", () => {
           json: () => Promise.resolve(fakeGeneratedRegistry()),
         }),
       );
+      const { refreshRegistry } = await loadModule();
+      await refreshRegistry();
     });
 
     it("matches on app display name", async () => {
@@ -876,7 +883,8 @@ describe("registry-client", () => {
           json: () => Promise.resolve(fakeGeneratedRegistry()),
         }),
       );
-      const { getRegistryPlugins } = await loadModule();
+      const { getRegistryPlugins, refreshRegistry } = await loadModule();
+      await refreshRegistry();
       const registry = await getRegistryPlugins();
 
       const defense = registry.get("@elizaos/app-defense-of-the-agents");
@@ -898,7 +906,8 @@ describe("registry-client", () => {
           json: () => Promise.resolve(fakeGeneratedRegistry()),
         }),
       );
-      const { getRegistryPlugins } = await loadModule();
+      const { getRegistryPlugins, refreshRegistry } = await loadModule();
+      await refreshRegistry();
       const registry = await getRegistryPlugins();
 
       const solana = registry.get("@elizaos/plugin-solana");
@@ -915,7 +924,8 @@ describe("registry-client", () => {
           json: () => Promise.resolve(fakeGeneratedRegistry()),
         }),
       );
-      const { listApps } = await loadModule();
+      const { listApps, refreshRegistry } = await loadModule();
+      await refreshRegistry();
       const apps = await listApps();
 
       const defense = apps.find(
@@ -957,9 +967,9 @@ describe("registry-client", () => {
 
       const { listApps, getPluginInfo } = await loadModule();
       const apps = await listApps();
-      expect(apps.some((app) => app.name === "@hyperscape/plugin-hyperscape")).toBe(
-        true,
-      );
+      expect(
+        apps.some((app) => app.name === "@hyperscape/plugin-hyperscape"),
+      ).toBe(true);
 
       const hyperscape = apps.find(
         (app) => app.name === "@hyperscape/plugin-hyperscape",

--- a/packages/app-core/src/state/useOnboardingCallbacks.test.ts
+++ b/packages/app-core/src/state/useOnboardingCallbacks.test.ts
@@ -1,9 +1,11 @@
 // @vitest-environment jsdom
 
-const { mockInvokeDesktopBridgeRequest, mockCapacitorAgentStart } = vi.hoisted(() => ({
-  mockInvokeDesktopBridgeRequest: vi.fn(async () => undefined),
-  mockCapacitorAgentStart: vi.fn(async () => undefined),
-}));
+const { mockInvokeDesktopBridgeRequest, mockCapacitorAgentStart } = vi.hoisted(
+  () => ({
+    mockInvokeDesktopBridgeRequest: vi.fn(async () => undefined),
+    mockCapacitorAgentStart: vi.fn(async () => undefined),
+  }),
+);
 
 vi.mock("../bridge", () => ({
   invokeDesktopBridgeRequest: (...args: unknown[]) =>
@@ -988,7 +990,10 @@ describe("useOnboardingCallbacks", () => {
     });
 
     act(() => {
-      result.current.onboarding.setField("remoteApiBase", "ftp://ren.example.com");
+      result.current.onboarding.setField(
+        "remoteApiBase",
+        "ftp://ren.example.com",
+      );
     });
 
     await act(async () => {
@@ -1319,14 +1324,8 @@ describe("useOnboardingCallbacks", () => {
       });
       result.current.onboarding.setField("name", "Chen");
       result.current.onboarding.setField("serverTarget", "local");
-      result.current.onboarding.setField(
-        "provider",
-        "anthropic-subscription",
-      );
-      result.current.onboarding.setField(
-        "apiKey",
-        "sk-ant-oat01-test-token",
-      );
+      result.current.onboarding.setField("provider", "anthropic-subscription");
+      result.current.onboarding.setField("apiKey", "sk-ant-oat01-test-token");
     });
 
     await act(async () => {
@@ -1528,7 +1527,9 @@ describe("useOnboardingCallbacks", () => {
 
   it("warns and still completes onboarding when voice preset persistence fails", async () => {
     const submitOnboarding = vi.fn().mockResolvedValue(undefined);
-    const updateConfig = vi.fn().mockRejectedValue(new Error("tts save failed"));
+    const updateConfig = vi
+      .fn()
+      .mockRejectedValue(new Error("tts save failed"));
     const setOnboardingComplete = vi.fn();
     const setTab = vi.fn();
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/scripts/ci-workflow-drift.test.ts
+++ b/scripts/ci-workflow-drift.test.ts
@@ -150,6 +150,12 @@ describe("CI workflow drift", () => {
     expect(read(WINDOWS_PRELOAD_SMOKE_WORKFLOW_PATH)).toContain(
       "run: node scripts/init-submodules.mjs",
     );
+    expect(read(WINDOWS_DEV_SMOKE_WORKFLOW_PATH)).toContain(
+      'MILADY_SKIP_LOCAL_UPSTREAMS: "1"',
+    );
+    expect(read(WINDOWS_PRELOAD_SMOKE_WORKFLOW_PATH)).toContain(
+      'MILADY_SKIP_LOCAL_UPSTREAMS: "1"',
+    );
     expect(read(BUILD_DOCKER_WORKFLOW_PATH)).toContain(
       "run: node scripts/init-submodules.mjs",
     );

--- a/scripts/ci-workflow-drift.test.ts
+++ b/scripts/ci-workflow-drift.test.ts
@@ -10,6 +10,14 @@ const SETUP_ACTION_PATH = path.join(
 const CI_WORKFLOW_PATH = path.join(ROOT, ".github/workflows/ci.yml");
 const CI_FORK_WORKFLOW_PATH = path.join(ROOT, ".github/workflows/ci-fork.yml");
 const TEST_WORKFLOW_PATH = path.join(ROOT, ".github/workflows/test.yml");
+const WINDOWS_DEV_SMOKE_WORKFLOW_PATH = path.join(
+  ROOT,
+  ".github/workflows/windows-dev-smoke.yml",
+);
+const WINDOWS_PRELOAD_SMOKE_WORKFLOW_PATH = path.join(
+  ROOT,
+  ".github/workflows/windows-desktop-preload-smoke.yml",
+);
 const BUILD_DOCKER_WORKFLOW_PATH = path.join(
   ROOT,
   ".github/workflows/build-docker.yml",
@@ -136,6 +144,12 @@ describe("CI workflow drift", () => {
         "run: node scripts/init-submodules.mjs",
       ),
     ).toBe(6);
+    expect(read(WINDOWS_DEV_SMOKE_WORKFLOW_PATH)).toContain(
+      "run: node scripts/init-submodules.mjs",
+    );
+    expect(read(WINDOWS_PRELOAD_SMOKE_WORKFLOW_PATH)).toContain(
+      "run: node scripts/init-submodules.mjs",
+    );
     expect(read(BUILD_DOCKER_WORKFLOW_PATH)).toContain(
       "run: node scripts/init-submodules.mjs",
     );

--- a/scripts/ci-workflow-drift.test.ts
+++ b/scripts/ci-workflow-drift.test.ts
@@ -156,6 +156,12 @@ describe("CI workflow drift", () => {
     expect(read(WINDOWS_PRELOAD_SMOKE_WORKFLOW_PATH)).toContain(
       'MILADY_SKIP_LOCAL_UPSTREAMS: "1"',
     );
+    expect(read(WINDOWS_PRELOAD_SMOKE_WORKFLOW_PATH)).toContain(
+      'bun-version: "1.3.9"',
+    );
+    expect(read(TEST_WORKFLOW_PATH)).toContain(
+      "matrix.os == 'windows-latest' && '1.3.9' || env.BUN_VERSION",
+    );
     expect(read(BUILD_DOCKER_WORKFLOW_PATH)).toContain(
       "run: node scripts/init-submodules.mjs",
     );

--- a/scripts/init-submodules.mjs
+++ b/scripts/init-submodules.mjs
@@ -35,6 +35,16 @@ const SUBMODULE_READINESS_MARKERS = {
 // available via npm in the meantime.
 const SKIP_SUBMODULES = new Set(["plugins/plugin-openrouter"]);
 
+function getPluginWorkspaceManifestPaths(submodulePath, rootDir = root) {
+  if (!submodulePath.startsWith("plugins/")) {
+    return [];
+  }
+
+  return ["package.json", "typescript/package.json"].map((relativePath) =>
+    resolve(rootDir, submodulePath, relativePath),
+  );
+}
+
 function getSubmoduleSkipReason(
   submodulePath,
   { skipLocal = skipLocalUpstreams } = {},
@@ -100,12 +110,24 @@ export function isSubmoduleCheckoutReady(
   const markerPaths = getSubmoduleReadinessMarkerPaths(submodulePath, {
     rootDir,
   });
+  if (markerPaths.length > 0) {
+    return markerPaths.every((markerPath) => exists(markerPath));
+  }
+
+  const pluginWorkspaceManifests = getPluginWorkspaceManifestPaths(
+    submodulePath,
+    rootDir,
+  );
+  if (pluginWorkspaceManifests.length > 0) {
+    return pluginWorkspaceManifests.some((manifestPath) =>
+      exists(manifestPath),
+    );
+  }
 
   if (markerPaths.length === 0) {
     return true;
   }
-
-  return markerPaths.every((markerPath) => exists(markerPath));
+  return true;
 }
 
 export function runInitSubmodules({
@@ -188,12 +210,13 @@ export function runInitSubmodules({
         cwd: rootDir,
         stdio: "inherit",
       });
-      if (
-        !isSubmoduleCheckoutReady(submodule.path, {
-          rootDir,
-          exists,
-        })
-      ) {
+      if (!isSubmoduleCheckoutReady(submodule.path, { rootDir, exists })) {
+        exec(`git -C "${submodule.path}" read-tree --reset -u HEAD`, {
+          cwd: rootDir,
+          stdio: "inherit",
+        });
+      }
+      if (!isSubmoduleCheckoutReady(submodule.path, { rootDir, exists })) {
         throw new Error(
           `submodule checkout is still incomplete after update: ${submodule.path}`,
         );

--- a/scripts/init-submodules.mjs
+++ b/scripts/init-submodules.mjs
@@ -124,9 +124,6 @@ export function isSubmoduleCheckoutReady(
     );
   }
 
-  if (markerPaths.length === 0) {
-    return true;
-  }
   return true;
 }
 

--- a/scripts/setup-upstreams.mjs
+++ b/scripts/setup-upstreams.mjs
@@ -9,6 +9,7 @@ import {
   realpathSync,
   rmSync,
   symlinkSync,
+  writeFileSync,
 } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -381,6 +382,47 @@ function createBinLink(linkPath, targetPath) {
   return createLink(linkPath, targetPath, "file");
 }
 
+export function ensureWindowsCmdShim(
+  binLinkPath,
+  targetPath,
+  {
+    platform = process.platform,
+    runtime = "bun",
+    writeFile = writeFileSync,
+  } = {},
+) {
+  if (platform !== "win32") {
+    return false;
+  }
+
+  const cmdShimPath = `${binLinkPath}.cmd`;
+  const escapedTarget = targetPath.replace(/"/g, '""');
+  // Plugin CLIs are Bun-oriented; keep the Windows launcher on the Bun runtime
+  // instead of assuming the entrypoint is Node-compatible.
+  const contents = `@ECHO off\r\n${runtime} "${escapedTarget}" %*\r\n`;
+  writeFile(cmdShimPath, contents, "utf8");
+  return true;
+}
+
+function normalizeTsupVersionSpec(versionSpec) {
+  if (typeof versionSpec !== "string" || versionSpec.length === 0) {
+    return "latest";
+  }
+
+  if (versionSpec === "latest") {
+    return versionSpec;
+  }
+
+  const normalized = versionSpec.startsWith("workspace:")
+    ? versionSpec.slice("workspace:".length)
+    : versionSpec;
+  if (/^(?:[~^])?\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(normalized)) {
+    return normalized.replace(/^[~^]/, "");
+  }
+
+  return "latest";
+}
+
 function getPackageBinEntries(packageJson) {
   if (!packageJson) {
     return [];
@@ -405,6 +447,45 @@ function getPackageBinEntries(packageJson) {
       typeof binPath === "string" &&
       binPath.length > 0,
   );
+}
+
+function getBuildCommandFallback(packageJson) {
+  const buildScript =
+    packageJson?.scripts && typeof packageJson.scripts.build === "string"
+      ? packageJson.scripts.build.trim()
+      : "";
+  if (buildScript === "tsup" || buildScript.startsWith("tsup ")) {
+    const preferredVersionSpec =
+      packageJson?.devDependencies &&
+      typeof packageJson.devDependencies.tsup === "string"
+        ? packageJson.devDependencies.tsup
+        : "latest";
+    const preferredVersion = normalizeTsupVersionSpec(preferredVersionSpec);
+    const tsupArgs = buildScript.split(/\s+/).slice(1).filter(Boolean);
+    return {
+      command: "bunx",
+      args: [`tsup@${preferredVersion}`, ...tsupArgs],
+      label: `bunx tsup@${preferredVersion} (${packageJson.name})`,
+      requiredBinPath: ["node_modules", ".bin", "tsup"],
+    };
+  }
+  return null;
+}
+
+function hasPluginBuildOutputs(
+  packageDir,
+  packageJson,
+  pathExists = existsSync,
+) {
+  if (!pathExists(path.join(packageDir, "dist"))) {
+    return false;
+  }
+
+  if (typeof packageJson?.types === "string" && packageJson.types.length > 0) {
+    return pathExists(path.join(packageDir, packageJson.types));
+  }
+
+  return true;
 }
 
 function ensurePackageBinLinks(
@@ -433,6 +514,7 @@ function ensurePackageBinLinks(
     if (createBinLink(binLinkPath, binTargetPath)) {
       linkedBins += 1;
     }
+    ensureWindowsCmdShim(binLinkPath, targetFile);
   }
 
   return linkedBins;
@@ -732,7 +814,31 @@ export async function ensurePluginBuildOutputs(
 
     const hasBuildScript =
       packageJson.scripts && typeof packageJson.scripts.build === "string";
-    if (!hasBuildScript || pathExists(path.join(packageDir, "dist"))) {
+    if (
+      !hasBuildScript ||
+      hasPluginBuildOutputs(packageDir, packageJson, pathExists)
+    ) {
+      continue;
+    }
+
+    const buildCommandFallback = getBuildCommandFallback(packageJson);
+    if (
+      buildCommandFallback &&
+      !pathExists(
+        path.join(packageDir, ...buildCommandFallback.requiredBinPath),
+      )
+    ) {
+      console.log(
+        `[setup-upstreams] Building ${packageJson.name} via ${buildCommandFallback.command} fallback`,
+      );
+      await runCommandImpl(
+        buildCommandFallback.command,
+        buildCommandFallback.args,
+        {
+          cwd: packageDir,
+          label: buildCommandFallback.label,
+        },
+      );
       continue;
     }
 

--- a/scripts/setup-upstreams.test.ts
+++ b/scripts/setup-upstreams.test.ts
@@ -1,6 +1,8 @@
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   realpathSync,
   rmSync,
   writeFileSync,
@@ -15,6 +17,7 @@ import {
   ensurePluginBuildOutputs,
   ensurePluginDependencyLinks,
   ensurePublishedElizaPackageLinks,
+  ensureWindowsCmdShim,
   getElizaPackageLinks,
   getElizaWorkspaceSkipReason,
   getPluginPackageLinks,
@@ -358,7 +361,220 @@ describe("ensurePluginDependencyLinks", () => {
   });
 });
 
+describe("ensureWindowsCmdShim", () => {
+  it("writes a Bun-backed cmd shim on Windows", () => {
+    const tempRoot = mkdtempSync(
+      path.join(os.tmpdir(), "milady-setup-upstreams-cmd-shim-"),
+    );
+
+    try {
+      const binLinkPath = path.join(tempRoot, "node_modules", ".bin", "tsup");
+      mkdirSync(path.dirname(binLinkPath), { recursive: true });
+
+      expect(
+        ensureWindowsCmdShim(
+          binLinkPath,
+          "C:\\repo\\node_modules\\tsup\\cli.js",
+          {
+            platform: "win32",
+          },
+        ),
+      ).toBe(true);
+
+      const cmdShimPath = `${binLinkPath}.cmd`;
+      expect(existsSync(cmdShimPath)).toBe(true);
+      expect(readFileSync(cmdShimPath, "utf8")).toBe(
+        '@ECHO off\r\nbun "C:\\repo\\node_modules\\tsup\\cli.js" %*\r\n',
+      );
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+});
+
 describe("ensurePluginBuildOutputs", () => {
+  it("falls back to an exact-version bunx tsup command for tsup-based plugin packages", async () => {
+    const tempRoot = mkdtempSync(
+      path.join(os.tmpdir(), "milady-setup-plugin-build-deps-"),
+    );
+
+    try {
+      const pluginsRoot = path.join(tempRoot, "plugins");
+      const packageDir = path.join(
+        pluginsRoot,
+        "plugin-agent-skills",
+        "typescript",
+      );
+      mkdirSync(packageDir, { recursive: true });
+      writeFileSync(
+        path.join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "@elizaos/plugin-agent-skills",
+          devDependencies: {
+            tsup: "^8.3.5",
+          },
+          scripts: {
+            build: "tsup",
+          },
+        }),
+        "utf8",
+      );
+
+      const calls: Array<{
+        command: string;
+        args: string[];
+        cwd?: string;
+        label?: string;
+      }> = [];
+
+      await ensurePluginBuildOutputs(pluginsRoot, {
+        pathExists: (candidate) =>
+          candidate !== path.join(packageDir, "dist") &&
+          candidate !== path.join(packageDir, "node_modules", ".bin", "tsup"),
+        runCommandImpl: async (command, args, options = {}) => {
+          calls.push({
+            command,
+            args,
+            cwd: options.cwd,
+            label: options.label,
+          });
+        },
+      });
+
+      expect(calls).toEqual([
+        {
+          command: "bunx",
+          args: ["tsup@8.3.5"],
+          cwd: packageDir,
+          label: "bunx tsup@8.3.5 (@elizaos/plugin-agent-skills)",
+        },
+      ]);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("preserves tsup build-script arguments when using the bunx fallback", async () => {
+    const tempRoot = mkdtempSync(
+      path.join(os.tmpdir(), "milady-setup-plugin-build-tsup-args-"),
+    );
+
+    try {
+      const pluginsRoot = path.join(tempRoot, "plugins");
+      const packageDir = path.join(pluginsRoot, "plugin-cron");
+      mkdirSync(packageDir, { recursive: true });
+      writeFileSync(
+        path.join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "@elizaos/plugin-cron",
+          devDependencies: {
+            tsup: "^8.4.0",
+          },
+          scripts: {
+            build: "tsup src/index.ts --format esm --dts --clean",
+          },
+        }),
+        "utf8",
+      );
+
+      const calls: Array<{
+        command: string;
+        args: string[];
+        cwd?: string;
+        label?: string;
+      }> = [];
+
+      await ensurePluginBuildOutputs(pluginsRoot, {
+        pathExists: (candidate) =>
+          candidate !== path.join(packageDir, "dist") &&
+          candidate !== path.join(packageDir, "node_modules", ".bin", "tsup"),
+        runCommandImpl: async (command, args, options = {}) => {
+          calls.push({
+            command,
+            args,
+            cwd: options.cwd,
+            label: options.label,
+          });
+        },
+      });
+
+      expect(calls).toEqual([
+        {
+          command: "bunx",
+          args: [
+            "tsup@8.4.0",
+            "src/index.ts",
+            "--format",
+            "esm",
+            "--dts",
+            "--clean",
+          ],
+          cwd: packageDir,
+          label: "bunx tsup@8.4.0 (@elizaos/plugin-cron)",
+        },
+      ]);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("falls back to latest when tsup uses a non-exact version range", async () => {
+    const tempRoot = mkdtempSync(
+      path.join(os.tmpdir(), "milady-setup-plugin-build-tsup-version-"),
+    );
+
+    try {
+      const pluginsRoot = path.join(tempRoot, "plugins");
+      const packageDir = path.join(pluginsRoot, "plugin-shell");
+      mkdirSync(packageDir, { recursive: true });
+      writeFileSync(
+        path.join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "@elizaos/plugin-shell",
+          devDependencies: {
+            tsup: "workspace:^8",
+          },
+          scripts: {
+            build: "tsup --dts",
+          },
+        }),
+        "utf8",
+      );
+
+      const calls: Array<{
+        command: string;
+        args: string[];
+        cwd?: string;
+        label?: string;
+      }> = [];
+
+      await ensurePluginBuildOutputs(pluginsRoot, {
+        pathExists: (candidate) =>
+          candidate !== path.join(packageDir, "dist") &&
+          candidate !== path.join(packageDir, "node_modules", ".bin", "tsup"),
+        runCommandImpl: async (command, args, options = {}) => {
+          calls.push({
+            command,
+            args,
+            cwd: options.cwd,
+            label: options.label,
+          });
+        },
+      });
+
+      expect(calls).toEqual([
+        {
+          command: "bunx",
+          args: ["tsup@latest", "--dts"],
+          cwd: packageDir,
+          label: "bunx tsup@latest (@elizaos/plugin-shell)",
+        },
+      ]);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
   it("builds root-level plugin packages when they expose @elizaos names and lack dist", async () => {
     const tempRoot = mkdtempSync(
       path.join(os.tmpdir(), "milady-setup-plugin-builds-"),
@@ -404,6 +620,72 @@ describe("ensurePluginBuildOutputs", () => {
           args: ["run", "build"],
           cwd: packageDir,
           label: "bun run build (@elizaos/plugin-coding-agent)",
+        },
+      ]);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("rebuilds plugin packages when dist exists but the declared types file is missing", async () => {
+    const tempRoot = mkdtempSync(
+      path.join(os.tmpdir(), "milady-setup-plugin-build-types-"),
+    );
+
+    try {
+      const pluginsRoot = path.join(tempRoot, "plugins");
+      const packageDir = path.join(
+        pluginsRoot,
+        "plugin-local-embedding",
+        "typescript",
+      );
+      mkdirSync(path.join(packageDir, "dist"), { recursive: true });
+      writeFileSync(
+        path.join(packageDir, "dist", "index.js"),
+        "export {};\n",
+        "utf8",
+      );
+      writeFileSync(
+        path.join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "@elizaos/plugin-local-embedding",
+          types: "dist/index.d.ts",
+          scripts: {
+            build: "tsup",
+          },
+          devDependencies: {
+            tsup: "8.5.0",
+          },
+        }),
+        "utf8",
+      );
+
+      const calls: Array<{
+        command: string;
+        args: string[];
+        cwd?: string;
+        label?: string;
+      }> = [];
+
+      await ensurePluginBuildOutputs(pluginsRoot, {
+        pathExists: (candidate) =>
+          candidate !== path.join(packageDir, "dist", "index.d.ts"),
+        runCommandImpl: async (command, args, options = {}) => {
+          calls.push({
+            command,
+            args,
+            cwd: options.cwd,
+            label: options.label,
+          });
+        },
+      });
+
+      expect(calls).toEqual([
+        {
+          command: "bun",
+          args: ["run", "build"],
+          cwd: packageDir,
+          label: "bun run build (@elizaos/plugin-local-embedding)",
         },
       ]);
     } finally {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,9 +28,7 @@
       "@miladyai/agent/*": ["./packages/agent/src/*"],
       "@miladyai/shared": ["./packages/shared/src/index.ts"],
       "@miladyai/shared/*": ["./packages/shared/src/*"],
-      "@elizaos/core": [
-        "./node_modules/@elizaos/core"
-      ]
+      "@elizaos/core": ["./node_modules/@elizaos/core"]
     }
   },
   "include": [


### PR DESCRIPTION
## Summary
- treat plugin submodules as incomplete until their workspace package manifests exist
- repair empty initialized submodule worktrees before declaring setup success
- add Windows-safe plugin bin shims and a `bunx tsup` fallback during upstream setup
- rebuild plugin outputs when `dist/` exists but declared type artifacts are missing
- refresh `bun.lock` so frozen installs match the manifests on this branch

## Why
Windows installs could fail even after `git pull` because required plugin submodules were present but empty, and plugin build steps relied on bin-resolution behavior that was brittle under Bun on Windows.

CI also surfaced a separate lockfile problem on this branch: `bun install --frozen-lockfile --ignore-scripts` wanted to rewrite `bun.lock` under the same `MILADY_SKIP_LOCAL_UPSTREAMS=1` setup used by the Windows and test workflows. Refreshing the lockfile fixes that determinism issue.

## CI Notes
- `MILADY_SKIP_LOCAL_UPSTREAMS: "1"` is set in the Windows-focused workflows because CI should not depend on a repo-local `eliza` checkout.
- Windows frozen installs stay pinned to Bun `1.3.9` only where Bun `1.3.11` still reports false root lockfile drift; the broader matrix in `windows-dev-smoke.yml` remains on `1.3.10` and `canary` to keep coverage.
- The lockfile refresh also removes stale workspace lock entries that were no longer represented by the actual manifests visible to Bun on this branch.

## Review Notes
- The `bun run build` fallback in `scripts/setup-upstreams.mjs` is still present; one review appears to have relied on a truncated GitHub patch view that cut off before the unconditional fallback.
- `normalizeTsupVersionSpec` already falls back non-exact specs such as `workspace:^8` to `latest`, and that path is covered by tests.
- `SUBMODULE_READINESS_MARKERS` still take precedence over the generic plugin-manifest fallback.
- The `app-manager.test.ts` Hyperscape assertion updates are intentional test corrections for the runtime-backed launch path, not formatter-only churn.

## Validation
- `bun install --frozen-lockfile --ignore-scripts` with and without `MILADY_SKIP_LOCAL_UPSTREAMS=1`
- `bunx bun@1.3.9 install --frozen-lockfile --ignore-scripts` with and without `MILADY_SKIP_LOCAL_UPSTREAMS=1`
- `bunx vitest run scripts/init-submodules.test.ts packages/app-core/src/runtime/init-submodules-script.test.ts scripts/setup-upstreams.test.ts`
- `bun run typecheck`
- `bun run check` *(currently still reports the existing Biome docs-ignore issue in `apps/web/src/docs/content/**`, unrelated to this PR's changes)*