### PR TITLE
docs: fix broken installation link in telegram bot tutorial

### DIFF
--- a/docs/es/guides/tutorial-telegram-bot.md
+++ b/docs/es/guides/tutorial-telegram-bot.md
@@ -11,7 +11,7 @@ description: "Aprende a crear y configurar un bot de Telegram con Milady en solo
 Comienza con la integración del bot de Telegram de Milady. Este tutorial te guía a través de la creación de tu primer bot, su configuración y las pruebas de extremo a extremo.
 
 <Info>
-  Este tutorial asume que tienes Milady instalado. Si aún no lo has hecho, consulta la [Guía de instalación](../getting-started/installation.md).
+  Este tutorial asume que tienes Milady instalado. Si aún no lo has hecho, consulta la [Guía de instalación](/es/installation).
 </Info>
 
 <div id="prerequisites">

--- a/docs/fr/guides/tutorial-telegram-bot.md
+++ b/docs/fr/guides/tutorial-telegram-bot.md
@@ -11,7 +11,7 @@ description: "Apprenez à créer et configurer un bot Telegram avec Milady en qu
 Démarrez avec l'intégration du bot Telegram de Milady. Ce tutoriel vous guide à travers la création de votre premier bot, sa configuration et ses tests de bout en bout.
 
 <Info>
-  Ce tutoriel suppose que vous avez installé Milady. Si ce n'est pas encore fait, consultez le [Guide d'installation](../getting-started/installation.md).
+  Ce tutoriel suppose que vous avez installé Milady. Si ce n'est pas encore fait, consultez le [Guide d'installation](/fr/installation).
 </Info>
 
 <div id="prerequisites">

--- a/docs/guides/tutorial-telegram-bot.md
+++ b/docs/guides/tutorial-telegram-bot.md
@@ -9,7 +9,7 @@ description: "Learn how to create and configure a Telegram bot with Milady in ju
 Get started with Milady's Telegram bot integration. This tutorial walks you through creating your first bot, configuring it, and testing it end-to-end.
 
 <Info>
-  This tutorial assumes you have Milady installed. If you haven't already, check out the [Installation Guide](../getting-started/installation.md).
+  This tutorial assumes you have Milady installed. If you haven't already, check out the [Installation Guide](/installation).
 </Info>
 
 ## Prerequisites

--- a/docs/zh/guides/tutorial-telegram-bot.md
+++ b/docs/zh/guides/tutorial-telegram-bot.md
@@ -11,7 +11,7 @@ description: "了解如何在几分钟内使用 Milady 创建和配置 Telegram 
 开始使用 Milady 的 Telegram 机器人集成。本教程将引导你完成创建第一个机器人、配置以及端到端测试的全过程。
 
 <Info>
-  本教程假设你已经安装了 Milady。如果还没有，请查看[安装指南](../getting-started/installation.md)。
+  本教程假设你已经安装了 Milady。如果还没有，请查看[安装指南](/zh/installation)。
 </Info>
 
 <div id="prerequisites">


### PR DESCRIPTION
## Summary

All four language versions of the Telegram bot tutorial linked to `../getting-started/installation.md`, but there is no `getting-started/` directory under `docs/`. The canonical install page is `docs/installation.mdx` (plus per-locale `docs/<lang>/installation.mdx`), and other docs reference it via the Mintlify-style absolute path `/installation` (see e.g. `docs/cli/overview.md:126`, `docs/what-you-can-build.md:173`).

Each tutorial now points at the locale-appropriate absolute path:

- `docs/guides/tutorial-telegram-bot.md` → `/installation`
- `docs/es/guides/tutorial-telegram-bot.md` → `/es/installation`
- `docs/fr/guides/tutorial-telegram-bot.md` → `/fr/installation`
- `docs/zh/guides/tutorial-telegram-bot.md` → `/zh/installation`

All four target files exist on disk, so the links now resolve.

## Test plan

- [x] Verified `docs/getting-started/` does not exist
- [x] Verified `docs/installation.mdx` and `docs/{es,fr,zh}/installation.mdx` all exist
- [x] Diff is 4 lines across 4 files, no behavioral changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)