### PR TITLE
fix: gate lifeops widgets and preserve streamed text on post-generation errors

### DIFF
--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -970,25 +970,60 @@ export async function handleConversationRoutes(
       }
     } catch (err) {
       if (!aborted) {
-        const providerIssueReply = getChatFailureReply(err, state.logBuffer);
-        try {
-          await persistAssistantConversationMemory(
-            runtime,
-            conv.roomId,
-            providerIssueReply,
-            channelType,
+        // If text was already streamed to the client (e.g. the initial
+        // response succeeded but a post-action continuation failed), use the
+        // streamed text as the final reply instead of replacing it with a
+        // generic fallback.
+        if (streamedText) {
+          logger.warn(
+            { err: getErrorMessage(err), streamedTextLength: streamedText.length },
+            "Post-generation error after text was already streamed — using streamed text",
           );
-          conv.updatedAt = new Date().toISOString();
-          writeSse(res, {
-            type: "done",
-            fullText: providerIssueReply,
-            agentName: state.agentName,
-          });
-        } catch (persistErr) {
-          writeSse(res, {
-            type: "error",
-            message: getErrorMessage(persistErr),
-          });
+          try {
+            await persistAssistantConversationMemory(
+              runtime,
+              conv.roomId,
+              streamedText,
+              channelType,
+              turnStartedAt,
+            );
+            conv.updatedAt = new Date().toISOString();
+            writeSseJson(res, {
+              type: "done",
+              fullText: streamedText,
+              agentName: state.agentName,
+            });
+          } catch (persistErr) {
+            writeSse(res, {
+              type: "error",
+              message: getErrorMessage(persistErr),
+            });
+          }
+        } else {
+          logger.warn(
+            { err: getErrorMessage(err) },
+            "Chat generation failed with no streamed text",
+          );
+          const providerIssueReply = getChatFailureReply(err, state.logBuffer);
+          try {
+            await persistAssistantConversationMemory(
+              runtime,
+              conv.roomId,
+              providerIssueReply,
+              channelType,
+            );
+            conv.updatedAt = new Date().toISOString();
+            writeSse(res, {
+              type: "done",
+              fullText: providerIssueReply,
+              agentName: state.agentName,
+            });
+          } catch (persistErr) {
+            writeSse(res, {
+              type: "error",
+              message: getErrorMessage(persistErr),
+            });
+          }
         }
       }
     } finally {

--- a/packages/app-core/src/components/chat/widgets/registry.test.ts
+++ b/packages/app-core/src/components/chat/widgets/registry.test.ts
@@ -24,4 +24,16 @@ describe("resolveChatSidebarWidgets", () => {
       "agent-orchestrator.activity",
     ]);
   });
+
+  it("hides widgets whose plugin is absent from the loaded plugin list", () => {
+    expect(
+      resolveChatSidebarWidgets([
+        { id: "agent-orchestrator", enabled: true, isActive: true },
+      ]).map((widget) => widget.id),
+    ).toEqual([
+      "agent-orchestrator.apps",
+      "agent-orchestrator.tasks",
+      "agent-orchestrator.activity",
+    ]);
+  });
 });

--- a/packages/app-core/src/components/chat/widgets/registry.ts
+++ b/packages/app-core/src/components/chat/widgets/registry.ts
@@ -22,7 +22,7 @@ function isWidgetEnabled(
 
   const plugin = plugins.find((candidate) => candidate.id === widget.pluginId);
   if (!plugin) {
-    return widget.defaultEnabled;
+    return false;
   }
 
   return plugin.isActive === true || plugin.enabled !== false;


### PR DESCRIPTION
## Summary
- **Lifeops widget gate**: sidebar widgets whose plugin is absent from the loaded runtime plugin list are now hidden. Stops lifeops overview and Google connector widgets from polling `/api/lifeops/*` every 15s when no Google connector is configured — eliminates noisy 503s and unnecessary requests.
- **SSE stream fallback fix**: when the initial LLM response streams successfully but a post-action continuation fails, the catch block now preserves the already-streamed text instead of replacing it with "Sorry, I'm having a provider issue". Adds error logging for diagnosis.

## Test plan
- [x] `registry.test.ts` — new test verifies widgets are hidden when their plugin is absent from the plugin list
- [ ] Manual: confirm lifeops widgets don't appear in sidebar when lifeops plugin is not loaded
- [ ] Manual: send a chat message and verify no duplicate "provider issue" second reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)