### PR TITLE
fix: rebuild bundled workspace plugins when dist is stale

### DIFF
--- a/scripts/ensure-bundled-workspaces.mjs
+++ b/scripts/ensure-bundled-workspaces.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -17,6 +17,24 @@ export const BUNDLED_WORKSPACE_BUILDS = [
     artifact: path.join(
       "plugins",
       "plugin-agent-orchestrator",
+      "dist",
+      "index.js",
+    ),
+    args: ["run", "build"],
+  },
+  {
+    label: "@elizaos/plugin-agent-skills",
+    cwd: path.join("plugins", "plugin-agent-skills", "typescript"),
+    manifest: path.join(
+      "plugins",
+      "plugin-agent-skills",
+      "typescript",
+      "package.json",
+    ),
+    artifact: path.join(
+      "plugins",
+      "plugin-agent-skills",
+      "typescript",
       "dist",
       "index.js",
     ),
@@ -58,11 +76,30 @@ function runCommand(command, args, { cwd, env = process.env, label } = {}) {
   });
 }
 
+/**
+ * Check if the source (package.json as proxy for "last submodule update")
+ * is newer than the built artifact. This catches the case where the
+ * submodule was updated with new source but the stale dist from a prior
+ * version still exists on disk.
+ */
+function isArtifactStale(manifestPath, artifactPath, { pathExists = existsSync, stat = statSync } = {}) {
+  if (!pathExists(artifactPath)) return true;
+  try {
+    const srcMtime = stat(manifestPath).mtimeMs;
+    const artMtime = stat(artifactPath).mtimeMs;
+    return srcMtime > artMtime;
+  } catch {
+    // If stat fails, rebuild to be safe
+    return true;
+  }
+}
+
 export async function ensureBundledWorkspaceBuilds(
   repoRoot = DEFAULT_REPO_ROOT,
   {
     commandRunner = runCommand,
     pathExists = existsSync,
+    stat = statSync,
     log = console.log,
   } = {},
 ) {
@@ -70,12 +107,20 @@ export async function ensureBundledWorkspaceBuilds(
     const manifestPath = path.join(repoRoot, workspace.manifest);
     const artifactPath = path.join(repoRoot, workspace.artifact);
 
-    if (!pathExists(manifestPath) || pathExists(artifactPath)) {
+    if (!pathExists(manifestPath)) {
       continue;
     }
 
+    const stale = isArtifactStale(manifestPath, artifactPath, { pathExists, stat });
+    if (!stale) {
+      continue;
+    }
+
+    const reason = !pathExists(artifactPath)
+      ? `${workspace.artifact} is missing`
+      : `${workspace.artifact} is older than ${workspace.manifest}`;
     log(
-      `[ensure-bundled-workspaces] Building ${workspace.label} because ${workspace.artifact} is missing in this checkout`,
+      `[ensure-bundled-workspaces] Building ${workspace.label} because ${reason}`,
     );
     await commandRunner("bun", workspace.args, {
       cwd: path.join(repoRoot, workspace.cwd),

--- a/scripts/ensure-bundled-workspaces.test.ts
+++ b/scripts/ensure-bundled-workspaces.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -37,7 +37,7 @@ describe("ensureBundledWorkspaceBuilds", () => {
     }
   });
 
-  it("skips bundled workspace builds when the artifact already exists", async () => {
+  it("skips bundled workspace builds when the artifact is newer than manifest", async () => {
     const repoRoot = mkdtempSync(
       path.join(os.tmpdir(), "milady-bundled-workspaces-"),
     );
@@ -49,7 +49,14 @@ describe("ensureBundledWorkspaceBuilds", () => {
     try {
       mkdirSync(path.dirname(artifactPath), { recursive: true });
       mkdirSync(workspaceDir, { recursive: true });
-      writeFileSync(path.join(workspaceDir, "package.json"), "{}", "utf8");
+
+      const manifestPath = path.join(workspaceDir, "package.json");
+      writeFileSync(manifestPath, "{}", "utf8");
+      // Set manifest mtime to the past
+      const past = new Date(Date.now() - 60_000);
+      utimesSync(manifestPath, past, past);
+
+      // Write artifact after manifest so it's newer
       writeFileSync(artifactPath, "export default {};\n", "utf8");
 
       await ensureBundledWorkspaceBuilds(repoRoot, {
@@ -58,6 +65,45 @@ describe("ensureBundledWorkspaceBuilds", () => {
       });
 
       expect(runner).not.toHaveBeenCalled();
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("rebuilds when artifact exists but is older than manifest (stale dist)", async () => {
+    const repoRoot = mkdtempSync(
+      path.join(os.tmpdir(), "milady-bundled-workspaces-"),
+    );
+    const workspace = BUNDLED_WORKSPACE_BUILDS[0];
+    const workspaceDir = path.join(repoRoot, workspace.cwd);
+    const artifactPath = path.join(repoRoot, workspace.artifact);
+    const runner = vi.fn(async () => undefined);
+
+    try {
+      mkdirSync(path.dirname(artifactPath), { recursive: true });
+      mkdirSync(workspaceDir, { recursive: true });
+
+      // Write artifact first
+      writeFileSync(artifactPath, "export default {};\n", "utf8");
+      // Set artifact mtime to the past (simulates old build)
+      const past = new Date(Date.now() - 60_000);
+      utimesSync(artifactPath, past, past);
+
+      // Write manifest after artifact so it's newer (simulates submodule update)
+      writeFileSync(path.join(workspaceDir, "package.json"), "{}", "utf8");
+
+      await ensureBundledWorkspaceBuilds(repoRoot, {
+        commandRunner: runner,
+        log: () => undefined,
+      });
+
+      expect(runner).toHaveBeenCalledWith(
+        "bun",
+        ["run", "build"],
+        expect.objectContaining({
+          cwd: workspaceDir,
+        }),
+      );
     } finally {
       rmSync(repoRoot, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- `ensure-bundled-workspaces.mjs` previously skipped building if `dist/index.js` existed, even when submodule source was newer
- This caused the cloud credential work in `plugin-agent-orchestrator` (published as `0.6.2-alpha.0`, merged days ago) to never actually run locally — everyone's dev env was silently using the stale `0.6.1` dist
- Now compares `package.json` mtime against `dist/index.js` mtime and triggers a rebuild when the manifest is newer

## Test plan
- [x] Unit tests pass (`vitest run scripts/ensure-bundled-workspaces.test.ts`)
- [ ] Fresh clone + `bun install` correctly builds bundled workspaces
- [ ] Existing checkout with stale dist triggers rebuild on next `bun install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)