### PR TITLE
refactor: reuse isTruthyEnvValue in runtime-env parseEnabledFlag

### DIFF
--- a/packages/shared/src/runtime-env.ts
+++ b/packages/shared/src/runtime-env.ts
@@ -1,10 +1,11 @@
+import { isTruthyEnvValue } from "./env-utils.js";
+
 const DEFAULT_API_BIND_HOST = "127.0.0.1";
 export const DEFAULT_SERVER_ONLY_PORT = 2138;
 // Dev mode splits the Milady API from the Vite UI: API on 31337, UI on 2138.
 export const DEFAULT_DESKTOP_API_PORT = 31337;
 export const DEFAULT_DESKTOP_UI_PORT = 2138;
 
-const ENABLED_ENV_VALUES = new Set(["1", "true", "yes", "on"]);
 const LOOPBACK_BIND_RE =
   /^(localhost|127(?:\.\d{1,3}){3}|::1|\[::1\]|0:0:0:0:0:0:0:1|::ffff:127(?:\.\d{1,3}){3})$/i;
 const WILDCARD_BIND_RE = /^(0\.0\.0\.0|::|0:0:0:0:0:0:0:0)$/i;
@@ -173,8 +174,7 @@ function parseEnabledFlag(
   env: RuntimeEnvRecord,
   keys: readonly string[],
 ): boolean {
-  const raw = firstNonEmpty(env, keys);
-  return raw ? ENABLED_ENV_VALUES.has(raw.toLowerCase()) : false;
+  return isTruthyEnvValue(firstNonEmpty(env, keys) ?? undefined);
 }
 
 export function stripOptionalHostPort(value: string): string {


### PR DESCRIPTION
## Summary

`packages/shared/src/runtime-env.ts` declared a local `ENABLED_ENV_VALUES` Set to decide whether an env value counts as "on" — but the sibling `packages/shared/src/env-utils.ts` already exports `isTruthyEnvValue` with the exact same accepted token set (`1`, `true`, `yes`, `on`). Two copies of the same list meant that adding a new alias (e.g. `enabled`) would need to happen in two places, and it is easy to miss one.

This PR collapses `parseEnabledFlag` down to a single call through the shared helper, removing the duplicate constant.

## Behaviour

No change. `firstNonEmpty` already trims its return value and `isTruthyEnvValue` lowercases internally against the same set, so every previously-accepted value is still accepted and nothing new is.

## Verification

- `tsc --noEmit -p packages/shared/tsconfig.json` — clean.
- `vitest run packages/shared/src/runtime-env.test.ts` — 6/6 pass (covers the `MILADY_ALLOW_NULL_ORIGIN=1` / `MILADY_DISABLE_AUTO_API_TOKEN=1` precedence cases that flow through `parseEnabledFlag`).