### PR TITLE
fix: pick newest claude jsonl by mtime, not filename order

### DIFF
--- a/packages/agent/src/runtime/claude-jsonl-completion-watcher.test.ts
+++ b/packages/agent/src/runtime/claude-jsonl-completion-watcher.test.ts
@@ -1,0 +1,159 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  findLatestJsonl,
+  readLatestAssistantEntry,
+} from "./claude-jsonl-completion-watcher";
+
+const tempDirs: string[] = [];
+const savedHome = process.env.HOME;
+
+afterEach(async () => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  }
+  if (savedHome === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = savedHome;
+  }
+});
+
+async function makeFakeHome(workdir: string): Promise<{
+  home: string;
+  projectDir: string;
+}> {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), "claude-jsonl-test-"));
+  tempDirs.push(home);
+  const projectKey = workdir.replace(/[/.]/g, "-");
+  const projectDir = path.join(home, ".claude", "projects", projectKey);
+  await fs.mkdir(projectDir, { recursive: true });
+  process.env.HOME = home;
+  return { home, projectDir };
+}
+
+describe("findLatestJsonl", () => {
+  it("returns the most recently modified jsonl regardless of filename order", async () => {
+    const workdir = "/home/user/.some/workspace";
+    const { projectDir } = await makeFakeHome(workdir);
+
+    // Claude Code names session files with UUIDs; write them in an order
+    // where the newest mtime belongs to a file that is NOT lexically last.
+    const older = path.join(
+      projectDir,
+      "ffffffff-0000-0000-0000-000000000000.jsonl",
+    );
+    const newer = path.join(
+      projectDir,
+      "11111111-0000-0000-0000-000000000000.jsonl",
+    );
+    await fs.writeFile(older, "older\n");
+    await fs.writeFile(newer, "newer\n");
+    // Force a clear mtime ordering: older 60s in the past, newer now.
+    const now = Date.now();
+    await fs.utimes(older, new Date(now - 60_000), new Date(now - 60_000));
+    await fs.utimes(newer, new Date(now), new Date(now));
+
+    const result = await findLatestJsonl(workdir);
+    expect(result).toBe(newer);
+  });
+
+  it("ignores non-jsonl files in the project directory", async () => {
+    const workdir = "/home/user/.some/workspace";
+    const { projectDir } = await makeFakeHome(workdir);
+
+    const jsonl = path.join(projectDir, "session.jsonl");
+    const other = path.join(projectDir, "session.log");
+    await fs.writeFile(other, "log\n");
+    await fs.writeFile(jsonl, "session\n");
+    const now = Date.now();
+    // Give the .log the newer mtime to prove we're filtering by extension.
+    await fs.utimes(jsonl, new Date(now - 60_000), new Date(now - 60_000));
+    await fs.utimes(other, new Date(now), new Date(now));
+
+    const result = await findLatestJsonl(workdir);
+    expect(result).toBe(jsonl);
+  });
+
+  it("returns null when the project directory does not exist", async () => {
+    await makeFakeHome("/home/user/unused");
+    const result = await findLatestJsonl("/home/user/does-not-exist");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the project directory has no jsonl files", async () => {
+    const workdir = "/home/user/.some/workspace";
+    const { projectDir } = await makeFakeHome(workdir);
+    await fs.writeFile(path.join(projectDir, "notes.txt"), "hi\n");
+    const result = await findLatestJsonl(workdir);
+    expect(result).toBeNull();
+  });
+});
+
+describe("readLatestAssistantEntry", () => {
+  it("returns the latest assistant text with isEndTurn=true for a finished turn", () => {
+    const jsonl = [
+      JSON.stringify({
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "hi" }],
+        },
+      }),
+      JSON.stringify({
+        message: {
+          role: "assistant",
+          stop_reason: "end_turn",
+          content: [{ type: "text", text: "hello there" }],
+        },
+      }),
+    ].join("\n");
+
+    const result = readLatestAssistantEntry(jsonl);
+    expect(result).toEqual({ text: "hello there", isEndTurn: true });
+  });
+
+  it("returns isEndTurn=false when the latest assistant turn is still in progress", () => {
+    const jsonl = [
+      JSON.stringify({
+        message: {
+          role: "assistant",
+          stop_reason: "tool_use",
+          content: [{ type: "text", text: "let me check" }],
+        },
+      }),
+    ].join("\n");
+
+    const result = readLatestAssistantEntry(jsonl);
+    expect(result).toEqual({ text: "let me check", isEndTurn: false });
+  });
+
+  it("returns null when no assistant message is present", () => {
+    const jsonl = JSON.stringify({
+      message: { role: "user", content: [{ type: "text", text: "hi" }] },
+    });
+    expect(readLatestAssistantEntry(jsonl)).toBeNull();
+  });
+
+  it("skips malformed lines without throwing", () => {
+    const jsonl = [
+      "{not json",
+      JSON.stringify({
+        message: {
+          role: "assistant",
+          stop_reason: "end_turn",
+          content: [{ type: "text", text: "done" }],
+        },
+      }),
+    ].join("\n");
+
+    expect(readLatestAssistantEntry(jsonl)).toEqual({
+      text: "done",
+      isEndTurn: true,
+    });
+  });
+});

--- a/packages/agent/src/runtime/claude-jsonl-completion-watcher.ts
+++ b/packages/agent/src/runtime/claude-jsonl-completion-watcher.ts
@@ -220,11 +220,17 @@ class Poller {
  * for a given workdir. Returns null if the directory or any matching
  * file does not yet exist (e.g., the session has not produced output).
  *
+ * "Newest" means most recently modified. Claude Code names session files
+ * with UUIDs, which do NOT sort chronologically — a workspace that has
+ * had multiple sessions will have multiple jsonl files, and picking the
+ * lexicographically last name returns a stale file from an older session
+ * roughly at random. We stat each file and pick the one with the greatest
+ * mtime instead. Files that fail to stat (e.g., deleted between readdir
+ * and stat) are skipped.
+ *
  * Exported for tests.
  */
-export async function findLatestJsonl(
-  workdir: string,
-): Promise<string | null> {
+export async function findLatestJsonl(workdir: string): Promise<string | null> {
   const home = process.env.HOME ?? os.homedir();
   // Claude Code encodes project paths by replacing both `/` and `.` with
   // `-`. For example:
@@ -238,9 +244,25 @@ export async function findLatestJsonl(
   } catch {
     return null;
   }
-  const jsonls = entries.filter((f) => f.endsWith(".jsonl")).sort();
+  const jsonls = entries.filter((f) => f.endsWith(".jsonl"));
   if (jsonls.length === 0) return null;
-  return path.join(projectDir, jsonls[jsonls.length - 1]);
+  const stats = await Promise.all(
+    jsonls.map(async (name) => {
+      const full = path.join(projectDir, name);
+      try {
+        const st = await fs.stat(full);
+        return { full, mtimeMs: st.mtimeMs };
+      } catch {
+        return null;
+      }
+    }),
+  );
+  let newest: { full: string; mtimeMs: number } | null = null;
+  for (const entry of stats) {
+    if (!entry) continue;
+    if (!newest || entry.mtimeMs > newest.mtimeMs) newest = entry;
+  }
+  return newest?.full ?? null;
 }
 
 /**


### PR DESCRIPTION
## Summary

`findLatestJsonl` in `packages/agent/src/runtime/claude-jsonl-completion-watcher.ts` sorted session jsonl files alphabetically and returned the lexicographically last one:

```ts
const jsonls = entries.filter((f) => f.endsWith(".jsonl")).sort();
if (jsonls.length === 0) return null;
return path.join(projectDir, jsonls[jsonls.length - 1]);
```

Claude Code names session files with UUIDs (e.g. `8c0aba4a-8dde-403e-8b03-35fdce7efac2.jsonl`), which do **not** sort chronologically. A workspace that has had multiple subagent sessions ends up with multiple jsonl files in `~/.claude/projects/<key>/`, and this function would return whichever one happened to sort last — potentially picking a stale file from a week-old session instead of the live one.

Concrete repro from this box (`~/.claude/projects/-home-milady-iqlabs-milady/` has 12 jsonls):

| file (UUID prefix) | mtime | lex order |
|---|---|---|
| `924a83a3-…` | Apr 10 08:36 ← **actual newest** | 5th |
| `f1752011-…` | Apr 10 08:08 | 12th (last) ← **returned by old code** |

The consumers are `Poller.tick` (the synthetic `task_complete` emitter) and `postFinalReport` (the discord-facing final report in `task-progress-streamer`). Reading the wrong jsonl means the streamer posts a stale final report back to the originating channel, or re-fires `task_complete` from an old end_turn line.

## Fix

Stat each `.jsonl` in the project dir and pick the one with the greatest `mtimeMs`. Files that fail to stat (e.g. deleted between `readdir` and `stat`) are skipped rather than poisoning the selection.

## Tests

New file `packages/agent/src/runtime/claude-jsonl-completion-watcher.test.ts` covers:

- **`findLatestJsonl`**
  - returns the most recently modified jsonl regardless of filename order (regression test — uses `ffffffff-…` older + `11111111-…` newer to force a lex vs mtime mismatch)
  - ignores non-jsonl files in the project directory
  - returns `null` when the project directory does not exist
  - returns `null` when the project directory has no jsonl files
- **`readLatestAssistantEntry`** (previously exported but untested)
  - returns `isEndTurn: true` for a finished `end_turn` turn
  - returns `isEndTurn: false` for a `tool_use` turn still in progress
  - skips malformed lines without throwing
  - returns `null` when no assistant message is present

Verified locally by running the tests against both the original and fixed implementations: the mtime-sort case fails on `develop` and passes with the fix; every other case passes on both.

`bunx @biomejs/biome@2.4.7 check packages/agent/src/runtime/claude-jsonl-completion-watcher.{ts,test.ts}` is clean.

## Scope

- `packages/agent/src/runtime/claude-jsonl-completion-watcher.ts` — one function body + one doc-comment update. No API change; the function signature and return type are unchanged.
- `packages/agent/src/runtime/claude-jsonl-completion-watcher.test.ts` — new file, no prior tests for this module.

No other files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)