### PR TITLE
fix: stub missing shopify-routes module to unblock api server boot

### DIFF
--- a/packages/app-core/src/api/shopify-routes.ts
+++ b/packages/app-core/src/api/shopify-routes.ts
@@ -1,0 +1,36 @@
+/**
+ * Shopify route handler — stub.
+ *
+ * Upstream commit c15213577 ("milady: unified inbox actions, shopify/vincent
+ * apps, i18n sync, and test fixes") added
+ *
+ *     import { handleShopifyRoute } from "./shopify-routes";
+ *
+ * and a matching `/api/shopify` dispatch block to
+ * `packages/app-core/src/api/server.ts`, but never committed the route
+ * handler module itself. As a result `develop` cannot resolve its own
+ * import and the API server fails to boot with:
+ *
+ *     Cannot find module './shopify-routes' from
+ *     '.../packages/app-core/src/api/server.ts'
+ *
+ * This stub makes the import resolve so the server boots again. The handler
+ * returns `false` for every request, which tells the dispatcher the route
+ * was not handled and lets it fall through to the default 404 path — the
+ * same behavior the frontend already sees for any other unimplemented API.
+ *
+ * Replace this file with the real implementation (products / orders /
+ * inventory / customers endpoints backed by `@elizaos/plugin-shopify`'s
+ * `ShopifyService`) once it lands upstream.
+ */
+
+import type http from "node:http";
+
+export async function handleShopifyRoute(
+  _req: http.IncomingMessage,
+  _res: http.ServerResponse,
+  _pathname: string,
+  _method: string,
+): Promise<boolean> {
+  return false;
+}


### PR DESCRIPTION
## Summary

Upstream commit c15213577 (`milady: unified inbox actions, shopify/vincent apps, i18n sync, and test fixes`) added

```ts
import { handleShopifyRoute } from "./shopify-routes";
```

and a matching `/api/shopify` dispatch block to `packages/app-core/src/api/server.ts` — but never committed the route handler module itself. `develop` is left in a state where `server.ts` cannot resolve its own import and the API server fails to boot:

```
Cannot find module './shopify-routes' from
'.../packages/app-core/src/api/server.ts'
```

This PR drops in a no-op stub that:

- Exports `handleShopifyRoute` with the exact signature `server.ts:896` invokes (`req, res, pathname, method`)
- Returns `false` so the dispatcher falls through to the normal 404 path
- Lets the API server boot again; Shopify UI stays inert until the real routes land

**Scope is intentionally minimal** — one new file, no touch to `server.ts` or the frontend — so this can be picked up independently of #1841, which bundles a full shopify-routes implementation with several unrelated fixes (openzeppelin submodule, bun.lock churn, etc.). Either PR unblocks boot; this one is just a smaller surface area to review.

## Test plan

- [x] Stub file compiles in isolation (matches the four-arg signature already in `server.ts`)
- [ ] CI typecheck green on this branch
- [ ] Manual: `bun run start` boots past the previous "Cannot find module" crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)