### PR TITLE
fix: concatenate multi-block assistant text in jsonl parser

### DIFF
--- a/packages/agent/src/runtime/claude-jsonl-completion-watcher.ts
+++ b/packages/agent/src/runtime/claude-jsonl-completion-watcher.ts
@@ -303,7 +303,7 @@ export function readLatestAssistantEntry(
     let text = "";
     for (const c of msg.content ?? []) {
       if (c.type === "text" && typeof c.text === "string" && c.text.trim()) {
-        text = c.text.trim();
+        text += (text ? "\n" : "") + c.text.trim();
       }
     }
     return { text, isEndTurn: msg.stop_reason === "end_turn" };


### PR DESCRIPTION
## Summary
- `readLatestAssistantEntry` in `claude-jsonl-completion-watcher.ts` used assignment (`text = ...`) instead of concatenation (`text += ...`) when iterating over content blocks
- Claude assistant messages can contain multiple text blocks interspersed with tool_use blocks
- Only the last text block was kept; earlier blocks (potentially containing URL lines or key output) were silently dropped
- Fix: join all text blocks with newline separators

## Test plan
- [ ] Create a session jsonl with an assistant message containing multiple text content blocks
- [ ] Verify `readLatestAssistantEntry` returns the concatenated text from all blocks
- [ ] Verify single-block messages are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)