### PR TITLE
fix: sort session jsonl files by mtime instead of lexicographically

### DIFF
--- a/packages/agent/src/runtime/claude-jsonl-completion-watcher.ts
+++ b/packages/agent/src/runtime/claude-jsonl-completion-watcher.ts
@@ -238,9 +238,24 @@ export async function findLatestJsonl(
   } catch {
     return null;
   }
-  const jsonls = entries.filter((f) => f.endsWith(".jsonl")).sort();
+  const jsonls = entries.filter((f) => f.endsWith(".jsonl"));
   if (jsonls.length === 0) return null;
-  return path.join(projectDir, jsonls[jsonls.length - 1]);
+  if (jsonls.length === 1) return path.join(projectDir, jsonls[0]);
+  // Sort by modification time (newest first). UUID-based filenames have no
+  // chronological order when sorted lexicographically.
+  const withMtime = await Promise.all(
+    jsonls.map(async (f) => {
+      const full = path.join(projectDir, f);
+      try {
+        const stat = await fs.stat(full);
+        return { f, mtime: stat.mtimeMs };
+      } catch {
+        return { f, mtime: 0 };
+      }
+    }),
+  );
+  withMtime.sort((a, b) => b.mtime - a.mtime);
+  return path.join(projectDir, withMtime[0].f);
 }
 
 /**


### PR DESCRIPTION
## Summary
- `findLatestJsonl` sorted session files lexicographically to find the "newest"
- Claude Code names session jsonl files with UUID v4 identifiers (e.g. `956f24b5-...jsonl`)
- UUIDs contain random hex — lexicographic sort has no correlation with creation time
- When multiple sessions exist, the function could return an older session's data
- Fix: sort by `stat.mtimeMs` (modification time) so the most recently written file wins
- Short-circuit added for the common single-file case to avoid unnecessary stat calls

## Test plan
- [ ] Create a project dir with two jsonl files where the lexicographically-last file is older
- [ ] Verify `findLatestJsonl` returns the newer file (by mtime)
- [ ] Verify single-file directories still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)