### PR TITLE
fix(windows): make inbox reply hint platform-neutral in Milady setup

### DIFF
--- a/scripts/setup-upstreams.mjs
+++ b/scripts/setup-upstreams.mjs
@@ -86,6 +86,16 @@ const PACKAGE_LINK_ROOTS = [
   ["apps", "home", "node_modules"],
 ];
 
+const INBOX_REPLY_HINT_LEGACY = [
+  "Sent through the connected {{source}} account on this Mac.",
+];
+const INBOX_REPLY_HINT_PLATFORM_NEUTRAL =
+  "Sent through the connected {{source}} account on this device.";
+const MILADY_COPY_PATCH_RELATIVE_PATHS = [
+  path.join("packages", "app-core", "src", "components", "pages", "ChatView.tsx"),
+  path.join("packages", "app-core", "src", "i18n", "locales", "en.json"),
+];
+
 function toDisplayPath(targetPath) {
   return path.normalize(targetPath);
 }
@@ -147,6 +157,38 @@ function writePackageJson(packagePath, raw, nextPackageJson) {
     packagePath,
     `${JSON.stringify(nextPackageJson, null, indent)}\n`,
   );
+}
+
+export function applyMiladyCopyPatches(elizaRoot) {
+  let patchedFiles = 0;
+
+  for (const relativePath of MILADY_COPY_PATCH_RELATIVE_PATHS) {
+    const filePath = path.join(elizaRoot, relativePath);
+    if (!existsSync(filePath)) {
+      continue;
+    }
+
+    const raw = readFileSync(filePath, "utf8");
+    let next = raw;
+    for (const legacyCopy of INBOX_REPLY_HINT_LEGACY) {
+      next = next.split(legacyCopy).join(INBOX_REPLY_HINT_PLATFORM_NEUTRAL);
+    }
+
+    if (next === raw) {
+      continue;
+    }
+
+    writeFileSync(filePath, next);
+    patchedFiles += 1;
+  }
+
+  if (patchedFiles > 0) {
+    console.log(
+      `[setup-upstreams] Applied ${patchedFiles} Milady copy patch(es) for inbox reply hint`,
+    );
+  }
+
+  return patchedFiles;
 }
 
 function uniqueLinks(links) {
@@ -1064,6 +1106,7 @@ export async function setupUpstreams(repoRoot = DEFAULT_REPO_ROOT) {
             );
           }
         }
+        applyMiladyCopyPatches(elizaRoot);
       }
     }
     console.log(`[setup-upstreams] Skipping: ${skipReason}`);
@@ -1083,6 +1126,7 @@ export async function setupUpstreams(repoRoot = DEFAULT_REPO_ROOT) {
   }
 
   const elizaRoot = await ensureRepoLocalEliza(repoRoot);
+  applyMiladyCopyPatches(elizaRoot);
   await ensureElizaDependencies(elizaRoot);
   await ensureElizaBuildOutputs(elizaRoot);
 


### PR DESCRIPTION
## Summary
- patch upstream eliza copy during Milady setup to replace Inbox reply hint text
- rewrite "Sent through the connected {{source}} account on this Mac." to "... on this device."

## Why
Milady desktop on Windows currently shows Mac-specific copy in the Inbox reply footer.
This lands as a Milady-only, auditable fix without redirecting submodule URLs.

## Scope
- Milady repo only (`scripts/setup-upstreams.mjs`)
- no `.gitmodules` URL changes
- no personal docs

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace legacy inbox reply hint strings with platform-neutral copy in Milady setup
> Adds `applyMiladyCopyPatches` in [setup-upstreams.mjs](https://github.com/milady-ai/milady/pull/1890/files#diff-61d81dba031f233c46c15e4239a053eb2d3c374a926939e24aba9abbf8c7df91) to replace Windows-specific inbox reply hint strings with platform-neutral equivalents in two targeted files under `elizaRoot`. The function is called twice during `setupUpstreams`: once when `elizaRoot` is already resolved, and once after `ensureRepoLocalEliza`. It logs the number of patched files when changes are made.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8dc3ef0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->