### PR TITLE
scripts: preserve explicit empty ELIZA env aliases

### DIFF
--- a/scripts/lib/sync-eliza-env-aliases.mjs
+++ b/scripts/lib/sync-eliza-env-aliases.mjs
@@ -37,7 +37,7 @@ export function syncElizaEnvAliases() {
     ["MILADY_PORT", "ELIZA_UI_PORT"],
   ];
   for (const [from, to] of pairs) {
-    if (!process.env[to] && process.env[from]) {
+    if (process.env[to] === undefined && process.env[from] !== undefined) {
       process.env[to] = process.env[from];
     }
   }

--- a/scripts/lib/sync-eliza-env-aliases.test.ts
+++ b/scripts/lib/sync-eliza-env-aliases.test.ts
@@ -56,6 +56,15 @@ describe("syncElizaEnvAliases", () => {
     expect(process.env.ELIZA_NAMESPACE).toBe("eliza-original");
   });
 
+  it("treats an empty ELIZA_* value as intentional and does not overwrite it", () => {
+    process.env.MILADY_API_TOKEN = "milady-token";
+    process.env.ELIZA_API_TOKEN = "";
+
+    syncElizaEnvAliases();
+
+    expect(process.env.ELIZA_API_TOKEN).toBe("");
+  });
+
   it("maps MILADY_PORT to ELIZA_UI_PORT (asymmetric alias)", () => {
     process.env.MILADY_PORT = "2138";
 


### PR DESCRIPTION
### Motivation
- When mirroring `MILADY_*` env vars into `ELIZA_*`, an intentionally set empty-string `ELIZA_*` value was treated as unset and overwritten, losing the explicit empty setting; the intent is to preserve explicit empty targets.

### Description
- Change the mirroring predicate in `scripts/lib/sync-eliza-env-aliases.mjs` to only copy when the target is truly `undefined` (use `process.env[to] === undefined` and `process.env[from] !== undefined`).
- Add a regression test in `scripts/lib/sync-eliza-env-aliases.test.ts` that asserts an empty `ELIZA_*` value (empty string) is preserved and not overwritten from `MILADY_*`.

### Testing
- Ran `bun test scripts/lib/sync-eliza-env-aliases.test.ts`, which passed all tests (8 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfa799670c8333bc4ab5860af0c2d3)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `syncElizaEnvAliases` to preserve explicit empty-string ELIZA env vars
> The aliasing condition in [sync-eliza-env-aliases.mjs](https://github.com/milady-ai/milady/pull/1894/files#diff-2a858041ab31a0691052f436e9d5d14ef4429f1e9d2a7f17d0a8a63e5a15def5) previously used a falsy check, which caused non-empty `MILADY_*` values to overwrite `ELIZA_*` variables set to an empty string. The condition now uses strict `=== undefined` checks so that empty-string values on either side are treated as intentional. A new test case in [sync-eliza-env-aliases.test.ts](https://github.com/milady-ai/milady/pull/1894/files#diff-d4a627cc464d4407337bc55726ae5fb532b0c964f66f580fc7155fe5a340883d) covers the empty-string preservation behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized da2060b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->