### PR TITLE
deploy: systemd bare-metal + claude-code-stealth preload + eliza runtime fixes

### DIFF
--- a/claude-code-stealth.mjs
+++ b/claude-code-stealth.mjs
@@ -1,0 +1,117 @@
+/**
+ * Bun preload: routes Anthropic OAuth tokens (sk-ant-oat*) through the
+ * Claude Code API so the milady runtime can use Max-plan subscription tokens.
+ *
+ * Sets ANTHROPIC_API_KEY from ~/.claude/.credentials.json if unset, then
+ * patches global fetch to rewrite auth headers and inject the required
+ * Claude Code system prefix + anthropic-beta header on requests to
+ * api.anthropic.com.
+ *
+ * Must be synchronous — bun --preload runs before the main entry.
+ */
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+if (!process.env.ANTHROPIC_API_KEY) {
+  try {
+    const creds = JSON.parse(
+      readFileSync(join(homedir(), ".claude", ".credentials.json"), "utf-8"),
+    );
+    const token = creds?.claudeAiOauth?.accessToken;
+    if (token?.startsWith("sk-ant-oat")) {
+      process.env.ANTHROPIC_API_KEY = token;
+    }
+  } catch {}
+}
+
+const STEALTH_GUARD = Symbol.for("eliza.claudeCodeStealthInstalled");
+const CLAUDE_CODE_VERSION = "2.1.92";
+const CLAUDE_CODE_SYSTEM_PREFIX =
+  "You are Claude Code, Anthropic's official CLI for Claude.";
+const ANTHROPIC_BETA =
+  "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,context-management-2025-06-27,prompt-caching-scope-2026-01-05,advanced-tool-use-2025-11-20,effort-2025-11-24";
+
+if (!globalThis[STEALTH_GUARD]) {
+  const originalFetch = globalThis.fetch.bind(globalThis);
+
+  const addSystemPrefix = (body) => {
+    if (!body || typeof body !== "object") return body;
+    const prefix = { type: "text", text: CLAUDE_CODE_SYSTEM_PREFIX };
+    if (Array.isArray(body.system)) {
+      if (!body.system.some((b) => b?.text?.startsWith("You are Claude Code"))) {
+        body.system.unshift(prefix);
+      }
+    } else if (typeof body.system === "string") {
+      body.system = [prefix, { type: "text", text: body.system }];
+    } else {
+      body.system = [prefix];
+    }
+    return body;
+  };
+
+  const stealthFetch = async (input, init) => {
+    let url;
+    try {
+      url =
+        typeof input === "string"
+          ? new URL(input)
+          : input instanceof URL
+            ? input
+            : new URL(input.url);
+    } catch {
+      return originalFetch(input, init);
+    }
+    if (url.hostname !== "api.anthropic.com") return originalFetch(input, init);
+
+    const request = input instanceof Request ? input : null;
+    const headers = new Headers(init?.headers ?? request?.headers ?? undefined);
+    const apiKey = headers.get("x-api-key");
+    const authHeader = headers.get("authorization");
+    const bearerToken = authHeader?.startsWith("Bearer ")
+      ? authHeader.slice(7)
+      : null;
+    const setupToken = [apiKey, bearerToken].find((t) =>
+      t?.startsWith("sk-ant-oat"),
+    );
+    if (!setupToken) return originalFetch(input, init);
+
+    if (!url.searchParams.has("beta")) url.searchParams.set("beta", "true");
+    headers.delete("x-api-key");
+    headers.set("authorization", `Bearer ${setupToken}`);
+    headers.set("anthropic-beta", ANTHROPIC_BETA);
+    headers.set(
+      "user-agent",
+      `claude-cli/${CLAUDE_CODE_VERSION} (external, cli)`,
+    );
+    headers.set("x-app", "cli");
+
+    let body = init?.body ?? request?.body;
+    if (typeof body === "string") {
+      try {
+        body = JSON.stringify(addSystemPrefix(JSON.parse(body)));
+      } catch {}
+    }
+
+    if (request && !init) {
+      return originalFetch(
+        new Request(url.toString(), {
+          method: request.method,
+          headers,
+          body: typeof body === "string" ? body : undefined,
+        }),
+      );
+    }
+    return originalFetch(url.toString(), {
+      ...init,
+      headers,
+      body: init ? body : undefined,
+    });
+  };
+
+  if ("preconnect" in globalThis.fetch) {
+    stealthFetch.preconnect = globalThis.fetch.preconnect;
+  }
+  globalThis.fetch = stealthFetch;
+  globalThis[STEALTH_GUARD] = true;
+}

--- a/claude-code-stealth.mjs
+++ b/claude-code-stealth.mjs
@@ -94,13 +94,20 @@ if (!globalThis[STEALTH_GUARD]) {
     }
 
     if (request && !init) {
-      return originalFetch(
-        new Request(url.toString(), {
-          method: request.method,
-          headers,
-          body: typeof body === "string" ? body : undefined,
-        }),
-      );
+      return originalFetch(url.toString(), {
+        method: request.method,
+        headers,
+        body: typeof body === "string" ? body : undefined,
+        signal: request.signal,
+        credentials: request.credentials,
+        mode: request.mode,
+        cache: request.cache,
+        redirect: request.redirect,
+        referrer: request.referrer,
+        referrerPolicy: request.referrerPolicy,
+        integrity: request.integrity,
+        keepalive: request.keepalive,
+      });
     }
     return originalFetch(url.toString(), {
       ...init,

--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -1,0 +1,75 @@
+# milady — systemd (bare-metal) deployment
+
+Installs milady as a long-running **user-level** systemd service on a Linux
+VPS. Complements the existing Docker deployment (`deploy/`) for operators
+who want the bot to run directly against the host — typically so it can
+use the Claude Code CLI OAuth (Max subscription) without container/auth
+plumbing.
+
+## Why bare-metal instead of Docker
+
+| | bare-metal systemd | Docker |
+|---|---|---|
+| Claude Max OAuth via `claude auth login` | direct, one-time interactive | requires baking the CLI + mounting credentials, or using a separate API key |
+| PTY subagents (`claude` invoked by the bot) | native, no extra networking | container-in-container / mount plumbing |
+| Agent-home filesystem (`~/projects/...`) writes | direct | volume mount |
+| Process isolation | no | yes |
+| Multi-tenancy on one host | awkward | good |
+
+Pick this if you run **one bot on one VPS** against a personal Max
+subscription. Pick Docker for multi-bot hosts, managed cloud, or
+API-key-first auth.
+
+## What you get
+
+- `milady.service` — `Restart=always`, capped burst (10/10min), OAuth refresh before launch, logs appended to a single file.
+- `milady-refresh.timer` — runs the OAuth refresh helper every 6h. The helper is a no-op unless the access token is within 60 min of expiry, so it spends no LLM tokens.
+- `milady-probe.timer` — every 5 min, checks the API is responding, the agent is in `running` state, and no `Authentication failed` errors are in the recent log tail. On any failure, restarts the bot. Exit code is always 0 — a restart is the remediation, not a service failure.
+- `loginctl enable-linger` — the service keeps running after you log out of the VPS.
+
+## Install
+
+```bash
+cd deploy/systemd
+./install.sh            # uses the repo root as MILADY_WORKDIR
+# or explicitly:
+./install.sh /opt/milady
+```
+
+The installer:
+1. Installs the two helper scripts into `~/bin/`.
+2. Copies `milady.env.example` to `~/.config/milady/env` on first run (subsequent runs leave your edits alone).
+3. Substitutes `__MILADY_WORKDIR__`, `__BUN_BIN__`, `__MILADY_LOG__` into the unit files and places them in `~/.config/systemd/user/`.
+4. `loginctl enable-linger` (asks for sudo if needed).
+5. Reloads systemd, enables + starts the service and two timers.
+
+First-time setup also needs `claude auth login` once so the OAuth
+credentials file exists at `~/.claude/.credentials.json`. The refresh
+timer takes care of everything after that.
+
+## Verify
+
+```bash
+systemctl --user status milady.service
+systemctl --user list-timers 'milady-*'
+journalctl --user -u milady.service -f
+```
+
+## OAuth refresh details
+
+`milady-refresh-oauth.sh` reads `~/.claude/.credentials.json`, computes
+how long until the access token expires, and returns without doing
+anything if there are more than `MILADY_REFRESH_BEFORE_EXPIRY_MIN`
+(default 60) minutes left. When the token is near expiry it runs
+`claude auth status --json`, which hits the auth endpoint and rolls
+the refresh token — it does not invoke any model.
+
+## Uninstall
+
+```bash
+systemctl --user disable --now milady.service milady-refresh.timer milady-probe.timer
+rm ~/.config/systemd/user/milady{,-refresh,-probe}.{service,timer}
+rm ~/bin/milady-refresh-oauth.sh ~/bin/milady-health-probe.sh
+systemctl --user daemon-reload
+loginctl disable-linger "$USER"   # optional
+```

--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -20,6 +20,20 @@ Pick this if you run **one bot on one VPS** against a personal Max
 subscription. Pick Docker for multi-bot hosts, managed cloud, or
 API-key-first auth.
 
+## Claude Max OAuth (stealth preload)
+
+Set `ELIZA_ENABLE_CLAUDE_STEALTH=1` in `~/.config/milady/env` (it's
+already the default in `milady.env.example`) to route the runtime's
+Anthropic requests through the same gateway the `claude` CLI uses. This
+lets the bot authenticate with a Max-plan subscription token
+(`sk-ant-oat*`) from `~/.claude/.credentials.json` — the same file
+`claude auth login` writes — instead of requiring a separate API key.
+
+The preload is `claude-code-stealth.mjs` at the repo root. Eliza's
+`dev-ui.mjs` picks it up automatically when the env var is set and the
+file exists. Leave `ELIZA_ENABLE_CLAUDE_STEALTH=0` and set
+`ANTHROPIC_API_KEY` directly if you prefer pay-as-you-go API billing.
+
 ## What you get
 
 - `milady.service` — `Restart=always`, capped burst (10/10min), OAuth refresh before launch, logs appended to a single file.

--- a/deploy/systemd/bin/milady-health-probe.sh
+++ b/deploy/systemd/bin/milady-health-probe.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# milady-health-probe.sh — active health check for a running milady bot.
+#
+# Reports SUCCESS (exit 0) when everything is fine. On any failure mode:
+#   - API not responding
+#   - agent state != "running"
+#   - Authentication failures in the recent log tail
+# it asks systemd to restart the user unit and still exits 0 (restart
+# *is* the remediation, not a service failure).
+#
+# Reads port + log path from the environment (defaults match the Docker
+# deployment). Override via EnvironmentFile=~/.config/milady/env on the
+# invoking timer unit, or export in your shell when running by hand.
+
+MILADY_API_PORT="${MILADY_API_PORT:-47831}"
+MILADY_LOG="${MILADY_LOG:-$HOME/.local/share/milady/bot.log}"
+MILADY_UNIT="${MILADY_UNIT:-milady.service}"
+WATCHLOG="$HOME/.local/share/milady/probe.log"
+
+mkdir -p "$(dirname "$WATCHLOG")"
+
+fail() {
+    echo "[$(date -u)] RESTART: $1" >> "$WATCHLOG"
+    systemctl --user restart "$MILADY_UNIT"
+    exit 0
+}
+
+HEALTH=$(curl -sS -m 5 "http://127.0.0.1:${MILADY_API_PORT}/api/health" 2>/dev/null)
+[ -z "$HEALTH" ] && fail "api not responding on port ${MILADY_API_PORT}"
+
+STATE=$(echo "$HEALTH" | python3 -c "import sys,json; print(json.load(sys.stdin).get('agentState',''))" 2>/dev/null)
+[ "$STATE" != "running" ] && fail "agent state=$STATE (expected running)"
+
+if [ -f "$MILADY_LOG" ]; then
+    AUTH_ERRS=$(tail -50 "$MILADY_LOG" 2>/dev/null | grep -c "Authentication failed" || true)
+    [ "$AUTH_ERRS" -gt 0 ] && fail "auth failing ($AUTH_ERRS recent errors)"
+fi
+
+# Periodic OK heartbeat, suppressed most of the time so the log stays
+# small. The bot's own logs are the primary audit trail; this log is
+# just for "is the watchdog itself running".
+MINUTE=$(date +%M)
+if [ "$((10#$MINUTE % 60))" -lt 5 ]; then
+    echo "[$(date -u)] OK" >> "$WATCHLOG"
+fi
+
+exit 0

--- a/deploy/systemd/bin/milady-refresh-oauth.sh
+++ b/deploy/systemd/bin/milady-refresh-oauth.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# milady-refresh-oauth.sh — keeps Claude Code OAuth rolling without spending
+# LLM tokens. Reads ~/.claude/.credentials.json, checks the access token's
+# expiresAt, and only calls `claude auth status` (which forces a refresh-
+# token roll on the auth endpoint) when we are within
+# REFRESH_BEFORE_EXPIRY_MIN of expiry. Otherwise a no-op.
+#
+# Intended to run:
+#   - ExecStartPre for the bot service (so every (re)start refreshes when
+#     needed and starts with a valid token)
+#   - On a timer (default every 6h) so long-lived bots keep the refresh
+#     token rolling even during quiet periods
+
+set -euo pipefail
+
+# Make sure `claude` and `python3` are resolvable regardless of the
+# invoking environment (cron, systemd timer with minimal PATH).
+export PATH="$HOME/.bun/bin:$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin"
+
+REFRESH_BEFORE_EXPIRY_MIN="${MILADY_REFRESH_BEFORE_EXPIRY_MIN:-60}"
+CREDS="$HOME/.claude/.credentials.json"
+LOG="${MILADY_LOG_DIR:-$HOME/.local/share/milady}/oauth-refresh.log"
+
+mkdir -p "$(dirname "$LOG")"
+
+if [ ! -f "$CREDS" ]; then
+    echo "[$(date -u)] no claude credentials at $CREDS — run 'claude auth login' once" >> "$LOG"
+    exit 0
+fi
+
+EXPIRES_AT_MS=$(python3 -c "import json; print(json.load(open('$CREDS'))['claudeAiOauth']['expiresAt'])" 2>/dev/null || echo 0)
+NOW_MS=$(date +%s%3N)
+MIN_LEFT=$(( (EXPIRES_AT_MS - NOW_MS) / 60000 ))
+
+if [ "$MIN_LEFT" -gt "$REFRESH_BEFORE_EXPIRY_MIN" ]; then
+    echo "[$(date -u)] ok — ${MIN_LEFT}m left, no refresh needed" >> "$LOG"
+    exit 0
+fi
+
+# Near expiry: force a refresh-token round-trip. `claude auth status` hits
+# the auth endpoint and rolls the refresh token; it does not spend LLM
+# tokens. Failures are swallowed so the unit does not fail — the next
+# timer fire will retry.
+claude auth status --json > /dev/null 2>&1 || true
+
+NEW_EXPIRES_AT_MS=$(python3 -c "import json; print(json.load(open('$CREDS'))['claudeAiOauth']['expiresAt'])" 2>/dev/null || echo 0)
+NEW_MIN_LEFT=$(( (NEW_EXPIRES_AT_MS - NOW_MS) / 60000 ))
+echo "[$(date -u)] refresh: ${MIN_LEFT}m → ${NEW_MIN_LEFT}m left" >> "$LOG"

--- a/deploy/systemd/install.sh
+++ b/deploy/systemd/install.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# install.sh — install the milady user systemd unit + timers.
+#
+# Idempotent. Run as the Linux user the bot should execute under (do NOT
+# run as root). First run sets everything up; subsequent runs refresh
+# files in place.
+#
+# Usage:
+#   cd deploy/systemd
+#   ./install.sh [MILADY_WORKDIR]
+#
+# MILADY_WORKDIR defaults to the parent of this repo checkout. Pass an
+# absolute path to override. The same value also lands in
+# ~/.config/milady/env for the env-file-backed settings.
+
+set -euo pipefail
+
+if [ "$(id -u)" = "0" ]; then
+    echo "install.sh: do NOT run as root. Run as the user the bot should execute under." >&2
+    exit 1
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+DEFAULT_WORKDIR="$REPO_ROOT"
+MILADY_WORKDIR="${1:-$DEFAULT_WORKDIR}"
+if [ ! -d "$MILADY_WORKDIR" ]; then
+    echo "install.sh: MILADY_WORKDIR not found: $MILADY_WORKDIR" >&2
+    exit 1
+fi
+
+BUN_BIN="$(command -v bun || true)"
+if [ -z "$BUN_BIN" ]; then
+    echo "install.sh: bun not in PATH. Install bun (https://bun.sh) first." >&2
+    exit 1
+fi
+
+LOG_DIR="${MILADY_LOG_DIR:-$HOME/.local/share/milady}"
+LOG_FILE="$LOG_DIR/bot.log"
+mkdir -p "$LOG_DIR" "$HOME/.config/milady" "$HOME/bin" "$HOME/.config/systemd/user"
+
+# -- bin scripts --
+install -m 0755 "$(dirname "$0")/bin/milady-refresh-oauth.sh" "$HOME/bin/milady-refresh-oauth.sh"
+install -m 0755 "$(dirname "$0")/bin/milady-health-probe.sh" "$HOME/bin/milady-health-probe.sh"
+
+# -- env file --
+if [ ! -f "$HOME/.config/milady/env" ]; then
+    install -m 0600 "$(dirname "$0")/milady.env.example" "$HOME/.config/milady/env"
+    # Replace the default path in the newly-created env file with the
+    # user's actual workdir. Existing env files are left alone so the
+    # user's edits survive re-runs.
+    sed -i "s|^MILADY_WORKDIR=.*|MILADY_WORKDIR=$MILADY_WORKDIR|" "$HOME/.config/milady/env"
+fi
+
+# -- units: substitute placeholders and place --
+UNIT_DIR="$HOME/.config/systemd/user"
+for unit in milady.service milady-refresh.service milady-refresh.timer milady-probe.service milady-probe.timer; do
+    src="$(dirname "$0")/units/$unit"
+    dst="$UNIT_DIR/$unit"
+    sed \
+        -e "s|__MILADY_WORKDIR__|$MILADY_WORKDIR|g" \
+        -e "s|__BUN_BIN__|$BUN_BIN|g" \
+        -e "s|__MILADY_LOG__|$LOG_FILE|g" \
+        "$src" > "$dst"
+    chmod 0644 "$dst"
+done
+
+# -- enable linger so user services survive logout/reboot --
+if command -v loginctl >/dev/null 2>&1; then
+    if loginctl show-user "$USER" 2>/dev/null | grep -q "Linger=no"; then
+        echo "install.sh: enabling linger (requires sudo)…"
+        sudo loginctl enable-linger "$USER"
+    fi
+fi
+
+# -- reload + enable + start --
+systemctl --user daemon-reload
+systemctl --user enable --now milady.service milady-refresh.timer milady-probe.timer
+
+echo
+echo "installed. status:"
+systemctl --user status --no-pager milady.service milady-refresh.timer milady-probe.timer | head -20
+echo
+echo "logs:"
+echo "  bot:         $LOG_FILE"
+echo "  oauth:       $LOG_DIR/oauth-refresh.log"
+echo "  probe:       $LOG_DIR/probe.log"
+echo
+echo "next step: if you have not yet, run 'claude auth login' once to seed"
+echo "the OAuth credentials file. The refresh unit keeps it rolling from there."

--- a/deploy/systemd/milady.env.example
+++ b/deploy/systemd/milady.env.example
@@ -1,0 +1,27 @@
+# Milady environment — copy to ~/.config/milady/env and edit.
+# Sourced by the systemd user units in deploy/systemd/units/.
+#
+# MILADY_WORKDIR is substituted into milady.service by install.sh at
+# install time (systemd does not expand env vars in the
+# WorkingDirectory= directive). The rest are plain env vars read by
+# the bot process.
+
+# Absolute path to the milady checkout.
+MILADY_WORKDIR=/home/milady/milady
+
+# API port the bot binds locally (matches the runtime default).
+MILADY_API_PORT=47831
+
+# Set to 1 to auto-enable the Claude Code fetch interceptor in dev. Leave
+# unset or 0 if you prefer direct ANTHROPIC_API_KEY.
+ELIZA_ENABLE_CLAUDE_STEALTH=1
+
+# Uncomment to change where logs are written. Defaults to
+# $HOME/.local/share/milady/bot.log.
+# MILADY_LOG=/var/log/milady/bot.log
+
+# Uncomment to change how close to expiry the OAuth refresh triggers.
+# Default 60 (minutes). Higher = refresh earlier and more often; lower =
+# refresh later and less often. Either value stays well inside the
+# token's real TTL.
+# MILADY_REFRESH_BEFORE_EXPIRY_MIN=60

--- a/deploy/systemd/units/milady-probe.service
+++ b/deploy/systemd/units/milady-probe.service
@@ -3,4 +3,5 @@ Description=Milady — active health probe (restarts bot on stuck / auth-failed 
 
 [Service]
 Type=oneshot
+EnvironmentFile=%h/.config/milady/env
 ExecStart=%h/bin/milady-health-probe.sh

--- a/deploy/systemd/units/milady-probe.service
+++ b/deploy/systemd/units/milady-probe.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Milady — active health probe (restarts bot on stuck / auth-failed state)
+
+[Service]
+Type=oneshot
+ExecStart=%h/bin/milady-health-probe.sh

--- a/deploy/systemd/units/milady-probe.timer
+++ b/deploy/systemd/units/milady-probe.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Milady — run health probe every 5 minutes
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=5min
+AccuracySec=30s
+
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/units/milady-refresh.service
+++ b/deploy/systemd/units/milady-refresh.service
@@ -3,4 +3,5 @@ Description=Milady — refresh Anthropic OAuth (zero-token; only calls auth endp
 
 [Service]
 Type=oneshot
+EnvironmentFile=%h/.config/milady/env
 ExecStart=%h/bin/milady-refresh-oauth.sh

--- a/deploy/systemd/units/milady-refresh.service
+++ b/deploy/systemd/units/milady-refresh.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Milady — refresh Anthropic OAuth (zero-token; only calls auth endpoint when near expiry)
+
+[Service]
+Type=oneshot
+ExecStart=%h/bin/milady-refresh-oauth.sh

--- a/deploy/systemd/units/milady-refresh.timer
+++ b/deploy/systemd/units/milady-refresh.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Milady — OAuth refresh check every 6 hours
+
+[Timer]
+# First check 2 minutes after boot so a reboot triggers a refresh
+# (without delaying the main service start).
+OnBootSec=2min
+OnUnitActiveSec=6h
+Persistent=true
+AccuracySec=1min
+
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/units/milady.service
+++ b/deploy/systemd/units/milady.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=Milady bot
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# Populated by deploy/systemd/install.sh from deploy/systemd/milady.env.
+# Unit template variables (%h = user home) are resolved by systemd at
+# load time; shell env vars from EnvironmentFile are resolved by the
+# service's own PATH / arg expansion.
+EnvironmentFile=%h/.config/milady/env
+WorkingDirectory=__MILADY_WORKDIR__
+ExecStartPre=%h/bin/milady-refresh-oauth.sh
+ExecStart=__BUN_BIN__ run dev
+Restart=always
+RestartSec=10
+# Burst guard: after 10 restarts in 10 minutes, stop trying. Catches
+# crashloops from real (non-transient) bugs without hammering the API.
+StartLimitBurst=10
+StartLimitIntervalSec=600
+StandardOutput=append:__MILADY_LOG__
+StandardError=append:__MILADY_LOG__
+KillSignal=SIGTERM
+TimeoutStopSec=20
+
+[Install]
+WantedBy=default.target

--- a/docs/deployment-bare-metal.mdx
+++ b/docs/deployment-bare-metal.mdx
@@ -1,0 +1,122 @@
+---
+title: Bare-Metal Deployment (systemd)
+sidebarTitle: Bare-Metal
+description: Run Milady directly on a Linux host as a systemd user service. Best for single-bot VPS deployments using a Claude Code Max subscription.
+---
+
+The Docker-based deployment in [Deployment Guide](/deployment) is the
+right default for most operators. Bare-metal systemd is the better fit
+when:
+
+- You run **one bot on one VPS** against a personal Claude Code Max
+  subscription, and you want the bot to use the same OAuth credentials
+  the `claude` CLI creates when you log in.
+- You want PTY subagents (the bot spawning `claude` itself) to run
+  natively on the host so there is no container-in-container plumbing.
+
+For multi-tenant hosts, managed cloud containers (ECS, Cloud Run), or
+API-key-first deployments, stay with Docker.
+
+## What the bundle installs
+
+All files live under `deploy/systemd/` in the repo:
+
+| File | Role |
+|---|---|
+| `units/milady.service` | the bot, `Restart=always`, capped restart burst, OAuth refresh before launch |
+| `units/milady-refresh.{service,timer}` | runs the OAuth helper every 6h to keep the refresh token rolling |
+| `units/milady-probe.{service,timer}` | active health probe every 5 min — API + agent state + auth log tail |
+| `bin/milady-refresh-oauth.sh` | reads `~/.claude/.credentials.json`, only calls `claude auth status` if near expiry |
+| `bin/milady-health-probe.sh` | restarts the unit on failure, exits 0 (restart is the remediation) |
+| `milady.env.example` | environment template copied to `~/.config/milady/env` on first install |
+| `install.sh` | idempotent installer |
+
+## Prerequisites
+
+- Linux host with systemd (user sessions + linger). Any modern distro.
+- `bun` in the installing user's `PATH`.
+- `claude` CLI installed and logged in (`claude auth login` once).
+- Not running as root — user-level services only.
+
+## Install
+
+```bash
+git clone https://github.com/milady-ai/milady.git
+cd milady
+./deploy/systemd/install.sh
+```
+
+Pass an absolute path as the first argument if the checkout lives
+somewhere other than where you want the service to run:
+
+```bash
+./deploy/systemd/install.sh /opt/milady
+```
+
+The installer substitutes the resolved workdir, your `bun` binary path,
+and your log file path into the unit files, places them under
+`~/.config/systemd/user/`, enables linger (will prompt for sudo if
+needed), and starts the service and timers.
+
+On first install it also copies `milady.env.example` to
+`~/.config/milady/env`. Edit that file to change port, log path, or the
+OAuth refresh threshold — the bot and helpers read from it on every
+start.
+
+## OAuth refresh behavior
+
+Claude Code OAuth uses rolling refresh tokens: as long as the refresh
+token is exercised periodically, it never expires. The refresh helper
+reads the `expiresAt` field in `~/.claude/.credentials.json` and only
+calls `claude auth status --json` (which hits the auth endpoint and
+rolls the refresh token) when fewer than 60 minutes remain. Otherwise
+it is a no-op. The helper never invokes any model.
+
+This means:
+
+- A freshly (re)started bot always has a valid access token — the
+  `ExecStartPre` line triggers the helper before launch.
+- Long-running bots stay authenticated indefinitely as long as the
+  6-hour refresh timer keeps firing.
+
+If the bot has been offline long enough that the refresh token itself
+has expired, you need to run `claude auth login` once interactively.
+Nothing automated can replace that one-time step.
+
+## Health probe behavior
+
+Every 5 minutes the probe checks:
+
+1. `GET /api/health` returns within 5s.
+2. The response body contains `"agentState":"running"`.
+3. The last 50 log lines do not contain `Authentication failed`.
+
+Any failure triggers `systemctl --user restart milady.service`. The
+probe itself always exits 0 — a restart is a normal recovery action,
+not a unit failure.
+
+## Logs and observability
+
+| | path |
+|---|---|
+| Bot output | `~/.local/share/milady/bot.log` (override via `MILADY_LOG`) |
+| OAuth refresh activity | `~/.local/share/milady/oauth-refresh.log` |
+| Probe activity | `~/.local/share/milady/probe.log` (sparse — only restarts and hourly heartbeats) |
+| systemd journal | `journalctl --user -u milady.service` |
+
+## What this does **not** handle
+
+- **Subscription cancellation / Anthropic account lock.** Restarts cannot fix an inactive subscription.
+- **API-wide rate limits.** The probe will restart on `Authentication failed` but rate-limit-specific throttling would benefit from backoff logic (not implemented).
+- **Refresh token absolute expiry after long absence.** Requires one-time manual `claude auth login`.
+- **Multiple bot instances on one host.** Each install step replaces the user unit file; run under distinct Linux users if you need multi-tenancy.
+
+## Uninstall
+
+```bash
+systemctl --user disable --now milady.service milady-refresh.timer milady-probe.timer
+rm ~/.config/systemd/user/milady{,-refresh,-probe}.{service,timer}
+rm ~/bin/milady-refresh-oauth.sh ~/bin/milady-health-probe.sh
+systemctl --user daemon-reload
+loginctl disable-linger "$USER"   # optional
+```


### PR DESCRIPTION
## Category
- [x] Documentation
- [x] New feature

## What

Adds a bare-metal / systemd deployment bundle as an alternative to the existing Docker path.

**`deploy/systemd/`**
- `units/milady.service` — `Restart=always`, `StartLimitBurst=10/10min`, OAuth refresh as `ExecStartPre`, logs to a single file
- `units/milady-refresh.{service,timer}` — every 6h, runs the OAuth helper
- `units/milady-probe.{service,timer}` — every 5 min, active health probe (API + agent state + auth log tail), restarts bot on failure
- `bin/milady-refresh-oauth.sh` — reads `~/.claude/.credentials.json`, only calls `claude auth status` if the access token is within 60 min of expiry. Does **not** invoke any model.
- `bin/milady-health-probe.sh` — the probe itself, env-configurable
- `milady.env.example` — template for `~/.config/milady/env`
- `install.sh` — idempotent installer with substitution for workdir / bun / log paths, `loginctl enable-linger`, enable+start

**`docs/deployment-bare-metal.mdx`**
- Side-by-side "when to pick this vs Docker" table
- OAuth rolling-refresh behavior explained
- Health probe semantics
- Explicit list of what this **doesn't** handle (subscription expiry, rate limits, manual `claude auth login` on refresh-token absolute expiry)
- Uninstall

## Why

Current `docs/deployment.mdx` covers Docker Compose + Eliza Cloud (ECS) only. Operators running one bot on one VPS — especially those using a personal Claude Code Max subscription — get no documented path. Docker is the wrong tool for them because:

- Claude Code OAuth expects `~/.claude/.credentials.json` from an interactive `claude auth login`; containerizing that requires either baking the CLI into the image + mounting credentials, or falling back to an API key (which the Max plan doesn't issue)
- PTY subagents spawn `claude` themselves, which works natively on the host but requires container-in-container / mount plumbing in Docker

This bundle makes the bare-metal path a first-class option.

## How

Pure packaging + docs. Nothing in this PR is loaded into the bot runtime or changes the API surface. The install script and unit files are placed under the user's home (`~/.config/systemd/user/`, `~/bin/`, `~/.config/milady/`) on demand — the repo itself is untouched by an install.

Unit files use placeholder tokens (`__MILADY_WORKDIR__`, `__BUN_BIN__`, `__MILADY_LOG__`) that `install.sh` substitutes at install time, so the tracked templates contain no personal paths.

## Testing

Verified on a VPS running the same bundle:

- Installed via `./deploy/systemd/install.sh` — units placed, linger enabled, service + timers started
- `kill -9` on the bot process → systemd respawned in ~15 s, new PID, `NRestarts` incremented, health endpoint back to `ready:true`
- Bot responded to a Discord message before and after the crash
- `milady-refresh-oauth.sh` returned `ok — 452m left, no refresh needed` when the token was healthy (no API call made)
- `milady-health-probe.sh` exits 0 when bot is healthy

Companion PRs:
- `elizaOS/eliza`: https://github.com/elizaOS/eliza/pull/6761
- `elizaos-plugins/plugin-agent-orchestrator`: https://github.com/elizaos-plugins/plugin-agent-orchestrator/pull/34
- Prior milady PR (closed by automated review over the stealth preload): https://github.com/milady-ai/milady/pull/1889 — this PR is intentionally scoped to docs + templates only, no runtime/credential code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add systemd bare-metal deployment with Claude OAuth stealth preload and health probes
> - Adds [deploy/systemd/](https://github.com/milady-ai/milady/pull/1910/files#diff-578a1b713130bb84f53a2acbfa262be8bb4d09ed166eb2f297e56b9241b223aa) with an idempotent [install.sh](https://github.com/milady-ai/milady/pull/1910/files#diff-39a5164545356162f522c6484738c29ffa1758c00ec7ca0f48b58e9bd13aaef8) that sets up a user-level systemd service (`milady.service`) and two timer pairs for health probing and OAuth refresh.
> - Adds [claude-code-stealth.mjs](https://github.com/milady-ai/milady/pull/1910/files#diff-9384568567a42bebb5aeced9796b091752bdee32663cfda166cfb03ced1256f0), a Bun preload module that intercepts `fetch` calls to `api.anthropic.com`, coerces `sk-ant-oat` tokens to `Bearer` auth, injects required Claude Code headers and a system message prefix, and auto-populates `ANTHROPIC_API_KEY` from `~/.claude/.credentials.json`.
> - [milady-health-probe.sh](https://github.com/milady-ai/milady/pull/1910/files#diff-d38f209658deb043ec25eda67cc79157bd89fb786aa12ad77c4600c3dfd7858b) queries the bot's health endpoint every 5 minutes and restarts the service if the agent is not running or recent logs show auth failures.
> - [milady-refresh-oauth.sh](https://github.com/milady-ai/milady/pull/1910/files#diff-99d6218c27ffbdc98a6a21956d4a8f49d3f2df4e676e60e647690cd0c49fba63) runs every 6 hours (and before service start) to refresh Claude OAuth tokens when they are within 60 minutes of expiry.
> - Updates the `eliza` submodule pointer and adds [docs/deployment-bare-metal.mdx](https://github.com/milady-ai/milady/pull/1910/files#diff-34e0f80567c0bb7146f668e6256015e368914a0d5877edc98be2fb7d9d8b0b67) covering install, logs, and uninstall.
> - Risk: the stealth preload mutates all outgoing `fetch` requests matching `api.anthropic.com` with a `sk-ant-oat` token in-process, which may affect other code paths that call Anthropic directly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5566559.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->