### PR TITLE
fix(vite): collapse three.js chunks for cloud staging blank screen

### DIFF
--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -381,11 +381,9 @@ function resolveManualChunk(id: string): string | undefined {
       return "vendor-vrm";
     }
 
-    if (normalizedId.includes("/three/examples/")) {
-      return "vendor-three-extras";
-    }
-
-    if (pathIncludesAny(normalizedId, ["/three/build/", "/three/src/"])) {
+    // Collapse all three.js code into one chunk to avoid cross-chunk TDZ
+    // init ordering bugs with WebGPU/TSL enums (see fix/three-chunk-tdz).
+    if (normalizedId.includes("/three/")) {
       return "vendor-three";
     }
   }


### PR DESCRIPTION
Production cloud staging agents can serve a blank web UI because three.js TSL/WebGPU chunk splitting creates a cross-chunk TDZ hazard. This change collapses all three.js modules into a single vendor-three chunk while leaving VRM separate.\n\nThis PR is specifically for the cloud/staging flow.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Collapse three.js chunks into single `vendor-three` bundle to fix blank screen on cloud staging
> The split between `vendor-three` and `vendor-three-extras` chunks was causing a blank screen on cloud staging. [vite.config.ts](https://github.com/milady-ai/milady/pull/1943/files#diff-0d80c2713ea1483c55bbc803b5d5d6a1f75654501e99a33c5d306cdbddd511e4) now maps all `/three/` paths to a single `vendor-three` chunk, removing the separate `vendor-three-extras` output.
>
> Behavioral Change: The `vendor-three-extras` chunk is no longer produced; all three.js code (core and examples) is bundled together.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c3ae44.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->