### PR TITLE
fix(app): polyfill WebGPU enums to fix three.js init crash

### DIFF
--- a/apps/app/index.html
+++ b/apps/app/index.html
@@ -2,6 +2,35 @@
 <html lang="en">
 
 <head>
+  <!-- Polyfill for three.js TSL WebGPU enum access.
+       Three.js assumes self.GPUShaderStage exists when self is defined,
+       but many browsers have self without WebGPU support. -->
+  <script>
+    if (typeof self !== 'undefined' && !self.GPUShaderStage) {
+      self.GPUShaderStage = Object.freeze({ VERTEX: 1, FRAGMENT: 2, COMPUTE: 4 });
+    }
+    if (typeof self !== 'undefined' && !self.GPUBufferUsage) {
+      self.GPUBufferUsage = Object.freeze({
+        MAP_READ: 1, MAP_WRITE: 2, COPY_SRC: 4, COPY_DST: 8,
+        INDEX: 16, VERTEX: 32, UNIFORM: 64, STORAGE: 128,
+        INDIRECT: 256, QUERY_RESOLVE: 512
+      });
+    }
+    if (typeof self !== 'undefined' && !self.GPUTextureUsage) {
+      self.GPUTextureUsage = Object.freeze({
+        COPY_SRC: 1, COPY_DST: 2, TEXTURE_BINDING: 4,
+        STORAGE_BINDING: 8, RENDER_ATTACHMENT: 16
+      });
+    }
+    if (typeof self !== 'undefined' && !self.GPUColorWrite) {
+      self.GPUColorWrite = Object.freeze({
+        RED: 1, GREEN: 2, BLUE: 4, ALPHA: 8, ALL: 15
+      });
+    }
+    if (typeof self !== 'undefined' && !self.GPUMapMode) {
+      self.GPUMapMode = Object.freeze({ READ: 1, WRITE: 2 });
+    }
+  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <meta name="apple-mobile-web-app-capable" content="yes" />


### PR DESCRIPTION
Agent web UI blank screen was NOT fixed by PR #1943. Real bug is a broken existence check in three.js 0.182's TSL code that assumes self.GPUShaderStage exists whenever self does. Polyfill the enum globals before any script loads.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Polyfill WebGPU enums in `index.html` to fix three.js init crash
> three.js reads WebGPU bitmask constants (`GPUShaderStage`, `GPUBufferUsage`, etc.) at init time and crashes when they are absent. An inline script in [index.html](https://github.com/milady-ai/milady/pull/1949/files#diff-21968f9dd9f7c3d57b4791441ac14e11fade383ab1709526cf0b711a46cefc58) defines and freezes these enums on `self` before any other scripts run, only when the environment lacks them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 49a25c3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->