### PR TITLE
fix(ci): snap chown soft-fail + viem fallback spec lookup

### DIFF
--- a/.github/actions/normalize-snapd-root/action.yml
+++ b/.github/actions/normalize-snapd-root/action.yml
@@ -1,5 +1,5 @@
 name: Normalize Snapd Root Ownership
-description: Repair root ownership on ephemeral runners before invoking snapd-based build steps.
+description: Best-effort repair of root ownership on ephemeral runners before invoking snapd-based build steps. Soft-fails when sudo is unavailable so downstream snapcraft errors remain the authoritative signal.
 runs:
   using: composite
   steps:
@@ -8,8 +8,13 @@ runs:
         set -euo pipefail
         ROOT_OWNER="$(stat -c '%u:%g' /)"
         echo "Runner root owner: ${ROOT_OWNER}"
-        if [ "${ROOT_OWNER}" != "0:0" ]; then
-          echo "Repairing / ownership so snapd/systemd path canonicalization accepts this runner"
-          sudo chown root:root /
+        if [ "${ROOT_OWNER}" = "0:0" ]; then
+          echo "Root is already 0:0 — snapd canonicalization OK"
+          exit 0
         fi
-        test "$(stat -c '%u:%g' /)" = "0:0"
+        echo "Attempting to repair / ownership so snapd/systemd path canonicalization accepts this runner"
+        if sudo -n chown root:root / 2>/dev/null; then
+          echo "Chown succeeded; new owner: $(stat -c '%u:%g' /)"
+        else
+          echo "::warning::Unable to chown / to root:root (sudo unavailable or passwordless sudo disabled). snapd may fail downstream. Remediation: run this job on a standard ubuntu-latest / ubuntu-24.04 GitHub-hosted runner, or configure the container image so / is owned by 0:0."
+        fi

--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -332,11 +332,16 @@ jobs:
           set -euo pipefail
           ROOT_OWNER="$(stat -c '%u:%g' /)"
           echo "Runner root owner: ${ROOT_OWNER}"
-          if [ "${ROOT_OWNER}" != "0:0" ]; then
-            echo "Repairing / ownership so snapd/systemd path canonicalization accepts this runner"
-            sudo chown root:root /
+          if [ "${ROOT_OWNER}" = "0:0" ]; then
+            echo "Root is already 0:0 — snapd canonicalization OK"
+            exit 0
           fi
-          test "$(stat -c '%u:%g' /)" = "0:0"
+          echo "Attempting to repair / ownership so snapd/systemd path canonicalization accepts this runner"
+          if sudo -n chown root:root / 2>/dev/null; then
+            echo "Chown succeeded; new owner: $(stat -c '%u:%g' /)"
+          else
+            echo "::warning::Unable to chown / to root:root (sudo unavailable or passwordless sudo disabled). snapd may fail downstream. Remediation: run this job on a standard ubuntu-latest / ubuntu-24.04 GitHub-hosted runner, or configure the container image so / is owned by 0:0."
+          fi
       - uses: snapcore/action-build@v1
         id: snap
       - name: Verify snap

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -200,11 +200,16 @@ jobs:
           set -euo pipefail
           ROOT_OWNER="$(stat -c '%u:%g' /)"
           echo "Runner root owner: ${ROOT_OWNER}"
-          if [ "${ROOT_OWNER}" != "0:0" ]; then
-            echo "Repairing / ownership so snapd/systemd path canonicalization accepts this runner"
-            sudo chown root:root /
+          if [ "${ROOT_OWNER}" = "0:0" ]; then
+            echo "Root is already 0:0 — snapd canonicalization OK"
+            exit 0
           fi
-          test "$(stat -c '%u:%g' /)" = "0:0"
+          echo "Attempting to repair / ownership so snapd/systemd path canonicalization accepts this runner"
+          if sudo -n chown root:root / 2>/dev/null; then
+            echo "Chown succeeded; new owner: $(stat -c '%u:%g' /)"
+          else
+            echo "::warning::Unable to chown / to root:root (sudo unavailable or passwordless sudo disabled). snapd may fail downstream. Remediation: run this job on a standard ubuntu-latest / ubuntu-24.04 GitHub-hosted runner, or configure the container image so / is owned by 0:0."
+          fi
 
       - name: Build snap
         uses: snapcore/action-build@v1

--- a/.github/workflows/snap-build-test.yml
+++ b/.github/workflows/snap-build-test.yml
@@ -59,11 +59,16 @@ jobs:
           set -euo pipefail
           ROOT_OWNER="$(stat -c '%u:%g' /)"
           echo "Runner root owner: ${ROOT_OWNER}"
-          if [ "${ROOT_OWNER}" != "0:0" ]; then
-            echo "Repairing / ownership so snapd/systemd path canonicalization accepts this runner"
-            sudo chown root:root /
+          if [ "${ROOT_OWNER}" = "0:0" ]; then
+            echo "Root is already 0:0 — snapd canonicalization OK"
+            exit 0
           fi
-          test "$(stat -c '%u:%g' /)" = "0:0"
+          echo "Attempting to repair / ownership so snapd/systemd path canonicalization accepts this runner"
+          if sudo -n chown root:root / 2>/dev/null; then
+            echo "Chown succeeded; new owner: $(stat -c '%u:%g' /)"
+          else
+            echo "::warning::Unable to chown / to root:root (sudo unavailable or passwordless sudo disabled). snapd may fail downstream. Remediation: run this job on a standard ubuntu-latest / ubuntu-24.04 GitHub-hosted runner, or configure the container image so / is owned by 0:0."
+          fi
 
       - name: Build snap
         uses: snapcore/action-build@v1

--- a/scripts/discord-export-to-markdown-log.mjs
+++ b/scripts/discord-export-to-markdown-log.mjs
@@ -82,7 +82,9 @@ function toMessage(rawMessage) {
       rawMessage.author?.id ||
       "Unknown",
     content: sanitizeContent(rawMessage.content ?? ""),
-    attachments: attachments.map((attachment) => attachment.fileName || "attachment"),
+    attachments: attachments.map(
+      (attachment) => attachment.fileName || "attachment",
+    ),
   };
 }
 
@@ -96,7 +98,8 @@ function splitIntoChunks(messages, chunkHours, maxMessagesPerChunk) {
     const shouldStartNewChunk =
       currentChunk.length === 0 ||
       currentChunk.length >= maxMessagesPerChunk ||
-      (previous && message.timestamp.getTime() - previous.timestamp.getTime() >= chunkMs);
+      (previous &&
+        message.timestamp.getTime() - previous.timestamp.getTime() >= chunkMs);
 
     if (shouldStartNewChunk && currentChunk.length > 0) {
       chunks.push(currentChunk);
@@ -199,7 +202,9 @@ function main() {
   const raw = JSON.parse(fs.readFileSync(options.inputPath, "utf8"));
   const messages = (raw.messages ?? [])
     .map((message) => toMessage(message))
-    .sort((left, right) => left.timestamp.getTime() - right.timestamp.getTime());
+    .sort(
+      (left, right) => left.timestamp.getTime() - right.timestamp.getTime(),
+    );
   const chunks = splitIntoChunks(
     messages,
     options.chunkHours,

--- a/scripts/install-published-workspace-fallback-deps.sh
+++ b/scripts/install-published-workspace-fallback-deps.sh
@@ -14,6 +14,31 @@ read_version_from_manifest() {
   ' "$manifest"
 }
 
+# Reads the pinned spec for `dep_name` from a manifest's dependencies /
+# devDependencies / peerDependencies. Used when the version we want is NOT
+# the manifest's own `version` field (e.g. viem is a transitive third-party
+# dep declared in eliza/packages/agent; reading the manifest's own version
+# yields @elizaos's alpha version and produces a non-existent specifier like
+# `viem@2.0.0-alpha.177`).
+read_dependency_spec_from_manifest() {
+  local manifest="$1"
+  local dep_name="$2"
+  [[ -f "$manifest" ]] || return 1
+
+  node -e '
+    const fs = require("node:fs");
+    const pkg = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+    const dep =
+      pkg.dependencies?.[process.argv[2]] ??
+      pkg.devDependencies?.[process.argv[2]] ??
+      pkg.peerDependencies?.[process.argv[2]] ??
+      pkg.optionalDependencies?.[process.argv[2]];
+    if (typeof dep === "string" && dep.length > 0) {
+      process.stdout.write(dep);
+    }
+  ' "$manifest" "$dep_name"
+}
+
 append_versioned_package() {
   local package_name="$1"
   shift
@@ -22,6 +47,25 @@ append_versioned_package() {
   for manifest in "$@"; do
     if version="$(read_version_from_manifest "$manifest" 2>/dev/null)" && [[ -n "$version" ]]; then
       packages+=("${package_name}@${version}")
+      return 0
+    fi
+  done
+
+  packages+=("$package_name")
+}
+
+# Like append_versioned_package, but reads the pinned spec for `package_name`
+# from each manifest's dependencies section rather than the manifest's own
+# `version` field. For transitive third-party deps (viem, pathe, etc.) that
+# we want to install at whatever range the source manifest declared.
+append_dependency_spec_package() {
+  local package_name="$1"
+  shift
+
+  local manifest spec
+  for manifest in "$@"; do
+    if spec="$(read_dependency_spec_from_manifest "$manifest" "$package_name" 2>/dev/null)" && [[ -n "$spec" ]]; then
+      packages+=("${package_name}@${spec}")
       return 0
     fi
   done
@@ -93,7 +137,12 @@ packages+=("coding-agent-adapters@0.16.3")
 # the root install by disable-local-eliza-workspace but still bundled by the
 # Docker CI smoke through the apps/app alias, producing "Rolldown failed to
 # resolve import viem/accounts".
-append_versioned_package \
+#
+# Must read viem's pinned spec from eliza/packages/agent's `dependencies`,
+# NOT the manifest's own `version` field — that field is @elizaos's alpha
+# version (e.g. 2.0.0-alpha.177) and produces a non-existent `viem@...`
+# specifier that fails `bun add` with ENOENT.
+append_dependency_spec_package \
   "viem" \
   "eliza/packages/agent/package.json" \
   ".eliza.ci-disabled/packages/agent/package.json"


### PR DESCRIPTION
## Summary

Two CI blockers currently failing on `develop`:

1. **Snap build `Normalize runner root ownership for snapd`** hard-fails on runners where `/` isn't owned by 0:0 (Depot + some container runners). `sudo chown root:root /` can't run (no passwordless sudo), then the downstream `test "$(stat -c '%u:%g' /)" = "0:0"` assertion kills the step. Fix: use `sudo -n`, emit `::warning::` with remediation guidance on failure, drop the hard assertion. Snapcraft downstream either succeeds or fails with its own clear error. Applied to the composite action and all 3 inline copies.

2. **`install-published-workspace-fallback-deps.sh` installs `viem@2.0.0-alpha.177`** (non-existent on npm). The script's `append_versioned_package "viem" "eliza/packages/agent/package.json"` reads the manifest's own `version` field — which after `disable-local-eliza-workspace.mjs` rewrites becomes the @elizaos alpha version, not viem's. Fix: new `append_dependency_spec_package` helper reads viem's pinned range from the manifest's dependencies section, producing `viem@^2.21.0` (correctly resolvable).

## Test plan

- [x] Local dry-run: `bash` sourcing confirms `viem@^2.21.0` now, not `viem@2.0.0-alpha.177`
- [x] `actionlint` passes on all 4 workflow files
- [x] `bash -n` passes on the edited shell script
- [ ] CI: `Snap Build & Test` + `Agent Release / npm package build` both pass on this PR

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix snap chown to soft-fail and resolve viem spec from agent package dependencies
> - Updates `normalize-snapd-root` steps across CI workflows to exit early if `/` is already owned by `0:0`, attempt `sudo -n chown` otherwise, and emit a `::warning::` instead of failing the job when sudo is unavailable.
> - Fixes `viem` installation in [`install-published-workspace-fallback-deps.sh`](https://github.com/milady-ai/milady/pull/1959/files#diff-e832c6e84272d53c69294ed3d371d1406135e28bc1adc129f6afc094872cb252) by reading the pinned version range from the agent package's `dependencies` field rather than using the manifest's own (invalid) version string.
> - Adds `read_dependency_spec_from_manifest` and `append_dependency_spec_package` helpers to the install script for resolving transitive third-party package specs from manifests.
> - Behavioral Change: CI jobs that previously failed when `chown /` could not be performed will now continue with a warning.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 372e2a5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->