### PR TITLE
fix(ci): snap chown soft-fail + viem fallback spec lookup

### DIFF
--- a/.github/actions/normalize-snapd-root/action.yml
+++ b/.github/actions/normalize-snapd-root/action.yml
@@ -1,5 +1,5 @@
 name: Normalize Snapd Root Ownership
-description: Repair root ownership on ephemeral runners before invoking snapd-based build steps.
+description: Best-effort repair of root ownership on ephemeral runners before invoking snapd-based build steps. Soft-fails when sudo is unavailable so downstream snapcraft errors remain the authoritative signal.
 runs:
   using: composite
   steps:
@@ -8,8 +8,13 @@ runs:
         set -euo pipefail
         ROOT_OWNER="$(stat -c '%u:%g' /)"
         echo "Runner root owner: ${ROOT_OWNER}"
-        if [ "${ROOT_OWNER}" != "0:0" ]; then
-          echo "Repairing / ownership so snapd/systemd path canonicalization accepts this runner"
-          sudo chown root:root /
+        if [ "${ROOT_OWNER}" = "0:0" ]; then
+          echo "Root is already 0:0 — snapd canonicalization OK"
+          exit 0
         fi
-        test "$(stat -c '%u:%g' /)" = "0:0"
+        echo "Attempting to repair / ownership so snapd/systemd path canonicalization accepts this runner"
+        if sudo -n chown root:root / 2>/dev/null; then
+          echo "Chown succeeded; new owner: $(stat -c '%u:%g' /)"
+        else
+          echo "::warning::Unable to chown / to root:root (sudo unavailable or passwordless sudo disabled). snapd may fail downstream. Remediation: run this job on a standard ubuntu-latest / ubuntu-24.04 GitHub-hosted runner, or configure the container image so / is owned by 0:0."
+        fi

--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -330,11 +330,16 @@ jobs:
           set -euo pipefail
           ROOT_OWNER="$(stat -c '%u:%g' /)"
           echo "Runner root owner: ${ROOT_OWNER}"
-          if [ "${ROOT_OWNER}" != "0:0" ]; then
-            echo "Repairing / ownership so snapd/systemd path canonicalization accepts this runner"
-            sudo chown root:root /
+          if [ "${ROOT_OWNER}" = "0:0" ]; then
+            echo "Root is already 0:0 — snapd canonicalization OK"
+            exit 0
           fi
-          test "$(stat -c '%u:%g' /)" = "0:0"
+          echo "Attempting to repair / ownership so snapd/systemd path canonicalization accepts this runner"
+          if sudo -n chown root:root / 2>/dev/null; then
+            echo "Chown succeeded; new owner: $(stat -c '%u:%g' /)"
+          else
+            echo "::warning::Unable to chown / to root:root (sudo unavailable or passwordless sudo disabled). snapd may fail downstream. Remediation: run this job on a standard ubuntu-latest / ubuntu-24.04 GitHub-hosted runner, or configure the container image so / is owned by 0:0."
+          fi
       - uses: snapcore/action-build@v1
         id: snap
       - name: Verify snap

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -196,11 +196,16 @@ jobs:
           set -euo pipefail
           ROOT_OWNER="$(stat -c '%u:%g' /)"
           echo "Runner root owner: ${ROOT_OWNER}"
-          if [ "${ROOT_OWNER}" != "0:0" ]; then
-            echo "Repairing / ownership so snapd/systemd path canonicalization accepts this runner"
-            sudo chown root:root /
+          if [ "${ROOT_OWNER}" = "0:0" ]; then
+            echo "Root is already 0:0 — snapd canonicalization OK"
+            exit 0
           fi
-          test "$(stat -c '%u:%g' /)" = "0:0"
+          echo "Attempting to repair / ownership so snapd/systemd path canonicalization accepts this runner"
+          if sudo -n chown root:root / 2>/dev/null; then
+            echo "Chown succeeded; new owner: $(stat -c '%u:%g' /)"
+          else
+            echo "::warning::Unable to chown / to root:root (sudo unavailable or passwordless sudo disabled). snapd may fail downstream. Remediation: run this job on a standard ubuntu-latest / ubuntu-24.04 GitHub-hosted runner, or configure the container image so / is owned by 0:0."
+          fi
 
       - name: Build snap
         uses: snapcore/action-build@v1

--- a/.github/workflows/snap-build-test.yml
+++ b/.github/workflows/snap-build-test.yml
@@ -59,11 +59,16 @@ jobs:
           set -euo pipefail
           ROOT_OWNER="$(stat -c '%u:%g' /)"
           echo "Runner root owner: ${ROOT_OWNER}"
-          if [ "${ROOT_OWNER}" != "0:0" ]; then
-            echo "Repairing / ownership so snapd/systemd path canonicalization accepts this runner"
-            sudo chown root:root /
+          if [ "${ROOT_OWNER}" = "0:0" ]; then
+            echo "Root is already 0:0 — snapd canonicalization OK"
+            exit 0
           fi
-          test "$(stat -c '%u:%g' /)" = "0:0"
+          echo "Attempting to repair / ownership so snapd/systemd path canonicalization accepts this runner"
+          if sudo -n chown root:root / 2>/dev/null; then
+            echo "Chown succeeded; new owner: $(stat -c '%u:%g' /)"
+          else
+            echo "::warning::Unable to chown / to root:root (sudo unavailable or passwordless sudo disabled). snapd may fail downstream. Remediation: run this job on a standard ubuntu-latest / ubuntu-24.04 GitHub-hosted runner, or configure the container image so / is owned by 0:0."
+          fi
 
       - name: Build snap
         uses: snapcore/action-build@v1

--- a/scripts/install-published-workspace-fallback-deps.sh
+++ b/scripts/install-published-workspace-fallback-deps.sh
@@ -14,6 +14,31 @@ read_version_from_manifest() {
   ' "$manifest"
 }
 
+# Reads the pinned spec for `dep_name` from a manifest's dependencies /
+# devDependencies / peerDependencies. Used when the version we want is NOT
+# the manifest's own `version` field (e.g. viem is a transitive third-party
+# dep declared in eliza/packages/agent; reading the manifest's own version
+# yields @elizaos's alpha version and produces a non-existent specifier like
+# `viem@2.0.0-alpha.177`).
+read_dependency_spec_from_manifest() {
+  local manifest="$1"
+  local dep_name="$2"
+  [[ -f "$manifest" ]] || return 1
+
+  node -e '
+    const fs = require("node:fs");
+    const pkg = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+    const dep =
+      pkg.dependencies?.[process.argv[2]] ??
+      pkg.devDependencies?.[process.argv[2]] ??
+      pkg.peerDependencies?.[process.argv[2]] ??
+      pkg.optionalDependencies?.[process.argv[2]];
+    if (typeof dep === "string" && dep.length > 0) {
+      process.stdout.write(dep);
+    }
+  ' "$manifest" "$dep_name"
+}
+
 append_versioned_package() {
   local package_name="$1"
   shift
@@ -22,6 +47,25 @@ append_versioned_package() {
   for manifest in "$@"; do
     if version="$(read_version_from_manifest "$manifest" 2>/dev/null)" && [[ -n "$version" ]]; then
       packages+=("${package_name}@${version}")
+      return 0
+    fi
+  done
+
+  packages+=("$package_name")
+}
+
+# Like append_versioned_package, but reads the pinned spec for `package_name`
+# from each manifest's dependencies section rather than the manifest's own
+# `version` field. For transitive third-party deps (viem, pathe, etc.) that
+# we want to install at whatever range the source manifest declared.
+append_dependency_spec_package() {
+  local package_name="$1"
+  shift
+
+  local manifest spec
+  for manifest in "$@"; do
+    if spec="$(read_dependency_spec_from_manifest "$manifest" "$package_name" 2>/dev/null)" && [[ -n "$spec" ]]; then
+      packages+=("${package_name}@${spec}")
       return 0
     fi
   done
@@ -93,7 +137,12 @@ packages+=("coding-agent-adapters@0.16.3")
 # the root install by disable-local-eliza-workspace but still bundled by the
 # Docker CI smoke through the apps/app alias, producing "Rolldown failed to
 # resolve import viem/accounts".
-append_versioned_package \
+#
+# Must read viem's pinned spec from eliza/packages/agent's `dependencies`,
+# NOT the manifest's own `version` field — that field is @elizaos's alpha
+# version (e.g. 2.0.0-alpha.177) and produces a non-existent `viem@...`
+# specifier that fails `bun add` with ENOENT.
+append_dependency_spec_package \
   "viem" \
   "eliza/packages/agent/package.json" \
   ".eliza.ci-disabled/packages/agent/package.json"


### PR DESCRIPTION
Two CI blockers on the release pipeline:

1. Snap build `Normalize runner root ownership for snapd` steps hard-fail on runners where / is owned by a non-root user (e.g. Depot / containers with 1001:1002). `sudo chown root:root /` fails without passwordless sudo, and the downstream `test "$(stat) = 0:0"` assertion kills the step. Fix: use `sudo -n` so failure is non-fatal, emit `::warning::` with remediation guidance, drop the hard assertion. snapcraft downstream either succeeds or fails with its own clear error. Applied to the composite action and all 3 inline copies (publish-packages, snap-build-test, agent-release).

2. `install-published-workspace-fallback-deps.sh` was installing `viem@2.0.0-alpha.177` (non-existent on npm) because `append_versioned_package "viem" "eliza/packages/agent/package.json"` reads the manifest's own `version` field — which after `disable-local-eliza-workspace.mjs` rewrites becomes the @elizaos alpha version, not viem's. Add `append_dependency_spec_package` that reads viem's pinned range from the manifest's dependencies section (yielding `viem@^2.21.0`, correctly resolvable).

This PR will be reviewed by an AI agent. Provide clear context to help it assess your changes.

Aesthetic/UI changes that don't improve agent capability are out of scope and will be rejected.

## Category
- [ ] Bug fix
- [ ] Security fix
- [ ] Performance improvement
- [ ] New feature
- [ ] Documentation
- [ ] Test coverage
- [ ] Other

## What
(brief description)

## Why
(motivation)

## How
(implementation approach)

## Testing
(what was tested, how to verify)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix snap `chown` soft-fail and viem fallback spec lookup in CI scripts
> - Replaces hard `chown` assertions in snapd root-ownership normalization steps across [`action.yml`](https://github.com/milady-ai/milady/pull/1960/files#diff-67e3028370495ff19b9d84abe8d9ea4261bf9ed3af2aa549a13f00ffe6ee5a26), [`agent-release.yml`](https://github.com/milady-ai/milady/pull/1960/files#diff-e6e19f9ab90dc6fa2053f119a13a1f08b8a95324ca73d82d96dd18d8d12e305b), [`publish-packages.yml`](https://github.com/milady-ai/milady/pull/1960/files#diff-f649dfa0883378db13b96d378fbaedfaf99e75a92d0962d813575b79643dd01b), and [`snap-build-test.yml`](https://github.com/milady-ai/milady/pull/1960/files#diff-3d753717a158ea76cda9bf521329485b47a9a62a0c42f526e0148071f2f4c50f): steps now early-exit when `/` is already owned by `0:0`, attempt passwordless `sudo -n chown`, and emit a warning instead of failing if sudo is unavailable.
> - Fixes incorrect `viem` version resolution in [`install-published-workspace-fallback-deps.sh`](https://github.com/milady-ai/milady/pull/1960/files#diff-e832c6e84272d53c69294ed3d371d1406135e28bc1adc129f6afc094872cb252) by reading the declared semver range from `eliza/packages/agent`'s `package.json` dependencies rather than using the `@elizaos` package's own version field, which produced a non-existent `viem@<alpha>` spec.
> - Behavioral Change: snapd root-ownership steps no longer block the job when sudo is unavailable; they log a warning and continue.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2a88592.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->