### PR TITLE
fix(cloud): wallet-core-routes stub + broaden wallet bridge fallback

### DIFF
--- a/deploy/Dockerfile.ci
+++ b/deploy/Dockerfile.ci
@@ -351,7 +351,7 @@ for (const name of apps) {
   fs.writeFileSync(dir + '/plugin.mjs', emptyPlugin);
   // app-steward has extra subpath imports from dist/api/server.js
   if (name === '@elizaos/app-steward') {
-    const routeStub = `export async function resolveWalletExportRejection() { return null; }\nexport default {};`;
+    const routeStub = `export async function resolveWalletExportRejection() { return null; }\nexport async function handleWalletCoreRoutes() { return false; }\nexport default {};`;
     const secStub = `export async function hydrateWalletKeysFromNodePlatformSecureStore() { return null; }\nexport async function deleteWalletSecretsFromOsStore() { return null; }\nexport default {};`;
     fs.writeFileSync(dir + '/routes-stub.mjs', routeStub);
     fs.writeFileSync(dir + '/security-stub.mjs', secStub);
@@ -360,6 +360,7 @@ for (const name of apps) {
       exports: {
         './plugin': './plugin.mjs', '.': './plugin.mjs',
         './routes/server-wallet-trade': './routes-stub.mjs',
+        './routes/wallet-core-routes': './routes-stub.mjs',
         './security/hydrate-wallet-keys-from-platform-store': './security-stub.mjs',
         './security/wallet-os-store-actions': './security-stub.mjs',
       }


### PR DESCRIPTION
Fixes agent web UI 'Failed to fetch balances' error. Two fixes:

1. deploy/Dockerfile.ci app-steward stub now exports ./routes/wallet-core-routes as a no-op handler returning false (triggers local bridge fallback)
2. eliza submodule bumped to broaden isModuleResolutionFailure() to recognize ERR_PACKAGE_PATH_NOT_EXPORTED

Both layers defend against similar stubbing issues going forward.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `handleWalletCoreRoutes` stub and wallet-core-routes subpath export to CI Dockerfile
> - Adds a `handleWalletCoreRoutes` async function (returning `false`) to the route stub string generated for `@elizaos/app-steward` in [deploy/Dockerfile.ci](https://github.com/milady-ai/milady/pull/1966/files#diff-e67773d363989b4d49146b7288ce4a3e1fa2a8d6d9408543e58d4d083c9e1234)
> - Maps the `./routes/wallet-core-routes` subpath export to `./routes-stub.mjs` so CI builds can resolve imports to that path without the full package
> - Updates the `eliza` submodule pointer to pick up upstream changes
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 36646a3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->