### PR TITLE
fix(ci): unblock staging build

### DIFF
--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -34,6 +34,7 @@ import {
 import {
   applyForceFreshOnboardingReset,
   applyLaunchConnectionFromUrl,
+  dispatchQueuedLifeOpsGithubCallbackFromUrl,
   installDesktopPermissionsClientPatch,
   installForceFreshOnboardingClientPatch,
   installLocalProviderCloudPreferencePatch,
@@ -42,7 +43,6 @@ import {
   shouldInstallMainWindowOnboardingPatches,
   syncDetachedShellLocation,
 } from "@elizaos/app-core";
-import { dispatchQueuedLifeOpsGithubCallbackFromUrl } from "@elizaos/app-lifeops/platform";
 import type { ShareTargetPayload } from "@elizaos/app-core/platform";
 import {
   DESKTOP_TRAY_MENU_ITEMS,


### PR DESCRIPTION
Fixes the staging UI build failure.

Root cause:
- apps/app/src/main.tsx imported dispatchQueuedLifeOpsGithubCallbackFromUrl from @elizaos/app-lifeops/platform
- that entrypoint does not exist in the eliza submodule at 66a4ea3c, so Vite tried to resolve eliza/apps/app-lifeops/src/platform and failed

Fix:
- import dispatchQueuedLifeOpsGithubCallbackFromUrl from @elizaos/app-core, where the canonical template already exports it via @elizaos/app-core/platform semantics

This is a minimal CI unblock only.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix staging build by correcting import source for `dispatchQueuedLifeOpsGithubCallbackFromUrl`
> Moves the import of `dispatchQueuedLifeOpsGithubCallbackFromUrl` in [main.tsx](https://github.com/milady-ai/milady/pull/1969/files#diff-daadf90e7c659872f2d40ccafd9ee93306e0d519e96acb61016e83722e6f129a) from `@elizaos/app-lifeops/platform` to `@elizaos/app-core`, unblocking the staging CI build.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2ce9a89.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->