### PR TITLE
fix(ci): remove stale lifeops app entrypoints

### DIFF
--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -68,8 +68,6 @@ import {
   useCompanionSceneStatus,
 } from "@elizaos/app-companion";
 import "@elizaos/app-companion/register";
-// Side-effect: register LifeOps sidebar widgets + client methods on ElizaClient.
-import "@elizaos/app-lifeops/widgets";
 // Side-effect: register game operator surfaces + detail extensions.
 import "@elizaos/app-babylon/ui";
 import "@elizaos/app-scape/ui";
@@ -82,7 +80,6 @@ import {
   LifeOpsPageView,
   WebsiteBlockerSettingsCard,
 } from "@elizaos/app-lifeops/ui";
-import { LifeOpsActivitySignalsEffect } from "@elizaos/app-lifeops/components/LifeOpsActivitySignalsEffect";
 import {
   ApprovalQueue,
   StewardLogo,
@@ -536,7 +533,6 @@ function mountReactApp(): void {
               <DesktopOnboardingRuntime />
               <DesktopSurfaceNavigationRuntime />
               <DesktopTrayRuntime />
-              <LifeOpsActivitySignalsEffect />
               <App />
             </>
           )}


### PR DESCRIPTION
Follow-up CI unblock for cloud/staging.

The previous fix exposed two more stale imports in apps/app/src/main.tsx:
- @elizaos/app-lifeops/widgets
- @elizaos/app-lifeops/components/LifeOpsActivitySignalsEffect

Those entrypoints do not exist in the cloud/staging eliza submodule. This patch removes the stale imports and the extra effect mount. app-core already contains the LifeOps activity signal hook, so this keeps the host app aligned with the actual package surface on staging.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove stale LifeOps app entrypoints from `main.tsx`
> Removes the side-effect import of `@elizaos/app-lifeops/widgets` and the `LifeOpsActivitySignalsEffect` component from [main.tsx](https://github.com/milady-ai/milady/pull/1970/files#diff-daadf90e7c659872f2d40ccafd9ee93306e0d519e96acb61016e83722e6f129a). Neither the LifeOps sidebar widgets nor the activity signals effect will run during app startup.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c1d0d74.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->