### PR TITLE
fix(ci): remove stale app ui side-effect imports

### DIFF
--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -68,12 +68,6 @@ import {
   useCompanionSceneStatus,
 } from "@elizaos/app-companion";
 import "@elizaos/app-companion/register";
-// Side-effect: register game operator surfaces + detail extensions.
-import "@elizaos/app-babylon/ui";
-import "@elizaos/app-scape/ui";
-import "@elizaos/app-hyperscape/ui";
-import "@elizaos/app-2004scape/ui";
-import "@elizaos/app-defense-of-the-agents/ui";
 import {
   AppBlockerSettingsCard,
   LifeOpsBrowserSetupPanel,


### PR DESCRIPTION
Third CI unblock pass for cloud/staging.

apps/app/src/main.tsx still had side-effect imports for several app UI entrypoints that are not exported by the current eliza submodule packages on staging:
- @elizaos/app-babylon/ui
- @elizaos/app-scape/ui
- @elizaos/app-hyperscape/ui
- @elizaos/app-2004scape/ui
- @elizaos/app-defense-of-the-agents/ui

This removes that stale block in one pass so the bundle only references actual exported entrypoints.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove stale game operator UI side-effect imports from app entry point
> Removes five unused side-effect imports (`@elizaos/app-babylon/ui`, `@elizaos/app-scape/ui`, `@elizaos/app-hyperscape/ui`, `@elizaos/app-2004scape/ui`, `@elizaos/app-defense-of-the-agents/ui`) from [main.tsx](https://github.com/milady-ai/milady/pull/1971/files#diff-daadf90e7c659872f2d40ccafd9ee93306e0d519e96acb61016e83722e6f129a). These imports were registering game operator UI surfaces and detail extensions at startup. Risk: any UI surfaces or extensions registered by these packages will no longer be registered at app startup.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ac8845c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->