### PR TITLE
fix(ci): prune stale app shell imports

### DIFF
--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -69,7 +69,6 @@ import {
 } from "@elizaos/app-companion";
 import "@elizaos/app-companion/register";
 import {
-  AppBlockerSettingsCard,
   LifeOpsBrowserSetupPanel,
   LifeOpsPageView,
   WebsiteBlockerSettingsCard,
@@ -88,7 +87,7 @@ import {
 import { FineTuningView } from "@elizaos/app-training/ui";
 import "@elizaos/app-shopify/register";
 import "@elizaos/app-vincent/client";
-import { useVincentState } from "@elizaos/app-vincent/ui";
+import { useVincentState } from "@elizaos/app-vincent/useVincentState";
 import "@elizaos/app-vincent/register";
 import { shouldUseCloudOnlyBranding } from "@elizaos/app-core";
 import {
@@ -233,7 +232,6 @@ const appBootConfig: AppBootConfig = {
   envAliases: APP_ENV_ALIASES,
   lifeOpsPageView: LifeOpsPageView,
   lifeOpsBrowserSetupPanel: LifeOpsBrowserSetupPanel,
-  appBlockerSettingsCard: AppBlockerSettingsCard,
   websiteBlockerSettingsCard: WebsiteBlockerSettingsCard,
   clientMiddleware: {
     forceFreshOnboarding:


### PR DESCRIPTION
Full audit of @elizaos/app-* subpath imports in apps/app/src/main.tsx against the pinned eliza package surfaces. Rewrites the stale Vincent hook import, removes the dead LifeOps AppBlocker symbol, and drops the stale boot config assignment.

Verified locally: bun run build:web passes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove stale `appBlockerSettingsCard` import and config entry from app shell
> Removes the unused `AppBlockerSettingsCard` import from `@elizaos/app-lifeops/ui` and drops the corresponding `appBlockerSettingsCard` property from `appBootConfig` in [main.tsx](https://github.com/milady-ai/milady/pull/1972/files#diff-daadf90e7c659872f2d40ccafd9ee93306e0d519e96acb61016e83722e6f129a). Also updates the `useVincentState` import path to `@elizaos/app-vincent/useVincentState`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7ba64e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->