### PR TITLE
Shaw/UI smoke e2e fixes 20260417

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,18 @@ jobs:
       - name: Restore eliza workspace paths for repo scripts
         run: node scripts/restore-local-eliza-workspace.mjs
 
+      - name: Install submodule verification dependencies
+        run: |
+          bun install --cwd eliza --no-frozen-lockfile --ignore-scripts
+          bun install --cwd eliza/cloud --no-frozen-lockfile --ignore-scripts
+          bun install --cwd eliza/steward-fi --no-frozen-lockfile --ignore-scripts
+
+      - name: Ensure biome uses correct architecture
+        run: |
+          mkdir -p eliza/node_modules
+          rm -rf eliza/node_modules/@biomejs
+          ln -s "${{ github.workspace }}/node_modules/@biomejs" eliza/node_modules/@biomejs
+
       - name: Fetch upstream develop for pre-review base
         run: |
           git remote add upstream https://github.com/milady-ai/milady.git || true

--- a/apps/app/test/ui-smoke/computer-use.spec.ts
+++ b/apps/app/test/ui-smoke/computer-use.spec.ts
@@ -29,17 +29,6 @@ test("onboarding exposes the computer use feature toggle", async ({ page }) => {
     "eliza:onboarding:step": "features",
     "elizaos:active-server": "",
   });
-  await page.route("**/api/onboarding/status", async (route) => {
-    if (route.request().method() !== "GET") {
-      await route.fallback();
-      return;
-    }
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({ complete: false }),
-    });
-  });
 
   await page.goto("/chat", { waitUntil: "domcontentloaded" });
 

--- a/scripts/action-e2e-workflow-contract.test.ts
+++ b/scripts/action-e2e-workflow-contract.test.ts
@@ -16,19 +16,19 @@ describe("action e2e workflow contract", () => {
 
     expect(workflow).toContain('name: "Action Invocation E2E"');
     expect(workflow).toContain(
-      "GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}",
+      `GOOGLE_GENERATIVE_AI_API_KEY: \${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}`,
     );
     expect(workflow).toContain(
-      "OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}",
+      `OPENROUTER_API_KEY: \${{ secrets.OPENROUTER_API_KEY }}`,
     );
     expect(workflow).toContain(
-      "ELIZAOS_CLOUD_API_KEY: ${{ secrets.ELIZAOS_CLOUD_API_KEY }}",
+      `ELIZAOS_CLOUD_API_KEY: \${{ secrets.ELIZAOS_CLOUD_API_KEY }}`,
     );
     expect(workflow).toContain(
-      "OPENAI_API_KEY: ${{ secrets.ELIZAOS_CLOUD_API_KEY != '' && secrets.ELIZAOS_CLOUD_API_KEY || secrets.OPENAI_API_KEY }}",
+      `OPENAI_API_KEY: \${{ secrets.ELIZAOS_CLOUD_API_KEY != '' && secrets.ELIZAOS_CLOUD_API_KEY || secrets.OPENAI_API_KEY }}`,
     );
     expect(workflow).toContain(
-      "OPENAI_BASE_URL: ${{ secrets.ELIZAOS_CLOUD_API_KEY != '' && 'https://elizacloud.ai/api/v1' || 'https://api.openai.com/v1' }}",
+      `OPENAI_BASE_URL: \${{ secrets.ELIZAOS_CLOUD_API_KEY != '' && 'https://elizacloud.ai/api/v1' || 'https://api.openai.com/v1' }}`,
     );
     expect(workflow).toContain(
       "Action Invocation E2E skipped because the configured live provider is unavailable.",

--- a/scripts/release-workflow-path-contract.test.ts
+++ b/scripts/release-workflow-path-contract.test.ts
@@ -85,9 +85,11 @@ describe("release workflow path contract", () => {
 
     for (const workflow of [snapBuild, publishPackages, agentRelease]) {
       expect(workflow).toContain("Normalize runner root ownership for snapd");
-      expect(workflow).toContain('ROOT_OWNER="$(stat -c \'%u:%g\' /)"');
-      expect(workflow).toContain('if [ "${ROOT_OWNER}" = "0:0" ]; then');
-      expect(workflow).toContain("if sudo -n chown root:root / 2>/dev/null; then");
+      expect(workflow).toContain("ROOT_OWNER=\"$(stat -c '%u:%g' /)\"");
+      expect(workflow).toContain(`if [ "\${ROOT_OWNER}" = "0:0" ]; then`);
+      expect(workflow).toContain(
+        "if sudo -n chown root:root / 2>/dev/null; then",
+      );
     }
   });
 

--- a/scripts/validate-ci-bootstrap-contract.mjs
+++ b/scripts/validate-ci-bootstrap-contract.mjs
@@ -86,6 +86,7 @@ for (const relativePath of Object.values(files).filter((value) =>
 const workflowText = readText(files.workflow, failures);
 const actionText = readText(files.action, failures);
 const packageJson = readJson(files.packageJson, failures);
+const ciWorkflowText = readText(".github/workflows/ci.yml", failures);
 
 assertContainsAll(
   workflowText,
@@ -93,6 +94,7 @@ assertContainsAll(
   requiredWorkflowSnippets,
   failures,
 );
+assertCiPreReviewBootstrap(ciWorkflowText, failures);
 assertContainsAll(actionText, files.action, requiredActionSnippets, failures);
 assertContainsNone(actionText, files.action, forbiddenActionSnippets, failures);
 
@@ -216,4 +218,36 @@ function assertContainsNone(text, relativePath, snippets, targetFailures) {
       );
     }
   }
+}
+
+function assertCiPreReviewBootstrap(workflowText, targetFailures) {
+  const preReviewBlockMatch = /\n {2}pre-review:\n([\s\S]*?)\n {2}lint:\n/.exec(
+    workflowText,
+  );
+
+  if (!preReviewBlockMatch) {
+    targetFailures.push(
+      '.github/workflows/ci.yml is missing the "pre-review" job block',
+    );
+    return;
+  }
+
+  const preReviewBlock = preReviewBlockMatch[1];
+  const requiredSnippets = [
+    "- name: Install submodule verification dependencies",
+    "bun install --cwd eliza --no-frozen-lockfile --ignore-scripts",
+    "bun install --cwd eliza/cloud --no-frozen-lockfile --ignore-scripts",
+    "bun install --cwd eliza/steward-fi --no-frozen-lockfile --ignore-scripts",
+    "- name: Ensure biome uses correct architecture",
+    `ln -s "\${{ github.workspace }}/node_modules/@biomejs" eliza/node_modules/@biomejs`,
+    "- name: Run local pre-review gate",
+    "run: bun run pre-review:local",
+  ];
+
+  assertContainsAll(
+    preReviewBlock,
+    ".github/workflows/ci.yml pre-review job",
+    requiredSnippets,
+    targetFailures,
+  );
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix UI smoke tests and CI pre-review bootstrap for eliza submodules
- Adds two CI pre-review steps in [ci.yml](.github/workflows/ci.yml): one installs dependencies for eliza submodules, another symlinks `@biomejs` from the repo root into `eliza/node_modules` to ensure correct architecture.
- Adds a contract validation helper `assertCiPreReviewBootstrap` in [validate-ci-bootstrap-contract.mjs](scripts/validate-ci-bootstrap-contract.mjs) that asserts these steps exist in the pre-review job block.
- Removes mocked onboarding status API response from the [computer-use smoke test](apps/app/test/ui-smoke/computer-use.spec.ts), allowing real requests to proceed.
- Fixes test assertions in [action-e2e-workflow-contract.test.ts](scripts/action-e2e-workflow-contract.test.ts) and [release-workflow-path-contract.test.ts](scripts/release-workflow-path-contract.test.ts) to match literal GitHub expression syntax and updated shell quoting.
- Updates the `eliza` submodule pointer to `124ac1bf`.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized e93ed0a.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->