### PR TITLE
docs: add agent-home surface note to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -484,3 +484,7 @@ This is a cleanup for correctness, maintainability, and architectural integrity.
 - **Push proactively when work is meaningful.** A branch that exists only on the local machine is one disk failure away from gone. If a chunk of work is worth keeping, it's worth pushing.
 
 The principle: **every change must end up as a commit on the current branch in the current worktree, and ideally pushed.** No stashes, no branch hopping, no work that exists only in the working tree or in `git stash list`.
+
+## agent-home
+
+The canonical public app-hosting surface is at https://milady.nubs.site — see eliza/apps/app-core/README for build steps.


### PR DESCRIPTION
Adds a brief note pointing to the canonical public app-hosting surface at milady.nubs.site.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add agent-home surface note to AGENTS.md
> Appends a new `agent-home` section to [AGENTS.md](https://github.com/milady-ai/milady/pull/1997/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9) that documents the canonical public app-hosting surface at `https://milady.nubs.site` and references `eliza/apps/app-core/README` for build steps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9650802.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->