### PR TITLE
fix(sweeper): include modules with no default export in summary report

### DIFF
--- a/scripts/sweeper/run.mjs
+++ b/scripts/sweeper/run.mjs
@@ -67,10 +67,10 @@ for (const svc of servicesToRun) {
     const mod = await import(modulePath);
     const sweepFn = mod.default ?? mod.sweep;
     if (typeof sweepFn !== "function") {
-      console.error(
-        `❌ ${svc}: ${modulePath} does not export a default function`,
-      );
+      const reason = `${modulePath} does not export a default function`;
+      console.error(`❌ ${svc}: ${reason}`);
       anyHardFailure = true;
+      results.push({ service: svc, status: "error", reason });
       continue;
     }
     const started = Date.now();


### PR DESCRIPTION
## Bug

In `scripts/sweeper/run.mjs`, when a service module fails the `typeof sweepFn !== "function"` guard (e.g. it imports successfully but does not export a default sweeper), the orchestrator logs an error to stderr, sets `anyHardFailure = true`, and `continue`s — but it never pushes a row to `results`. The aggregated Markdown summary (which gets written to `$GITHUB_STEP_SUMMARY`) iterates over `results`, so the misconfigured service is silently absent from the report. The job fails with no indication of which sweeper was the culprit.

## Fix

Push an `error` result with the same reason string before `continue`, so the missing-export case shows up in the summary table alongside other errors. Behavior on success and on caught exceptions is unchanged.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Include modules with no default export in sweeper summary report
> Previously, when a service module lacked a default export, the sweeper logged an error and set `anyHardFailure = true` but did not add an entry to `results`, so these failures were absent from the summary report. Now, an error object `{ service, status: 'error', reason }` is appended to `results` in [run.mjs](https://github.com/milady-ai/milady/pull/1999/files#diff-87ad6f2f491b01460db447d987d7e3809c9f5f9133815bd728a784a435deac6e) before continuing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized da574e7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->