### PR TITLE
fix(test): remove timed-out ActionSpy waiters from queue

### DIFF
--- a/test/helpers/action-spy.ts
+++ b/test/helpers/action-spy.ts
@@ -197,8 +197,14 @@ export class ActionSpy {
     }
 
     return new Promise<SpiedAction>((resolve, reject) => {
-      const timer = setTimeout(() => {
-        const idx = this.waiters.findIndex((w) => w.resolve === resolve);
+      let timer: ReturnType<typeof setTimeout>;
+      const wrappedResolve = (action: SpiedAction) => {
+        clearTimeout(timer);
+        resolve(action);
+      };
+
+      timer = setTimeout(() => {
+        const idx = this.waiters.findIndex((w) => w.resolve === wrappedResolve);
         if (idx !== -1) {
           this.waiters.splice(idx, 1);
         }
@@ -211,10 +217,7 @@ export class ActionSpy {
 
       this.waiters.push({
         normalizedName: normalized,
-        resolve: (action) => {
-          clearTimeout(timer);
-          resolve(action);
-        },
+        resolve: wrappedResolve,
       });
     });
   }


### PR DESCRIPTION
`ActionSpy.waitForAction` was supposed to splice a waiter out of `this.waiters` when its timeout fired, but the cleanup check compared the wrong function references:

```ts
const timer = setTimeout(() => {
  const idx = this.waiters.findIndex((w) => w.resolve === resolve);
  ...
});

this.waiters.push({
  normalizedName: normalized,
  resolve: (action) => { clearTimeout(timer); resolve(action); },
});
```

`w.resolve` is the wrapped arrow function (which clears the timer before calling the outer `resolve`), not the Promise `resolve` itself, so `findIndex` returned `-1` every time and the waiter was never removed. The outer Promise still rejected correctly, but the stale waiter sat in the array until a matching `ACTION_COMPLETED` event eventually arrived — if one never did, it leaked for the lifetime of the spy.

Fix: hoist the wrapped resolver into a named `wrappedResolve` and compare against that in both the push and the timeout cleanup, so timed-out waiters are always dropped.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix timed-out `ActionSpy.waitForAction` waiters not being removed from queue
> Previously, when `waitForAction` timed out, the waiter removal logic failed because it compared against the wrong function reference. The fix introduces a stable `wrappedResolve` function that is both pushed into the waiters array and used as the removal reference on timeout, ensuring the entry is correctly cleared.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f5c476.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->