### PR TITLE
fix(scripts): always sync submodule URLs from .gitmodules on init

### DIFF
--- a/scripts/init-submodules.mjs
+++ b/scripts/init-submodules.mjs
@@ -231,6 +231,26 @@ export function runInitSubmodules({
     exists,
   });
 
+  // Re-align every submodule's .git/config remote URL with .gitmodules before
+  // doing anything else. Without this, flipping a submodule URL upstream (e.g.
+  // retargeting eliza between elizaOS/eliza and milady-ai/eliza) leaves the
+  // local .git/modules/<name>/config stuck on the old remote — so `git pull`
+  // later fails to fetch commits that only exist on the new remote. The
+  // per-submodule sync below only runs when `needsInit` is true, which misses
+  // the common case where the submodule is still checked out cleanly.
+  try {
+    exec("git submodule sync --recursive", {
+      cwd: rootDir,
+      stdio: "inherit",
+    });
+  } catch (err) {
+    logError(
+      `[init-submodules] git submodule sync --recursive failed: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+
   let initialized = 0;
   let alreadyInitialized = 0;
   let failed = 0;

--- a/scripts/init-submodules.test.ts
+++ b/scripts/init-submodules.test.ts
@@ -204,7 +204,7 @@ describe("init-submodules", () => {
         return "";
       }
 
-      if (command === "git submodule sync --recursive" && cwd === elizaRoot) {
+      if (command === "git submodule sync --recursive") {
         return "";
       }
 
@@ -322,7 +322,7 @@ describe("init-submodules", () => {
         return "";
       }
 
-      if (command === "git submodule sync --recursive" && cwd === elizaRoot) {
+      if (command === "git submodule sync --recursive") {
         return "";
       }
 


### PR DESCRIPTION
## Summary
- Move `git submodule sync --recursive` to run **unconditionally** at the top of `runInitSubmodules`, instead of only when a submodule needs init.
- Fixes the daily `upload-pack: not our ref` failure when pulling `develop` after any `.gitmodules` URL flip.

## Why

`.gitmodules` has been flipped between `milady-ai/eliza` and `elizaos/eliza` multiple times recently (see `dc48e71de`, `750173576`, `e66eacc28`, `45534d53b`). Every flip leaves local `.git/modules/<name>/config` stuck on the old remote URL. The next `git pull` then fails to fetch commits that only exist on the new remote.

The script already called `git submodule sync` — but only **inside** the `if (needsInit)` block (line 312). When the submodule is still checked out cleanly (the common case), `needsInit` is false and the sync is skipped entirely. So `bun install` silently failed to re-align URLs.

Moving the sync above the status loop makes every `bun install` re-align all submodule URLs with whatever `.gitmodules` currently declares. No more manual `git submodule sync --recursive` after every pull.

## Commits
1. `fix(scripts): always sync submodule URLs from .gitmodules on init` — the actual fix + test mock update.
2. `chore(lint): clear pre-existing biome failures` — unrelated pre-existing lint/format failures on develop that were blocking `bun run verify:lint` on the pre-push hook. Mostly auto-formatter output plus one unused-variable removal and one non-null-assertion narrowing.

## Test plan
- [x] `bun run vitest run scripts/init-submodules.test.ts -t "initializes the top-level eliza submodule"` passes (the cross-platform test; tests 2/3 have a pre-existing Windows path-resolution issue unrelated to this change, unaffected by the fix).
- [x] `bun run verify:lint` passes (was failing on develop before commit 2).
- [x] Manually verified the symptom: with stale local `.git/modules/eliza/config` pointing at `elizaos/eliza`, running the patched flow via `git submodule sync --recursive && git submodule update --init --recursive` recovers cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Always run `git submodule sync --recursive` before submodule init in `runInitSubmodules`
> Adds a `git submodule sync --recursive` step at the start of `runInitSubmodules` in [init-submodules.mjs](https://github.com/milady-ai/milady/pull/2015/files#diff-927ba7fd8e1b3fbce8af2599149349017e91a9f97cab5d670b967df7f77ba209) to ensure submodule URLs from `.gitmodules` are applied before initialization. Errors from the sync step are logged via `logError` but do not halt execution. Tests in [init-submodules.test.ts](https://github.com/milady-ai/milady/pull/2015/files#diff-cf14bad25d1d51102f9264dd56b197acfeb0b3251fc0207cc0984229320a0b9c) are updated to match the unconditional sync call without a `cwd` constraint.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ae86a73.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->