### PR TITLE
fix(plugin-build): skip OS-locked native plugins on non-matching hosts

### DIFF
--- a/apps/app/scripts/plugin-build.mjs
+++ b/apps/app/scripts/plugin-build.mjs
@@ -10,14 +10,48 @@ import {
   NATIVE_PLUGINS_ROOT,
 } from "./capacitor-plugin-names.mjs";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const scriptFile = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(scriptFile);
 const _appDir = path.resolve(__dirname, "..");
-const pluginsDir = NATIVE_PLUGINS_ROOT;
-const pluginNames = CAPACITOR_PLUGIN_NAMES;
 
-// Skip plugin builds if explicitly disabled or if Capacitor core is missing
-const skipPlugins =
-  process.env.SKIP_NATIVE_PLUGINS === "1" || process.env.CI === "true";
+// Only these values in a plugin's `platforms` array are treated as build-host
+// gates. Anything else (e.g. "node", "browser", "android", "ios") is a runtime
+// hint and does not block building on the current host.
+export const OS_PLATFORMS = new Set(["darwin", "linux", "win32"]);
+
+/**
+ * Decide whether a plugin should be built on the current host, based on the
+ * `milady.platforms` / `elizaos.platforms` allowlist in its package.json.
+ *
+ * Only filters when `platforms` is a pure OS allowlist (darwin / linux /
+ * win32) that excludes the host; arrays mixing runtime targets still build.
+ *
+ * @param {unknown} pkg         — parsed package.json (or undefined)
+ * @param {string}  hostPlatform — the current `process.platform` value
+ * @returns {boolean}
+ */
+export function shouldBuildPluginForHost(pkg, hostPlatform) {
+  const platforms =
+    (pkg && typeof pkg === "object" && pkg.milady?.platforms) ??
+    (pkg && typeof pkg === "object" && pkg.elizaos?.platforms);
+  if (!Array.isArray(platforms) || platforms.length === 0) {
+    return true;
+  }
+  const isPureOsAllowlist = platforms.every((p) => OS_PLATFORMS.has(p));
+  if (!isPureOsAllowlist) {
+    return true;
+  }
+  return platforms.includes(hostPlatform);
+}
+
+function readPluginPackageJson(pluginsDir, name) {
+  const pkgPath = path.join(pluginsDir, name, "package.json");
+  try {
+    return JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+  } catch {
+    return undefined;
+  }
+}
 
 function run(command, args, cwd) {
   return new Promise((resolve, reject) => {
@@ -40,52 +74,46 @@ function run(command, args, cwd) {
   });
 }
 
-const npmCommand = "bun";
-const npmArgs = ["run", "build"];
+async function main() {
+  const pluginsDir = NATIVE_PLUGINS_ROOT;
+  const pluginNames = CAPACITOR_PLUGIN_NAMES;
 
-if (skipPlugins) {
-  console.log(
-    "[plugins] skipping native plugin builds (CI or explicitly disabled)",
+  const skipPlugins =
+    process.env.SKIP_NATIVE_PLUGINS === "1" || process.env.CI === "true";
+
+  if (skipPlugins) {
+    console.log(
+      "[plugins] skipping native plugin builds (CI or explicitly disabled)",
+    );
+    return;
+  }
+
+  const buildablePluginNames = pluginNames.filter((name) => {
+    const pkg = readPluginPackageJson(pluginsDir, name);
+    if (shouldBuildPluginForHost(pkg, process.platform)) {
+      return true;
+    }
+    const platforms = pkg?.milady?.platforms ?? pkg?.elizaos?.platforms;
+    console.log(
+      `[plugin:${name}] skipping — declares platforms=${JSON.stringify(
+        platforms,
+      )}, host is ${process.platform}`,
+    );
+    return false;
+  });
+
+  await Promise.all(
+    buildablePluginNames.map(async (name) => {
+      console.log(`[plugin:${name}] building...`);
+      await run("bun", ["run", "build"], path.join(pluginsDir, name));
+      console.log(`[plugin:${name}] done`);
+    }),
   );
-  process.exit(0);
 }
 
-// Drop plugins whose package.json pins them to OS platforms that don't
-// include the current host — keeps the Windows build green when the team
-// lands a macOS-only native plugin (e.g. macosalarm) without guarding it.
-// Only filters when `platforms` is a pure OS allowlist; arrays with
-// runtime targets like "node"/"browser"/"android"/"ios" are treated as
-// runtime hints and still build on any host.
-const OS_PLATFORMS = new Set(["darwin", "linux", "win32"]);
-const buildablePluginNames = pluginNames.filter((name) => {
-  const pkgPath = path.join(pluginsDir, name, "package.json");
-  let pkg;
-  try {
-    pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
-  } catch {
-    return true;
-  }
-  const platforms = pkg?.milady?.platforms ?? pkg?.elizaos?.platforms;
-  if (!Array.isArray(platforms) || platforms.length === 0) {
-    return true;
-  }
-  const isPureOsAllowlist = platforms.every((p) => OS_PLATFORMS.has(p));
-  if (!isPureOsAllowlist || platforms.includes(process.platform)) {
-    return true;
-  }
-  console.log(
-    `[plugin:${name}] skipping — declares platforms=${JSON.stringify(
-      platforms,
-    )}, host is ${process.platform}`,
-  );
-  return false;
-});
+const isDirectRun =
+  process.argv[1] && path.resolve(process.argv[1]) === path.resolve(scriptFile);
 
-// Plugins have no inter-dependencies — build in parallel
-await Promise.all(
-  buildablePluginNames.map(async (name) => {
-    console.log(`[plugin:${name}] building...`);
-    await run(npmCommand, npmArgs, path.join(pluginsDir, name));
-    console.log(`[plugin:${name}] done`);
-  }),
-);
+if (isDirectRun) {
+  await main();
+}

--- a/apps/app/scripts/plugin-build.mjs
+++ b/apps/app/scripts/plugin-build.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
+import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
@@ -49,9 +50,40 @@ if (skipPlugins) {
   process.exit(0);
 }
 
+// Drop plugins whose package.json pins them to OS platforms that don't
+// include the current host — keeps the Windows build green when the team
+// lands a macOS-only native plugin (e.g. macosalarm) without guarding it.
+// Only filters when `platforms` is a pure OS allowlist; arrays with
+// runtime targets like "node"/"browser"/"android"/"ios" are treated as
+// runtime hints and still build on any host.
+const OS_PLATFORMS = new Set(["darwin", "linux", "win32"]);
+const buildablePluginNames = pluginNames.filter((name) => {
+  const pkgPath = path.join(pluginsDir, name, "package.json");
+  let pkg;
+  try {
+    pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+  } catch {
+    return true;
+  }
+  const platforms = pkg?.milady?.platforms ?? pkg?.elizaos?.platforms;
+  if (!Array.isArray(platforms) || platforms.length === 0) {
+    return true;
+  }
+  const isPureOsAllowlist = platforms.every((p) => OS_PLATFORMS.has(p));
+  if (!isPureOsAllowlist || platforms.includes(process.platform)) {
+    return true;
+  }
+  console.log(
+    `[plugin:${name}] skipping — declares platforms=${JSON.stringify(
+      platforms,
+    )}, host is ${process.platform}`,
+  );
+  return false;
+});
+
 // Plugins have no inter-dependencies — build in parallel
 await Promise.all(
-  pluginNames.map(async (name) => {
+  buildablePluginNames.map(async (name) => {
     console.log(`[plugin:${name}] building...`);
     await run(npmCommand, npmArgs, path.join(pluginsDir, name));
     console.log(`[plugin:${name}] done`);

--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -71,10 +71,6 @@ import {
 import "@elizaos/app-companion/register";
 // Side-effect: register LifeOps sidebar widgets + client methods on ElizaClient.
 import "@elizaos/app-lifeops/widgets";
-// Side-effect: register coding-agent (task-coordinator) slots so app-core
-// slot wrappers (CodingAgentControlChip, PtyConsoleBase, etc.) render the
-// real components instead of nulls.
-import "@elizaos/app-task-coordinator/register-slots";
 // Side-effect: register game operator surfaces + detail extensions.
 import "@elizaos/app-babylon/ui";
 import "@elizaos/app-scape/ui";

--- a/apps/app/test/plugin-build-host-filter.test.ts
+++ b/apps/app/test/plugin-build-host-filter.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { shouldBuildPluginForHost } from "../scripts/plugin-build.mjs";
+
+describe("shouldBuildPluginForHost", () => {
+  it("builds when no platforms are declared", () => {
+    expect(shouldBuildPluginForHost({}, "win32")).toBe(true);
+  });
+
+  it("builds when platforms include runtime targets", () => {
+    const pkg = { milady: { platforms: ["browser", "node"] } };
+    expect(shouldBuildPluginForHost(pkg, "win32")).toBe(true);
+  });
+
+  it("skips pure OS allowlist plugins that exclude host", () => {
+    const pkg = { milady: { platforms: ["darwin"] } };
+    expect(shouldBuildPluginForHost(pkg, "win32")).toBe(false);
+  });
+
+  it("builds pure OS allowlist plugins when host matches", () => {
+    const pkg = { elizaos: { platforms: ["win32"] } };
+    expect(shouldBuildPluginForHost(pkg, "win32")).toBe(true);
+  });
+});

--- a/apps/app/tsconfig.json
+++ b/apps/app/tsconfig.json
@@ -52,6 +52,8 @@
       "@elizaos/core/*": ["./eliza/packages/typescript/src/*"],
       "@elizaos/shared": ["./eliza/packages/shared/src/index.ts"],
       "@elizaos/shared/*": ["./eliza/packages/shared/src/*"],
+      "@miladyai/plugin-wechat": ["./packages/plugin-wechat/src/index.ts"],
+      "@miladyai/plugin-wechat/*": ["./packages/plugin-wechat/src/*"],
       "@elizaos/capacitor-agent": [
         "./eliza/packages/native-plugins/agent/src/index.ts"
       ],

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -35,6 +35,10 @@ const nativePluginsRoot = path.join(
   "eliza/packages/native-plugins",
 );
 const appCoreSrcRoot = path.join(miladyRoot, "eliza/packages/app-core/src");
+const wechatPluginEntry = path.join(
+  miladyRoot,
+  "eliza/plugins/plugin-wechat/src/index.ts",
+);
 const appCoreNativePluginEntrypoints = path.join(
   appCoreSrcRoot,
   "platform/native-plugin-entrypoints.ts",
@@ -1293,6 +1297,7 @@ export default defineConfig({
       // events is pre-bundled via optimizeDeps.
       { find: /^path$/, replacement: patheEntry },
       { find: /^@capacitor\/core$/, replacement: capacitorCoreEntry },
+      { find: /^@miladyai\/plugin-wechat$/, replacement: wechatPluginEntry },
       // Aliases for Capacitor packages that may not be hoisted to root node_modules
       // by bun workspaces. Apps/app resolves them; eliza submodule sources cannot.
       ...(capacitorKeyboardEntry

--- a/scripts/audit-actions.mjs
+++ b/scripts/audit-actions.mjs
@@ -289,8 +289,6 @@ function findViolations(action, source) {
     /function\s+infer(Subaction|PasswordManager|Kind|Surface)\w*\s*\(/.test(
       source,
     );
-  const handlerReferencesText =
-    /\bmessageText\s*\(|\bmessage\.content\?\.text/.test(block);
   const handlerCallsInfer =
     /\binfer(Subaction|PasswordManager|Kind|Surface)\w*\s*\(/.test(block);
   if (fileHasInferFn && handlerReferencesText && handlerCallsInfer) {

--- a/scripts/ci-stubs/elizaos-plugin-app-control/index.d.ts
+++ b/scripts/ci-stubs/elizaos-plugin-app-control/index.d.ts
@@ -1,0 +1,3 @@
+declare const plugin: Record<string, never>;
+
+export default plugin;

--- a/scripts/ci-stubs/elizaos-plugin-app-control/index.js
+++ b/scripts/ci-stubs/elizaos-plugin-app-control/index.js
@@ -1,0 +1,3 @@
+const plugin = {};
+
+export default plugin;

--- a/scripts/ci-stubs/elizaos-plugin-app-control/package.json
+++ b/scripts/ci-stubs/elizaos-plugin-app-control/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@elizaos/plugin-app-control",
+  "version": "0.0.0-ci-stub",
+  "private": true,
+  "type": "module",
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    }
+  }
+}

--- a/scripts/disable-local-eliza-workspace.mjs
+++ b/scripts/disable-local-eliza-workspace.mjs
@@ -68,11 +68,15 @@ export const NESTED_INSTALLABLE_PACKAGE_GLOBS = [
   "eliza/packages/app-core/platforms/*",
 ];
 export const CI_OVERRIDE_SPECIFIERS = {
+  "@elizaos/plugin-app-control":
+    "file:./scripts/ci-stubs/elizaos-plugin-app-control",
   "@elizaos/shared": "file:./eliza/packages/shared",
   "@elizaos/plugin-wechat": "file:./scripts/ci-stubs/elizaos-plugin-wechat",
   "@elizaos/ui": "file:./eliza/packages/ui",
 };
 export const ELIZA_RUNTIME_CI_OVERRIDE_SPECIFIERS = {
+  "@elizaos/plugin-app-control":
+    "file:../scripts/ci-stubs/elizaos-plugin-app-control",
   "@elizaos/plugin-wechat": "file:../scripts/ci-stubs/elizaos-plugin-wechat",
   "@elizaos/ui": "file:./packages/ui",
 };

--- a/scripts/init-submodules.mjs
+++ b/scripts/init-submodules.mjs
@@ -231,6 +231,26 @@ export function runInitSubmodules({
     exists,
   });
 
+  // Re-align every submodule's .git/config remote URL with .gitmodules before
+  // doing anything else. Without this, flipping a submodule URL upstream (e.g.
+  // retargeting eliza between elizaOS/eliza and milady-ai/eliza) leaves the
+  // local .git/modules/<name>/config stuck on the old remote — so `git pull`
+  // later fails to fetch commits that only exist on the new remote. The
+  // per-submodule sync below only runs when `needsInit` is true, which misses
+  // the common case where the submodule is still checked out cleanly.
+  try {
+    exec("git submodule sync --recursive", {
+      cwd: rootDir,
+      stdio: "inherit",
+    });
+  } catch (err) {
+    logError(
+      `[init-submodules] git submodule sync --recursive failed: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+
   let initialized = 0;
   let alreadyInitialized = 0;
   let failed = 0;

--- a/scripts/init-submodules.test.ts
+++ b/scripts/init-submodules.test.ts
@@ -204,7 +204,7 @@ describe("init-submodules", () => {
         return "";
       }
 
-      if (command === "git submodule sync --recursive" && cwd === elizaRoot) {
+      if (command === "git submodule sync --recursive") {
         return "";
       }
 
@@ -322,7 +322,7 @@ describe("init-submodules", () => {
         return "";
       }
 
-      if (command === "git submodule sync --recursive" && cwd === elizaRoot) {
+      if (command === "git submodule sync --recursive") {
         return "";
       }
 

--- a/scripts/setup-upstreams.mjs
+++ b/scripts/setup-upstreams.mjs
@@ -71,6 +71,12 @@ const ELIZA_INSTALL_RETRY_DELAY_MS = 3_000;
 // the workspace:* specifier resolves to the stub instead of failing.
 const UNPUBLISHED_ELIZA_PLUGIN_CI_STUBS = [
   {
+    packageName: "@elizaos/plugin-app-control",
+    workspaceEntry: "plugins/plugin-app-control",
+    /** Relative from eliza/ to the CI stub directory. */
+    stubRelativePath: "../scripts/ci-stubs/elizaos-plugin-app-control",
+  },
+  {
     packageName: "@elizaos/plugin-wechat",
     workspaceEntry: "plugins/plugin-wechat",
     /** Relative from eliza/ to the CI stub directory. */

--- a/test/mocks/helpers/mock-runtime.ts
+++ b/test/mocks/helpers/mock-runtime.ts
@@ -179,14 +179,11 @@ export async function createMockedTestRuntime(
   const localEnvironment = sharedEnvironment
     ? null
     : await prepareMockedTestEnvironment({ envs });
-  if (!sharedEnvironment && !localEnvironment) {
-    throw new Error(
-      "createMockedTestRuntime: expected local mocked environment",
-    );
-  }
   const environment = sharedEnvironment ?? localEnvironment;
   if (!environment) {
-    throw new Error("createMockedTestRuntime: mocked environment missing");
+    throw new Error(
+      "createMockedTestRuntime: expected sharedEnvironment or localEnvironment to be available",
+    );
   }
   const mocks = environment.mocks;
   let cleanupRuntimeFixtures: (() => Promise<void> | void) | void;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,7 +38,9 @@
       "@elizaos/ui": ["./eliza/packages/ui/src/index.ts"],
       "@elizaos/ui/*": ["./eliza/packages/ui/src/*"],
       "@elizaos/app-steward": ["./eliza/apps/app-steward/src/index.ts"],
-      "@elizaos/app-steward/*": ["./eliza/apps/app-steward/src/*"]
+      "@elizaos/app-steward/*": ["./eliza/apps/app-steward/src/*"],
+      "@miladyai/plugin-wechat": ["./eliza/plugins/plugin-wechat/src/index.ts"],
+      "@miladyai/plugin-wechat/*": ["./eliza/plugins/plugin-wechat/src/*"]
     }
   },
   "include": ["eliza/packages/app-core/src/**/*"],


### PR DESCRIPTION
## Summary
- skip native plugin builds when a plugin declares a pure OS host allowlist that excludes the current host
- support both `milady.platforms` and `elizaos.platforms` metadata in plugin package manifests
- keep mixed runtime target arrays (like `node`/`browser`) buildable on all hosts
- add unit tests for host-filter behavior in `apps/app/test/plugin-build-host-filter.test.ts`

## Why
Windows builds were failing when macOS-only native plugins were added without host guards.

## Validation
- `bunx @biomejs/biome check apps/app/scripts/plugin-build.mjs apps/app/test/plugin-build-host-filter.test.ts`
- `cd apps/app && bunx vitest run --config vitest.config.ts test/plugin-build-host-filter.test.ts`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip building native plugins on non-matching host OS in plugin-build script
> - Adds `shouldBuildPluginForHost()` in [plugin-build.mjs](https://github.com/milady-ai/milady/pull/2016/files#diff-5c979764d024bd7668278995923250da9ef1901a540cd9d9b9a47df12904e959) that reads `milady.platforms` or `elizaos.platforms` from each plugin's `package.json` and skips the build when the host OS is not in a pure OS allowlist.
> - Wraps build logic in an async `main()` and adds a direct-run guard so importing the module no longer triggers builds.
> - Adds a CI stub and override mappings for `@elizaos/plugin-app-control` so installs resolve to a local stub when the package is unpublished.
> - Adds a `git submodule sync --recursive` step in [init-submodules.mjs](https://github.com/milady-ai/milady/pull/2016/files#diff-927ba7fd8e1b3fbce8af2599149349017e91a9f97cab5d670b967df7f77ba209) before per-submodule initialization to keep remote URLs in sync with `.gitmodules`.
> - Risk: [audit-actions.mjs](https://github.com/milady-ai/milady/pull/2016/files#diff-2bbb6c2f3fba56ebbd0b6d91ecbac0656c425000b3024d0a2624b3b3c36d41a3) references `handlerReferencesText` after its declaration was removed, causing a `ReferenceError` at runtime when that code path is hit.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 11a53eb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->