### PR TITLE
fix(plugin-build): skip Capacitor mobile plugins on desktop hosts

### DIFF
--- a/apps/app/scripts/plugin-build.mjs
+++ b/apps/app/scripts/plugin-build.mjs
@@ -15,18 +15,22 @@ const __dirname = path.dirname(scriptFile);
 const _appDir = path.resolve(__dirname, "..");
 
 // Only these values in a plugin's `platforms` array are treated as build-host
-// gates. Anything else (e.g. "node", "browser", "android", "ios") is a runtime
-// hint and does not block building on the current host.
+// gates. Anything else (e.g. "node", "browser") is a runtime hint and does
+// not block building on the current host.
 export const OS_PLATFORMS = new Set(["darwin", "linux", "win32"]);
 
 /**
  * Decide whether a plugin should be built on the current host, based on the
- * `milady.platforms` / `elizaos.platforms` allowlist in its package.json.
+ * `milady.platforms` / `elizaos.platforms` allowlist in its package.json, or
+ * by detecting Capacitor mobile plugins via their peer dependency.
  *
- * Only filters when `platforms` is a pure OS allowlist (darwin / linux /
- * win32) that excludes the host; arrays mixing runtime targets still build.
+ * Rules (in order):
+ * 1. Explicit `platforms` pure-OS allowlist → build only when host is listed.
+ * 2. `platforms` mixing runtime hints (e.g. "node", "browser") → build everywhere.
+ * 3. No `platforms` but `@capacitor/core` peer dep → mobile-only, skip on desktop.
+ * 4. No signal → build everywhere.
  *
- * @param {unknown} pkg         — parsed package.json (or undefined)
+ * @param {unknown} pkg          — parsed package.json (or undefined)
  * @param {string}  hostPlatform — the current `process.platform` value
  * @returns {boolean}
  */
@@ -34,14 +38,21 @@ export function shouldBuildPluginForHost(pkg, hostPlatform) {
   const platforms =
     (pkg && typeof pkg === "object" && pkg.milady?.platforms) ??
     (pkg && typeof pkg === "object" && pkg.elizaos?.platforms);
-  if (!Array.isArray(platforms) || platforms.length === 0) {
-    return true;
+  if (Array.isArray(platforms) && platforms.length > 0) {
+    const isPureOsAllowlist = platforms.every((p) => OS_PLATFORMS.has(p));
+    if (!isPureOsAllowlist) {
+      return true;
+    }
+    return platforms.includes(hostPlatform);
   }
-  const isPureOsAllowlist = platforms.every((p) => OS_PLATFORMS.has(p));
-  if (!isPureOsAllowlist) {
-    return true;
+  // No explicit metadata — @capacitor/core peer dep is a reliable mobile-only
+  // signal (every proper Capacitor plugin lists it). Skip on all desktop hosts.
+  const peerDeps =
+    (pkg && typeof pkg === "object" && pkg.peerDependencies) ?? {};
+  if ("@capacitor/core" in peerDeps) {
+    return false;
   }
-  return platforms.includes(hostPlatform);
+  return true;
 }
 
 function readPluginPackageJson(pluginsDir, name) {

--- a/apps/app/test/plugin-build-host-filter.test.ts
+++ b/apps/app/test/plugin-build-host-filter.test.ts
@@ -20,4 +20,20 @@ describe("shouldBuildPluginForHost", () => {
     const pkg = { elizaos: { platforms: ["win32"] } };
     expect(shouldBuildPluginForHost(pkg, "win32")).toBe(true);
   });
+
+  it("skips Capacitor mobile plugins (peer dep heuristic) on all desktop hosts", () => {
+    const pkg = { peerDependencies: { "@capacitor/core": "^8.0.0" } };
+    expect(shouldBuildPluginForHost(pkg, "win32")).toBe(false);
+    expect(shouldBuildPluginForHost(pkg, "darwin")).toBe(false);
+    expect(shouldBuildPluginForHost(pkg, "linux")).toBe(false);
+  });
+
+  it("explicit platforms metadata takes precedence over Capacitor heuristic", () => {
+    const pkg = {
+      peerDependencies: { "@capacitor/core": "^8.0.0" },
+      milady: { platforms: ["darwin"] },
+    };
+    expect(shouldBuildPluginForHost(pkg, "darwin")).toBe(true);
+    expect(shouldBuildPluginForHost(pkg, "win32")).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- Adds a fallback heuristic to `shouldBuildPluginForHost`: if a plugin declares no explicit `milady/elizaos` platforms metadata but has `@capacitor/core` in its `peerDependencies`, it is treated as mobile-only and skipped on all desktop hosts (darwin / linux / win32).
- This fixes the `@elizaos/capacitor-llama` build failure on Windows, where the plugin's `tsc` step was emitting declaration errors from its test file — the plugin should never be built on desktop at all.
- Explicit `milady.platforms` / `elizaos.platforms` metadata continues to take precedence.

## Why
The `@elizaos/capacitor-llama` plugin is a mobile Capacitor plugin (iOS + Android). It has no platform metadata, so the existing OS-allowlist filter passed it through and tried to build it on Windows. Its `tsc` build then failed on a type error in `src/index.test.ts`. Every proper Capacitor plugin lists `@capacitor/core` as a peer dependency — that is a reliable mobile-only signal that doesn't require modifying the eliza submodule.

## Validation
- `cd apps/app && bunx vitest run test/plugin-build-host-filter.test.ts` — 6/6 pass (4 existing + 2 new)
- `bunx @biomejs/biome check apps/app/scripts/plugin-build.mjs apps/app/test/plugin-build-host-filter.test.ts` — clean
- `bun run verify:typecheck` — exit 0
- `bun run verify:lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip Capacitor mobile plugins on desktop hosts in plugin build
> - Updates `shouldBuildPluginForHost` in [plugin-build.mjs](https://github.com/milady-ai/milady/pull/2023/files#diff-5c979764d024bd7668278995923250da9ef1901a540cd9d9b9a47df12904e959) to skip builds for packages that declare a `@capacitor/core` peer dependency but have no explicit `platforms` metadata.
> - Explicit `platforms` allowlists still take precedence: a pure-OS list gates by `hostPlatform`, and mixed-runtime targets always build.
> - Adds two test cases in [plugin-build-host-filter.test.ts](https://github.com/milady-ai/milady/pull/2023/files#diff-886fbb11bad2fc839db7d1988a2a63842272a659bafb77bc685da5b23f122b6d) covering the new Capacitor heuristic and the precedence of explicit metadata.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 20a6a60.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->