### PR TITLE
feat(homepage): restore cloud agent delete + provisioning UX (H7/H7B)

### DIFF
--- a/apps/homepage/src/__tests__/InstanceCard.test.tsx
+++ b/apps/homepage/src/__tests__/InstanceCard.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { InstanceCard } from "../components/dashboard/InstanceCard";
+import type { ManagedAgent } from "../lib/AgentProvider";
+
+function makeAgent(overrides: Partial<ManagedAgent> = {}): ManagedAgent {
+  return {
+    id: "agent-1",
+    name: "goldie",
+    source: "cloud",
+    status: "running",
+    model: "milady runtime",
+    webUiUrl: "https://example.com",
+    ...overrides,
+  };
+}
+
+describe("InstanceCard", () => {
+  it("opens normally when the agent is running", () => {
+    const onOpen = vi.fn();
+
+    render(
+      <InstanceCard
+        agent={makeAgent({ status: "running" })}
+        onOpen={onOpen}
+        onCopyUrl={() => {}}
+      />,
+    );
+
+    const openButton = screen.getByRole("button", { name: /open/i });
+    expect(openButton).toBeEnabled();
+
+    fireEvent.click(openButton);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables opening while the agent is provisioning", () => {
+    const onOpen = vi.fn();
+
+    render(
+      <InstanceCard
+        agent={makeAgent({ status: "provisioning" })}
+        onOpen={onOpen}
+        onCopyUrl={() => {}}
+      />,
+    );
+
+    const disabledButton = screen.getByRole("button", { name: /starting…/i });
+    expect(disabledButton).toBeDisabled();
+    expect(disabledButton).toHaveAttribute("aria-disabled", "true");
+    expect(disabledButton).toHaveAttribute(
+      "title",
+      "Agent is booting up. This usually takes 30–60s.",
+    );
+    expect(disabledButton).toHaveAttribute("tabindex", "-1");
+
+    fireEvent.click(disabledButton);
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+});

--- a/apps/homepage/src/components/dashboard/InstanceCard.tsx
+++ b/apps/homepage/src/components/dashboard/InstanceCard.tsx
@@ -29,6 +29,35 @@ const SOURCE_LABEL: Record<ManagedAgent["source"], string> = {
 type DeleteState = "idle" | "confirm" | "deleting";
 
 /**
+ * Copy + tooltip per non-running status. When the underlying container isn't
+ * reachable we replace the "open" button with a muted, disabled variant so
+ * users don't click through into a dead page.
+ */
+const OPEN_DISABLED_COPY: Partial<
+  Record<
+    import("../../lib/AgentProvider").ManagedAgent["status"],
+    { label: string; title: string }
+  >
+> = {
+  provisioning: {
+    label: "starting\u2026",
+    title: "Agent is booting up. This usually takes 30\u201360s.",
+  },
+  stopped: {
+    label: "stopped",
+    title: "Agent is stopped.",
+  },
+  paused: {
+    label: "paused",
+    title: "Agent is paused.",
+  },
+  unknown: {
+    label: "unreachable",
+    title: "Agent not responding to health checks.",
+  },
+};
+
+/**
  * Runtime card — typography + data, no image.
  *
  * Action model (post-H7):
@@ -94,6 +123,12 @@ export function InstanceCard({
   const runtimeLabel = agent.model ?? "milady runtime";
 
   const hasMenu = !!onDelete || !!onForget;
+
+  // Only allow opening the web UI when the runtime is actually reachable.
+  // During provisioning / boot / stopped states, the button flips to a muted,
+  // disabled variant with italic status text so nobody clicks into a dead page.
+  const canOpen = agent.status === "running";
+  const disabledCopy = canOpen ? null : OPEN_DISABLED_COPY[agent.status];
 
   const handleDeleteClick = async () => {
     if (!onDelete) return;
@@ -164,30 +199,53 @@ export function InstanceCard({
 
       {/* Row 3 — action strip */}
       <div className="mt-1 flex items-center gap-1.5">
-        <button
-          type="button"
-          onClick={onOpen}
-          className="group/btn flex flex-1 items-center justify-between rounded-md bg-brand/90 px-3 py-2 text-[12px] font-semibold text-black transition duration-200 hover:bg-brand active:scale-[0.98] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand/70"
-        >
-          <span className="inline-flex items-center gap-1.5">
-            <svg
-              viewBox="0 0 24 24"
-              width="12"
-              height="12"
-              fill="currentColor"
-              aria-hidden="true"
-            >
-              <path d="M8 5v14l11-7z" />
-            </svg>
-            <span>open</span>
-          </span>
-          <span
-            aria-hidden="true"
-            className="transition group-hover/btn:translate-x-0.5"
+        {canOpen ? (
+          <button
+            type="button"
+            onClick={onOpen}
+            className="group/btn flex flex-1 items-center justify-between rounded-md bg-brand/90 px-3 py-2 text-[12px] font-semibold text-black transition duration-200 hover:bg-brand active:scale-[0.98] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand/70"
           >
-            ↗
-          </span>
-        </button>
+            <span className="inline-flex items-center gap-1.5">
+              <svg
+                viewBox="0 0 24 24"
+                width="12"
+                height="12"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path d="M8 5v14l11-7z" />
+              </svg>
+              <span>open</span>
+            </span>
+            <span
+              aria-hidden="true"
+              className="transition group-hover/btn:translate-x-0.5"
+            >
+              ↗
+            </span>
+          </button>
+        ) : (
+          <button
+            type="button"
+            disabled
+            aria-disabled="true"
+            tabIndex={-1}
+            title={disabledCopy?.title}
+            className="flex flex-1 items-center justify-between rounded-md border border-brand/20 bg-brand/[0.06] px-3 py-2 text-[12px] font-medium text-brand/60 cursor-not-allowed"
+          >
+            <span className="inline-flex items-center gap-2">
+              {agent.status === "provisioning" ? (
+                <span
+                  aria-hidden="true"
+                  className="h-1.5 w-1.5 rounded-full bg-brand animate-pulse"
+                />
+              ) : null}
+              <span className="italic lowercase tracking-wide">
+                {disabledCopy?.label ?? "unavailable"}
+              </span>
+            </span>
+          </button>
+        )}
         <button
           type="button"
           onClick={onCopyUrl}


### PR DESCRIPTION
Cherry-picks the remaining homepage provisioning UX improvement from feat/dashboard-redesign-gold onto develop so milady.ai gets it.

Note: H7 (cbd572b49, cloud delete + deduped card actions) is already effectively present on develop, so its cherry-pick was empty. This PR carries the missing H7B behavior.

## H7 (already present on develop)
- Cloud agents can be deleted again (wires through existing cloudClient.deleteAgent)
- Card action surface deduped: primary Open button + single copy icon
- Per-source menu: (none) for local, "delete agent" with 2-step confirm for cloud, "forget connection" for remote

## H7B (this PR)
- Animated gold dot + italic "starting…" + tooltip while agent is provisioning
- Open button disabled (aria-disabled, keyboard-unfocusable, cursor-not-allowed) when status !== "running"

Co-authored-by: wakesync <shadow@shad0w.xyz>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable the open button in `InstanceCard` when a cloud agent is not running
> - Adds a status-aware `canOpen` check in [`InstanceCard.tsx`](https://github.com/milady-ai/milady/pull/2024/files#diff-f5738fb43bad73f86d17716ceb5e096a22f5d49cbeb76c7081c9e4d1ce11065c): when `agent.status` is not `'running'`, the primary button is replaced with a disabled variant (`aria-disabled`, `tabIndex={-1}`, `cursor-not-allowed`).
> - Status-specific labels and tooltips are shown via a new `OPEN_DISABLED_COPY` map (e.g. `'starting…'` for `provisioning`, `'stopped'`, `'paused'`, `'unreachable'`).
> - A pulsing dot is shown next to the label when status is `'provisioning'`.
> - Adds a Vitest suite in [`InstanceCard.test.tsx`](https://github.com/milady-ai/milady/pull/2024/files#diff-41d0bef9edd6672f17caa5bfe2ec60a82db1327b147107202a53d0346b850583) covering the running and provisioning states.
> - Behavioral Change: clicking the open button no longer calls `onOpen` for any non-running agent status.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c883250.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->