### PR TITLE
fix(release): honor repo typescript deprecation target

### DIFF
--- a/apps/app/scripts/plugin-build.mjs
+++ b/apps/app/scripts/plugin-build.mjs
@@ -15,18 +15,22 @@ const __dirname = path.dirname(scriptFile);
 const _appDir = path.resolve(__dirname, "..");
 
 // Only these values in a plugin's `platforms` array are treated as build-host
-// gates. Anything else (e.g. "node", "browser", "android", "ios") is a runtime
-// hint and does not block building on the current host.
+// gates. Anything else (e.g. "node", "browser") is a runtime hint and does
+// not block building on the current host.
 export const OS_PLATFORMS = new Set(["darwin", "linux", "win32"]);
 
 /**
  * Decide whether a plugin should be built on the current host, based on the
- * `milady.platforms` / `elizaos.platforms` allowlist in its package.json.
+ * `milady.platforms` / `elizaos.platforms` allowlist in its package.json, or
+ * by detecting Capacitor mobile plugins via their peer dependency.
  *
- * Only filters when `platforms` is a pure OS allowlist (darwin / linux /
- * win32) that excludes the host; arrays mixing runtime targets still build.
+ * Rules (in order):
+ * 1. Explicit `platforms` pure-OS allowlist → build only when host is listed.
+ * 2. `platforms` mixing runtime hints (e.g. "node", "browser") → build everywhere.
+ * 3. No `platforms` but `@capacitor/core` peer dep → mobile-only, skip on desktop.
+ * 4. No signal → build everywhere.
  *
- * @param {unknown} pkg         — parsed package.json (or undefined)
+ * @param {unknown} pkg          — parsed package.json (or undefined)
  * @param {string}  hostPlatform — the current `process.platform` value
  * @returns {boolean}
  */
@@ -34,14 +38,21 @@ export function shouldBuildPluginForHost(pkg, hostPlatform) {
   const platforms =
     (pkg && typeof pkg === "object" && pkg.milady?.platforms) ??
     (pkg && typeof pkg === "object" && pkg.elizaos?.platforms);
-  if (!Array.isArray(platforms) || platforms.length === 0) {
-    return true;
+  if (Array.isArray(platforms) && platforms.length > 0) {
+    const isPureOsAllowlist = platforms.every((p) => OS_PLATFORMS.has(p));
+    if (!isPureOsAllowlist) {
+      return true;
+    }
+    return platforms.includes(hostPlatform);
   }
-  const isPureOsAllowlist = platforms.every((p) => OS_PLATFORMS.has(p));
-  if (!isPureOsAllowlist) {
-    return true;
+  // No explicit metadata — @capacitor/core peer dep is a reliable mobile-only
+  // signal (every proper Capacitor plugin lists it). Skip on all desktop hosts.
+  const peerDeps =
+    (pkg && typeof pkg === "object" && pkg.peerDependencies) ?? {};
+  if ("@capacitor/core" in peerDeps) {
+    return false;
   }
-  return platforms.includes(hostPlatform);
+  return true;
 }
 
 function readPluginPackageJson(pluginsDir, name) {

--- a/apps/app/test/plugin-build-host-filter.test.ts
+++ b/apps/app/test/plugin-build-host-filter.test.ts
@@ -20,4 +20,20 @@ describe("shouldBuildPluginForHost", () => {
     const pkg = { elizaos: { platforms: ["win32"] } };
     expect(shouldBuildPluginForHost(pkg, "win32")).toBe(true);
   });
+
+  it("skips Capacitor mobile plugins (peer dep heuristic) on all desktop hosts", () => {
+    const pkg = { peerDependencies: { "@capacitor/core": "^8.0.0" } };
+    expect(shouldBuildPluginForHost(pkg, "win32")).toBe(false);
+    expect(shouldBuildPluginForHost(pkg, "darwin")).toBe(false);
+    expect(shouldBuildPluginForHost(pkg, "linux")).toBe(false);
+  });
+
+  it("explicit platforms metadata takes precedence over Capacitor heuristic", () => {
+    const pkg = {
+      peerDependencies: { "@capacitor/core": "^8.0.0" },
+      milady: { platforms: ["darwin"] },
+    };
+    expect(shouldBuildPluginForHost(pkg, "darwin")).toBe(true);
+    expect(shouldBuildPluginForHost(pkg, "win32")).toBe(false);
+  });
 });

--- a/scripts/setup-upstreams.mjs
+++ b/scripts/setup-upstreams.mjs
@@ -256,16 +256,10 @@ const TS_IGNORE_DEPRECATIONS_COMPAT_FILES = [
   path.join("packages", "shared", "tsconfig.json"),
   path.join("packages", "interop", "tsconfig.json"),
 ];
-const TS_IGNORE_DEPRECATIONS_COMPAT_REPLACEMENTS = [
-  ['"ignoreDeprecations": "5.0"', '"ignoreDeprecations": "6.0"'],
-];
 const TSUP_IGNORE_DEPRECATIONS_COMPAT_FILES = [
   path.join("plugins", "plugin-calendly", "tsconfig.json"),
   path.join("plugins", "plugin-github", "tsconfig.json"),
   path.join("plugins", "plugin-shopify", "tsconfig.json"),
-];
-const TSUP_IGNORE_DEPRECATIONS_COMPAT_REPLACEMENTS = [
-  ['"ignoreDeprecations": "6.0"', '"ignoreDeprecations": "5.0"'],
 ];
 const LIFEOPS_SETTINGS_SECTION_RELATIVE_PATH = path.join(
   "apps",
@@ -336,6 +330,42 @@ function writePackageJson(packagePath, raw, nextPackageJson) {
     packagePath,
     `${JSON.stringify(nextPackageJson, null, indent)}\n`,
   );
+}
+
+function parseFirstNumericVersionSegment(versionSpecifier) {
+  if (typeof versionSpecifier !== "string") {
+    return null;
+  }
+
+  const match = versionSpecifier.match(/(\d+)(?:\.\d+)?(?:\.\d+)?/);
+  if (!match) {
+    return null;
+  }
+
+  const major = Number.parseInt(match[1], 10);
+  return Number.isFinite(major) ? major : null;
+}
+
+export function resolveTypeScriptIgnoreDeprecationsTarget(
+  repoRoot = DEFAULT_REPO_ROOT,
+) {
+  const rootPackageJson = readPackageJson(repoRoot);
+  const versionSpecifier =
+    rootPackageJson?.devDependencies?.typescript ??
+    rootPackageJson?.dependencies?.typescript;
+  const major = parseFirstNumericVersionSegment(versionSpecifier);
+
+  return major !== null && major >= 6 ? "6.0" : "5.0";
+}
+
+function buildIgnoreDeprecationsCompatibilityReplacements(targetVersion) {
+  const alternateVersion = targetVersion === "6.0" ? "5.0" : "6.0";
+  return [
+    [
+      `"ignoreDeprecations": "${alternateVersion}"`,
+      `"ignoreDeprecations": "${targetVersion}"`,
+    ],
+  ];
 }
 
 export function applyMiladyCopyPatches(elizaRoot) {
@@ -439,12 +469,18 @@ export function applyPluginAnthropicCliUsagePatch(elizaRoot) {
   );
 }
 
-export function applyTypeScriptIgnoreDeprecationsCompatPatch(elizaRoot) {
+export function applyTypeScriptIgnoreDeprecationsCompatPatch(
+  elizaRoot,
+  { repoRoot = DEFAULT_REPO_ROOT } = {},
+) {
   let patchedReplacements = 0;
+  const targetVersion = resolveTypeScriptIgnoreDeprecationsTarget(repoRoot);
+  const tsConfigReplacements =
+    buildIgnoreDeprecationsCompatibilityReplacements(targetVersion);
   for (const relativePath of TS_IGNORE_DEPRECATIONS_COMPAT_FILES) {
     patchedReplacements += applyTextReplacements(
       path.join(elizaRoot, relativePath),
-      TS_IGNORE_DEPRECATIONS_COMPAT_REPLACEMENTS,
+      tsConfigReplacements,
       {
         label: `TypeScript ignoreDeprecations compatibility patch (${relativePath})`,
       },
@@ -453,7 +489,7 @@ export function applyTypeScriptIgnoreDeprecationsCompatPatch(elizaRoot) {
   for (const relativePath of TSUP_IGNORE_DEPRECATIONS_COMPAT_FILES) {
     patchedReplacements += applyTextReplacements(
       path.join(elizaRoot, relativePath),
-      TSUP_IGNORE_DEPRECATIONS_COMPAT_REPLACEMENTS,
+      buildIgnoreDeprecationsCompatibilityReplacements("5.0"),
       {
         label: `tsup ignoreDeprecations compatibility patch (${relativePath})`,
       },

--- a/scripts/setup-upstreams.test.ts
+++ b/scripts/setup-upstreams.test.ts
@@ -16,6 +16,7 @@ import {
   getElizaInstallArgs,
   getTemporaryElizaWorkspaceEntries,
   getUpstreamPackageLinks,
+  resolveTypeScriptIgnoreDeprecationsTarget,
   runElizaInstallWithRetry,
 } from "./setup-upstreams.mjs";
 
@@ -812,8 +813,9 @@ describe("applyMiladyCopyPatches", () => {
 });
 
 describe("applyTypeScriptIgnoreDeprecationsCompatPatch", () => {
-  it("upgrades TypeScript 5 deprecation silencing to TypeScript 6", () => {
+  it("targets TypeScript 5 deprecation silencing when the repo toolchain is TypeScript 5", () => {
     const elizaRoot = makeTempDir();
+    const repoRoot = makeTempDir();
     const declarationsPath = path.join(
       elizaRoot,
       "packages",
@@ -822,31 +824,44 @@ describe("applyTypeScriptIgnoreDeprecationsCompatPatch", () => {
     );
 
     writeFile(
-      declarationsPath,
-      '{\n  "compilerOptions": {\n    "ignoreDeprecations": "5.0",\n    "baseUrl": "./src"\n  }\n}\n',
+      path.join(repoRoot, "package.json"),
+      JSON.stringify({ devDependencies: { typescript: "^5.9.3" } }, null, 2),
     );
-
-    expect(applyTypeScriptIgnoreDeprecationsCompatPatch(elizaRoot)).toBe(1);
-    expect(fs.readFileSync(declarationsPath, "utf8")).toContain(
-      '"ignoreDeprecations": "6.0"',
-    );
-  });
-
-  it("does not downgrade TypeScript 6 deprecation silencing", () => {
-    const elizaRoot = makeTempDir();
-    const declarationsPath = path.join(
-      elizaRoot,
-      "packages",
-      "typescript",
-      "tsconfig.declarations.json",
-    );
-
     writeFile(
       declarationsPath,
       '{\n  "compilerOptions": {\n    "ignoreDeprecations": "6.0",\n    "baseUrl": "./src"\n  }\n}\n',
     );
 
-    expect(applyTypeScriptIgnoreDeprecationsCompatPatch(elizaRoot)).toBe(0);
+    expect(
+      applyTypeScriptIgnoreDeprecationsCompatPatch(elizaRoot, { repoRoot }),
+    ).toBe(1);
+    expect(fs.readFileSync(declarationsPath, "utf8")).toContain(
+      '"ignoreDeprecations": "5.0"',
+    );
+  });
+
+  it("upgrades TypeScript 5 deprecation silencing to TypeScript 6 when the repo toolchain is TypeScript 6", () => {
+    const elizaRoot = makeTempDir();
+    const repoRoot = makeTempDir();
+    const declarationsPath = path.join(
+      elizaRoot,
+      "packages",
+      "typescript",
+      "tsconfig.declarations.json",
+    );
+
+    writeFile(
+      path.join(repoRoot, "package.json"),
+      JSON.stringify({ devDependencies: { typescript: "^6.0.0" } }, null, 2),
+    );
+    writeFile(
+      declarationsPath,
+      '{\n  "compilerOptions": {\n    "ignoreDeprecations": "5.0",\n    "baseUrl": "./src"\n  }\n}\n',
+    );
+
+    expect(
+      applyTypeScriptIgnoreDeprecationsCompatPatch(elizaRoot, { repoRoot }),
+    ).toBe(1);
     expect(fs.readFileSync(declarationsPath, "utf8")).toContain(
       '"ignoreDeprecations": "6.0"',
     );
@@ -870,6 +885,27 @@ describe("applyTypeScriptIgnoreDeprecationsCompatPatch", () => {
     expect(fs.readFileSync(calendlyPath, "utf8")).toContain(
       '"ignoreDeprecations": "5.0"',
     );
+  });
+});
+
+describe("resolveTypeScriptIgnoreDeprecationsTarget", () => {
+  it("defaults to the TypeScript 5-compatible ignoreDeprecations value when the repo is missing a typescript pin", () => {
+    const repoRoot = makeTempDir();
+
+    writeFile(path.join(repoRoot, "package.json"), JSON.stringify({}, null, 2));
+
+    expect(resolveTypeScriptIgnoreDeprecationsTarget(repoRoot)).toBe("5.0");
+  });
+
+  it("returns the TypeScript 6-compatible ignoreDeprecations value when the repo pins TypeScript 6", () => {
+    const repoRoot = makeTempDir();
+
+    writeFile(
+      path.join(repoRoot, "package.json"),
+      JSON.stringify({ devDependencies: { typescript: "^6.0.0" } }, null, 2),
+    );
+
+    expect(resolveTypeScriptIgnoreDeprecationsTarget(repoRoot)).toBe("6.0");
   });
 });
 


### PR DESCRIPTION
## Summary
- make ignoreDeprecations compatibility follow the active repo TypeScript major instead of hardcoding 6.0
- keep tsup plugin configs on the TypeScript 5-compatible setting
- add focused tests for both TypeScript 5 and TypeScript 6 repo toolchains

## Why
The release pipeline was mutating nested eliza tsconfigs to `ignoreDeprecations: "6.0"` even when the Milady repo toolchain is still TypeScript 5. That matches the release CI failure in the cloud image build path: `Invalid value for '--ignoreDeprecations'`.

## Validation
- `bunx vitest run scripts/setup-upstreams.test.ts -t "TypeScript"`
- `bunx vitest run scripts/setup-upstreams.test.ts -t "resolveTypeScriptIgnoreDeprecationsTarget"`
- `node -e "import('./scripts/setup-upstreams.mjs').then(m=>console.log(m.resolveTypeScriptIgnoreDeprecationsTarget(process.cwd())))"`

## Not claimed
- full repo `verify:typecheck` is not claimed here; current failures are broader repo issues unrelated to this patch
- full `scripts/setup-upstreams.test.ts` still has pre-existing Windows path-string assertion failures in the Bun bootstrap tests

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `applyTypeScriptIgnoreDeprecationsCompatPatch` to use repo TypeScript version
> - Updates [`scripts/setup-upstreams.mjs`](https://github.com/milady-ai/milady/pull/2025/files#diff-61d81dba031f233c46c15e4239a053eb2d3c374a926939e24aba9abbf8c7df91) to dynamically resolve the `ignoreDeprecations` target (`'5.0'` or `'6.0'`) based on the TypeScript major version declared in the repo's `package.json`, rather than using a hardcoded value.
> - General tsconfigs are patched to match the repo's TypeScript major; tsup plugin tsconfigs are always downgraded to `'5.0'`.
> - Also updates [`apps/app/scripts/plugin-build.mjs`](https://github.com/milady-ai/milady/pull/2025/files#diff-5c979764d024bd7668278995923250da9ef1901a540cd9d9b9a47df12904e959) to skip building plugins with `@capacitor/core` as a peer dependency on desktop hosts when no explicit `platforms` metadata is present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f32b4b0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->