### PR TITLE
fix(release): stabilize agent release validation on develop

### DIFF
--- a/.github/workflows/build-cloud-agent.yml
+++ b/.github/workflows/build-cloud-agent.yml
@@ -389,17 +389,45 @@ jobs:
       # ── 11. Login to GHCR ──────────────────────────────────────────────────
       - name: Login to GHCR
         uses: docker/login-action@v3
+        if: ${{ github.event_name == 'push' || inputs.push_image != false }}
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # ── 12. Build and push via Depot (persistent layer cache + Depot infra) ──
-      - name: Build and push Docker image
+      - name: Build and push Docker image with Depot
+        id: depot-build
+        continue-on-error: true
         uses: depot/build-push-action@v1
         with:
           project: ${{ env.DEPOT_PROJECT_ID }}
           token: ${{ secrets.DEPOT_TOKEN }}
+          context: .
+          file: deploy/Dockerfile.ci
+          platforms: linux/amd64
+          push: ${{ github.event_name == 'push' || inputs.push_image != false }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.latest_tag }}
+          build-args: |
+            APP_ENTRYPOINT=${{ env.APP_ENTRYPOINT }}
+            APP_CMD_START=${{ env.APP_CMD_START }}
+            APP_PORT=${{ env.APP_PORT }}
+            APP_API_BIND=${{ env.APP_API_BIND }}
+            OCI_SOURCE=${{ env.OCI_SOURCE }}
+            OCI_TITLE=${{ env.OCI_TITLE }}
+            OCI_DESCRIPTION=${{ env.OCI_DESCRIPTION }}
+            OCI_LICENSES=${{ env.OCI_LICENSES }}
+            VERSION=${{ steps.version.outputs.version }}
+            VERSION_CLEAN=${{ steps.version.outputs.version_clean }}
+            REVISION=${{ github.sha }}
+          provenance: false
+
+      - name: Build and push Docker image with Buildx fallback
+        if: steps.depot-build.outcome == 'failure'
+        uses: docker/build-push-action@v6
+        with:
           context: .
           file: deploy/Dockerfile.ci
           platforms: linux/amd64

--- a/.github/workflows/build-cloud-image.yml
+++ b/.github/workflows/build-cloud-image.yml
@@ -267,11 +267,37 @@ jobs:
             type=raw,value=cloud-app
             type=raw,value=cloud-app-${{ steps.version.outputs.version_clean }}
 
-      - name: Build and push cloud app image
+      - name: Build and push cloud app image with Depot
+        id: depot-build
+        continue-on-error: true
         uses: depot/build-push-action@v1
         with:
           project: ${{ env.DEPOT_PROJECT_ID }}
           token: ${{ secrets.DEPOT_TOKEN }}
+          context: .
+          file: eliza/packages/app-core/deploy/Dockerfile.cloud
+          platforms: linux/amd64
+          push: ${{ github.event_name == 'push' || inputs.push_image != false }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            APP_ENTRYPOINT=${{ env.APP_ENTRYPOINT }}
+            APP_CMD_START=${{ env.APP_CMD_START }}
+            APP_PORT=${{ env.APP_PORT }}
+            APP_API_BIND=${{ env.APP_API_BIND }}
+            OCI_SOURCE=${{ env.OCI_SOURCE }}
+            OCI_TITLE=${{ env.OCI_TITLE }}
+            OCI_DESCRIPTION=${{ env.OCI_DESCRIPTION }}
+            OCI_LICENSES=${{ env.OCI_LICENSES }}
+            VERSION=${{ steps.version.outputs.version }}
+            VERSION_CLEAN=${{ steps.version.outputs.version_clean }}
+            REVISION=${{ github.sha }}
+          provenance: false
+
+      - name: Build and push cloud app image with Buildx fallback
+        if: steps.depot-build.outcome == 'failure'
+        uses: docker/build-push-action@v6
+        with:
           context: .
           file: eliza/packages/app-core/deploy/Dockerfile.cloud
           platforms: linux/amd64

--- a/scripts/patch-release-check-pack-fallback.mjs
+++ b/scripts/patch-release-check-pack-fallback.mjs
@@ -147,6 +147,34 @@ const canonicalLocalPackHotspotPaths = [
   "apps/app/dist/vrms",
   "apps/app/dist/animations",
 ];
+const workflowSnippetCompatReplacements = [
+  [
+    "name: Build LifeOps Browser companions",
+    "name: Build Agent Browser Bridge companions",
+  ],
+  [
+    "if bun run lifeops:browser:package:release; then",
+    "if bun run browser-bridge:package:release; then",
+  ],
+  [
+    "LifeOps Browser packaging failed; desktop release will continue without browser companion bundles.",
+    "Agent Browser Bridge packaging failed; desktop release will continue without browser companion bundles.",
+  ],
+  [
+    "name: Upload LifeOps Browser release artifacts",
+    "name: Upload Agent Browser Bridge release artifacts",
+  ],
+  ["name: lifeops-browser-store-bundles", "name: browser-bridge-store-bundles"],
+  [
+    "name: Publish LifeOps Browser companions",
+    "name: Publish Agent Browser Bridge companions",
+  ],
+  [
+    "name: Attach LifeOps Browser assets to GitHub release",
+    "name: Attach Agent Browser Bridge assets to GitHub release",
+  ],
+  ["pattern: lifeops-browser-*", "pattern: browser-bridge-*"],
+];
 
 function getLocalPackHotspotPathsBlock(source) {
   return source.match(/const localPackHotspotPaths = \[[\s\S]*?\];/)?.[0];
@@ -211,6 +239,12 @@ export function applyReleaseCheckPackFallback(source) {
 
   if (!hasRequiredLocalPackHotspots(patched)) {
     patched = patchLocalPackHotspotPathsBlock(patched);
+  }
+
+  for (const [from, to] of workflowSnippetCompatReplacements) {
+    if (!patched.includes(to) && patched.includes(from)) {
+      patched = patched.replaceAll(from, to);
+    }
   }
 
   return patched;

--- a/scripts/patch-release-check-pack-fallback.test.ts
+++ b/scripts/patch-release-check-pack-fallback.test.ts
@@ -62,6 +62,16 @@ const upstreamLocalPackHotspotPathsBlock = `const localPackHotspotPaths = [
   "apps/app/dist/vrms",
   "apps/app/dist/animations",
 ];`;
+const upstreamLifeOpsWorkflowSnippetBlock = `const requiredWorkflowSnippets = [
+  "name: Build LifeOps Browser companions",
+  "if bun run lifeops:browser:package:release; then",
+  "LifeOps Browser packaging failed; desktop release will continue without browser companion bundles.",
+  "name: Upload LifeOps Browser release artifacts",
+  "name: lifeops-browser-store-bundles",
+  "name: Publish LifeOps Browser companions",
+  "name: Attach LifeOps Browser assets to GitHub release",
+  "pattern: lifeops-browser-*",
+];`;
 
 describe("patch-release-check-pack-fallback", () => {
   it("patches the upstream release-check pack fallback and hotspot blocks", () => {
@@ -83,6 +93,26 @@ describe("patch-release-check-pack-fallback", () => {
 
     expect(patched).toContain('  "dist",');
     expect(patched).toContain('  "apps/app/dist",');
+  });
+
+  it("rewrites stale LifeOps browser workflow snippets to the current Agent Browser Bridge naming", () => {
+    const patched = applyReleaseCheckPackFallback(
+      `before\n${upstreamLifeOpsWorkflowSnippetBlock}\nafter\n`,
+    );
+
+    expect(patched).toContain("name: Build Agent Browser Bridge companions");
+    expect(patched).toContain(
+      "if bun run browser-bridge:package:release; then",
+    );
+    expect(patched).toContain(
+      "Agent Browser Bridge packaging failed; desktop release will continue without browser companion bundles.",
+    );
+    expect(patched).toContain("name: browser-bridge-store-bundles");
+    expect(patched).toContain(
+      "name: Attach Agent Browser Bridge assets to GitHub release",
+    );
+    expect(patched).toContain("pattern: browser-bridge-*");
+    expect(patched).not.toContain("lifeops-browser-*");
   });
 
   it("patches hotspot blocks that drifted from the original upstream shape", () => {

--- a/scripts/setup-upstreams.mjs
+++ b/scripts/setup-upstreams.mjs
@@ -348,14 +348,24 @@ function parseFirstNumericVersionSegment(versionSpecifier) {
 
 export function resolveTypeScriptIgnoreDeprecationsTarget(
   repoRoot = DEFAULT_REPO_ROOT,
+  { fallbackRoot } = {},
 ) {
-  const rootPackageJson = readPackageJson(repoRoot);
-  const versionSpecifier =
-    rootPackageJson?.devDependencies?.typescript ??
-    rootPackageJson?.dependencies?.typescript;
-  const major = parseFirstNumericVersionSegment(versionSpecifier);
+  const candidateRoots = [repoRoot, fallbackRoot].filter(
+    (candidate) => typeof candidate === "string" && candidate.length > 0,
+  );
 
-  return major !== null && major >= 6 ? "6.0" : "5.0";
+  for (const candidateRoot of candidateRoots) {
+    const rootPackageJson = readPackageJson(candidateRoot);
+    const versionSpecifier =
+      rootPackageJson?.devDependencies?.typescript ??
+      rootPackageJson?.dependencies?.typescript;
+    const major = parseFirstNumericVersionSegment(versionSpecifier);
+    if (major !== null) {
+      return major >= 6 ? "6.0" : "5.0";
+    }
+  }
+
+  return "5.0";
 }
 
 function buildIgnoreDeprecationsCompatibilityReplacements(targetVersion) {
@@ -474,7 +484,9 @@ export function applyTypeScriptIgnoreDeprecationsCompatPatch(
   { repoRoot = DEFAULT_REPO_ROOT } = {},
 ) {
   let patchedReplacements = 0;
-  const targetVersion = resolveTypeScriptIgnoreDeprecationsTarget(repoRoot);
+  const targetVersion = resolveTypeScriptIgnoreDeprecationsTarget(elizaRoot, {
+    fallbackRoot: repoRoot,
+  });
   const tsConfigReplacements =
     buildIgnoreDeprecationsCompatibilityReplacements(targetVersion);
   for (const relativePath of TS_IGNORE_DEPRECATIONS_COMPAT_FILES) {

--- a/scripts/setup-upstreams.test.ts
+++ b/scripts/setup-upstreams.test.ts
@@ -907,6 +907,26 @@ describe("resolveTypeScriptIgnoreDeprecationsTarget", () => {
 
     expect(resolveTypeScriptIgnoreDeprecationsTarget(repoRoot)).toBe("6.0");
   });
+
+  it("prefers the nested workspace TypeScript pin before falling back to the root repo", () => {
+    const repoRoot = makeTempDir();
+    const elizaRoot = makeTempDir();
+
+    writeFile(
+      path.join(repoRoot, "package.json"),
+      JSON.stringify({ devDependencies: { typescript: "^5.9.3" } }, null, 2),
+    );
+    writeFile(
+      path.join(elizaRoot, "package.json"),
+      JSON.stringify({ devDependencies: { typescript: "^6.0.0" } }, null, 2),
+    );
+
+    expect(
+      resolveTypeScriptIgnoreDeprecationsTarget(elizaRoot, {
+        fallbackRoot: repoRoot,
+      }),
+    ).toBe("6.0");
+  });
 });
 
 describe("applyPluginAnthropicCliUsagePatch", () => {


### PR DESCRIPTION
## Summary
This fixes the current agent release path on `develop` rather than stale PR branches.

## What changed
- add Buildx fallback to cloud image workflows so validation runs do not hard-fail on missing Depot auth
- prefer the nested `eliza` TypeScript pin when patching `ignoreDeprecations`, which matches the TS6 release-build path
- normalize stale browser companion `release-check` snippets to the current Agent Browser Bridge naming used by Milady

## Validated
- `bunx vitest run scripts/setup-upstreams.test.ts -t "prefers the nested workspace TypeScript pin before falling back to the root repo"`
- `bunx vitest run scripts/patch-release-check-pack-fallback.test.ts -t "rewrites stale LifeOps browser workflow snippets to the current Agent Browser Bridge naming"`
- `bunx tsdown --fail-on-warn false`
- `node --import tsx scripts/write-build-info.ts`
- `node scripts/patch-release-check-pack-fallback.mjs`
- `bun run release:check`

## Not claimed
- full Windows `bun run postinstall` is not claimed here; local Windows hydration still hits separate `canvas` / dependency-install issues that are outside this targeted release-path fix


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix agent release validation by adding Docker build fallbacks and workflow naming patches
> - Docker image build workflows ([build-cloud-agent.yml](https://github.com/milady-ai/milady/pull/2027/files#diff-0970cca1db47f9deab06e9fd087f8ddda0e14e5ede6f9be402a5433d885eab31) and [build-cloud-image.yml](https://github.com/milady-ai/milady/pull/2027/files#diff-36255d6c516f80a5b37564db52b52f50b80174f309fd56e2250c741e64052d61)) now attempt a primary build with [depot](https://depot.dev) and fall back to `docker/build-push-action` if it fails.
> - [patch-release-check-pack-fallback.mjs](https://github.com/milady-ai/milady/pull/2027/files#diff-ac3baf15927f57de668127c24ee87ec5b9542c02717291bf090f04bfac961d19) rewrites stale 'lifeops browser' naming to 'agent browser bridge' in workflow snippets during release validation.
> - [setup-upstreams.mjs](https://github.com/milady-ai/milady/pull/2027/files#diff-61d81dba031f233c46c15e4239a053eb2d3c374a926939e24aba9abbf8c7df91) extends `resolveTypeScriptIgnoreDeprecationsTarget` to accept a fallback root, checking the nested `elizaRoot` workspace for a TypeScript version before falling back to the repo root.
> - Risk: `continue-on-error: true` on the depot step means a silent depot failure will not block the build but may produce different image metadata than expected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 475f91a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->