### PR TITLE
fix: correct malformed Anthropic Haiku model ID

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -250,7 +250,7 @@
           "description": "Override the default Anthropic small model identifier used by the plugin",
           "required": false,
           "sensitive": false,
-          "default": "claude-haiku-4-5-20251001-5-20251001"
+          "default": "claude-haiku-4-5-20251001"
         },
         "ANTHROPIC_LARGE_MODEL": {
           "type": "string",


### PR DESCRIPTION
## Summary

Fixes malformed Anthropic Haiku model ID that causes 404 errors on every API call.

The default small model ID was wrong in three places:
- **plugin-anthropic config/package.json**: `claude-haiku-4-5-20251001-5-20251001` (duplicated suffix)
- **provider-switch-config.ts**: `claude-haiku-4-5-20251001-5` (trailing `-5`)
- **plugins.json**: `claude-haiku-4-5-20251001-5-20251001` (duplicated suffix)

All corrected to `claude-haiku-4-5-20251001`.

Users who already onboarded will also have the bad value cached in `~/.milady/milady.json` — they'll need to manually update `ANTHROPIC_SMALL_MODEL` there or re-run onboarding.

## Test plan
- [ ] Start the app and send a message via the web UI
- [ ] Confirm API requests use model `claude-haiku-4-5-20251001`
- [ ] Confirm no 404 errors in console


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix malformed Anthropic Haiku model ID in plugins.json
> Corrects a duplicated suffix in the default model identifier for the Claude Haiku plugin entry, changing `claude-haiku-4-5-20251001-5-20251001` to `claude-haiku-4-5-20251001` in [plugins.json](https://github.com/milady-ai/milady/pull/2035/files#diff-18d7f9b905f83805c42db6d239a7fb0207d4b32193202eb13ba077caed424c3c).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e8f991.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->