### PR TITLE
WIP: free-tier CI wins — path filters, test shard, Depot opt-out

### DIFF
--- a/.github/workflows/build-cloud-agent.yml
+++ b/.github/workflows/build-cloud-agent.yml
@@ -384,8 +384,15 @@ jobs:
           echo '!eliza/apps/app-lifeops' >> .dockerignore
 
       # ── 10. Set up Depot builder ────────────────────────────────
+      # Set repo variable DEPOT_ENABLED=false to skip Depot and use the
+      # Buildx fallback below (e.g. when the Depot account is unavailable).
       - name: Set up Depot CLI
+        if: vars.DEPOT_ENABLED != 'false'
         uses: depot/setup-action@v1
+
+      - name: Set up Docker Buildx fallback
+        if: vars.DEPOT_ENABLED == 'false'
+        uses: docker/setup-buildx-action@v3
 
       # ── 11. Login to GHCR ──────────────────────────────────────────────────
       - name: Login to GHCR
@@ -399,6 +406,7 @@ jobs:
       # ── 12. Build and push via Depot (persistent layer cache + Depot infra) ──
       - name: Build and push Docker image with Depot
         id: depot-build
+        if: vars.DEPOT_ENABLED != 'false'
         continue-on-error: true
         uses: depot/build-push-action@v1
         with:
@@ -426,7 +434,7 @@ jobs:
           provenance: false
 
       - name: Build and push Docker image with Buildx fallback
-        if: steps.depot-build.outcome == 'failure'
+        if: vars.DEPOT_ENABLED == 'false' || steps.depot-build.outcome == 'failure'
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/.github/workflows/build-cloud-image.yml
+++ b/.github/workflows/build-cloud-image.yml
@@ -328,6 +328,7 @@ jobs:
         run: cp eliza/packages/app-core/deploy/Dockerfile.cloud.dockerignore .dockerignore
 
       - name: Set up Depot CLI
+        if: vars.DEPOT_ENABLED != 'false'
         uses: depot/setup-action@v1
 
       - name: Set up Docker Buildx fallback
@@ -352,6 +353,7 @@ jobs:
 
       - name: Build and push cloud app image
         id: depot-build
+        if: vars.DEPOT_ENABLED != 'false'
         continue-on-error: true
         uses: depot/build-push-action@v1
         with:
@@ -378,7 +380,7 @@ jobs:
           provenance: false
 
       - name: Build and push cloud app image with Buildx fallback
-        if: steps.depot-build.outcome == 'failure'
+        if: vars.DEPOT_ENABLED == 'false' || steps.depot-build.outcome == 'failure'
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -267,7 +267,11 @@ jobs:
       # ── 13. Set up Depot CLI ────────────────────────────────────────────────
       # Docker builds run on Depot infrastructure (persistent cache, no GHA
       # docker-daemon fragility). `DEPOT_TOKEN` secret must be set on the repo.
+      # Set repo variable DEPOT_ENABLED=false to skip Depot entirely and go
+      # straight to the Buildx fallback (e.g. when the Depot account is
+      # unavailable).
       - name: Set up Depot CLI
+        if: vars.DEPOT_ENABLED != 'false'
         uses: depot/setup-action@v1
 
       - name: Set up Docker Buildx fallback
@@ -299,6 +303,7 @@ jobs:
       # sidestepping the GHA → GHCR 403 class of failures on restricted tokens.
       - name: Build and push Docker image with Depot
         id: depot-build
+        if: vars.DEPOT_ENABLED != 'false'
         continue-on-error: true
         uses: depot/build-push-action@v1
         with:
@@ -327,7 +332,7 @@ jobs:
           buildx-fallback: true
 
       - name: Build and push Docker image with Buildx fallback
-        if: steps.depot-build.outcome == 'failure'
+        if: vars.DEPOT_ENABLED == 'false' || steps.depot-build.outcome == 'failure'
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,24 @@ name: CI
 on:
   pull_request:
     branches: [main, develop]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "AGENTS.md"
+      - "CHANGELOG.md"
+      - "LICENSE"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/pull_request_template.md"
   push:
     branches: [main, develop, "codex/**"]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "AGENTS.md"
+      - "CHANGELOG.md"
+      - "LICENSE"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/pull_request_template.md"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,24 @@ name: Tests
 on:
   pull_request:
     branches: [main, develop]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "AGENTS.md"
+      - "CHANGELOG.md"
+      - "LICENSE"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/pull_request_template.md"
   push:
     branches: [main, develop]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "AGENTS.md"
+      - "CHANGELOG.md"
+      - "LICENSE"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/pull_request_template.md"
   workflow_dispatch:
 
 concurrency:
@@ -54,9 +70,13 @@ jobs:
         run: bun run test:regression-matrix:pr
 
   unit-tests:
-    name: Real tests (Vitest, no mocks)
+    name: Real tests (Vitest, shard ${{ matrix.shard }}/${{ strategy.job-total }})
     runs-on: ubuntu-24.04
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -91,9 +111,10 @@ jobs:
         run: bun run build
 
       - name: Run real integration tests (live/real suite)
-        run: bun run test:ci:real
+        run: bun run test:ci:real -- --shard=${{ matrix.shard }}/${{ strategy.job-total }}
 
       - name: Run startup script drift guard
+        if: matrix.shard == 1
         run: bun run test:startup:contract
 
   db-check:

--- a/docs/ci-depot.md
+++ b/docs/ci-depot.md
@@ -43,6 +43,36 @@ gh secret set DEPOT_TOKEN --repo milady-ai/milady --body "<new-token>"
 
 ---
 
+## Disabling Depot (account unavailable / billing hold)
+
+`build-docker.yml`, `build-cloud-agent.yml`, and `build-cloud-image.yml` all
+gate their Depot steps on the **`DEPOT_ENABLED`** repo variable. Default
+behavior is unchanged (Depot runs when the variable is unset or any value
+other than `false`).
+
+To force Docker builds onto the in-workflow Buildx fallback — useful when the
+Depot account is on hold and you don't want every run to waste ~30s failing
+the Depot step before falling back:
+
+```bash
+# Disable
+gh variable set DEPOT_ENABLED --repo milady-ai/milady --body "false"
+
+# Re-enable
+gh variable delete DEPOT_ENABLED --repo milady-ai/milady
+```
+
+Or via the GitHub UI: **Settings → Secrets and variables → Actions → Variables → New repository variable**, name `DEPOT_ENABLED`, value `false`.
+
+When disabled:
+- `Set up Depot CLI` and `Build and push Docker image with Depot` are skipped.
+- The Buildx fallback (`docker/build-push-action@v6` on the GHA-native daemon)
+  runs unconditionally.
+- All other Depot infrastructure (`.depot/`, `scripts/depot-ci-sync.mjs`,
+  CI mirror workflows) stays in place — flip the variable back to re-enable.
+
+---
+
 ## Regenerating the Depot mirror safely
 
 **Never run `depot ci migrate workflows --overwrite` by hand.** The wrapper below

--- a/docs/ci-local-act.md
+++ b/docs/ci-local-act.md
@@ -1,0 +1,78 @@
+# Running CI locally with `act`
+
+`nektos/act` runs `.github/workflows/*.yml` against a local Docker daemon so you can iterate on workflow YAML without a push-trigger-wait loop.
+
+## Install
+
+```bash
+# macOS
+brew install act
+
+# Linux (or any platform with the install script)
+curl -s https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash
+```
+
+Requires Docker Desktop (or any local Docker daemon). The first run downloads runner images (~1–2 GB).
+
+## First-run config
+
+Create `~/.actrc` (or `./.actrc` for repo-local) to pin the runner image. The medium image matches `ubuntu-24.04` closely enough for our CI:
+
+```
+-P ubuntu-24.04=catthehacker/ubuntu:act-latest
+-P ubuntu-latest=catthehacker/ubuntu:act-latest
+--container-architecture linux/amd64
+```
+
+The `--container-architecture` flag is required on Apple Silicon — without it `act` runs `arm64` containers and most setup actions break.
+
+## Common commands
+
+```bash
+# List jobs that would run for the default event (push)
+act -l
+
+# Run a specific workflow + job
+act -j lint -W .github/workflows/ci.yml
+
+# Run on the pull_request event
+act pull_request -W .github/workflows/test.yml -j unit-tests
+
+# Pass a secret (won't read from the GitHub UI)
+act -j build -s GITHUB_TOKEN="$(gh auth token)"
+
+# Pass a whole .env file of secrets
+act -j publish -W .github/workflows/publish-npm.yml --secret-file .secrets.local
+```
+
+## Caveats specific to this repo
+
+1. **Submodules.** Workflows here check out with `submodules: false` and restore via `scripts/restore-local-eliza-workspace.mjs`. `act` runs against your existing working tree, so make sure your submodules are already initialized (`git submodule update --init --recursive`) before invoking.
+
+2. **Bun version pin.** Workflows pin `BUN_VERSION` and use `oven-sh/setup-bun@v2`. The `catthehacker` images include bun, but the version differs. Use `--env BUN_VERSION=1.3.11` if a step is sensitive.
+
+3. **GitHub Actions cache.** `actions/cache@v4` is a no-op under `act` by default. Pass `--use-action-cache` to enable a host-side cache, or accept that local runs will always be cold.
+
+4. **Skipping heavy jobs.** Many of our workflows have docker, mobile, or signing steps that won't run locally. Use `act -j <single-job-id>` to target the one you actually want to test.
+
+5. **Secrets.** Never commit `.secrets.local`. Add it to `.gitignore` if you create one.
+
+6. **Limitations.** `act` cannot replicate macOS or Windows runners — those workflows (`release-electrobun.yml`, `windows-*-smoke.yml`, `apple-store-release.yml`) must be tested via `workflow_dispatch` on a branch.
+
+## When `act` is the right tool
+
+- Iterating on a new job's setup steps before the first push.
+- Reproducing a CI failure locally that doesn't reproduce in `bun run verify`.
+- Validating workflow YAML changes (path filters, matrix definitions, conditionals) without spamming branches.
+
+## When it isn't
+
+- Anything that hits real GitHub APIs that require live tokens (PR comments, deployment APIs).
+- macOS/Windows-only steps.
+- Behavior that depends on the actual GitHub-hosted runner image (rare, but happens with native binaries).
+
+## See also
+
+- Upstream docs: <https://nektosact.com/>
+- Source: <https://github.com/nektos/act>
+- Existing pre-push gate: `bun run pre-review:local` (see `.github/workflows/ci.yml` `pre-review` job)

--- a/patches/eliza/ci-release-contracts.patch
+++ b/patches/eliza/ci-release-contracts.patch
@@ -128,6 +128,15 @@ index 40eea15ff9..3d852ccb06 100755
  		bun run build; \
  	else \
  		npm install --ignore-scripts; \
+@@ -23 +24 @@ override_dh_auto_install:
+-	cp elizaos-app.mjs debian/elizaos-app/usr/lib/elizaos-app/
++	cp milady.mjs debian/elizaos-app/usr/lib/elizaos-app/elizaos-app.mjs
+diff --git a/packages/app-core/packaging/debian/install b/packages/app-core/packaging/debian/install
+index 998ae35c63..f09fae624e 100644
+--- a/packages/app-core/packaging/debian/install
++++ b/packages/app-core/packaging/debian/install
+@@ -2 +1,0 @@
+-elizaos-app.mjs usr/lib/elizaos-app/
 diff --git a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/MiladyBootReceiver.java b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/MiladyBootReceiver.java
 index 8a999411b9..ef72354bef 100644
 --- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/MiladyBootReceiver.java

--- a/scripts/release-workflow-path-contract.test.ts
+++ b/scripts/release-workflow-path-contract.test.ts
@@ -989,6 +989,10 @@ describe("release workflow path contract", () => {
     expect(patch).toContain(
       "node --import tsx scripts/copy-runtime-node-modules.ts --link-only || exit $$?",
     );
+    expect(patch).toContain(
+      "cp milady.mjs debian/elizaos-app/usr/lib/elizaos-app/elizaos-app.mjs",
+    );
+    expect(patch).toContain("-elizaos-app.mjs usr/lib/elizaos-app/");
     expect(
       patch.indexOf("ELIZAOS_APP_SKIP_LOCAL_UPSTREAMS=1 bun install"),
     ).toBeLessThan(

--- a/scripts/sanitize-npm-package-metadata.mjs
+++ b/scripts/sanitize-npm-package-metadata.mjs
@@ -10,6 +10,7 @@ const DEPENDENCY_FIELDS = [
   "peerDependencies",
   "devDependencies",
 ];
+const BUNDLE_DEPENDENCY_FIELDS = ["bundleDependencies", "bundledDependencies"];
 const LOCAL_PROTOCOLS = ["workspace:", "file:", "link:", "portal:"];
 
 function isPlainObject(value) {
@@ -75,35 +76,51 @@ export function sanitizeNpmPackageMetadata(
   const overrides = isPlainObject(packageJson.overrides)
     ? packageJson.overrides
     : null;
+  const removed = [];
+  const removedBundledDependencies = [];
+  let changed = false;
 
-  if (!overrides) {
-    return { changed: false, removed: [] };
+  if (overrides) {
+    const directDependencySpecs = collectDirectDependencySpecs(packageJson);
+    const sanitizedOverrides = {};
+
+    for (const [name, overrideValue] of Object.entries(overrides)) {
+      const reason = removalReason(name, overrideValue, directDependencySpecs);
+      if (reason) {
+        removed.push({ name, reason });
+        continue;
+      }
+      sanitizedOverrides[name] = overrideValue;
+    }
+
+    if (removed.length > 0) {
+      if (Object.keys(sanitizedOverrides).length === 0) {
+        delete packageJson.overrides;
+      } else {
+        packageJson.overrides = sanitizedOverrides;
+      }
+      changed = true;
+    }
   }
 
-  const directDependencySpecs = collectDirectDependencySpecs(packageJson);
-  const sanitizedOverrides = {};
-  const removed = [];
-
-  for (const [name, overrideValue] of Object.entries(overrides)) {
-    const reason = removalReason(name, overrideValue, directDependencySpecs);
-    if (reason) {
-      removed.push({ name, reason });
+  for (const field of BUNDLE_DEPENDENCY_FIELDS) {
+    const bundledDependencies = packageJson[field];
+    if (
+      !Array.isArray(bundledDependencies) ||
+      bundledDependencies.length === 0
+    ) {
       continue;
     }
-    sanitizedOverrides[name] = overrideValue;
+    removedBundledDependencies.push(...bundledDependencies);
+    delete packageJson[field];
+    changed = true;
   }
 
-  if (removed.length === 0) {
+  if (!changed) {
     options.log?.(
-      "[sanitize-npm-package-metadata] no npm override metadata changes needed",
+      "[sanitize-npm-package-metadata] no npm package metadata changes needed",
     );
-    return { changed: false, removed };
-  }
-
-  if (Object.keys(sanitizedOverrides).length === 0) {
-    delete packageJson.overrides;
-  } else {
-    packageJson.overrides = sanitizedOverrides;
+    return { changed: false, removed, removedBundledDependencies };
   }
 
   if (!options.dryRun) {
@@ -114,13 +131,21 @@ export function sanitizeNpmPackageMetadata(
     );
   }
 
-  options.log?.(
-    `[sanitize-npm-package-metadata] removed ${removed.length} npm-unsafe override(s): ${removed
-      .map(({ name, reason }) => `${name} (${reason})`)
-      .join(", ")}`,
-  );
+  if (removed.length > 0) {
+    options.log?.(
+      `[sanitize-npm-package-metadata] removed ${removed.length} npm-unsafe override(s): ${removed
+        .map(({ name, reason }) => `${name} (${reason})`)
+        .join(", ")}`,
+    );
+  }
 
-  return { changed: true, removed };
+  if (removedBundledDependencies.length > 0) {
+    options.log?.(
+      `[sanitize-npm-package-metadata] removed ${removedBundledDependencies.length} bundled dependencies from package metadata: ${removedBundledDependencies.join(", ")}`,
+    );
+  }
+
+  return { changed: true, removed, removedBundledDependencies };
 }
 
 export function isDirectRun(

--- a/scripts/sanitize-npm-package-metadata.test.ts
+++ b/scripts/sanitize-npm-package-metadata.test.ts
@@ -95,6 +95,34 @@ describe("sanitize-npm-package-metadata", () => {
     expect(readPackageJson(repoRoot).overrides).toEqual({ undici: "7.24.6" });
   });
 
+  it("removes bundled dependencies before npm pack or publish", () => {
+    const repoRoot = makeTempDir();
+    const log = vi.fn();
+    writePackageJson(repoRoot, {
+      name: "milady",
+      bundleDependencies: [
+        "@elizaos/core",
+        "@elizaos/plugin-agent-orchestrator",
+      ],
+      dependencies: {
+        "@elizaos/core": "2.0.0-alpha.353",
+        "@elizaos/plugin-agent-orchestrator": "0.3.9",
+      },
+    });
+
+    const result = sanitizeNpmPackageMetadata(repoRoot, { log });
+
+    expect(result.changed).toBe(true);
+    expect(result.removedBundledDependencies).toEqual([
+      "@elizaos/core",
+      "@elizaos/plugin-agent-orchestrator",
+    ]);
+    expect(readPackageJson(repoRoot).bundleDependencies).toBeUndefined();
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining("removed 2 bundled dependencies"),
+    );
+  });
+
   it("supports dry-run without mutating package.json", () => {
     const repoRoot = makeTempDir();
     const packageJson = {


### PR DESCRIPTION
## Summary

Three free-tier CI wins identified after a workflow audit confirmed most other "free wins" (caching, concurrency, job summaries) are already in place.

- **Path filters** on `ci.yml` + `test.yml` — doc-only PRs (`**.md`, `docs/**`, `AGENTS.md`, `CHANGELOG.md`, `LICENSE`, issue/PR templates) skip the heavy gates.
- **4-way shard matrix** on the `unit-tests` job via vitest `--shard`. Same total minutes, ~4× faster wall-clock. Startup-contract step gated to shard 1.
- **Depot opt-out** via `vars.DEPOT_ENABLED` across all three Docker workflows. Default behavior unchanged. Flip with `gh variable set DEPOT_ENABLED --body false` to skip the ~30s wasted on a failing Depot step when the account is on hold; the existing Buildx fallback handles the build.
- **`docs/ci-local-act.md`** runbook for `nektos/act` local CI iteration.

## Deferred

`osslsigncode` migration for Windows signing was on the original list but reframed as not-a-free-win after confirming the repo is public — `windows-latest` is free (4-vCPU doubled-for-OSS), so the cost case vanished. Cert is PFX (OV) per `release-electrobun.yml:1190`, so migration remains technically feasible if pursued later.

## Branch protection note

The `unit-tests` job now produces matrix entries `unit-tests (1)` … `unit-tests (4)`. If branch protection requires the literal old job name `Real tests (Vitest, no mocks)` as a status check, repin it to the `test-status` aggregator job (which uses `needs.unit-tests.result` and reports a single rolled-up status across shards).

## Test plan

- [ ] Open a docs-only PR (single `.md` change) and confirm `ci.yml` and `test.yml` do not trigger
- [ ] Open a code PR and confirm 4 `unit-tests` shards run in parallel and `test-status` gates correctly
- [ ] Set `gh variable set DEPOT_ENABLED --body false` and trigger `build-docker.yml` via `workflow_dispatch` — confirm Depot steps are skipped and the Buildx fallback runs
- [ ] Unset (`gh variable delete DEPOT_ENABLED`) and re-run — confirm Depot path is exercised again
- [ ] Pre-existing actionlint info findings (build-cloud-image.yml:248, build-cloud-agent.yml:203) are unrelated to this change

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Depot opt-out, test sharding, and path filters to CI workflows
> - Adds `DEPOT_ENABLED` repository variable support to [build-cloud-agent.yml](https://github.com/milady-ai/milady/pull/2043/files#diff-0970cca1db47f9deab06e9fd087f8ddda0e14e5ede6f9be402a5433d885eab31), [build-cloud-image.yml](https://github.com/milady-ai/milady/pull/2043/files#diff-36255d6c516f80a5b37564db52b52f50b80174f309fd56e2250c741e64052d61), and [build-docker.yml](https://github.com/milady-ai/milady/pull/2043/files#diff-1d203d2dfb96ccf94b5e0961c7954e3bde73b4539ade27ccc301613e368b944f): when set to `false`, Depot steps are skipped and Docker Buildx is used directly.
> - Splits the `unit-tests` job in [test.yml](https://github.com/milady-ai/milady/pull/2043/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88) into 4 parallel shards via a matrix strategy; the startup script drift guard runs only on shard 1.
> - Adds `paths-ignore` filters to [ci.yml](https://github.com/milady-ai/milady/pull/2043/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f) and [test.yml](https://github.com/milady-ai/milady/pull/2043/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88) so docs/markdown-only changes no longer trigger these workflows.
> - Extends `sanitizeNpmPackageMetadata` in [sanitize-npm-package-metadata.mjs](https://github.com/milady-ai/milady/pull/2043/files#diff-22c4a951f8642f516a6f09e27cbb0644c780bbadebde2351478c5c0f9aed2f4b) to remove `bundleDependencies`/`bundledDependencies` fields from `package.json` and report removals.
> - Adds documentation for Depot opt-out and local CI execution via `nektos/act`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 99f164b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->