### PR TITLE
feat(patches): elizacloud bridge mirror — JSON output + fence-strip

### DIFF
--- a/patches/elizacloud/0001-json-output-enforcement-and-fence-strip.patch
+++ b/patches/elizacloud/0001-json-output-enforcement-and-fence-strip.patch
@@ -1,0 +1,72 @@
+diff --git a/dist/node/index.node.js b/dist/node/index.node.js
+index 4fe5094b9..79a0f4796 100644
+--- a/dist/node/index.node.js
++++ b/dist/node/index.node.js
+@@ -1327,7 +1327,12 @@ async function generateObjectByModelType(runtime, params, modelType, getModelFn)
+   const requestBody = {
+     model: modelName,
+     input,
+-    max_output_tokens: params.maxTokens ?? 8192
++    max_output_tokens: params.maxTokens ?? 8192,
++    // Milady patch: enforce JSON output at the API layer. Without this, the
++    // cloud plugin ignores the caller's `schema` parameter and the model
++    // returns prose ("I'll help you..." or markdown-fenced JSON), choking
++    // JSON.parse downstream.
++    text: { format: { type: "json_object" } }
+   };
+   if (!reasoning && typeof params.temperature === "number") {
+     requestBody.temperature = params.temperature;
+@@ -1366,10 +1371,17 @@ async function generateObjectByModelType(runtime, params, modelType, getModelFn)
+       totalTokens: data.usage.total_tokens ?? 0
+     });
+   }
+-  const jsonText = extractResponsesOutputText(data);
++  let jsonText = extractResponsesOutputText(data);
+   if (!jsonText.trim()) {
+     throw new Error("Object generation returned empty response");
+   }
++  // Milady patch: strip leading/trailing markdown code fences before JSON.parse.
++  // Models routinely wrap structured output in ```json ... ``` even when JSON
++  // is requested. The repair function does not handle the leading backtick.
++  jsonText = jsonText
++    .replace(/^[\s]*```(?:json)?\s*\n?/i, "")
++    .replace(/\n?```\s*$/i, "")
++    .trim();
+   try {
+     return JSON.parse(jsonText);
+   } catch (error) {
+diff --git a/dist/cjs/index.node.cjs b/dist/cjs/index.node.cjs
+index b496504b9..62772d917 100644
+--- a/dist/cjs/index.node.cjs
++++ b/dist/cjs/index.node.cjs
+@@ -1368,7 +1368,12 @@ async function generateObjectByModelType(runtime, params, modelType, getModelFn)
+   const requestBody = {
+     model: modelName,
+     input,
+-    max_output_tokens: params.maxTokens ?? 8192
++    max_output_tokens: params.maxTokens ?? 8192,
++    // Milady patch: enforce JSON output at the API layer for OBJECT_*
++    // requests. The cloud plugin otherwise ignores the caller's `schema`
++    // parameter and the model returns prose ("I'll help you...") or
++    // markdown-fenced JSON, breaking JSON.parse downstream.
++    text: { format: { type: "json_object" } }
+   };
+   if (!reasoning && typeof params.temperature === "number") {
+     requestBody.temperature = params.temperature;
+@@ -1407,10 +1412,15 @@ async function generateObjectByModelType(runtime, params, modelType, getModelFn)
+       totalTokens: data.usage.total_tokens ?? 0
+     });
+   }
+-  const jsonText = extractResponsesOutputText(data);
++  let jsonText = extractResponsesOutputText(data);
+   if (!jsonText.trim()) {
+     throw new Error("Object generation returned empty response");
+   }
++  // Milady patch: strip leading/trailing markdown code fences before JSON.parse.
++  jsonText = jsonText
++    .replace(/^[\s]*```(?:json)?\s*\n?/i, "")
++    .replace(/\n?```\s*$/i, "")
++    .trim();
+   try {
+     return JSON.parse(jsonText);
+   } catch (error) {

--- a/scripts/milady-postinstall-repo-setup.mjs
+++ b/scripts/milady-postinstall-repo-setup.mjs
@@ -7,7 +7,14 @@
  * post-install patch/link/seed pipeline. Submodule init runs as
  * `preinstall` (see scripts/init-submodules.mjs), not here, so
  * `run-repo-setup` no longer tries to init submodules itself.
+ *
+ * After elizaOS's pipeline runs, we apply Milady-only bridge patches
+ * that target node_modules artifacts whose upstream PRs are still in
+ * flight. These steps are kept in this Milady-only entry point (NOT in
+ * eliza/.../run-repo-setup.mjs) so they don't affect other consumers
+ * of @elizaos/app-core.
  */
+import { spawn } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -23,3 +30,38 @@ const setupHref = pathToFileURL(setupPath).href;
 const { runRepoSetup } = await import(setupHref);
 
 await runRepoSetup(repoRoot);
+
+// Milady-only bridge patches. Each entry runs after elizaOS's pipeline
+// because that pipeline may itself rewrite node_modules (patch-deps,
+// link-external-plugins, etc.) and we want our patches to win on top.
+// Remove an entry once the corresponding upstream PR lands and a new
+// alpha is published.
+const miladyBridgePatchScripts = [
+  // https://github.com/elizaos-plugins/plugin-elizacloud/pull/15
+  "patch-elizacloud.mjs",
+];
+
+for (const scriptName of miladyBridgePatchScripts) {
+  const scriptPath = path.join(repoRoot, "scripts", scriptName);
+  await new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      env: process.env,
+      stdio: "inherit",
+    });
+    child.on("error", (err) => {
+      reject(new Error(`${scriptName} failed to spawn: ${err.message}`));
+    });
+    child.on("exit", (code, signal) => {
+      if (signal) {
+        reject(new Error(`${scriptName} exited due to signal ${signal}`));
+        return;
+      }
+      if ((code ?? 1) !== 0) {
+        reject(new Error(`${scriptName} exited with code ${code ?? 1}`));
+        return;
+      }
+      resolve();
+    });
+  });
+}

--- a/scripts/patch-elizacloud.mjs
+++ b/scripts/patch-elizacloud.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * Bridge patch — apply Milady-local fixes to @elizaos/plugin-elizacloud
+ * dist files in node_modules. These patches are also being upstreamed
+ * (see https://github.com/elizaos-plugins/plugin-elizacloud/pull/15).
+ * Once that PR merges and a new alpha is published, delete this script,
+ * the patches/elizacloud/ directory, and the postinstall hook entry.
+ *
+ * Pinned to @elizaos/plugin-elizacloud@2.0.0-alpha.8 — refuses to apply
+ * to other versions because the patch context lines may have shifted.
+ */
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PINNED_VERSION = "2.0.0-alpha.8";
+const PATCH_REL_PATH = "patches/elizacloud/0001-json-output-enforcement-and-fence-strip.patch";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const repoRoot = path.resolve(path.dirname(scriptPath), "..");
+const patchPath = path.join(repoRoot, PATCH_REL_PATH);
+const pluginLink = path.join(repoRoot, "node_modules", "@elizaos", "plugin-elizacloud");
+
+function log(msg) {
+  console.log(`[patch-elizacloud] ${msg}`);
+}
+
+function fail(msg) {
+  console.error(`[patch-elizacloud] ${msg}`);
+  process.exit(1);
+}
+
+function main() {
+  if (!fs.existsSync(patchPath)) {
+    fail(`patch file missing: ${path.relative(repoRoot, patchPath)}`);
+  }
+
+  if (!fs.existsSync(pluginLink)) {
+    log("@elizaos/plugin-elizacloud not installed — skipping (will retry on next install)");
+    return;
+  }
+
+  // node_modules entry is typically a symlink to the workspace package.
+  // Resolve it so git apply can work against a real path.
+  const pluginRoot = fs.realpathSync(pluginLink);
+
+  const pkgJsonPath = path.join(pluginRoot, "package.json");
+  if (!fs.existsSync(pkgJsonPath)) {
+    fail(`plugin package.json missing at ${pkgJsonPath}`);
+  }
+  const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, "utf8"));
+  if (pkg.version !== PINNED_VERSION) {
+    fail(
+      `version mismatch — patch was authored against @elizaos/plugin-elizacloud@${PINNED_VERSION}, ` +
+      `but installed version is ${pkg.version}. Regenerate the patch against the new version, ` +
+      `or update PINNED_VERSION in this script if the patch still applies cleanly.`,
+    );
+  }
+
+  // Reverse-check first: if patches are already applied, exit cleanly.
+  const reverseCheck = spawnSync("git", [
+    "apply",
+    "--reverse",
+    "--check",
+    "--unsafe-paths",
+    `--directory=${pluginRoot}`,
+    patchPath,
+  ], { encoding: "utf8" });
+
+  if (reverseCheck.status === 0) {
+    log("patches already applied");
+    return;
+  }
+
+  // Forward-check
+  const forwardCheck = spawnSync("git", [
+    "apply",
+    "--check",
+    "--unsafe-paths",
+    `--directory=${pluginRoot}`,
+    patchPath,
+  ], { encoding: "utf8" });
+
+  if (forwardCheck.status !== 0) {
+    fail(`patch no longer applies cleanly:\n${forwardCheck.stderr.trim()}`);
+  }
+
+  // Apply
+  const apply = spawnSync("git", [
+    "apply",
+    "--unsafe-paths",
+    `--directory=${pluginRoot}`,
+    patchPath,
+  ], { encoding: "utf8" });
+
+  if (apply.status !== 0) {
+    fail(`apply failed:\n${apply.stderr.trim()}`);
+  }
+
+  log("applied 2 patches across 2 files");
+}
+
+try {
+  main();
+} catch (error) {
+  fail(error instanceof Error ? error.message : String(error));
+}

--- a/scripts/patch-elizacloud.mjs
+++ b/scripts/patch-elizacloud.mjs
@@ -15,12 +15,18 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const PINNED_VERSION = "2.0.0-alpha.8";
-const PATCH_REL_PATH = "patches/elizacloud/0001-json-output-enforcement-and-fence-strip.patch";
+const PATCH_REL_PATH =
+  "patches/elizacloud/0001-json-output-enforcement-and-fence-strip.patch";
 
 const scriptPath = fileURLToPath(import.meta.url);
 const repoRoot = path.resolve(path.dirname(scriptPath), "..");
 const patchPath = path.join(repoRoot, PATCH_REL_PATH);
-const pluginLink = path.join(repoRoot, "node_modules", "@elizaos", "plugin-elizacloud");
+const pluginLink = path.join(
+  repoRoot,
+  "node_modules",
+  "@elizaos",
+  "plugin-elizacloud",
+);
 
 function log(msg) {
   console.log(`[patch-elizacloud] ${msg}`);
@@ -37,7 +43,9 @@ function main() {
   }
 
   if (!fs.existsSync(pluginLink)) {
-    log("@elizaos/plugin-elizacloud not installed — skipping (will retry on next install)");
+    log(
+      "@elizaos/plugin-elizacloud not installed — skipping (will retry on next install)",
+    );
     return;
   }
 
@@ -53,20 +61,24 @@ function main() {
   if (pkg.version !== PINNED_VERSION) {
     fail(
       `version mismatch — patch was authored against @elizaos/plugin-elizacloud@${PINNED_VERSION}, ` +
-      `but installed version is ${pkg.version}. Regenerate the patch against the new version, ` +
-      `or update PINNED_VERSION in this script if the patch still applies cleanly.`,
+        `but installed version is ${pkg.version}. Regenerate the patch against the new version, ` +
+        `or update PINNED_VERSION in this script if the patch still applies cleanly.`,
     );
   }
 
   // Reverse-check first: if patches are already applied, exit cleanly.
-  const reverseCheck = spawnSync("git", [
-    "apply",
-    "--reverse",
-    "--check",
-    "--unsafe-paths",
-    `--directory=${pluginRoot}`,
-    patchPath,
-  ], { encoding: "utf8" });
+  const reverseCheck = spawnSync(
+    "git",
+    [
+      "apply",
+      "--reverse",
+      "--check",
+      "--unsafe-paths",
+      `--directory=${pluginRoot}`,
+      patchPath,
+    ],
+    { encoding: "utf8" },
+  );
 
   if (reverseCheck.status === 0) {
     log("patches already applied");
@@ -74,25 +86,28 @@ function main() {
   }
 
   // Forward-check
-  const forwardCheck = spawnSync("git", [
-    "apply",
-    "--check",
-    "--unsafe-paths",
-    `--directory=${pluginRoot}`,
-    patchPath,
-  ], { encoding: "utf8" });
+  const forwardCheck = spawnSync(
+    "git",
+    [
+      "apply",
+      "--check",
+      "--unsafe-paths",
+      `--directory=${pluginRoot}`,
+      patchPath,
+    ],
+    { encoding: "utf8" },
+  );
 
   if (forwardCheck.status !== 0) {
     fail(`patch no longer applies cleanly:\n${forwardCheck.stderr.trim()}`);
   }
 
   // Apply
-  const apply = spawnSync("git", [
-    "apply",
-    "--unsafe-paths",
-    `--directory=${pluginRoot}`,
-    patchPath,
-  ], { encoding: "utf8" });
+  const apply = spawnSync(
+    "git",
+    ["apply", "--unsafe-paths", `--directory=${pluginRoot}`, patchPath],
+    { encoding: "utf8" },
+  );
 
   if (apply.status !== 0) {
     fail(`apply failed:\n${apply.stderr.trim()}`);


### PR DESCRIPTION
## Summary

Captures two patches that have been living in `node_modules/@elizaos/plugin-elizacloud` since alpha.4 in a downstream Milady checkout, and adds a postinstall step that re-applies them after every `bun install`.

The same two patches are being upstreamed in **[elizaos-plugins/plugin-elizacloud#15](https://github.com/elizaos-plugins/plugin-elizacloud/pull/15)**. Once that PR merges and a new alpha publishes, this bridge can be reverted in a single commit. Until then, this keeps Milady installs working out of the box.

## What the patches do

Both target `dist/{node,cjs}/index.node.{js,cjs}` in `@elizaos/plugin-elizacloud@2.0.0-alpha.8`:

1. **JSON output enforcement** — adds `text: { format: { type: "json_object" } }` to the `/responses` request body in `generateObjectByModelType`. Without this, the cloud plugin can ignore the caller's `schema` parameter and the model returns prose (`"I'll help you..."`) or markdown-fenced JSON, both of which choke `JSON.parse` downstream.

2. **Fence-strip before parse** — strips leading/trailing markdown code fences from the response text before `JSON.parse`. Models routinely wrap structured output in ` ```json ... ``` ` even when JSON is requested. The existing `getJsonRepairFunction()` doesn't handle leading backticks.

## What's added

- **`patches/elizacloud/0001-json-output-enforcement-and-fence-strip.patch`** — unified diff against `@elizaos/plugin-elizacloud@2.0.0-alpha.8` covering both hunks across both build outputs (4 hunks total).
- **`scripts/patch-elizacloud.mjs`** — idempotent applier: resolves the symlinked `node_modules` entry to its workspace path, version-pinned to alpha.8 (errors loudly on drift), reverse-checks first (no-op when already applied), then forward-applies.
- **`scripts/milady-postinstall-repo-setup.mjs`** — extended with a `miladyBridgePatchScripts` array. Runs after `runRepoSetup(repoRoot)` so elizaOS's pipeline (`patch-deps`, `link-external-plugins`, etc.) gets a chance to rewrite `node_modules` first; our patches win on top.

## Why a Milady-only entry point (not in `eliza/.../run-repo-setup.mjs`)

Adding the patch step to elizaOS's `repoSetupSteps` would force every other consumer of `@elizaos/app-core` to provide a `scripts/patch-elizacloud.mjs` in their own repo root, or installs would fail. Keeping it in Milady's own postinstall hook avoids that blast radius.

## Verified

- Reverse-apply strips both patches cleanly → 0 markers in dist files.
- Forward apply via script → 4 markers in dist files (Patch A + Patch B in each of 2 files).
- Re-run is idempotent → "patches already applied".
- Version-mismatch path errors with a clear message + non-zero exit.
- Round-trip: `rm -rf node_modules && bun install` → patches reapplied automatically; canonical Gmail→Discord workflow generation works on first try.

## Lifecycle

| Phase | Action |
|---|---|
| Now | Merge this PR; bridge keeps `bun install` survivable until upstream alpha publishes the fix. |
| When [elizaos-plugins/plugin-elizacloud#15](https://github.com/elizaos-plugins/plugin-elizacloud/pull/15) merges | Bump `@elizaos/plugin-elizacloud` dep to the new alpha. |
| Then | Delete `patches/elizacloud/`, `scripts/patch-elizacloud.mjs`, and the `miladyBridgePatchScripts` array entry. One commit. |

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add elizacloud bridge patch to enforce JSON output and strip markdown fences from model responses
> - Adds [0001-json-output-enforcement-and-fence-strip.patch](https://github.com/milady-ai/milady/pull/2048/files#diff-3aa53d7adb5dc89a1eafe61864ef88936a42299915bdbf5cfff28eb119098cf4) which modifies `generateObjectByModelType` in `@elizaos/plugin-elizacloud` dist artifacts to include `text: { format: { type: "json_object" } }` in request bodies and strip markdown code fences before `JSON.parse`.
> - Adds [patch-elizacloud.mjs](https://github.com/milady-ai/milady/pull/2048/files#diff-4917eb675fee6cbcddc73b6f937c9a67b107f6cf1dbad369720388dac3347e1b) which applies the patch only when the installed plugin matches the pinned version (`2.0.0-alpha.8`), skips if already applied, no-ops if the plugin is absent, and exits non-zero on version mismatch or patch failure.
> - Extends [milady-postinstall-repo-setup.mjs](https://github.com/milady-ai/milady/pull/2048/files#diff-f19495e066c61c71c1e3d74546e022726f4597109b995ed3a799e0179519c84a) to spawn `patch-elizacloud.mjs` (and any future patch scripts) after `runRepoSetup()`, failing postinstall if a script exits non-zero.
> - Risk: postinstall will now fail hard if the plugin is installed at the wrong version, blocking environment setup until the pinned version matches.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fd3dd56.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->