### PR TITLE
fix(postinstall): set HOME from USERPROFILE on Windows

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -407,6 +407,7 @@
         "@elizaos/plugin-imessage": "workspace:*",
         "@elizaos/plugin-signal": "workspace:*",
         "@elizaos/plugin-telegram": "workspace:*",
+        "@elizaos/plugin-whatsapp": "workspace:*",
         "@elizaos/shared": "workspace:*",
         "@elizaos/ui": "workspace:*",
         "drizzle-orm": "^0.45.1",
@@ -552,7 +553,7 @@
     },
     "eliza/packages/agent": {
       "name": "@elizaos/agent",
-      "version": "2.0.0-alpha.428",
+      "version": "2.0.0-alpha.446",
       "bin": {
         "eliza-autonomous": "./src/bin.ts",
       },
@@ -625,7 +626,7 @@
     },
     "eliza/packages/app-core": {
       "name": "@elizaos/app-core",
-      "version": "2.0.0-alpha.428",
+      "version": "2.0.0-alpha.446",
       "dependencies": {
         "@capacitor/barcode-scanner": "^3.0.0",
         "@capacitor/core": "8.3.1",
@@ -736,7 +737,7 @@
     },
     "eliza/packages/elizaos": {
       "name": "elizaos",
-      "version": "2.0.0-alpha.428",
+      "version": "2.0.0-alpha.446",
       "bin": {
         "elizaos": "./dist/cli.js",
       },
@@ -753,7 +754,7 @@
     },
     "eliza/packages/interop": {
       "name": "@elizaos/interop",
-      "version": "2.0.0-alpha.428",
+      "version": "2.0.0-alpha.446",
       "dependencies": {
         "@elizaos/core": "workspace:*",
       },
@@ -1083,11 +1084,11 @@
     },
     "eliza/packages/rust": {
       "name": "@elizaos/rust",
-      "version": "2.0.0-alpha.428",
+      "version": "2.0.0-alpha.446",
     },
     "eliza/packages/scenario-runner": {
       "name": "@elizaos/scenario-runner",
-      "version": "2.0.0-alpha.428",
+      "version": "2.0.0-alpha.446",
       "bin": {
         "milady-scenarios": "./bin/milady-scenarios",
       },
@@ -1103,18 +1104,18 @@
     },
     "eliza/packages/scenario-schema": {
       "name": "@elizaos/scenario-schema",
-      "version": "2.0.0-alpha.428",
+      "version": "2.0.0-alpha.446",
     },
     "eliza/packages/schemas": {
       "name": "@elizaos/schemas",
-      "version": "2.0.0-alpha.428",
+      "version": "2.0.0-alpha.446",
       "devDependencies": {
         "@bufbuild/buf": "^1.47.2",
       },
     },
     "eliza/packages/shared": {
       "name": "@elizaos/shared",
-      "version": "2.0.0-alpha.428",
+      "version": "2.0.0-alpha.446",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "zod": "^4.3.6",
@@ -1130,7 +1131,7 @@
     },
     "eliza/packages/skills": {
       "name": "@elizaos/skills",
-      "version": "2.0.0-alpha.428",
+      "version": "2.0.0-alpha.446",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "yaml": "^2.8.2",
@@ -1141,7 +1142,7 @@
     },
     "eliza/packages/typescript": {
       "name": "@elizaos/core",
-      "version": "2.0.0-alpha.428",
+      "version": "2.0.0-alpha.446",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.13",
         "@ai-sdk/google": "^3.0.8",
@@ -1197,7 +1198,7 @@
     },
     "eliza/packages/ui": {
       "name": "@elizaos/ui",
-      "version": "2.0.0-alpha.428",
+      "version": "2.0.0-alpha.446",
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",

--- a/scripts/milady-postinstall-repo-setup.mjs
+++ b/scripts/milady-postinstall-repo-setup.mjs
@@ -21,6 +21,13 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "..");
 
+// On Windows, PowerShell does not set HOME — ensure-type-package-aliases.mjs
+// and similar scripts use it to locate the bun global cache. Fall back to
+// USERPROFILE (the Windows equivalent) so child processes find the cache.
+if (!process.env.HOME && process.env.USERPROFILE) {
+  process.env.HOME = process.env.USERPROFILE;
+}
+
 const setupPath = path.join(
   repoRoot,
   "eliza/packages/app-core/scripts/run-repo-setup.mjs",


### PR DESCRIPTION
## Summary

- `ensure-type-package-aliases.mjs` (elizaOS upstream) uses `process.env.HOME` to find the bun global cache (`~/.bun/install/cache/@types/`)
- PowerShell on Windows does not set `HOME` — it uses `USERPROFILE` instead
- Result: 0 `@types` packages materialized → `@elizaos/core` declarations build fails with missing type errors during `bun install`
- Fix: in Milady's postinstall entry point, set `process.env.HOME = process.env.USERPROFILE` when `HOME` is absent, before spawning the elizaOS setup pipeline — all child processes inherit it

Guard only fires when `HOME` is absent and `USERPROFILE` is present, so macOS/Linux are unaffected.

## Test plan

- [ ] `bun install` completes cleanly on Windows + PowerShell (202 `@types` packages materialized, `@elizaos/core` build succeeds)
- [ ] `bun install` on macOS/Linux unchanged — guard does not fire when `HOME` is already set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set `HOME` from `USERPROFILE` in postinstall script on Windows
> In Windows PowerShell environments, `HOME` is often unset while `USERPROFILE` is available. [milady-postinstall-repo-setup.mjs](https://github.com/milady-ai/milady/pull/2055/files#diff-f19495e066c61c71c1e3d74546e022726f4597109b995ed3a799e0179519c84a) now sets `process.env.HOME = process.env.USERPROFILE` at startup when `HOME` is missing, preventing path resolution failures during postinstall.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d376709.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->