### PR TITLE
chore: regenerate static asset manifest for new hero PNGs

### DIFF
--- a/scripts/generated/static-asset-manifest.json
+++ b/scripts/generated/static-asset-manifest.json
@@ -2,6 +2,8 @@
   "app": [
     "apps/app/public/android-chrome-192x192.png",
     "apps/app/public/android-chrome-512x512.png",
+    "apps/app/public/app-heroes/agentDOD.png",
+    "apps/app/public/app-heroes/clawville.png",
     "apps/app/public/app-heroes/database-viewer.png",
     "apps/app/public/app-heroes/fine-tuning.png",
     "apps/app/public/app-heroes/lifeops.png",


### PR DESCRIPTION
## Summary

Follow-up to [#2058](https://github.com/milady-ai/milady/pull/2058) — that PR landed the new \`agentDOD.png\` and \`clawville.png\` heroes but merged before the manifest regen could be applied. Develop's \`release-check\` is currently failing with:

\`release-check: static asset manifest is stale. Run node scripts/generate-static-asset-manifest.mjs.\`

This PR runs that script and commits the result. Diff is just two new entries.

## Test plan
- [x] Generated by \`node eliza/packages/app-core/scripts/generate-static-asset-manifest.mjs\` against current develop.
- [ ] release-check turns green again on develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add hero PNGs for agentDOD and clawville to static asset manifest
> Updates [static-asset-manifest.json](https://github.com/milady-ai/milady/pull/2060/files#diff-fc147302bde46a687c55864a1701acfea27f9b7fdee4427e3d623a725dfd3bf1) to include entries for `agentDOD.png` and `clawville.png` in `apps/app/public/app-heroes/`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized df3220a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->