### PR TITLE
fix(release): generate eliza i18n keyword data before Debian build

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -519,6 +519,14 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
+      - name: Generate eliza i18n keyword data
+        # eliza/packages/shared/src/i18n/keyword-matching.ts imports from
+        # ./generated/validation-keyword-data.js, which is gitignored and
+        # produced by packages/shared/scripts/generate-keywords.mjs. The
+        # Debian build runs a Vite/Rolldown production build via
+        # debian/rules and will fail to resolve the generated module on a
+        # fresh checkout unless this step runs first.
+        run: node eliza/packages/app-core/scripts/ensure-shared-i18n-data.mjs
       - name: Stage Debian packaging
         run: |
           rm -rf debian


### PR DESCRIPTION
## Summary

The \`Debian package build\` job in the release pipeline has been failing on develop with:

\`[UNRESOLVED_IMPORT] Could not resolve './generated/validation-keyword-data.js' in eliza/packages/shared/src/i18n/keyword-matching.ts\`

That file is generated by \`eliza/packages/shared/scripts/generate-keywords.mjs\` from the JSON keyword sources. It's gitignored, so a fresh checkout doesn't have it. Other build paths run this generator implicitly through repo postinstall or setup-upstreams, but the Debian workflow skips those steps to keep the runtime image minimal.

This PR adds a dedicated step in \`agent-release.yml\` that calls the existing \`ensure-shared-i18n-data.mjs\` helper before \`dpkg-buildpackage\`, so the generated file is in place when Vite/Rolldown resolves imports during the production build run from \`debian/rules\`.

## Test plan
- [ ] Debian package build job passes on this PR.
- [x] Helper exists at \`eliza/packages/app-core/scripts/ensure-shared-i18n-data.mjs\` and is idempotent (same output on re-runs per its docstring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Generate eliza i18n keyword data before Debian build in agent-release workflow
> Adds a step to [agent-release.yml](.github/workflows/agent-release.yml) that runs `node eliza/packages/app-core/scripts/ensure-shared-i18n-data.mjs` before Debian packaging. This generates the shared i18n keyword data required by `eliza/packages/shared/src/i18n/keyword-matching.ts`, which is sourced from a gitignored generated module not present in the repo.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6273466.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->