### PR TITLE
fix(release): unblock Electrobun matrix + Debian deb build

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -531,6 +531,15 @@ jobs:
         run: |
           rm -rf debian
           cp -R eliza/packages/app-core/packaging/debian debian
+          # Eliza's debian packaging hardcodes the legacy entry name
+          # "elizaos-app.mjs" from before the upstream rename. Milady's
+          # actual entry script is milady.mjs, so rewrite the install
+          # manifest and rules to point at it. The package itself stays
+          # named elizaos-app for now (binary path /usr/bin/elizaos-app)
+          # since renaming the deb package is its own task.
+          if [ -f milady.mjs ] && [ ! -f elizaos-app.mjs ]; then
+            sed -i 's/elizaos-app\.mjs/milady.mjs/g' debian/install debian/rules
+          fi
           test -f debian/changelog
           test -x debian/rules
           dpkg-checkbuilddeps debian/control


### PR DESCRIPTION
## Summary

Tackles the two pre-existing release-pipeline residuals called out after the #2055/#2056/#2058/#2060/#2061/#2062 merge train. Both have been broken since at least 2026-04-25 — every \`agent-release.yml\` run on develop in that window is cancelled or failed.

### 1. Electrobun matrix builds — \`Cannot find package '@elizaos/plugin-anthropic'\`

\`copy-runtime-node-modules\` runs in the desktop release pipeline to walk \`dist/\` and bundle the bare-spec runtime imports it finds. Its helper, \`runtime-package-manifest.ts\`, pulled \`BASELINE_BUNDLED_RUNTIME_PACKAGES\` and \`getBundledRuntimePackages\` from the package root \`@elizaos/agent\`. That root re-exports \`./runtime/eliza.js\`, whose top-level imports of \`@elizaos/plugin-anthropic\`, \`@elizaos/plugin-sql\`, \`@elizaos/plugin-agent-skills\`, \`@elizaos/plugin-browser-bridge\`, \`@elizaos/plugin-local-embedding\`, and \`@elizaos/plugin-pdf\` crashed with \`ERR_MODULE_NOT_FOUND\` because the runner doesn't have those plugin packages hoisted in node_modules at scan time.

Eliza-side fix already on develop: [elizaOS/eliza@374d73aa7c](https://github.com/elizaOS/eliza/commit/374d73aa7c) scopes the import to \`@elizaos/agent/runtime/release-plugin-policy.js\`, which only depends on \`./core-plugins.ts\` (constant arrays). This PR bumps the submodule.

### 2. Debian build — \`dh_install: missing files: elizaos-app.mjs\`

Eliza's debian packaging template hardcodes the legacy entry name \`elizaos-app.mjs\` from before the upstream rename. It doesn't exist in eliza (renamed) or milady (which has \`milady.mjs\`). The packaging is copied wholesale into milady's workspace at release time, so \`dh_install\` aborted on every run.

Quick fix in this PR: at the \"Stage Debian packaging\" step, after copying the template, \`sed\` swap \`elizaos-app.mjs → milady.mjs\` in \`debian/install\` and \`debian/rules\` if the milady entry exists and the legacy one doesn't. Package name stays \`elizaos-app\` for now — renaming the deb itself is its own task.

## Test plan
- [ ] Electrobun full matrix (Build Linux / macOS Intel / macOS Apple Silicon / Windows) all pass.
- [ ] Debian package build passes.
- [ ] No regression in other release jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Debian .deb build to handle `milady.mjs` when `elizaos-app.mjs` is absent
> - During the Debian packaging step in [agent-release.yml](.github/workflows/agent-release.yml), adds a guard that rewrites references from `elizaos-app.mjs` to `milady.mjs` in `debian/install` and `debian/rules` using `sed` when `milady.mjs` exists and `elizaos-app.mjs` does not.
> - Updates the `eliza` submodule pointer to `374d73aa`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 736a2d5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->