### PR TITLE
fix(release): mirror generated keyword data into bun's Windows cache

### DIFF
--- a/.github/workflows/release-electrobun.yml
+++ b/.github/workflows/release-electrobun.yml
@@ -615,6 +615,25 @@ jobs:
         run: |
           node eliza/packages/shared/scripts/generate-keywords.mjs --target ts
           test -f eliza/packages/shared/src/i18n/generated/validation-keyword-data.js
+          # Bun's per-package workspace cache (node_modules/.bun/<spec>/node_modules/<pkg>/)
+          # is populated at `bun install` time. On Windows it doesn't symlink to
+          # the workspace source like Linux/macOS do, so the keyword data we
+          # just generated never reaches the cached copy of @elizaos/shared
+          # that subsequent bun-build / Rolldown-bundling steps consume —
+          # leading to "Could not resolve './generated/validation-keyword-data.js'"
+          # in keyword-matching.ts. Mirror the generated files into every
+          # bun-cache location for @elizaos/shared so resolution succeeds.
+          src_generated="eliza/packages/shared/src/i18n/generated"
+          if [ -d node_modules/.bun ]; then
+            while IFS= read -r cache_pkg_dir; do
+              [ -d "$cache_pkg_dir" ] || continue
+              cache_generated="$cache_pkg_dir/src/i18n/generated"
+              mkdir -p "$cache_generated"
+              cp -f "$src_generated"/validation-keyword-data.ts "$cache_generated/" 2>/dev/null || true
+              cp -f "$src_generated"/validation-keyword-data.js "$cache_generated/" 2>/dev/null || true
+              echo "[release] mirrored keyword data to $cache_generated"
+            done < <(find node_modules/.bun -maxdepth 4 -type d -path "*@elizaos+shared*/node_modules/@elizaos/shared" 2>/dev/null)
+          fi
           if [ -d eliza/packages/schemas ] && [ -f eliza/packages/schemas/buf.gen.yaml ]; then
             pushd eliza/packages/schemas
             for attempt in 1 2 3; do


### PR DESCRIPTION
## Summary

Last residual from the agent-release.yml run on develop after #2063: the **Electrobun full matrix / Build Windows** job fails with

\`\`\`
error: Could not resolve: \"./generated/validation-keyword-data.js\"
    at D:\\a\\milady\\milady\\node_modules\\.bun\\@elizaos+shared@file+...\\node_modules\\@elizaos\\shared\\src\\i18n\\keyword-matching.ts:14:41
\`\`\`

Linux + macOS pass because their bun-cache copy of \`@elizaos/shared\` is a symlink to the workspace source — the generated keyword data files we produce in \`eliza/packages/shared/src/i18n/generated/\` propagate to the cache for free. On Windows, bun materializes the cache as real directories at \`bun install\` time and never refreshes them. So the cache copy of \`keyword-matching.ts\` exists but its sibling \`generated/\` directory is empty when Rolldown bundles \`apps/app/electrobun/src/index.ts\` in the \"Probe Electrobun bun entry build\" step.

## Fix

Right after \`generate-keywords.mjs\` runs in the build matrix, walk \`node_modules/.bun\` for any \`@elizaos+shared@*/node_modules/@elizaos/shared\` directory and mirror the generated \`.ts\` + \`.js\` into its \`src/i18n/generated/\`. Find returns nothing on Linux/macOS (the cache is a symlink there, so the path doesn't match the \`-type d\` filter for a directory in the cache root) — no-op on those platforms. Windows gets the files before the next bundling step.

## Test plan
- [ ] Electrobun full matrix / Build Windows passes on this PR's agent-release run.
- [ ] Linux + macOS variants still pass (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mirror generated keyword data into Bun's Windows workspace cache during release
> During the release workflow's 'Generate protobuf types' step, generated `validation-keyword-data.ts` and `validation-keyword-data.js` files are now copied into every matching `@elizaos/shared` package location inside the Bun per-package cache (`node_modules/.bun`). This ensures subsequent build steps that resolve from the cache find the freshly generated files rather than stale or missing ones.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ae13d8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->