### PR TITLE
feat(scripts): bridge patch for coding-agent-adapters --tools (claude.ai OAuth tier fix)

### DIFF
--- a/patches/coding-agent-adapters/PR-DRAFT.md
+++ b/patches/coding-agent-adapters/PR-DRAFT.md
@@ -1,0 +1,49 @@
+# PR draft: drop `--tools <list>` from claude `autonomous` preset
+
+**Repo:** https://github.com/HaruHunab1320/parallax  
+**Path:** `packages/coding-agent-adapters/src/approval/claude.ts` (or wherever `generateClaudeApprovalConfig` lives — confirm in fork)  
+**Pinned version we observed the bug on:** `0.16.3`
+
+## Problem
+
+`generateClaudeApprovalConfig('autonomous')` currently emits two CLI flags:
+
+```ts
+cliFlags.push("--dangerously-skip-permissions");
+const allTools = Object.keys(CLAUDE_TOOL_CATEGORIES);
+cliFlags.push("--tools", allTools.join(","));
+```
+
+The hardcoded list in `CLAUDE_TOOL_CATEGORIES` (`Read,Grep,Glob,LS,NotebookRead,Write,Edit,MultiEdit,NotebookEdit,Bash,BashOutput,KillShell,WebSearch,WebFetch,Task,Skill,TodoWrite,AskUserQuestion`) reflects Claude Code's **dev-tier** tool registry. On builds/accounts where the runtime exposes a *different* toolset (e.g. claude.ai consumer-tier OAuth, which ships `Monitor`, `ScheduleWakeup`, `ToolSearch`, `EnterPlanMode`/`ExitPlanMode`, `EnterWorktree`/`ExitWorktree`, `Cron*`, `TaskOutput`, `PushNotification`, `RemoteTrigger` instead of `Bash`/`Edit`/`Write`/`Task`/`Skill`), `--tools` does not just allow the listed names — it **filters away** anything not in the list, including the tier's actual shell-execution tools.
+
+Result: an "autonomous" sub-agent on a non-dev tier gets only `Read,Grep,Glob,AskUserQuestion,TodoWrite` and refuses any task that needs to write, search the web, or run shell — even though `--dangerously-skip-permissions` is set and the orchestrator wired full permissions in `.claude/settings.json`. Downstream orchestrators (e.g. `@elizaos/plugin-agent-orchestrator`) can't tell the difference between this and a model hallucination, so their watchdogs burn turns "correcting" an agent that's accurately reporting its actual toolset.
+
+## Proposed fix
+
+Drop the `--tools` push from the `autonomous` branch. With `--dangerously-skip-permissions` already set, `--tools` was redundant for the autonomous case — the preset's intent is "all tools auto-approved", which is exactly what skipping permissions gives you. Removing the explicit list makes the preset tier-agnostic: each Claude Code build exposes whatever tools it ships, and the orchestrator's `.claude/settings.json` `permissions.allow` list still documents intent for any consumer that reads it.
+
+```diff
+   if (preset === "autonomous") {
+     cliFlags.push("--dangerously-skip-permissions");
+     if (!_autonomousSandboxWarningLogged) {
+       console.warn(
+         "Autonomous preset uses --dangerously-skip-permissions. Ensure agents run in a sandboxed environment.",
+       );
+       _autonomousSandboxWarningLogged = true;
+     }
+-    const allTools = Object.keys(CLAUDE_TOOL_CATEGORIES);
+-    cliFlags.push("--tools", allTools.join(","));
+   }
+```
+
+## Alternative considered
+
+Adding an `applyToolsFilter?: boolean` option to `generateClaudeApprovalConfig` so consumers can opt out. Rejected because the filter has no value when `--dangerously-skip-permissions` is already set: the autonomous preset's stated purpose is "everything auto-approved", and limiting tools is the opposite of that. The filter is the bug, not the lack of an opt-out.
+
+## Test impact
+
+Tests that pin the autonomous preset's `cliFlags` to `["--dangerously-skip-permissions", "--tools", "Read,..."]` need updating to `["--dangerously-skip-permissions"]`. The settings.json output (`permissions.allow` listing) is unchanged.
+
+## Rollout for downstream consumers
+
+`@elizaos/plugin-agent-orchestrator` (and Milady) currently carry a postinstall bridge patch that does this same edit in node_modules. Once a `coding-agent-adapters` release contains this fix, the bridge patch is deleted. No code changes in downstream beyond bumping the dep version.

--- a/scripts/milady-postinstall-repo-setup.mjs
+++ b/scripts/milady-postinstall-repo-setup.mjs
@@ -39,6 +39,8 @@ await runRepoSetup(repoRoot);
 const miladyBridgePatchScripts = [
   // https://github.com/elizaos-plugins/plugin-elizacloud/pull/15
   "patch-elizacloud.mjs",
+  // milady-only fix for claude.ai OAuth tier — see script header.
+  "patch-coding-agent-adapters-tools-flag.mjs",
 ];
 
 for (const scriptName of miladyBridgePatchScripts) {

--- a/scripts/patch-coding-agent-adapters-tools-flag.mjs
+++ b/scripts/patch-coding-agent-adapters-tools-flag.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * Bridge patch — strip `--tools <list>` from coding-agent-adapters' Claude
+ * autonomous preset. The hardcoded list (Bash, Edit, Write, etc.) only
+ * matches Claude Code's dev-tier tool registry; on the claude.ai OAuth tier
+ * Milady's bot user runs under, those names are not in the registry, so
+ * passing them via --tools FILTERS the model down to a tiny read-only set
+ * (Read, Grep, Glob, AskUserQuestion, TodoWrite). Skipping the flag entirely
+ * lets claude expose its actual default toolset (Monitor, ScheduleWakeup,
+ * etc.) and --dangerously-skip-permissions still bypasses approval.
+ *
+ * Pinned to coding-agent-adapters@0.16.3 — refuses to apply to other
+ * versions because the patch context lines may shift.
+ *
+ * Patches BOTH index.js (ESM) and index.cjs (CJS), and both the project's
+ * node_modules copy AND bun's global install cache. Idempotent — re-running
+ * after the patch is already applied is a no-op.
+ *
+ * Remove this script once the upstream package exposes a config knob to
+ * disable the --tools cliFlag (or the claude.ai tier ships dev-tier tool
+ * names — whichever comes first).
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const PINNED_VERSION = "0.16.3";
+const OLD = `    const allTools = Object.keys(CLAUDE_TOOL_CATEGORIES);\n    cliFlags.push("--tools", allTools.join(","));`;
+const NEW = `    // milady patch: --tools <list> filters out tools claude.ai OAuth tier exposes\n    // (Monitor, ScheduleWakeup, etc.) because they are not in CLAUDE_TOOL_CATEGORIES.\n    // Skipping --tools entirely lets claude expose its full default toolset;\n    // --dangerously-skip-permissions still bypasses approval. See\n    // scripts/patch-coding-agent-adapters-tools-flag.mjs for context.\n    void CLAUDE_TOOL_CATEGORIES;`;
+
+function candidatePaths() {
+  const candidates = [];
+  const home = os.homedir();
+  const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
+  // Project's resolved node_modules — symlink chain ends at .bun/.../dist/
+  candidates.push(path.join(repoRoot, "node_modules", ".bun", `coding-agent-adapters@${PINNED_VERSION}`, "node_modules", "coding-agent-adapters", "dist"));
+  // Bun's global install cache — Bun resolves imports through this path.
+  candidates.push(path.join(home, ".bun", "install", "cache", `coding-agent-adapters@${PINNED_VERSION}@@@1`, "dist"));
+  return candidates.flatMap((dir) => ["index.js", "index.cjs"].map((f) => path.join(dir, f)));
+}
+
+function patchOne(file) {
+  if (!fs.existsSync(file)) return { file, status: "missing" };
+  const src = fs.readFileSync(file, "utf-8");
+  if (src.includes("milady patch: --tools")) return { file, status: "already-applied" };
+  if (!src.includes(OLD)) {
+    return { file, status: "marker-not-found" };
+  }
+  fs.writeFileSync(file, src.replace(OLD, NEW), "utf-8");
+  return { file, status: "patched" };
+}
+
+let exitCode = 0;
+const results = [];
+for (const file of candidatePaths()) {
+  const r = patchOne(file);
+  results.push(r);
+  if (r.status === "marker-not-found") {
+    exitCode = 1;
+  }
+}
+
+const tag = "[patch-coding-agent-adapters-tools-flag]";
+for (const r of results) {
+  console.log(`${tag} ${r.status}: ${r.file}`);
+}
+
+if (exitCode !== 0) {
+  console.error(`${tag} aborting — context lines have shifted; review the script.`);
+}
+process.exit(exitCode);


### PR DESCRIPTION
## Summary

Adds a postinstall bridge patch that strips the `--tools <list>` flag from `coding-agent-adapters@0.16.3`'s Claude `autonomous` preset. The flag breaks Milady's bot when sub-agents run against the claude.ai consumer-tier OAuth (which exposes a different tool registry than the hardcoded list).

## The bug we're working around

`coding-agent-adapters@0.16.3` ships with this in `generateClaudeApprovalConfig('autonomous')`:

```js
cliFlags.push("--dangerously-skip-permissions");
const allTools = Object.keys(CLAUDE_TOOL_CATEGORIES);
cliFlags.push("--tools", allTools.join(","));
```

The hardcoded list (`Read,Grep,Glob,LS,NotebookRead,Write,Edit,MultiEdit,NotebookEdit,Bash,BashOutput,KillShell,WebSearch,WebFetch,Task,Skill,TodoWrite,AskUserQuestion`) is the **dev-tier** Claude Code tool registry. On the **claude.ai-tier** OAuth that Milady's bot user is logged into, those names are not in claude's registry — so `--tools` doesn't *allow* them, it **filters down to** the names claude actually does have. Result: spawned sub-agents lose access to `Monitor`, `ScheduleWakeup`, `EnterPlanMode`, `EnterWorktree`, `Cron*`, `TaskOutput`, etc., and end up with only `Read,Grep,Glob,AskUserQuestion,TodoWrite`.

Sub-agents then truthfully report "I don't have Bash" — but the `SwarmCoordinator` mistakes this for hallucination and burns turns trying to "correct" them. Anyone running this orchestrator against a claude.ai-tier account sees the same loop.

## What this PR does

`scripts/patch-coding-agent-adapters-tools-flag.mjs` (71 LOC) removes the `--tools` push from the autonomous branch in four file copies (project node_modules + bun global install cache, both `.js` and `.cjs`). Pinned to `coding-agent-adapters@0.16.3` — refuses to apply on other versions. Idempotent. Wired into the existing `miladyBridgePatchScripts` list in `scripts/milady-postinstall-repo-setup.mjs`.

`patches/coding-agent-adapters/PR-DRAFT.md` is the upstream PR draft that, once merged into `HaruHunab1320/parallax`, lets us delete this whole bridge patch.

## Test results

10/10 skill-targeted tests in Milady's discord test channel pass with this patch active. Before: sub-agents loop reporting "no Bash" while the orchestrator's small-LLM keeps "correcting" them. After: sub-agents enumerate their actual tier-specific toolset and use it (Monitor for shell, etc).

## Why this lives in milady, not in coding-agent-adapters

Two reasons:

1. The fix has a long-tail upstream path (need to draft PR, get review, get release). Milady users need this working today.
2. Even after upstream lands, milady's bot will still want to pin a working setup until everyone's on the new alpha.

Once the upstream PR ships, this script + the postinstall entry get deleted in one cleanup commit.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add bridge patch script to remove `--tools` flag from `coding-agent-adapters` Claude autonomous preset
> - Adds [patch-coding-agent-adapters-tools-flag.mjs](https://github.com/milady-ai/milady/pull/2066/files#diff-77a2c79ceaeb5cf677cc6fed0d2d28a5fc9fcf3a817af02b7e43c9688d0abfda), a Node ESM script that patches `coding-agent-adapters@0.16.3` dist files (`index.js`/`index.cjs`) to remove the `--tools` flag injection, which breaks the claude.ai OAuth tier.
> - The patch is idempotent: it skips files already patched, logs per-file status, and exits with code 1 if a target file exists but lacks the expected marker.
> - Registers the new script in [milady-postinstall-repo-setup.mjs](https://github.com/milady-ai/milady/pull/2066/files#diff-f19495e066c61c71c1e3d74546e022726f4597109b995ed3a799e0179519c84a) so it runs automatically as part of the bridge patch sequence on postinstall.
> - Adds [PR-DRAFT.md](https://github.com/milady-ai/milady/pull/2066/files#diff-8e62e1038c4b41bceb9228699c13ecc841419712423670de8f7a426a88e29430) describing the proposed upstream change to drop the flag from the preset.
> - Risk: patch targets a pinned version (`0.16.3`); upgrading `coding-agent-adapters` will cause the script to exit with code 1 if the old marker is no longer present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 46f2939.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->