### PR TITLE
fix(ci): allow skipped builds in agent-release publish jobs

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -694,20 +694,20 @@ jobs:
       ]
     if: >-
       always() &&
-      needs.smoke-auth.result == 'success' &&
-      needs.build-electrobun.result == 'success' &&
-      needs.build-docker.result == 'success' &&
-      needs.build-cloud-image.result == 'success' &&
-      needs.build-npm.result == 'success' &&
-      needs.build-android.result == 'success' &&
-      needs.build-snap.result == 'success' &&
-      needs.build-flatpak.result == 'success' &&
-      needs.build-pypi.result == 'success' &&
-      needs.build-debian.result == 'success' &&
-      needs.build-ios.result == 'success' &&
-      needs.build-macos-store.result == 'success' &&
-      needs.build-homepage.result == 'success' &&
-      needs.build-docs.result == 'success'
+      (needs.smoke-auth.result == 'success' || needs.smoke-auth.result == 'skipped') &&
+      (needs.build-electrobun.result == 'success' || needs.build-electrobun.result == 'skipped') &&
+      (needs.build-docker.result == 'success' || needs.build-docker.result == 'skipped') &&
+      (needs.build-cloud-image.result == 'success' || needs.build-cloud-image.result == 'skipped') &&
+      (needs.build-npm.result == 'success' || needs.build-npm.result == 'skipped') &&
+      (needs.build-android.result == 'success' || needs.build-android.result == 'skipped') &&
+      (needs.build-snap.result == 'success' || needs.build-snap.result == 'skipped') &&
+      (needs.build-flatpak.result == 'success' || needs.build-flatpak.result == 'skipped') &&
+      (needs.build-pypi.result == 'success' || needs.build-pypi.result == 'skipped') &&
+      (needs.build-debian.result == 'success' || needs.build-debian.result == 'skipped') &&
+      (needs.build-ios.result == 'success' || needs.build-ios.result == 'skipped') &&
+      (needs.build-macos-store.result == 'success' || needs.build-macos-store.result == 'skipped') &&
+      (needs.build-homepage.result == 'success' || needs.build-homepage.result == 'skipped') &&
+      (needs.build-docs.result == 'success' || needs.build-docs.result == 'skipped')
     runs-on: ${{ vars.RUNNER_UBUNTU || 'ubuntu-24.04' }}
     permissions:
       contents: write
@@ -895,7 +895,7 @@ jobs:
   push-agent-image:
     name: Push agent image to GHCR
     needs: [version, publish]
-    if: needs.publish.result == 'success'
+    if: (needs.publish.result == 'success' || needs.publish.result == 'skipped')
     uses: ./.github/workflows/build-docker.yml
     with:
       version: ${{ needs.version.outputs.tag }}
@@ -906,7 +906,7 @@ jobs:
   push-cloud-image:
     name: Push cloud app image to GHCR
     needs: [version, publish]
-    if: needs.publish.result == 'success'
+    if: (needs.publish.result == 'success' || needs.publish.result == 'skipped')
     uses: ./.github/workflows/build-cloud-image.yml
     with:
       version: ${{ needs.version.outputs.tag }}
@@ -917,7 +917,7 @@ jobs:
   distribute-release:
     name: Distribute release
     needs: [version, publish, push-agent-image, push-cloud-image]
-    if: needs.publish.result == 'success' && needs.push-agent-image.result == 'success' && needs.push-cloud-image.result == 'success'
+    if: (needs.publish.result == 'success' || needs.publish.result == 'skipped') && (needs.push-agent-image.result == 'success' || needs.push-agent-image.result == 'skipped') && (needs.push-cloud-image.result == 'success' || needs.push-cloud-image.result == 'skipped')
     uses: ./.github/workflows/release-orchestrator.yml
     with:
       version: ${{ needs.version.outputs.version }}


### PR DESCRIPTION
Jobs such as `publish`, `push-agent-image`, and `distribute-release` explicitly check that their `needs` succeeded. When builds are intentionally skipped based on release conditionals, this strict check fails the entire release pipeline. Updating to `(success || skipped)` enables fully green releases across all environments.

---
*PR created automatically by Jules for task [17330049733393941019](https://jules.google.com/task/17330049733393941019) started by @Dexploarer*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow skipped prerequisite jobs in agent-release publish pipeline
> Updates `if` conditions in [agent-release.yml](https://github.com/milady-ai/milady/pull/2077/files#diff-e6e19f9ab90dc6fa2053f119a13a1f08b8a95324ca73d82d96dd18d8d12e305b) so that `publish`, `push-agent-image`, `push-cloud-image`, and `distribute-release` jobs treat upstream `skipped` results the same as `success`. Previously, any skipped prerequisite would block these jobs from running.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e1062d.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->