### PR TITLE
docs(agents): fix stale paths in AGENTS.md/CLAUDE.md and document loopback bridge routes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,526 +1,197 @@
-# Milady — Agent Conventions
+# Milady — Project Codex Guidance
 
-## What This Is
+Milady is a local-first AI assistant built on [elizaOS](https://github.com/elizaOS). It wraps the elizaOS runtime with a CLI, desktop app (Electrobun), web dashboard, and platform connectors (Telegram, Discord, WeChat, etc.). Inherits `~/.codex/AGENTS.md`.
 
-Milady is a local-first AI assistant built on [elizaOS](https://github.com/elizaOS). It wraps the elizaOS runtime with a CLI, desktop app (Electrobun), web dashboard, and platform connectors (Telegram, Discord, etc.).
+## elizaOS naming
 
-### elizaOS naming (agents & editors)
+- Write the framework name as **elizaOS** in prose, comments, user-facing strings, and docs — never `ElizaOS`. The npm scope remains **`@elizaos/*`** (lowercase).
+- Say **Eliza agents** (not "elizaOS agents") in plain language.
+- The **Eliza Classic** plugin name is the one exception (Eliza = the 1966 chatbot).
 
-Write the framework name as **elizaOS** in prose, comments, user-facing strings, and documentation — not `ElizaOS`. The npm scope remains **`@elizaos/*`** (lowercase). Say **Eliza agents** when you mean agents in plain language (not **elizaOS agents**). The **Eliza Classic** plugin name is an exception (**Eliza** = the 1966 chatbot), not “elizaOS Classic”. Cursor picks this up via `.cursor/rules/elizaos-branding.mdc`.
-
-## Quick Start (Dev)
-
-```bash
-bun install          # runs postinstall hooks automatically
-bun run dev          # API on :31337, UI on :2138 with hot reload (defaults; busy ports → next free + env sync)
-bun run dev:desktop  # Electrobun; skips vite build when apps/app/dist is up to date
-bun run dev:desktop:watch  # Vite **dev** server + Electrobun `MILADY_RENDERER_URL` (HMR). Orchestrator pre-picks free API/UI loopback ports when defaults are in use so proxy + env match. Rollup watch: also set MILADY_DESKTOP_VITE_BUILD_WATCH=1
-
-Desktop dev observability (agents cannot see the native window; Cursor does not auto-poll localhost): `GET /api/dev/stack` on the API; `bun run desktop:stack-status -- --json`; default-on aggregated log (`.milady/desktop-dev-console.log`) + `GET /api/dev/console-log` (loopback tail); default-on screenshot proxy `GET /api/dev/cursor-screenshot` (loopback, full-screen OS capture). Opt-out: `MILADY_DESKTOP_SCREENSHOT_SERVER=0`, `MILADY_DESKTOP_DEV_LOG=0`. See `docs/apps/desktop-local-development.md` and `.cursor/rules/milady-desktop-dev-observability.mdc`.
-```
-
-Desktop dev rationale (signals, Quit, `detached` children): `docs/apps/desktop-local-development.md`.
-
-Optional — link a local elizaOS source checkout for live package development:
-```bash
-bun run setup:upstreams   # initializes repo-local ./eliza and links local @elizaos/* packages
-```
-
-## Build & Test
+## Quick start (dev)
 
 ```bash
-bun run build        # tsdown + vite
-bun run verify       # typecheck + lint (`bun run check` aliases this)
-bun run test         # parallel test suite
-bun run test:e2e     # end-to-end tests
-bun run db:check     # database security + readonly tests
+bun install                # postinstall hooks run automatically
+bun run dev                # API on :31337, UI on :2138 with hot reload (busy ports → next free + env sync)
+bun run dev:desktop        # Electrobun; skips vite build when apps/app/dist is up to date
+bun run dev:desktop:watch  # Vite dev server + Electrobun (HMR). Set MILADY_DESKTOP_VITE_BUILD_WATCH=1 for rollup watch.
 ```
 
-## Project Layout
+Optional — link a local elizaOS source checkout:
 
-```
-packages/
-  app-core/             Main application package (source of truth for runtime)
-    src/
-      entry.ts          CLI bootstrap (env, log level)
-      cli/              Commander CLI (milady command)
-      runtime/
-        eliza.ts        Agent loader — sets NODE_PATH, loads plugins dynamically
-        dev-server.ts   Dev mode entry point (started by dev-ui.mjs)
-      api/              Dashboard API (port 31337 in dev, 2138 in prod)
-      config/           Plugin auto-enable, config schemas
-      connectors/       Connector integration code
-      services/         Business logic
-  agent/                Upstream elizaOS agent (core plugins, auto-enable maps)
-  plugin-wechat/        WeChat connector plugin (@elizaos/plugin-wechat)
-  ui/                   Shared UI component library
-  shared/               Shared utilities
-apps/
-  app/                  Main web + desktop UI (Vite + React)
-    electrobun/         Electrobun desktop shell
-  homepage/             Marketing site
-scripts/
-  dev-ui.mjs            Dev orchestrator (API + Vite)
-  eliza/packages/app-core/scripts/run-node.mjs   CLI runner (spawns entry.js with NODE_PATH)
-  run-repo-setup.mjs    Postinstall sequencer
-  setup-upstreams.mjs   Initialize repo-local upstreams and link @elizaos packages
-  patch-deps.mjs        Post-install patches for broken upstream exports
+```bash
+bun run setup:upstreams    # initialize repo-local ./eliza and link local @elizaos/* packages
 ```
 
-## Default Agent Knowledge
+Desktop dev observability (Codex cannot see the native window):
 
-Treat bundled skills from `@elizaos/skills` as the default knowledge base for code agents working in this repo. Repo setup mirrors those defaults into `skills/.defaults/` so task agents like Claude and Codex can open them directly from the workspace. The canonical repo-local entry points are:
+- `GET /api/dev/stack` (or `bun run desktop:stack-status -- --json`) — running window/process state.
+- `GET /api/dev/console-log` — loopback tail of `.milady/desktop-dev-console.log` (default-on aggregated log).
+- `GET /api/dev/cursor-screenshot` — loopback full-screen OS capture (default-on).
 
-- `skills/.defaults/eliza-app-development/SKILL.md` — this repo as an elizaOS app (Milady is this checkout’s product name), layout, and how local, remote, and cloud paths fit together
-- `skills/.defaults/elizaos/SKILL.md` — elizaOS runtime concepts, plugin abstractions, and extension points
-- `skills/.defaults/eliza-cloud/SKILL.md` — Eliza Cloud as a managed backend, app platform, deployment target, and monetization surface
+See `eliza/docs/apps/desktop-local-development.md`.
 
-The source of truth remains under `eliza/packages/skills/skills/`. `scripts/sync-workspace-default-skills.mjs` refreshes the repo-local mirrors during repo setup.
+## Build & test
 
-`scripts/ensure-skills.mjs` seeds bundled skills from `@elizaos/skills` into the managed skills store on first run.
-Separately, `packages/agent/src/runtime/default-knowledge.ts` seeds bundled runtime knowledge items for Milady itself, including the baseline Eliza Cloud app/backend guidance.
+```bash
+bun run build       # tsdown + vite
+bun run verify      # typecheck + lint  (alias: bun run check)
+bun run test        # parallel test suite
+bun run test:e2e    # end-to-end
+bun run db:check    # database security + readonly tests
+```
 
-For source checkouts and app repos, the default agent workspace now follows the runtime `cwd` when that directory looks like a real project workspace (`package.json`, `AGENTS.md`, `skills/`, etc.). That makes the repo's own `AGENTS.md` and `skills/` available to the runtime by default, which is what lets Milady reason about and patch the checkout it is running in. Packaged installs still fall back to the state-dir workspace, and `MILADY_WORKSPACE_DIR` / `ELIZA_WORKSPACE_DIR` always win when set explicitly.
+## Project layout
 
-When Eliza Cloud is enabled, linked, or explicitly requested, prefer it as the default managed backend for app-building work before inventing custom auth, billing, or hosting. In this repo, Eliza Cloud already supports app registration (`appId`), user auth/redirect flows, cloud-hosted APIs, usage tracking, billing, app domains, creator monetization, and Docker container deployments for server-side workloads.
+First-party packages, apps, and orchestrator scripts live under the `eliza/` submodule. The top-level repo holds Milady-specific glue (`apps/app/`, `packages/{vault,confidant}/`, top-level `scripts/`).
 
-Cloud monetization is a first-class product constraint. App creators can earn through inference markups and purchase-share settings, and published apps, agents, and MCPs can feed redeemable earnings flows. If docs disagree, prefer the current schema/UI/API implementation in this repo over older marketing prose.
+```
+eliza/                              Submodule (milady-ai/eliza) — source of truth for runtime
+  packages/
+    app-core/                       Main runtime package
+      src/
+        entry.ts                    CLI bootstrap (env, log level)
+        cli/                        Commander CLI (milady command)
+        runtime/eliza.ts            Agent loader — sets NODE_PATH, loads plugins dynamically
+        runtime/dev-server.ts       Dev mode entry point (started by dev-ui.mjs)
+        api/                        Dashboard API (port 31337 in dev, 2138 in prod)
+        config/                     Plugin auto-enable, config schemas
+        services/                   Business logic
+      scripts/
+        dev-ui.mjs                  Dev orchestrator (API + Vite) — driven by `bun run dev`
+        run-repo-setup.mjs          Postinstall sequencer
+        setup-upstreams.mjs         Initialize repo-local upstreams and link @elizaos packages
+        patch-deps.mjs              Post-install patches for broken upstream exports
+    agent/                          Upstream elizaOS agent (core plugins, auto-enable maps)
+    ui/                             Shared UI component library
+    shared/                         Shared utilities
+    skills/                         Bundled @elizaos/skills (source of truth for default knowledge)
+  plugins/
+    plugin-wechat/                  WeChat connector plugin (@elizaos/plugin-wechat)
+    plugin-agent-orchestrator/      Sub-agent dispatch (workspace:* in dev)
+    plugin-app-control/             APP action surface (modes: launch / relaunch / load_from_directory / list / create)
+    plugin-plugin-manager/          PLUGIN action surface (modes: install / eject / sync / reinject / list / search / core_status / create)
+    plugin-agent-skills/            USE_SKILL action + enabled_skills provider
+  apps/
+    app-companion/                  Companion app
+    app-training/                   Training pipeline (privacy filter lives here)
+    app-form/, app-knowledge/, ... (see eliza/apps/)
+  templates/
+    min-app/                        Minimal Eliza app scaffold (used by APP create)
+    min-plugin/                     Minimal Eliza plugin scaffold (used by PLUGIN create)
+  docs/apps/desktop-local-development.md
+
+apps/                               Top-level Milady-specific apps
+  app/                              Main web + desktop UI (Vite + React)
+    electrobun/                     Electrobun desktop shell
+  browser-bridge/, home/, homepage/
+
+packages/                           Top-level Milady-specific packages
+  vault/                            Secrets / wallet vault
+  confidant/                        Confidant integration
+
+scripts/                            Top-level Milady scripts
+  milady-postinstall-repo-setup.mjs Top-level postinstall entry
+  sync-workspace-default-skills.mjs Mirrors @elizaos/skills into skills/.defaults/
+  ...                               (audit, drift checks, fixtures)
+```
+
+## Default agent knowledge
+
+Two distinct skill systems live in this repo. Don't conflate them.
+
+### 1. elizaOS runtime skills (knowledge base for the Eliza agent)
+
+Bundled `@elizaos/skills` are the default knowledge base for the running Eliza agent and for any code agent working in this repo. Repo setup mirrors them into `skills/.defaults/` for workspace access.
+
+- **Source of truth:** `eliza/packages/skills/skills/` (31 bundled skills).
+- **Workspace mirror:** `skills/.defaults/` — refreshed by `scripts/sync-workspace-default-skills.mjs` during setup; do not hand-edit.
+- **Managed store seed:** `eliza/packages/app-core/scripts/ensure-skills.mjs` seeds the bundled skills on first run.
+- **Runtime knowledge seed:** `eliza/packages/agent/src/runtime/default-knowledge.ts` seeds baseline runtime knowledge (including Eliza Cloud guidance).
+- **Repo-local custom skills:** put workspace-specific skills in visible subdirectories under `skills/` (e.g. `skills/plan-my-day/`).
+
+Open the `SKILL.md` of any of these from the workspace mirror when relevant:
+
+**Core eliza/cloud (read first when touching app, runtime, or Cloud work):**
+- `eliza-app-development` — this repo as an elizaOS app; layout; local/remote/cloud routing.
+- `elizaos` — runtime concepts, plugin abstractions, AgentRuntime, actions/providers/evaluators/services.
+- `eliza-cloud` — Cloud as managed backend, app registration, hosted APIs, billing, monetization, container deploys.
+- `build-monetized-app` — building a Cloud app that earns via inference markup; pairs with `eliza-cloud`.
+
+**Agent-orchestration / authoring:**
+- `coding-agent` — spawning Codex / Claude Code / OpenCode / Pi via PTY-backed bash for sub-agent work.
+- `claude-subagent-milady-bridge` — loopback endpoints exposing parent runtime context to a spawned coding sub-agent.
+- `skill-creator` — authoring new SKILL.md packages (frontmatter, scripts, references, progressive disclosure).
+
+**Connectors / OS / SaaS integrations** (use when the task touches that surface):
+- iMessage / macOS: `imsg`, `bluebubbles`, `apple-notes`, `apple-reminders`, `things-mac`, `camsnap`
+- Productivity: `obsidian`, `notion`, `slack`, `discord`, `github`, `trello`, `canvas`, `spotify-player`
+- CLI tools: `blucli`, `wacli`, `ordercli`, `tmux`, `1password`
+- Media / generation: `nano-banana-pro`, `nano-pdf`
+- Misc: `weather`, `healthcheck`, `yara-authoring`
+
+When Eliza Cloud is enabled or requested, prefer it as the managed backend (app registration, auth, hosted APIs, usage tracking, billing, app domains, creator monetization, Docker container deployments) before inventing custom infrastructure. Cloud monetization (inference markups, purchase-share, redeemable earnings) is a first-class product constraint. If docs disagree with the current schema/UI/API in this repo, the repo wins.
+
+### 2. Claude Code project skills (out-of-band for Codex)
+
+`.claude/skills/<name>/SKILL.md` files exist in this repo (currently `phase-review`) but they are **Claude Code slash commands** — they only fire when the user is running Claude Code, not Codex. Codex agents can ignore them. Documented here so you don't mistake them for elizaOS runtime skills if you encounter them in a directory listing.
 
 ## Dependencies on elizaOS
 
-All `@elizaos/*` packages use the `alpha` dist-tag. When developing locally, `bun run setup:upstreams` links packages from repo-local `./eliza` and `./plugins` so changes are picked up immediately. Set `MILADY_SKIP_LOCAL_UPSTREAMS=1` to use only npm-published versions.
+- All `@elizaos/*` packages use the `alpha` dist-tag. `bun run setup:upstreams` links repo-local `./eliza` and `./plugins` packages so changes are picked up immediately. `MILADY_SKIP_LOCAL_UPSTREAMS=1` falls back to npm.
+- `@elizaos/plugin-agent-orchestrator` resolves from `eliza/plugins/plugin-agent-orchestrator` via `workspace:*`. Updating the submodule updates the orchestrator.
+- All official elizaOS plugin repos live under https://github.com/elizaOS-plugins. For plugin work, prefer adding the plugin repo as a git submodule under `eliza/plugins/` (tracked in `eliza/.gitmodules`) and depending via `workspace:*`. Publish to npm when ready.
+- The eliza submodule is hosted at **milady-ai/eliza**, not the personal `Dexploarer` fork. Pushes and PRs always go to `milady-ai/eliza`.
 
-**`@elizaos/plugin-agent-orchestrator`:** Milady currently resolves this plugin from the repo-local `eliza/plugins/plugin-agent-orchestrator` submodule (nested under the `eliza/` submodule) via `workspace:*`. That submodule tracks upstream `alpha`, so updating the submodule updates the orchestrator used in local development checkouts. Set `MILADY_SKIP_LOCAL_UPSTREAMS=1` to force npm-published packages instead.
+## Environment variables (commonly touched)
 
-All official elizaOS plugin repos live under [https://github.com/elizaOS-plugins](https://github.com/elizaOS-plugins). For plugin work, prefer adding the relevant plugin repo as a git submodule under `eliza/plugins/` (tracked in `eliza/.gitmodules`) so we keep a local checkout we can patch when needed, and depend on it via `workspace:*` so Milady resolves the local package directly during development. Publish new versions to npm when ready.
+- `MILADY_STATE_DIR` / `ELIZA_STATE_DIR` — per-user state root (default `~/.milady`).
+- `MILADY_CONFIG_PATH` / `ELIZA_CONFIG_PATH` — config file resolution.
+- `ELIZA_DISABLE_TRAJECTORY_LOGGING=1` (or `NODE_ENV=test`) — opt out of trajectory persistence.
+- `MILADY_DISABLE_AUTO_BOOTSTRAP=1` — skip the runtime native-optimization bootstrap.
+- `MILADY_ENABLE_CHILD_SKILL_CALLBACK=0` — disable the child→parent `USE_SKILL` bridge for spawned coding agents.
+- `EXECUTECODE_TIMEOUT_MS` (default `30000`), `EXECUTECODE_DISABLE` — `EXECUTE_CODE` action knobs.
+- `MILADY_APP_VERIFICATION_MAX_RETRIES` (default `3`) — `APP create` / `PLUGIN create` verification retry cap.
+- `MILADY_PROTECTED_APPS` — comma-separated names that cannot be overridden via `APP load_from_directory`. First-party apps under `eliza/apps/` are always implicitly included.
+- `MILADY_BROWSER_VERIFY_OPTIONAL=1` — explicit opt-out for the headless-browser check when `puppeteer-core` is absent.
 
-# AGENTS.md
+Model defaults (sub-agents inherit unless overridden):
+- Anthropic large: `claude-opus-4-7` (override: `ANTHROPIC_LARGE_MODEL`). Small: `claude-haiku-4-5-20251001`.
+- OpenAI large/small: `gpt-5.5` / `gpt-5.5-mini` (override: `OPENAI_LARGE_MODEL` / `OPENAI_SMALL_MODEL`).
 
-## Mission
+Port env vars (never hardcoded — the dev orchestrator auto-shifts to the next free port and syncs env): `MILADY_API_PORT` (31337), `MILADY_PORT` (2138), `ELIZA_GATEWAY_PORT` (18789), `ELIZA_HOME_PORT` (2142), `MILADY_WECHAT_WEBHOOK_PORT` (18790).
 
-Clean up the codebase aggressively and raise code quality without drifting from the real architecture. This work is not cosmetic. The goal is to remove duplication, dead code, weak typing, fallback sludge, and AI-generated nonsense while preserving correctness and simplifying the system.
+## Skills + training
 
-This is a complex task. Use **8 focused subagents** working in parallel where possible, each with a clear scope, concrete deliverables, and authority to make **high-confidence** changes.
+- `USE_SKILL` is the only canonical entry point for invoking an enabled skill. Legacy `RUN_SKILL_SCRIPT` / `GET_SKILL_GUIDANCE` are removed; `RUN_SKILL` / `INVOKE_SKILL` remain as similes.
+- The `enabled_skills` provider runs at position `-10` and surfaces eligible skills to the planner each turn.
+- Trajectory persistence is on by default. Every turn lands in the `trajectories` table unless `ELIZA_DISABLE_TRAJECTORY_LOGGING=1`.
+- Native optimization (`--backend native`) is the default training backend (MIPRO / GEPA / bootstrap-fewshot). Outputs land under `~/.milady/optimized-prompts/<task>/` and `OptimizedPromptService` auto-loads at boot.
+- Auto-training defaults: 100 trajectories per task, 12h cooldown. Adjust via `/api/training/auto/config` or Settings → Auto-Training.
+- The privacy filter at `eliza/apps/app-training/src/core/privacy-filter.ts` is mandatory on every write path that touches real user trajectories — both the nightly export cron and the on-demand training orchestrator run it before any JSONL is written.
 
-Every subagent must:
+## App and plugin primitives
 
-1. **Research first.** Inspect the codebase, dependencies, package structure, build/test/lint/typecheck configuration, and relevant external package types/docs when needed.
-2. **Write a critical assessment** of the current state in its area.
-3. **Produce recommendations** ranked by confidence and expected impact.
-4. **Implement all high-confidence recommendations.**
-5. **Avoid speculative rewrites.** Prefer targeted, verifiable simplification.
-6. **Verify results** with available tests, typechecks, linting, import graph tools, and direct codepath inspection.
+The runtime exposes two unified action surfaces — `APP` and `PLUGIN` — that replace the older single-purpose actions. New code MUST call `APP` / `PLUGIN`. Legacy actions (`LAUNCH_APP`, `RELAUNCH_APP`, `LIST_APPS`, `INSTALL_PLUGIN`, `UNINSTALL_PLUGIN`, `EJECT_PLUGIN`, `SYNC_PLUGINS`, `REINJECT_PLUGINS`, `LIST_PLUGINS`, `SEARCH_PLUGINS`, `CORE_STATUS`, etc.) remain as similes but are no longer canonical.
 
----
+`APP` modes: `launch`, `relaunch`, `load_from_directory`, `list`, `create`.
+`PLUGIN` modes: `install`, `eject`, `sync`, `reinject`, `list`, `search`, `core_status`, `create`.
 
-## Non-Negotiable Architecture Rules
+### Sub-agent invocation and loopback bridge
 
-These rules govern all changes. If existing code conflicts with them, fix the code.
+Coding sub-agents spawned by the orchestrator (Claude Code, Codex, etc.) live in sealed PTY workspaces with no direct access to the parent Milady runtime. They have two channels back to the parent:
 
-### 10 Clean Architecture Commandments
+**1. PTY stdout — `USE_SKILL` (write channel).** Emit `USE_SKILL <slug> <json>` lines on stdout; the orchestrator parses them and dispatches the matching skill in the parent runtime. This is how a sub-agent invokes `APP`, `PLUGIN`, or any other parent skill. Enabled by default; disable with `MILADY_ENABLE_CHILD_SKILL_CALLBACK=0`.
 
-1. **Dependencies point inward only.** Presentation → Application → Domain → Infrastructure. Never import from an outer layer.
-   - Violation: broken architecture boundary.
+**2. Loopback HTTP bridge (read channel).** Three endpoints on `127.0.0.1:31337` (or whatever `MILADY_API_PORT` resolves to). Loopback-only, agent-authed via the `:sessionId` path segment (must match an active task in the orchestrator's `tasks` map; unknown sessions 404, completed/stopped sessions 410):
 
-2. **Use Cases are the only computation layer.** All derived values (multipliers, percentages, totals, fee breakdowns) are computed in use cases and returned as named DTO fields.
-   - Violation: client-side drift, stale calculations.
+- `GET /api/coding-agents/:sessionId/parent-context` — parent character, world/room context, the human user's identity. Use this to resolve pronouns the task brief left unresolved.
+- `GET /api/coding-agents/:sessionId/memory?q=<query>&limit=<N>` — query the parent agent's memory.
+- `GET /api/coding-agents/:sessionId/active-workspaces` — list the parent's currently-active workspaces.
 
-3. **Client displays, never computes.** Zero financial math (`*`, `/`, `%`), zero business logic, zero aggregation in presentation code. Read DTO fields and format for display only.
-   - Violation: conflicting definitions between client and server.
+All bridge responses are read-only. Mutations stay with the orchestrator — sub-agents cannot write parent state through the bridge. The `claude-subagent-milady-bridge` skill (in `skills/.defaults/`) documents the calling pattern in detail.
 
-4. **BFF is auth + proxy. Nothing else.** Validate JWT, inject `userId`, forward request, `unwrapServerResponse()`. No field additions, no calculations, no transformations.
-   - Violation: shadow API contract divergence.
-
-5. **Zero polymorphism for runtime game/content type branching.** Separate classes, methods, and routes per type. No `if (gameType === ...)`, no union parameters, no union return types where separate flows should exist.
-   - Violation: runtime type checks, hidden branches.
-
-6. **CQRS: readers read, writers write.** Separate classes. Readers return domain objects. Writers return `void` or ID only. Mappers handle all DB-to-domain translation.
-   - Violation: mixed concerns, untraceable mutations.
-
-7. **Single source of truth for validation.** Route-layer schemas validate and transform input. Use cases trust pre-validated input and perform presence/invariant checks only. No duplicate inline regex validation.
-   - Violation: dual validation paths, inconsistent acceptance criteria.
-
-8. **DTO fields are required by default.** Optional only when genuinely nullable. No `as` casts to skip missing fields. No `?? 0` or similar fallbacks that hide broken pipelines. If TypeScript says a field is missing, fix the pipeline.
-   - Violation: silent data loss, conflating “not loaded” with “zero”.
-
-9. **Logger only, never console.** Server logging uses the structured logger only (for example `Logger.info/warn/error/debug`). Prefix messages with `[ClassName]` and include structured context objects on errors.
-   - Violation: uncontrollable log output, missing levels.
-
-10. **Every endpoint needs a client trigger.** Every POST/PUT/DELETE must have a button/form/invocation path. Every GET must have a consuming component/hook. `N/A` requires written justification. A server endpoint without a UI or real caller is a broken pipeline.
-   - Violation: shipped features users cannot access.
-
----
-
-## Global Standards for All Subagents
-
-### What good changes look like
-
-- Fewer codepaths.
-- Fewer special cases.
-- Fewer fallback branches.
-- Stronger types.
-- Shared definitions only where sharing reduces complexity.
-- Cleaner layer boundaries.
-- Easier traceability from input → use case → DTO → UI.
-- No dead abstractions.
-- No defensive code that obscures failures.
-
-### What to remove on sight
-
-- Unused code.
-- Duplicate types and near-duplicate types.
-- Legacy branches and migration leftovers.
-- AI slop, stubs, placeholders, fake TODO implementations.
-- Comments describing churn instead of helping understanding.
-- “Temporary” fallback behavior that became permanent.
-- Broad `try/catch` blocks that just swallow, log-and-continue, or replace errors with defaults.
-- `any`, `unknown`, unsafe casts, and weak unions used to avoid thinking.
-
-### Constraints
-
-- Do not preserve bad patterns for compatibility unless there is a documented, verified reason.
-- Do not add new abstractions unless they reduce total complexity.
-- Do not DRY code that should remain separate because the domains differ.
-- Do not centralize unlike concepts into giant shared utility files.
-- Do not hide uncertainty with fallback values.
-- Do not keep both old and new paths unless a live migration explicitly requires it.
-
----
-
-## Subagent Plan
-
-Spawn one subagent for each of the following tasks.
-
-### 1) Deduplication and Consolidation Agent
-
-**Goal:** Deduplicate and consolidate code, and apply DRY only where it reduces complexity.
-
-**Responsibilities:**
-- Find duplicated logic, duplicate utilities, repeated query/build patterns, repeated DTO mapping, repeated validation glue, repeated UI state handling, and repeated infrastructure wrappers.
-- Distinguish between:
-  - true duplication that should be unified,
-  - parallel domain logic that only looks similar and should remain separate.
-- Consolidate only when the resulting abstraction is simpler than the duplicates.
-- Prefer deleting duplicate branches over introducing configuration-heavy helpers.
-
-**Deliverables:**
-- Inventory of duplicated code.
-- Critical assessment of why duplication exists.
-- Recommended consolidations with rationale.
-- Implementation of high-confidence deduplication.
-
-**Guardrails:**
-- No premature utility extraction.
-- No “god helper” files.
-- Respect the architecture layers.
-
-### 2) Shared Types Consolidation Agent
-
-**Goal:** Find all type definitions and consolidate any that should be shared.
-
-**Responsibilities:**
-- Audit interfaces, types, enums, DTOs, schema-inferred types, API contracts, and domain models.
-- Identify duplicate or divergent definitions representing the same real concept.
-- Consolidate canonical shared types where appropriate.
-- Separate domain models from transport DTOs when they should not be conflated.
-- Ensure route schemas, DTOs, and consuming code agree exactly.
-
-**Deliverables:**
-- Map of duplicated/conflicting type definitions.
-- Critical assessment of type fragmentation and contract drift.
-- Canonical ownership plan for shared types.
-- Implementation of high-confidence consolidations.
-
-**Guardrails:**
-- Do not create giant shared “types” dumps.
-- Do not merge types that exist at different boundaries for good reason.
-- Prefer schema-derived types where possible.
-
-### 3) Unused Code Removal Agent
-
-**Goal:** Use tools like `knip` to find all unused code and remove it, ensuring it is truly unreferenced.
-
-**Responsibilities:**
-- Run and interpret unused-code tooling such as `knip`.
-- Manually verify reported files, exports, dependencies, scripts, components, hooks, routes, tests, fixtures, and types before deletion.
-- Check dynamic imports, generated references, config-driven references, framework conventions, and CLI/script usage.
-- Remove code only after confirming it is not used anywhere meaningful.
-
-**Deliverables:**
-- Verified unused-code report.
-- Critical assessment of why dead code accumulated.
-- Safe deletion plan.
-- Implementation of high-confidence removals.
-
-**Guardrails:**
-- Never trust tooling blindly.
-- Validate framework-specific entrypoints and implicit references.
-- Prefer deletion over deprecation.
-
-### 4) Circular Dependency Untangler Agent
-
-**Goal:** Untangle circular dependencies using tools like `madge` and direct graph analysis.
-
-**Responsibilities:**
-- Generate and inspect dependency graphs.
-- Identify all cycles across layers, modules, barrels, and utility folders.
-- Break cycles by moving ownership inward, splitting modules, removing barrel misuse, or extracting the right internal seam.
-- Fix boundary violations, not just the symptom.
-
-**Deliverables:**
-- Circular dependency graph and root-cause assessment.
-- Critical assessment of architectural coupling.
-- Recommendations for cycle removal.
-- Implementation of high-confidence fixes.
-
-**Guardrails:**
-- Do not “solve” cycles with lazy imports unless that is the correct architectural answer.
-- Prefer removing the wrong dependency edge.
-- Ensure final dependency direction points inward only.
-
-### 5) Strong Typing Agent
-
-**Goal:** Remove all weak types such as `unknown` and `any` (and equivalents in other languages), then replace them with researched, strong types.
-
-**Responsibilities:**
-- Find all `any`, `unknown`, unsafe casts, loose generics, nullable abuse, and weak externally sourced types.
-- Research the real types by inspecting calling code, callee expectations, schemas, package definitions, generated clients, and external library docs/types.
-- Replace weak types with strong, explicit types.
-- Resolve resulting type errors properly rather than suppressing them.
-
-**Deliverables:**
-- Weak-type inventory.
-- Critical assessment of type debt and its causes.
-- Strong replacement plan with evidence.
-- Implementation of high-confidence type strengthening.
-
-**Guardrails:**
-- No replacement with fake precision.
-- No `as unknown as X` escapes.
-- No widened unions to avoid fixing callsites.
-- If a runtime boundary is uncertain, validate at the boundary and type the validated result.
-
-### 6) Error-Handling Simplification Agent
-
-**Goal:** Remove unnecessary `try/catch` and equivalent defensive programming unless it has a specific justified role.
-
-**Responsibilities:**
-- Audit all `try/catch`, broad rescue patterns, silent fallbacks, default-return error handling, swallowed promise rejections, and “best effort” code.
-- Keep only error handling that has a clear purpose, such as:
-  - handling unknown or unsanitized input,
-  - translating infrastructure errors at a boundary,
-  - adding meaningful context before rethrowing,
-  - enforcing user-facing behavior explicitly.
-- Remove error hiding and fallback patterns that mask real failures.
-- Ensure failures surface clearly and observably.
-
-**Deliverables:**
-- Error-handling audit.
-- Critical assessment of defensive-programming misuse.
-- Recommendations for removal vs retention.
-- Implementation of high-confidence simplifications.
-
-**Guardrails:**
-- Never catch an error only to log and continue unless that behavior is intentionally required.
-- Never replace missing or failed data with silent defaults.
-- Prefer explicit failure over ambiguous success.
-
-### 7) Legacy and Fallback Code Removal Agent
-
-**Goal:** Find deprecated, legacy, or fallback code, remove it, and make codepaths singular, clean, and concise.
-
-**Responsibilities:**
-- Identify deprecated APIs, old adapters, compatibility shims, “v1/v2” bridges, migration leftovers, fallback branches, duplicate implementations, and disabled-but-kept code.
-- Verify whether each legacy path is still live.
-- Remove obsolete branches and collapse to one canonical codepath.
-- Update references, tests, and docs accordingly.
-
-**Deliverables:**
-- Legacy/fallback inventory.
-- Critical assessment of historical cruft and path divergence.
-- Removal plan.
-- Implementation of high-confidence cleanup.
-
-**Guardrails:**
-- Keep only what is actually required now.
-- No “just in case” retention.
-- Prefer one obvious path through the system.
-
-### 8) Slop and Comment Cleanup Agent
-
-**Goal:** Remove AI slop, stubs, larp, unnecessary comments, and unhelpful narrative churn.
-
-**Responsibilities:**
-- Find placeholder code, pseudo-implementations, generated sludge, fake abstraction layers, noisy comments, status-update comments, migration-story comments, and comments that narrate obvious code.
-- Remove comments that describe in-motion work, prior replacements, or internal drama.
-- Replace only when a concise explanatory comment would genuinely help a new engineer understand the codebase.
-- Remove stubbed helpers and speculative extension points that are not real.
-
-**Deliverables:**
-- Slop inventory.
-- Critical assessment of readability and trust issues.
-- Cleanup plan.
-- Implementation of high-confidence cleanup.
-
-**Guardrails:**
-- Comments must earn their keep.
-- Prefer self-explanatory code over commentary.
-- If a short comment is needed, make it factual and durable.
-
----
-
-## Required Research and Verification
-
-Each subagent must use the relevant tools for its job. Examples:
-
-- **Unused code:** `knip`, package manager scripts, framework entrypoints, import search, route discovery.
-- **Circular dependencies:** `madge`, import graph inspection, barrel analysis.
-- **Type research:** schema definitions, generated code, external package type declarations, usage traces, test fixtures.
-- **Architecture verification:** import direction checks, route-to-use-case tracing, DTO origin tracing, client usage inspection.
-- **Behavior verification:** tests, typecheck, lint, build, and targeted runtime inspection where available.
-
-Do not stop at tool output. Tooling is a lead, not proof.
-
----
-
-## Execution Order
-
-Use this order unless the codebase suggests a better dependency-aware sequence:
-
-1. Map architecture, layers, package boundaries, build/test/lint/typecheck setup.
-2. Run dead-code, cycle, and type-analysis tools.
-3. Fix architecture boundary violations and circular dependencies.
-4. Consolidate duplicated and conflicting types.
-5. Remove dead code and legacy/fallback paths.
-6. Strengthen types and remove unsafe escapes.
-7. Simplify error handling and defensive patterns.
-8. Remove slop and fix comments.
-9. Re-run all verification.
-10. Summarize changes, risks, and any remaining low-confidence findings.
-
----
-
-## Output Format
-
-Each subagent should produce:
-
-### A. Critical Assessment
-- What is wrong.
-- Why it exists.
-- How it violates architecture or maintainability.
-- What risk it creates.
-
-### B. Recommendations
-- High confidence.
-- Medium confidence.
-- Low confidence / needs human decision.
-
-### C. Implemented Changes
-- Exact files/modules changed.
-- What was removed, consolidated, or rewritten.
-- Why the resulting design is simpler.
-
-### D. Verification
-- Commands run.
-- Results.
-- Any residual issues.
-
----
-
-## Hard Rules for Implementation
-
-- **Implement all high-confidence recommendations.**
-- Do not leave obvious cleanup undone.
-- Do not keep duplicate paths to avoid making a decision.
-- Do not introduce broad abstractions to “support future flexibility.”
-- Do not preserve weak typing behind helper wrappers.
-- Do not add fallbacks to make broken flows appear healthy.
-- Do not perform business logic in presentation or proxy layers.
-- Do not merge unlike concepts just because names are similar.
-
-When in doubt, choose the option that yields:
-- fewer moving parts,
-- stronger guarantees,
-- cleaner boundaries,
-- more direct code.
-
----
-
-## Definition of Done
-
-The task is complete when:
-
-- Dead code is removed.
-- Circular dependencies are removed or reduced to only justified, documented exceptions.
-- Type definitions are canonical and consistent.
-- Weak types are replaced with researched strong types.
-- Unnecessary `try/catch`, fallback logic, and defensive sludge are removed.
-- Deprecated and legacy paths are gone.
-- AI slop and unhelpful comments are gone.
-- Architecture rules are enforced in the resulting code.
-- The codebase is smaller, clearer, and easier to reason about.
-- Verification passes, or remaining failures are explicitly documented with root cause.
-
----
-
-## Tone and Standard
-
-Be ruthless about quality and honest in assessment. The current state may be messy. Call that out clearly. But every code change must still be precise, justified, and verifiable.
-
-This is not a refactor for style points.
-This is a cleanup for correctness, maintainability, and architectural integrity.
-
----
-
-## Git Workflow Rules
-
-**Motto: move fast and break things — but never lose work to dangling branches or stashes.**
-
-- **Never `git stash`.** Stashes are invisible state that gets forgotten and lost. If you need to set something aside, commit it.
-- **Always commit to the current branch.** Whatever branch is checked out is the branch you commit to. Use WIP commits liberally — they can always be amended, squashed, or rewritten later.
-- **Never switch branches unless explicitly told to.** No `git checkout <other-branch>`, no `git switch`, no implicit branch changes as part of "cleanup." If a task seems to require a different branch, ask first.
-- **Always commit work in the current worktree.** Don't move changes to another worktree, don't copy files across worktrees, don't `git worktree add` unless asked. The worktree you're in is where the work lands.
-- **Prefer many small commits over uncommitted changes.** A messy commit history on a pushed branch is recoverable. Lost work is not.
-- **Push proactively when work is meaningful.** A branch that exists only on the local machine is one disk failure away from gone. If a chunk of work is worth keeping, it's worth pushing.
-
-The principle: **every change must end up as a commit on the current branch in the current worktree, and ideally pushed.** No stashes, no branch hopping, no work that exists only in the working tree or in `git stash list`.
-
----
-
-## App and Plugin primitives
-
-The runtime exposes two unified action surfaces — `APP` and `PLUGIN` — that replace the older single-purpose actions. New code MUST call `APP` / `PLUGIN`. The legacy actions (`LAUNCH_APP`, `RELAUNCH_APP`, `LIST_APPS`, `INSTALL_PLUGIN`, `UNINSTALL_PLUGIN`, `EJECT_PLUGIN`, `SYNC_PLUGINS`, `REINJECT_PLUGINS`, `LIST_PLUGINS`, `SEARCH_PLUGINS`, `CORE_STATUS`, etc.) remain registered as **similes** on the unified actions so older inbound callers and prompt patterns still resolve, but they are no longer canonical entry points.
-
-### `APP` action
-
-Sub-modes (the action takes a structured `{ mode, ... }` payload):
-
-- `launch` — start an app session for a registered app (reuse if one is already running for the user).
-- `relaunch` — terminate any running session and start a new one (used after configuration changes or crash recovery).
-- `load_from_directory` — register a new app source from a local directory (path validated, scoped to allowed roots, audited to `MILADY_APP_LOAD_AUDIT_LOG`).
-- `list` — return registered apps and their session state for the dashboard / planner.
-- `create` — scaffold a new app from `eliza/templates/min-app` and hand it to a coding sub-agent for customization. The orchestrator runs verification (see below) before reporting success.
-
-### `PLUGIN` action
-
-Sub-modes:
-
-- `install` — add a plugin from the registry (or a local path) and enable it.
-- `eject` — remove a plugin and clean up its config.
-- `sync` — reconcile installed plugins against the manifest (idempotent).
-- `reinject` — re-load already-installed plugins after a runtime reset.
-- `list` — list installed + enabled plugins.
-- `search` — query the registry by name / tag / category.
-- `core_status` — health check on the core / runtime plugin set.
-- `create` — scaffold a new plugin from `eliza/templates/min-plugin` and hand it to a coding sub-agent. Runs the same verification loop as `APP create`.
-
-### Sub-agent invocation via the `USE_SKILL` bridge
-
-Coding sub-agents spawned by the orchestrator (Claude Code, Codex, etc.) talk back to the parent runtime by emitting `USE_SKILL <slug> <json>` lines on PTY stdout. The parent watches for those lines and dispatches the matching skill in the parent runtime. This is the mechanism a child uses to invoke `APP` or `PLUGIN` — there is no separate child→parent RPC channel.
-
-The bridge is enabled by default. Set `MILADY_ENABLE_CHILD_SKILL_CALLBACK=0` to disable it (useful for sandboxed runs).
-
-### Verification loop (mandatory for `create` modes)
+### Mandatory verification loop for `create` modes
 
 Any sub-agent writing an app or plugin MUST run, in order, before signaling completion:
 
@@ -528,28 +199,59 @@ Any sub-agent writing an app or plugin MUST run, in order, before signaling comp
 2. `bun run lint`
 3. `bun run test`
 
-After all three succeed, the sub-agent emits exactly one structured completion line on stdout:
+Then emit exactly one structured completion line on stdout:
 
 ```
 APP_CREATE_DONE {"appName":"...","files":[...],"tests":{"passed":N,"failed":0},"lint":"ok","typecheck":"ok"}
 ```
 
-(or `PLUGIN_CREATE_DONE {...}` for plugins).
-
-The parent **does not trust the line**. It cross-checks every claim against disk and the verification log:
+(or `PLUGIN_CREATE_DONE {...}`). The parent does not trust the line — it cross-checks every claim against disk and the verification log:
 
 - Every file in `files` must exist and be non-empty.
-- The `tests.passed` count must match the parsed vitest report.
-- `lint` and `typecheck` claims are verified against the recorded exit codes.
+- `tests.passed` must match the parsed vitest report.
+- `lint` and `typecheck` claims are verified against recorded exit codes.
 - No remaining `__APP_NAME__` / `__PLUGIN_NAME__` / `__APP_DISPLAY_NAME__` / `__PLUGIN_DISPLAY_NAME__` placeholders are allowed.
 
-If any claim fails verification, the parent issues a follow-up prompt to the same sub-agent with a structured failure report (which checks failed, exact error output, what to fix). The sub-agent fixes and re-emits the completion line. The retry cap is `MILADY_APP_VERIFICATION_MAX_RETRIES` (default `3`). After the cap, the parent surfaces the failure to the user verbatim — no silent fallback, no "best effort" success.
+If any claim fails verification, the parent issues a structured failure prompt and the sub-agent fixes and re-emits. Retry cap: `MILADY_APP_VERIFICATION_MAX_RETRIES` (default `3`). After the cap, the failure surfaces verbatim — no silent fallback.
 
 ### Templates
 
-The canonical scaffold sources live in the `eliza/` submodule:
+- `eliza/templates/min-app/` — minimal Eliza app (Vite + React entry, `Plugin` with one action, `package.json` with `elizaos.app` metadata, vitest smoke test, hero image placeholder, `SCAFFOLD.md` agent contract).
+- `eliza/templates/min-plugin/` — minimal Eliza runtime plugin (one action, one provider, `package.json` with `elizaos.plugin` metadata, vitest smoke test, `SCAFFOLD.md` agent contract).
 
-- `eliza/templates/min-app/` — minimal Eliza app (Vite + React UI + `Plugin` with one action, `package.json` with `elizaos.app` metadata, vitest smoke test, hero image placeholder, `SCAFFOLD.md` with the agent contract).
-- `eliza/templates/min-plugin/` — minimal Eliza runtime plugin (one action, one provider, `package.json` with `elizaos.plugin` metadata, vitest smoke test, `SCAFFOLD.md` with the agent contract).
+Both use placeholders (`__APP_NAME__`, `__APP_DISPLAY_NAME__`, `__PLUGIN_NAME__`, `__PLUGIN_DISPLAY_NAME__`) replaced by the scaffold copy step. Read each template's `SCAFFOLD.md` before customizing.
 
-Both templates use the placeholders `__APP_NAME__` / `__APP_DISPLAY_NAME__` and `__PLUGIN_NAME__` / `__PLUGIN_DISPLAY_NAME__` that the scaffold copy step replaces. Read each template's `SCAFFOLD.md` before customizing.
+## Architecture rules (non-negotiable)
+
+These govern every change. If existing code conflicts, fix the code.
+
+1. **Dependencies point inward only.** Presentation → Application → Domain → Infrastructure. Never import from an outer layer.
+2. **Computation lives in domain code, not presentation.** Derived values are computed in services / actions / use cases and returned as named fields. Clients format DTO fields for display; they do not aggregate, compute, or branch on raw data.
+3. **API routes are auth + dispatch.** Route handlers validate input, resolve the caller, and dispatch to a service / action. No business logic, no transformations, no calculations in route bodies.
+4. **No runtime type-tag branching where separate flows belong.** Distinct content kinds (apps, plugins, providers, actions) get separate handlers, not `if (kind === ...)` chains.
+5. **CQRS.** Readers read and return domain objects. Writers return `void` or an ID. Mappers handle DB↔domain translation.
+6. **Single source of truth for validation.** Route-layer schemas validate and transform input. Services / actions trust pre-validated input and perform presence/invariant checks only. No duplicate inline regex.
+7. **DTO fields are required by default.** Optional only when genuinely nullable. No `as` casts to skip missing fields. No `?? 0` to hide broken pipelines. If TypeScript says a field is missing, fix the pipeline.
+8. **Logger only, never console.** Server logging uses the structured logger only (`Logger.info/warn/error/debug`). Prefix `[ClassName]`. Include structured context on errors.
+9. **Every action and endpoint needs a real caller.** Every POST/PUT/DELETE has a UI invocation path. Every GET has a consuming component/hook. Every action has a planner trigger or programmatic caller. Anything else is dead code.
+
+## Quality bar
+
+What good changes look like: fewer codepaths, fewer special cases, fewer fallback branches, stronger types, cleaner layer boundaries, easier traceability from input → use case → DTO → UI, no dead abstractions, no defensive code that obscures failures.
+
+Remove on sight: unused code, near-duplicate types, legacy / migration leftovers, AI slop and fake TODO implementations, comments describing churn, "temporary" fallbacks that became permanent, broad `try/catch` that just swallows or replaces errors with defaults, `any` / `unknown` / unsafe casts used to avoid thinking.
+
+Constraints: do not preserve bad patterns "for compat" without a documented, verified live caller. Do not add abstractions unless they reduce total complexity. Do not DRY code that should remain separate because the domains differ. Do not centralize unlike concepts. Do not hide uncertainty with fallback values. Do not keep both old and new paths unless a live migration explicitly requires it.
+
+## Git workflow
+
+**Motto: move fast, but never lose work to dangling branches or stashes.**
+
+- **Never `git stash`.** Commit instead — WIP commits are fine and can be amended or squashed later.
+- **Always commit to the current branch in the current worktree.** Do not `git checkout`/`git switch` to another branch as part of "cleanup." If a task seems to need a different branch, ask first.
+- **Prefer many small commits over uncommitted changes.** Push proactively when work is meaningful.
+- **Never `--no-verify`, `--no-gpg-sign`, force-push to main/master, or amend a published commit** unless explicitly asked. After a hook failure, fix the issue and create a NEW commit (`--amend` modifies the wrong commit).
+- **Never blanket-discard uncommitted edits as "dev-env churn."** `git checkout -- <file>` on uncommitted edits is destructive — confirm per-file, especially for binaries.
+- Stage by name. Avoid `git add -A` / `git add .`.
+
+The principle: every change ends up as a commit on the current branch in the current worktree, and ideally pushed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,12 @@ Milady is a local-first AI assistant built on [elizaOS](https://github.com/eliza
 
 Write the framework name as **elizaOS** in prose, comments, user-facing strings, and documentation — not `ElizaOS`. The npm scope remains **`@elizaos/*`** (lowercase). Say **Eliza agents** when you mean agents in plain language (not **elizaOS agents**). The **Eliza Classic** plugin name is an exception (**Eliza** = the 1966 chatbot), not “elizaOS Classic”. Cursor picks this up via `.cursor/rules/elizaos-branding.mdc`.
 
+## Scope Discipline
+
+- Do NOT invent features, grace periods, or product behaviors not explicitly requested or documented.
+- Before adding new capabilities, verify they align with the existing product model by reading docs/README first.
+- When unsure about product semantics (e.g., SOL-only vs SPL, community vs custom flows), ASK before implementing.
+
 ## Quick Start (Dev)
 
 ```bash
@@ -116,16 +122,45 @@ Both use placeholders (`__APP_NAME__`, `__APP_DISPLAY_NAME__`, `__PLUGIN_NAME__`
 
 ## Default Agent Knowledge
 
-Treat bundled skills from `@elizaos/skills` as the default knowledge base for code agents working in this repo. Repo setup mirrors those defaults into `skills/.defaults/` so task agents like Claude and Codex can open them directly from the workspace. The canonical repo-local entry points are:
+Two distinct skill systems live in this repo. Don't conflate them.
 
-- `skills/.defaults/eliza-app-development/SKILL.md` — this repo as an elizaOS app (Milady is this checkout’s product name), layout, and how local, remote, and cloud paths fit together
-- `skills/.defaults/elizaos/SKILL.md` — elizaOS runtime concepts, plugin abstractions, and extension points
-- `skills/.defaults/eliza-cloud/SKILL.md` — Eliza Cloud as a managed backend, app platform, deployment target, and monetization surface
+### 1. elizaOS runtime skills (knowledge base for the Eliza agent)
 
-The source of truth remains under `eliza/packages/skills/skills/`. `scripts/sync-workspace-default-skills.mjs` refreshes the repo-local mirrors during repo setup.
+Bundled `@elizaos/skills` are the default knowledge base for the running Eliza agent and for any code agent working in this repo. Repo setup mirrors them into `skills/.defaults/` so workspace task agents (Claude, Codex) can read them directly from the checkout.
 
-`scripts/ensure-skills.mjs` seeds bundled skills from `@elizaos/skills` into the managed skills store on first run.
-Separately, `packages/agent/src/runtime/default-knowledge.ts` seeds bundled runtime knowledge items for Milady itself, including the baseline Eliza Cloud app/backend guidance.
+- **Source of truth:** `eliza/packages/skills/skills/` (31 bundled skills).
+- **Workspace mirror:** `skills/.defaults/` — refreshed by `scripts/sync-workspace-default-skills.mjs` during repo setup.
+- **Managed store seed:** `eliza/packages/app-core/scripts/ensure-skills.mjs` seeds the bundled skills into the user's managed skills store on first run.
+- **Runtime knowledge seed:** `eliza/packages/agent/src/runtime/default-knowledge.ts` seeds baseline runtime knowledge items (including Eliza Cloud guidance) into the agent.
+- **Repo-local custom skills:** put workspace-specific skills in visible subdirectories under `skills/` (e.g. `skills/plan-my-day/`). The `.defaults/` mirror is regenerated and should not be hand-edited.
+
+Open the `SKILL.md` of any of these directly from the workspace mirror when relevant:
+
+**Core eliza/cloud (read these first when touching app, runtime, or Cloud work):**
+- `eliza-app-development` — this repo as an elizaOS app; layout; local/remote/cloud routing.
+- `elizaos` — runtime concepts, plugin abstractions, AgentRuntime, actions/providers/evaluators/services.
+- `eliza-cloud` — Cloud as managed backend, app registration, hosted APIs, billing, monetization, container deploys.
+- `build-monetized-app` — building a Cloud app that earns via inference markup; pairs with `eliza-cloud`.
+
+**Agent-orchestration / authoring:**
+- `coding-agent` — spawning Codex / Claude Code / OpenCode / Pi via PTY-backed bash for sub-agent work.
+- `claude-subagent-milady-bridge` — read-only loopback endpoints (`/api/coding-agents/<sessionId>/...`) that give a spawned coding sub-agent access to parent runtime context.
+- `skill-creator` — authoring new SKILL.md packages (frontmatter, scripts, references, progressive disclosure).
+
+**Connectors / OS / SaaS integrations** (use when the task touches that surface):
+- iMessage / macOS: `imsg`, `bluebubbles`, `apple-notes`, `apple-reminders`, `things-mac`, `camsnap`
+- Productivity: `obsidian`, `notion`, `slack`, `discord`, `github`, `trello`, `canvas`, `spotify-player`
+- CLI tools: `blucli`, `wacli`, `ordercli`, `tmux`, `1password`
+- Media / generation: `nano-banana-pro`, `nano-pdf`
+- Misc: `weather`, `healthcheck`, `yara-authoring`
+
+### 2. Claude Code project skills (slash commands for THIS coding tool)
+
+These live under `.claude/skills/<name>/SKILL.md` and are surfaced as `/<name>` slash commands in Claude Code. They are the coding-tool's own skills — they have **nothing to do with the elizaOS `USE_SKILL` action** above.
+
+- `.claude/skills/phase-review/SKILL.md` — `/phase-review`. Use at every Phase A/B/C or P0/P1 boundary: runs `bun run test` + `bun run verify`, summarizes changed files, flags out-of-scope edits, and pauses for explicit confirmation before advancing. Always invoke before declaring a phase done.
+
+To add a new project skill: create `.claude/skills/<name>/SKILL.md` with `---\nname: <name>\ndescription: <one-line trigger>\n---` frontmatter. Use the bundled `skill-creator` skill (above) for authoring guidance — its conventions apply to both skill systems.
 
 For source checkouts and app repos, the default agent workspace now follows the runtime `cwd` when that directory looks like a real project workspace (`package.json`, `AGENTS.md`, `skills/`, etc.). That makes the repo's own `AGENTS.md` and `skills/` available to the runtime by default, which is what lets Milady reason about and patch the checkout it is running in. Packaged installs still fall back to the state-dir workspace, and `MILADY_WORKSPACE_DIR` / `ELIZA_WORKSPACE_DIR` always win when set explicitly.
 
@@ -140,6 +175,20 @@ All `@elizaos/*` packages use the `alpha` dist-tag. When developing locally, `bu
 **`@elizaos/plugin-agent-orchestrator`:** Milady currently resolves this plugin from the repo-local `eliza/plugins/plugin-agent-orchestrator` submodule (nested under the `eliza/` submodule) via `workspace:*`. That submodule tracks upstream `alpha`, so updating the submodule updates the orchestrator used in local development checkouts. Set `MILADY_SKIP_LOCAL_UPSTREAMS=1` to force npm-published packages instead.
 
 All official elizaOS plugin repos live under [https://github.com/elizaOS-plugins](https://github.com/elizaOS-plugins). For plugin work, prefer adding the relevant plugin repo as a git submodule under `eliza/plugins/` (tracked in `eliza/.gitmodules`) so we keep a local checkout we can patch when needed, and depend on it via `workspace:*` so Milady resolves the local package directly during development. Publish new versions to npm when ready.
+
+## File Operations
+
+### Review-First File Writes
+
+- When user says 'write to temp' or 'for review', always write to /tmp/ or a scratch path, never to the project or home directory.
+- For config files like AGENTS.md, CLAUDE.md, or dotfiles, confirm target location before writing.
+
+## Working Style
+
+### Debugging Focus
+
+- When the user reports runtime errors, prioritize reproducing and fixing the actual error trace before investigating tangential issues like version strings or naming.
+- Do not fixate on cosmetic discrepancies when functional bugs are the stated concern.
 
 # AGENTS.md
 


### PR DESCRIPTION
## Summary

- AGENTS.md and CLAUDE.md both referenced paths and env vars that no longer match the repo. Fixed to match what's actually in source.
- Documented the loopback HTTP bridge routes that spawned coding sub-agents (Codex, Claude Code) can use to read parent runtime state — they exist in `bridge-routes.ts` but weren't surfaced in AGENTS.md.
- Rewrote AGENTS.md's architecture rules 2–4 in Milady terms (services/actions, API routes, content kinds). The originals referenced fee breakdowns, JWT/BFF, and game-type branching — none of which exist in this product.

## Specific fixes

**Both files:**
- Bundled skills count: `33` → `31` (matches `ls eliza/packages/skills/skills/`).
- `scripts/ensure-skills.mjs` → `eliza/packages/app-core/scripts/ensure-skills.mjs`.
- `packages/agent/src/runtime/default-knowledge.ts` → `eliza/packages/agent/src/runtime/default-knowledge.ts`.

**AGENTS.md only:**
- Rewrote project layout tree — top-level `packages/` only holds `vault/` and `confidant/`; runtime packages and orchestrator scripts are under `eliza/packages/`; plugins are under `eliza/plugins/`.
- Removed phantom env vars not read anywhere in source: `MILADY_APP_VERIFICATION_DEFAULT_PROFILE`, `MILADY_APP_LOAD_AUDIT_LOG`, `MILADY_DESKTOP_SCREENSHOT_SERVER`, `MILADY_DESKTOP_DEV_LOG`.
- Fixed gateway/home port env var names: `MILADY_GATEWAY_PORT` → `ELIZA_GATEWAY_PORT`, `MILADY_HOME_PORT` → `ELIZA_HOME_PORT`.
- Fixed desktop dev doc path: `docs/apps/...` → `eliza/docs/apps/...`.
- Rewrote architecture rules 2–4 to match Milady's actual architecture; dropped the BFF rule.
- Tightened verbose prose (header ceremony, run-on observability paragraph).

**New content (AGENTS.md):**

Documented the three loopback bridge endpoints (read channel for spawned coding sub-agents), defined in `eliza/plugins/plugin-agent-orchestrator/src/api/bridge-routes.ts`:

```
GET /api/coding-agents/:sessionId/parent-context
GET /api/coding-agents/:sessionId/memory?q=<query>&limit=<N>
GET /api/coding-agents/:sessionId/active-workspaces
```

Loopback-only, agentId-authed via the path. Read-only — mutations stay with the orchestrator.

## Test plan

- [ ] Spot-check the rewritten project layout against actual repo: `ls packages/ apps/ scripts/ eliza/packages/ eliza/plugins/`.
- [ ] Verify the bridge endpoints are still defined in `eliza/plugins/plugin-agent-orchestrator/src/api/bridge-routes.ts`.
- [ ] Verify env var changes against `grep -r "ELIZA_GATEWAY_PORT\|ELIZA_HOME_PORT" --include="*.ts" --include="*.mjs"`.
- [ ] Confirm no Codex/Claude session relies on the removed env vars (they were never read in source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale paths and document loopback bridge routes in AGENTS.md and CLAUDE.md
> - Updates [AGENTS.md](https://github.com/milady-ai/milady/pull/2078/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9) with a restructured project layout centered on the `eliza/` submodule, corrected paths, and a new environment variables section covering ports, logging flags, model defaults, and skill toggles.
> - Documents sub-agent communication pathways: PTY stdout `USE_SKILL` bridge (write) and read-only loopback HTTP endpoints for parent context, memory search, and active workspaces.
> - Updates [CLAUDE.md](https://github.com/milady-ai/milady/pull/2078/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7) to distinguish elizaOS runtime skills from Claude Code project slash commands under `.claude/skills`, and adds scope discipline and file operation guidance.
> - Rewrites the create-mode verification loop to a mandatory 3-step run with a single structured completion line and retry policy.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized be3ddc8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->