### PR TITLE
Revert "fix(deps): remove non-existent eliza/cloud/packages/sdk workspace entry"

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eliza/packages/native-plugins/*",
     "eliza/packages/app-core/platforms/*",
     "eliza/apps/*",
+    "eliza/cloud/packages/sdk",
     "eliza/plugins/*",
     "eliza/plugins/plugin-*/typescript",
     "eliza/packages/*"


### PR DESCRIPTION
Reverts milady-ai/milady#2083

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Revert removal of `eliza/cloud/packages/sdk` workspace entry in `package.json`
> Re-adds the `eliza/cloud/packages/sdk` entry to the workspaces list in [package.json](https://github.com/milady-ai/milady/pull/2084/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519), reverting a prior fix that removed it as non-existent. Package managers will now include this path during install and workspace operations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4fdf7c5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->