### PR TITLE
Harden release validation workflow permissions

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -44,12 +44,8 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: read
-  issues: write
-  packages: write
-  id-token: write
-  pages: write
 
 env:
   BUN_VERSION: "1.3.13"
@@ -402,37 +398,42 @@ jobs:
   build-electrobun:
     name: Electrobun full matrix
     needs: [version]
+    permissions:
+      contents: read
     uses: ./.github/workflows/release-electrobun.yml
     with:
       tag: ${{ needs.version.outputs.tag }}
       draft: false
       publish_release: false
-    secrets: inherit
 
   build-docker:
     name: Agent image build
     needs: [version]
+    permissions:
+      contents: read
     uses: ./.github/workflows/build-docker.yml
     with:
       version: ${{ needs.version.outputs.tag }}
       push_image: false
       source_sha: ${{ github.sha }}
-    secrets: inherit
 
   build-cloud-image:
     name: Cloud app image build
     needs: [version]
+    permissions:
+      contents: read
     uses: ./.github/workflows/build-cloud-image.yml
     with:
       version: ${{ needs.version.outputs.tag }}
       push_image: false
       source_sha: ${{ github.sha }}
-    secrets: inherit
 
   build-npm:
     name: npm package build
     needs: [version]
     runs-on: ${{ vars.RUNNER_UBUNTU || 'ubuntu-24.04' }}
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
### Motivation
- Close a CI supply-chain exposure where the top-level release workflow granted broad write/OIDC scopes and passed repository secrets into pre-release validation jobs, allowing merged build code to access signing/API/registry credentials before the release gate.

### Description
- Reduced the workflow-level token scope in `.github/workflows/agent-release.yml` to read-only defaults (`contents: read`, `pull-requests: read`).
- Removed `secrets: inherit` from build-only reusable workflow calls (`build-electrobun`, `build-docker`, `build-cloud-image`) that run with `publish_release: false` / `push_image: false` so validation jobs no longer receive repository-wide secrets by default.
- Added explicit `permissions: contents: read` to the build-only reusable workflow-call jobs and to the `build-npm` job to ensure least-privilege during the validation phase.

### Testing
- No automated tests were run because the change is limited to CI workflow configuration; the patch was validated by reviewing the resulting workflow diff and ensuring the validation jobs no longer inherit broad permissions or `secrets: inherit`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6ca3732c08332946401dc83d70abc)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden release validation workflow permissions in `agent-release.yml`
> - Reduces top-level workflow token scope by downgrading `contents` from `write` to `read` and removing `issues`, `packages`, `id-token`, and `pages` write permissions.
> - Adds explicit `contents: read` permissions to `build-electrobun`, `build-docker`, `build-cloud-image`, and `build-npm` jobs.
> - Removes `secrets: inherit` from the `build-electrobun`, `build-docker`, and `build-cloud-image` reusable workflow calls so repository secrets are no longer propagated to those jobs.
> - Behavioral Change: reusable workflow jobs that previously inherited all repository secrets will no longer have access to them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c46d814.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->