### PR TITLE
fix(ci): enforce Bun lockfile in cloud image workflows

### DIFF
--- a/.github/workflows/build-cloud-agent.yml
+++ b/.github/workflows/build-cloud-agent.yml
@@ -197,7 +197,7 @@ jobs:
 
       # ── 4. Install dependencies ─────────────────────────────────────────────
       - name: Install dependencies
-        run: bun install --ignore-scripts --no-frozen-lockfile
+        run: bun install --ignore-scripts --frozen-lockfile
 
       - name: Hoist missing runtime deps
         run: |

--- a/.github/workflows/build-cloud-image.yml
+++ b/.github/workflows/build-cloud-image.yml
@@ -120,7 +120,7 @@ jobs:
           node scripts/disable-local-eliza-workspace.mjs
 
       - name: Install dependencies
-        run: bun install --ignore-scripts --no-frozen-lockfile
+        run: bun install --ignore-scripts --frozen-lockfile
 
       - name: Install published-workspace fallback dependencies
         run: bash scripts/install-published-workspace-fallback-deps.sh


### PR DESCRIPTION
### Motivation
- A recent change disabled Bun lockfile enforcement in cloud image builds, allowing dependency graph drift at CI time and creating a supply-chain integrity risk for published GHCR images.
- Official cloud images must be built from a reviewed, reproducible dependency graph to prevent unreviewed transitive updates from being incorporated into released artifacts.

### Description
- Restored lockfile enforcement by replacing `--no-frozen-lockfile` with `--frozen-lockfile` in the cloud build steps while preserving `--ignore-scripts`.
- Applied the change to both workflow files: `.github/workflows/build-cloud-agent.yml` and `.github/workflows/build-cloud-image.yml`.
- No other workflow steps or runtime behavior were modified by this change.

### Testing
- Verified the install step now runs `bun install --ignore-scripts --frozen-lockfile` in both workflows using `rg` and line checks, and the updated lines appear in the two workflow files. 
- Ran a line-numbered inspection with `nl -ba` to confirm the replacement at the expected locations and observed the expected `--frozen-lockfile` flag. 
- Confirmed there are no other changes to workflow behavior beyond enforcing the committed Bun lockfile.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f639370e64833289dd09a420fb7547)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce frozen lockfile in cloud image CI workflows
> Adds `--frozen-lockfile` to the `bun install` command in [build-cloud-agent.yml](https://github.com/milady-ai/milady/pull/2095/files#diff-0970cca1db47f9deab06e9fd087f8ddda0e14e5ede6f9be402a5433d885eab31) and [build-cloud-image.yml](https://github.com/milady-ai/milady/pull/2095/files#diff-36255d6c516f80a5b37564db52b52f50b80174f309fd56e2250c741e64052d61), replacing `--no-frozen-lockfile`. Builds now fail if the lockfile is outdated or inconsistent rather than silently updating it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c8afd34.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->