### PR TITLE
fix(ci): pin PR electrobun release check to hosted runner

### DIFF
--- a/.github/workflows/test-electrobun-release.yml
+++ b/.github/workflows/test-electrobun-release.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   validate-release-workflow:
     name: Release Workflow Contract
-    runs-on: ${{ vars.RUNNER_UBUNTU || 'ubuntu-24.04' }}
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-24.04' || (vars.RUNNER_UBUNTU || 'ubuntu-24.04') }}
     timeout-minutes: 30
     defaults:
       run:


### PR DESCRIPTION
### Motivation
- Prevent untrusted pull requests from executing repository code on potentially self-hosted runners by ensuring PR-triggered runs of the electrobun release-check workflow use a GitHub-hosted runner.

### Description
- Update the `runs-on` expression in `.github/workflows/test-electrobun-release.yml` so `pull_request` events are forced onto `ubuntu-24.04` while preserving the existing `RUNNER_UBUNTU` override for non-PR events (`workflow_dispatch`).

### Testing
- No automated tests were executed for this YAML-only security fix; the change was limited to `runs-on` logic in `test-electrobun-release.yml` and was validated by inspecting the updated file contents.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f533c5e3a0833284dc4485f9281096)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin electrobun release check to hosted runner on pull_request events
> Updates [test-electrobun-release.yml](.github/workflows/test-electrobun-release.yml) to always use `ubuntu-24.04` for `pull_request` events, while other events continue to use `vars.RUNNER_UBUNTU` if set, falling back to `ubuntu-24.04`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f771239.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->