### PR TITLE
fix(ci): build @elizaos/cloud-routing before dependent plugins

### DIFF
--- a/scripts/setup-upstreams.mjs
+++ b/scripts/setup-upstreams.mjs
@@ -73,6 +73,16 @@ export const ELIZA_BUILD_STEPS = [
     args: ["run", "build"],
     label: "@elizaos/cloud-sdk",
   },
+  {
+    // plugin-streaming / plugin-tailscale / plugin-wallet import types from
+    // @elizaos/cloud-routing; their tsup DTS step resolves the package via
+    // its `types` field (./dist/index.d.ts), so the routing package must be
+    // built before any dependent plugin DTS runs.
+    check: path.join("packages", "cloud-routing", "dist", "index.d.ts"),
+    cwd: path.join("packages", "cloud-routing"),
+    args: ["run", "build"],
+    label: "@elizaos/cloud-routing",
+  },
 ];
 export const ELIZA_TYPESCRIPT_BUILD_DEPENDENCIES = [
   "@types/node",


### PR DESCRIPTION
## Summary
- The previous submodule bump ([3883ac3b9](https://github.com/milady-ai/milady/commit/3883ac3b9)) shipped the plugin-n8n-workflow TypeScript fixes via the eliza submodule, but the cloud-routing build step it added lives in `eliza/packages/app-core/scripts/setup-upstreams.mjs` — and Milady actually runs the local `./scripts/setup-upstreams.mjs` (resolved by `run-repo-setup` under the `"scripts/"` prefix). Plugin-streaming's `tsup --dts` pass continued failing with `TS2307: Cannot find module '@elizaos/cloud-routing'` on `develop` after that commit.
- Add a cloud-routing entry to Milady's own `ELIZA_BUILD_STEPS` so `packages/cloud-routing/dist/index.d.ts` exists before plugin-streaming / plugin-tailscale / plugin-wallet build their declarations.
- Bump eliza submodule `a1c2f138 → 67c06677` to pick up the follow-up CI fixes (plugin-sql build order, Windows bun materialization skip, format pass).

## Test plan
- [ ] Build: setup-workspace dependencies succeeds (no TS2307 from plugin-streaming)
- [ ] Type Check: passes
- [ ] Pre-Review: passes
- [ ] Lint & Format: passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Build `@elizaos/cloud-routing` before dependent plugins in CI
> Adds a build step for `@elizaos/cloud-routing` to the `ELIZA_BUILD_STEPS` constant in [setup-upstreams.mjs](https://github.com/milady-ai/milady/pull/2099/files#diff-61d81dba031f233c46c15e4239a053eb2d3c374a926939e24aba9abbf8c7df91). The step checks for `packages/cloud-routing/dist/index.d.ts` and runs the build if missing, ensuring the package is built before any plugins that depend on it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc984eb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->