### PR TITLE
feat(skills): standardize cloud app build workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,7 @@ Open the `SKILL.md` of any of these from the workspace mirror when relevant:
 
 **Agent-orchestration / authoring:**
 - `coding-agent` — spawning Codex / Claude Code / OpenCode / Pi via PTY-backed bash for sub-agent work.
-- `claude-subagent-milady-bridge` — loopback endpoints exposing parent runtime context to a spawned coding sub-agent.
+- `task-agent-eliza-bridge` — loopback endpoints exposing parent runtime context to a spawned coding task agent.
 - `skill-creator` — authoring new SKILL.md packages (frontmatter, scripts, references, progressive disclosure).
 
 **Connectors / OS / SaaS integrations** (use when the task touches that surface):
@@ -203,7 +203,7 @@ Coding sub-agents spawned by the orchestrator (Claude Code, Codex, etc.) live in
 - `GET /api/coding-agents/:sessionId/memory?q=<query>&limit=<N>` — query the parent agent's memory.
 - `GET /api/coding-agents/:sessionId/active-workspaces` — list the parent's currently-active workspaces.
 
-All bridge responses are read-only. Mutations stay with the orchestrator — sub-agents cannot write parent state through the bridge. The `claude-subagent-milady-bridge` skill (in `skills/.defaults/`) documents the calling pattern in detail.
+All bridge responses are read-only. Mutations stay with the orchestrator — sub-agents cannot write parent state through the bridge. The `task-agent-eliza-bridge` skill (in `skills/.defaults/`) documents the calling pattern in detail.
 
 ### Mandatory verification loop for `create` modes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,7 +148,7 @@ Open the `SKILL.md` of any of these directly from the workspace mirror when rele
 
 **Agent-orchestration / authoring:**
 - `coding-agent` — spawning Codex / Claude Code / OpenCode / Pi via PTY-backed bash for sub-agent work.
-- `claude-subagent-milady-bridge` — read-only loopback endpoints (`/api/coding-agents/<sessionId>/...`) that give a spawned coding sub-agent access to parent runtime context.
+- `task-agent-eliza-bridge` — read-only loopback endpoints (`/api/coding-agents/<sessionId>/...`) that give a spawned coding task agent access to parent runtime context.
 - `skill-creator` — authoring new SKILL.md packages (frontmatter, scripts, references, progressive disclosure).
 
 **Connectors / OS / SaaS integrations** (use when the task touches that surface):

--- a/skills/.defaults/build-monetized-app/SKILL.md
+++ b/skills/.defaults/build-monetized-app/SKILL.md
@@ -35,7 +35,9 @@ const { app, apiKey } = await cloud.routes.postApiV1Apps({
 // 3. deploy container
 // 4. set markup %
 // 5. patch app_url + allowed_origins to the container URL
-// 6. report URLs to the human
+// 6. report URLs to the human (the auto-assigned *.apps.elizacloud.ai
+//    subdomain is the default; if the user wants a custom branded domain
+//    instead, hand off to the `eliza-cloud-buy-domain` skill)
 ```
 
 Full code in `references/sdk-flow.md`. The skill assumes you have:
@@ -49,9 +51,27 @@ Full code in `references/sdk-flow.md`. The skill assumes you have:
 Every cloud-SDK call your deployed app makes on behalf of a user MUST carry:
 
 - `Authorization: Bearer <user_jwt>` — the JWT from the app-auth OAuth redirect
-- `x-affiliate-code: <your_affiliate_code>` — the owner's affiliate code; this is what credits earnings
+- Optional `x-affiliate-code: <your_affiliate_code>` when the owner has configured an affiliate code
 
 This pattern is shared with the [`eliza-cloud`](../eliza-cloud/SKILL.md) skill; see that skill for the auth flow itself. This skill assumes you've already read it.
+
+## Legacy static-hosted variant
+
+Some old/local apps are static frontends served by an existing host instead of
+Cloud containers. They are still real Eliza Cloud apps when they use AI
+inference, but this is not the production default for Nubilio builds. New
+production apps should deploy as their own Eliza Cloud container.
+
+For a static-hosted AI app:
+
+1. Build the static UI under the host's app directory.
+2. Register the app with `/api/v1/apps` using the public URL and `skipGitHubRepo:true`.
+3. Enable monetization with `PUT /api/v1/apps/<appId>/monetization` and the current markup/share schema:
+   `{"monetizationEnabled":true,"inferenceMarkupPercentage":100,"purchaseSharePercentage":10}`.
+4. Write `data/apps/<slug>/cloud.json` with only non-secret config: `appId`, `cloudUrl`, `apiBase`, optional `affiliateCode`, and a model such as `openai/gpt-4o-mini`. `cloudUrl` is the browser-facing Cloud frontend/OAuth base that serves `/app-auth/authorize`; `apiBase` is the Cloud API base. Use `ELIZA_CLOUD_PUBLIC_URL` if set, otherwise `ELIZA_CLOUD_URL`, otherwise use `ELIZA_CLOUD_BASE_URL` only when that origin also serves the frontend. In local testing, if `apiBase` is `http://localhost:8787/api/v1`, `cloudUrl` must be `http://127.0.0.1:3000`. Do not point OAuth at an API-only local worker such as `:8787`, and do not silently mix a localhost API base with production OAuth.
+5. The browser must use app auth: fetch config, redirect to `/app-auth/authorize`, verify `state`, store the returned user token, and send it as `x-user-token`.
+6. The browser must call a same-origin proxy that forwards to Eliza Cloud `/api/v1/apps/<appId>/chat` with `Authorization: Bearer <user_jwt>`. Do not put owner API keys in frontend code and do not fake model responses in local JavaScript.
+7. Verify the app route, config route, that `${cloudUrl}/app-auth/authorize?...` returns the Cloud frontend HTML/redirect rather than JSON `resource_not_found`, and that chat without a user token returns `401 not_signed_in`. If the upstream provider fails, report that as a Cloud provider issue instead of replacing it with a mock assistant.
 
 ## Read these references in order
 
@@ -65,3 +85,24 @@ This pattern is shared with the [`eliza-cloud`](../eliza-cloud/SKILL.md) skill; 
 - **It is not a retry loop.** Each SDK call is idempotent; if step 5 fails, restart from there.
 - **It does not configure affiliate codes.** Affiliate codes belong to the owner, not the app, and live across all of an owner's apps. The skill inherits whatever is configured.
 - **It does not assume always-on billing.** The org may have set `pay_as_you_go_from_earnings = false`, in which case hosting comes purely from credits and earnings stay on the redemption ledger. The skill works either way; the org's owner controls the toggle.
+
+## After the app is live — ALWAYS offer a custom domain
+
+The deployed app gets an auto-assigned `*.apps.elizacloud.ai` subdomain that works immediately. **At the end of every successful build, proactively offer the user a custom branded domain** (this is part of the standard build flow, not optional polish). Pattern:
+
+1. Use the `eliza-cloud-buy-domain` skill to call `POST /api/v1/domains/search` with the app name as the query (limit 3-5 candidates).
+2. Filter to `.com` / `.io` / `.dev` / `.app` if available, sort by price ascending.
+3. Present the top 1-2 in your reply, e.g.:
+
+   > Your app is live at `<subdomain>` — works right now.
+   > Want me to also grab one of these custom domains for it (one-time charge from your cloud credits)?
+   >  • `myapp.com` — $14.95/yr
+   >  • `myapp.io` — $35.20/yr
+   > Reply yes/no/pick-one.
+
+4. If user accepts, call `POST /api/v1/apps/{id}/domains/buy` with the chosen domain. The buy is atomic: debit credits → register → DNS → attach.
+5. If user declines, do nothing — the auto-subdomain stays as the canonical URL.
+
+**Never auto-buy without explicit user yes** — every paid step requires confirmation. If the buy succeeds, surface the new URL + note that SSL takes ~1-2 minutes to provision.
+
+After the buy, future "edit dns / detach / list domains" requests are handled by the `eliza-cloud-manage-domain` skill — point the user there if they ask follow-ups.

--- a/skills/.defaults/build-monetized-app/references/sdk-flow.md
+++ b/skills/.defaults/build-monetized-app/references/sdk-flow.md
@@ -45,7 +45,7 @@ The agent's job, not the SDK's. Use the org's container registry creds (default 
 
 - Listen on `$PORT` (cloud sets this at runtime)
 - Expose a `GET /health` endpoint that returns 200 quickly (the cloud's deploy step polls it before flipping the load balancer)
-- For chat-style apps, expose a server route that forwards user-bearing requests upstream to cloud's `/api/v1/messages` (or `/v1/chat/completions`) with the user's bearer token AND your affiliate code
+- For chat-style apps, expose a server route that forwards user-bearing requests upstream to cloud's app-specific chat endpoint, `/api/v1/apps/<appId>/chat`, with the user's bearer token AND your affiliate code. That endpoint is the monetized path: it applies app credits, markup, analytics, and creator earnings.
 
 The canonical reference for this shape is [`apps/edad-chat/server.ts` and `apps/edad-chat/api/proxy.ts`](https://github.com/elizaOS/cloud-mini-apps/tree/main/apps/edad-chat) in `elizaOS/cloud-mini-apps`. Copy that pattern when your app is a chat shell.
 
@@ -56,6 +56,8 @@ import { ElizaCloudClient } from "@elizaos/cloud-sdk";
 
 const cloud = new ElizaCloudClient({ apiKey: process.env.ELIZAOS_CLOUD_API_KEY });
 const AFFILIATE = process.env.ELIZA_AFFILIATE_CODE!; // your owner's affiliate code
+const API_BASE = (process.env.ELIZA_CLOUD_API_BASE_URL ??
+  `${process.env.ELIZA_CLOUD_BASE_URL}/api/v1`).replace(/\/+$/, "");
 
 export async function handleChat(req: Request): Promise<Response> {
   const userToken = req.headers.get("authorization") ?? req.headers.get("x-user-token");
@@ -63,15 +65,14 @@ export async function handleChat(req: Request): Promise<Response> {
 
   const body = await req.json();
 
-  // Forward to cloud /messages with the user's token AND our affiliate code.
-  // The user's balance is debited; the affiliate header is what credits us.
-  const upstream = await fetch(`${process.env.ELIZA_CLOUD_URL}/api/v1/messages`, {
+  // Forward to the app-specific chat route with the user's token and optional affiliate code.
+  // The user's app balance is debited; the app's configured markup credits us.
+  const upstream = await fetch(`${API_BASE}/apps/${process.env.ELIZA_APP_ID}/chat`, {
     method: "POST",
     headers: {
       "content-type": "application/json",
-      authorization: userToken,
-      "x-affiliate-code": AFFILIATE,
-      "x-app-id": process.env.ELIZA_APP_ID!,
+      authorization: userToken.startsWith("Bearer ") ? userToken : `Bearer ${userToken}`,
+      ...(AFFILIATE ? { "x-affiliate-code": AFFILIATE } : {}),
     },
     body: JSON.stringify(body),
   });
@@ -87,11 +88,14 @@ That's the full server-side surface. Add a `/health` route that returns 200 and 
 
 For frontend, ship a static page that:
 
-1. Reads the user's intended-flow choice (sign in / paste API key / etc.)
-2. Posts user prompts to your chat route with the user-token in the `authorization` header
-3. Renders streaming responses
+1. Reads non-secret config from your own backend or static config: `appId`, browser-facing `cloudUrl`, API/proxy path, and default model.
+2. Sends users to `${cloudUrl}/app-auth/authorize?app_id=<appId>&redirect_uri=<app-url>&state=<random>`, verifies the returned `state`, and stores only the returned user token.
+3. Posts user prompts to your same-origin chat route with `x-user-token: <token>` from browser code. The server-side proxy converts that to the upstream `Authorization: Bearer <token>` header.
+4. Renders streaming responses or a clear upstream error. Never fake fallback model answers locally.
 
 The frontend can be served by the same container or by any static host pointing at the same domain — the cloud doesn't care.
+
+For local development, keep frontend/OAuth and API bases distinct when they are distinct services. `cloudUrl` must be the browser-facing Cloud frontend that serves `/app-auth/authorize`; `apiBase` must be the API worker base ending in `/api/v1`. In the local Cloud stack, `apiBase` is `http://localhost:8787/api/v1` and `cloudUrl` is `http://127.0.0.1:3000`. Do not point OAuth at an API-only worker such as local `:8787`, and do not silently mix local API with production OAuth.
 
 ## 3. Deploy the container
 

--- a/skills/.defaults/eliza-app-development/SKILL.md
+++ b/skills/.defaults/eliza-app-development/SKILL.md
@@ -56,6 +56,14 @@ bun run test:e2e
 
 If the task involves building an app and Eliza Cloud is enabled, linked, or explicitly requested, treat Cloud as the default managed backend before inventing custom auth, billing, analytics, or hosting. Use the `eliza-cloud` skill for app, monetization, and container details.
 
+When the app clearly uses AI inference, treat it as a Cloud-backed monetized app
+even if the user does not say "monetized", "OAuth", or "domain". Chatbots,
+companions, assistants, generators, summarizers, and model-backed tools must use
+Eliza Cloud app auth and `/api/v1/apps/{id}/chat` through the local app proxy.
+Do not satisfy these requests with local canned responses. If the request is
+ambiguous about whether AI/auth is needed, ask one concise clarification before
+building.
+
 ## Related Skills
 
 - `elizaos` — core runtime abstractions and upstream plugin patterns

--- a/skills/.defaults/eliza-cloud-buy-domain/SKILL.md
+++ b/skills/.defaults/eliza-cloud-buy-domain/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: eliza-cloud-buy-domain
+description: "Use whenever a user wants to register or buy a custom domain for an Eliza Cloud app — including in the same request as building the app (\"build me X and put it on Y.com\"). Uses cloudflare as registrar, no human in the loop, paid from the user's existing cloud credit balance. Pairs with `build-monetized-app` (build first, then buy domain) and `eliza-cloud-manage-domain` (post-purchase: list, edit dns records, detach). Skip when the user is fine with the auto-assigned `*.apps.elizacloud.ai` subdomain."
+---
+
+# Buy a domain for your app on Eliza Cloud
+
+Use this skill when an Eliza Cloud app needs a real custom domain (e.g. `myapp.com`) instead of the auto-assigned `*.apps.elizacloud.ai` subdomain.
+
+The cloud handles everything: domain availability check, registration through cloudflare, DNS pointing at your app's container, and attachment to your app record. You pay from your existing cloud credit balance — no separate cloudflare account, no manual DNS config, no credit card paste.
+
+## Prerequisites
+
+- An app registered on Eliza Cloud (use `build-monetized-app` first if you haven't shipped one yet)
+- Enough cloud credit balance to cover the domain (cloudflare wholesale + a fixed eliza cloud margin; a `.com` is roughly $14–15 USD/year)
+- `ELIZAOS_CLOUD_API_KEY` in env (provided by the runtime)
+
+## Default flow
+
+```ts
+import { ElizaCloudClient } from "@elizaos/cloud-sdk";
+
+const cloud = new ElizaCloudClient({
+  apiKey: process.env.ELIZAOS_CLOUD_API_KEY,
+  // optional override for local dev / staging / preview deploys.
+  // unset in prod → SDK defaults to https://www.elizacloud.ai
+  baseUrl: process.env.ELIZA_CLOUD_BASE_URL,
+});
+
+// 1. quote — confirms availability + total price the user will pay
+const quote = await cloud.routes.postApiV1AppsByIdDomainsCheck({
+  appId,
+  json: { domain: "myapp.com" },
+});
+if (!quote.available) {
+  // try a different domain or pick an alternate TLD
+  return;
+}
+const totalUsd = quote.price.totalUsdCents / 100;
+
+// 2. confirm with the user (one-line ack is enough; the SDK will throw
+//    if the org balance is insufficient)
+//
+//    "buying myapp.com for $14.95 from your cloud balance — ok?"
+
+// 3. buy — atomic on the cloud side: debit credits → register via cloudflare
+//    → write managed_domains row + attach to app → CNAME the new zone at
+//    the app's container url. Refunds credits if registration fails.
+const result = await cloud.routes.postApiV1AppsByIdDomainsBuy({
+  appId,
+  json: { domain: "myapp.com" },
+});
+
+// 4. (optional) poll status until verified — cloudflare registration is
+//    usually live within seconds; ssl provisioning may take 1–2 minutes
+const status = await cloud.routes.postApiV1AppsByIdDomainsStatus({
+  appId,
+  json: { domain: "myapp.com" },
+});
+```
+
+## Failure modes
+
+The buy route handles refunds and surfaces specific HTTP statuses; treat them like:
+
+| Status | Meaning | Action |
+|---|---|---|
+| 400 | invalid domain format | re-prompt user for valid domain |
+| 402 | insufficient credit balance | tell user to top up at /dashboard/billing |
+| 404 | app not found / wrong org | re-check appId |
+| 409 | domain already registered | suggest alternates or add a suffix |
+| 502 | cloudflare returned an error (refund issued) | retry with different domain |
+| 500 | partial failure (rare; user owns the domain but DNS not set) | escalate — manual DNS may be needed |
+
+The skill assumes idempotency at the step boundary: if step 3 fails after the credit debit, eliza cloud automatically refunds. If the user retries, they get a fresh credit-debit attempt.
+
+## Read these references in order
+
+1. `references/api-shape.md` — the actual request/response shape for each cloud endpoint
+2. `references/dns-and-ssl.md` — what happens after the buy (CNAME setup, SSL provisioning timing)
+3. `references/failure-modes.md` — recovery table for the failures you'll actually hit
+
+After the buy succeeds, future "list / edit / delete dns / detach" requests on this domain are handled by the `eliza-cloud-manage-domain` skill — point the user there if they ask follow-up questions.
+
+## What this skill is NOT
+
+- **Not for "attaching a domain you already own elsewhere."** That path goes through `POST /api/v1/apps/[id]/domains` directly (which generates a `_eliza-cloud-verify.<domain>` TXT record the user adds at their existing dns provider, then re-checks via `POST /api/v1/apps/[id]/domains/verify`). Use this `buy-domain` skill only when the user does NOT already own the domain.
+- **Not for cancelling a registration.** Cloudflare registrations are non-refundable after they're complete; you can detach from the app via `DELETE /api/v1/apps/[id]/domains` but the registration itself stays active until expiration.
+- **Not for transferring an existing domain into eliza cloud.** Out of scope for v1.

--- a/skills/.defaults/eliza-cloud-buy-domain/references/api-shape.md
+++ b/skills/.defaults/eliza-cloud-buy-domain/references/api-shape.md
@@ -1,0 +1,128 @@
+# API shape
+
+The endpoints this skill calls, in canonical order.
+
+## `POST /api/v1/domains/search`
+
+Availability + price discovery for proactive offers. Does NOT debit credits and
+does not require an app id. Use this after an app build to suggest 1-2 domains
+before the user has chosen one.
+
+**Request:**
+```json
+{ "query": "myapp", "limit": 5 }
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "query": "myapp",
+  "candidates": [
+    {
+      "domain": "myapp.com",
+      "available": true,
+      "currency": "USD",
+      "years": 1,
+      "price": {
+        "wholesaleUsdCents": 1099,
+        "marginUsdCents": 396,
+        "totalUsdCents": 1495,
+        "marginBps": 3600
+      }
+    }
+  ]
+}
+```
+
+Filter to available `.com`, `.io`, `.dev`, or `.app` candidates where possible,
+sort by `price.totalUsdCents` ascending, and show prices as annual USD. Older
+Cloud responses may use `results[].priceUsdCents`; accept that as a fallback,
+but prefer the current `candidates[].price.totalUsdCents` shape. Search is only
+for quoting options; use `/apps/{appId}/domains/check` before a paid buy.
+
+## `POST /api/v1/apps/{appId}/domains/check`
+
+Dry-run availability + price quote. Does NOT debit credits.
+
+**Request:**
+```json
+{ "domain": "myapp.com" }
+```
+
+**Response (available):**
+```json
+{
+  "success": true,
+  "domain": "myapp.com",
+  "available": true,
+  "currency": "USD",
+  "years": 1,
+  "price": {
+    "wholesaleUsdCents": 1099,
+    "marginUsdCents": 396,
+    "totalUsdCents": 1495,
+    "marginBps": 3600
+  }
+}
+```
+
+**Response (unavailable):**
+```json
+{ "success": true, "domain": "myapp.com", "available": false }
+```
+
+`totalUsdCents` is what the user's cloud balance will be debited if they proceed to `/buy`. `marginBps` is the eliza cloud margin in basis points (3600 = 36% by default).
+
+## `POST /api/v1/apps/{appId}/domains/buy`
+
+Atomic buy: check → debit → register → DNS → attach. Refunds credits on registration failure.
+
+**Request:**
+```json
+{ "domain": "myapp.com" }
+```
+
+**Response (success):**
+```json
+{
+  "success": true,
+  "domain": "myapp.com",
+  "appDomainId": "uuid",
+  "zoneId": "<cloudflare-zone-id>",
+  "expiresAt": "2027-05-03T...",
+  "debited": { "totalUsdCents": 1495, "currency": "USD" }
+}
+```
+
+**Errors:**
+- 400 `Invalid domain format`
+- 402 `Insufficient credit balance for this domain`
+- 404 `App not found`
+- 409 `Domain is not available for registration`
+- 502 (cloudflare-side error; credits refunded automatically)
+
+## `POST /api/v1/apps/{appId}/domains/status`
+
+Read current verification + SSL status.
+
+**Request:**
+```json
+{ "domain": "myapp.com" }
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "domain": "myapp.com",
+  "registrar": "cloudflare",
+  "status": "active",
+  "verified": true,
+  "sslStatus": "active",
+  "expiresAt": "2027-05-03T...",
+  "live": { "status": "active", "completedAt": "...", "failureReason": null }
+}
+```
+
+`sslStatus` progresses `pending → provisioning → active` over the first ~1–2 minutes after registration.

--- a/skills/.defaults/eliza-cloud-buy-domain/references/dns-and-ssl.md
+++ b/skills/.defaults/eliza-cloud-buy-domain/references/dns-and-ssl.md
@@ -1,0 +1,22 @@
+# DNS and SSL behavior
+
+When `/buy` succeeds, the cloud:
+
+1. Registers `myapp.com` via cloudflare's Registrar API. Cloudflare creates a managed zone for the domain.
+2. Inserts the domain into eliza cloud's `managed_domains` table with `registrar='cloudflare'`, `nameserver_mode='cloudflare'`, `verified=true`, `paymentMethod='credits'`. The `cloudflare_zone_id` is stored for future DNS edits.
+3. Assigns the domain to the app row (polymorphic — sets `appId`, leaves container/agent/mcp pointers null).
+4. Adds a CNAME record on the new cloudflare zone pointing the apex at the app's container public URL (the `app_url` field on the app record). DNS failure here is non-fatal: the domain is owned, the app_url just won't resolve through the new domain until DNS is fixed manually.
+
+## SSL provisioning timing
+
+Because the domain is on cloudflare's nameservers from the moment of registration, cloudflare's automatic SSL kicks in immediately. The progression is:
+
+- `pending` (right after registration; domain registered, cert not requested yet)
+- `provisioning` (cert request in flight)
+- `active` (cert issued, domain live over HTTPS)
+
+Typical end-to-end time from `/buy` returning to `sslStatus: active`: **30 seconds to 2 minutes**. Polling `/status` every 10s is reasonable.
+
+## What if the user wants a non-cloudflare nameserver?
+
+Not supported in v1 — every domain bought through this skill stays on cloudflare's nameservers. If a future user wants to use external DNS, that requires the (also-unimplemented) external-domain attach flow, not this skill.

--- a/skills/.defaults/eliza-cloud-buy-domain/references/failure-modes.md
+++ b/skills/.defaults/eliza-cloud-buy-domain/references/failure-modes.md
@@ -1,0 +1,27 @@
+# Failure modes
+
+Recovery table for the failures you'll actually hit.
+
+| Failure | Symptom | Recovery |
+|---|---|---|
+| Invalid domain | 400 from `/check` or `/buy` | Re-prompt user. Validate format client-side: `/^([a-z0-9]([a-z0-9-]*[a-z0-9])?\.)+[a-z]{2,}$/` |
+| Insufficient credits | 402 from `/buy` | Quote with `/check` first so you know the cost. If 402, link user to `/dashboard/billing` to top up. |
+| Domain unavailable | `available: false` from `/check`, OR 409 from `/buy` if availability changed between check and buy | Suggest 2-3 alternates (different TLD or short suffix). Don't try the same domain again. |
+| Cloudflare registration error | 502 from `/buy` | Credits already refunded automatically. Surface the error message; suggest retry with a different domain. |
+| Partial failure: registered but DNS not set | 500 from `/buy` (rare, registry-side issue) | User owns the domain. Do NOT auto-retry the buy (that would double-charge). Tell user the domain is owned but DNS needs attention; they can set it manually via the cloudflare dashboard or `POST /domains/sync`. |
+| App not found | 404 | Confirm the appId is right and belongs to the calling user's org. |
+
+## Idempotency
+
+Each step boundary is idempotent on its own:
+
+- `/check` is read-only; safe to call repeatedly.
+- `/buy` is atomic: either credits debited + domain registered + DB row created, or credits refunded.
+- `/status` is read-only.
+- `/sync` is read-only (in v1; future versions may write back).
+
+## What never to do
+
+- **Never call `/buy` in a retry loop without exponential backoff** — a 502 may be a transient cloudflare issue, but retrying immediately wastes credits if the buy actually succeeded and the response was lost.
+- **Never assume a 500 means "not registered"** — a partial-failure 500 means the domain IS registered but post-registration DB/DNS work failed. Re-running `/buy` would attempt to register a domain that's already yours.
+- **Never debit credits manually** — the cloud handles all credit movement. Your job is to call the cloud endpoint and read the result.

--- a/skills/.defaults/eliza-cloud-manage-domain/SKILL.md
+++ b/skills/.defaults/eliza-cloud-manage-domain/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: eliza-cloud-manage-domain
+description: "Use after a domain has been purchased through Eliza Cloud (via the `eliza-cloud-buy-domain` skill) when the user wants to look at, edit, or remove a domain or its DNS records. Covers org-wide domain listing, per-app DNS record CRUD on cloudflare-managed zones, status re-sync, external-attachment verification, and detaching a domain from an app. Use this skill any time the user references domains they already own (`my domains`, `edit dns for myapp.com`, `delete that A record`, `is myapp.com still pointing at my app`)."
+---
+
+# Manage your Eliza Cloud domains
+
+Use this skill once the user already has at least one domain attached to one of their apps (registered via `eliza-cloud-buy-domain` or attached as external via the `/domains` POST). It covers everything after the buy: looking at what they own, editing DNS records on cloudflare-managed zones, refreshing live status, and detaching from an app.
+
+It does NOT register new domains — that's `eliza-cloud-buy-domain`. It does not modify DNS on external (user-owned-elsewhere) domains — those records live at the user's existing DNS provider.
+
+## What this skill can do
+
+| User intent | Endpoint | Notes |
+|---|---|---|
+| "list my domains" / "what domains do I own" | `GET /api/v1/domains` | org-wide across all their apps |
+| "what domains does {app} have" | `GET /api/v1/apps/{appId}/domains` | per-app |
+| "show dns records for myapp.com" | `GET /api/v1/apps/{appId}/domains/{domain}/dns` | cloudflare zones only |
+| "add a CNAME pointing www.myapp.com to ..." | `POST /api/v1/apps/{appId}/domains/{domain}/dns` | cloudflare zones only |
+| "change the A record for myapp.com to ..." | `PATCH /api/v1/apps/{appId}/domains/{domain}/dns/{recordId}` | get the recordId from the list call first |
+| "delete that record" | `DELETE /api/v1/apps/{appId}/domains/{domain}/dns/{recordId}` | irreversible; warn the user |
+| "is myapp.com still pointing at my app" | `POST /api/v1/apps/{appId}/domains/sync` | refresh from cloudflare into the managed_domains row |
+| "I added the verification record, check it" | `POST /api/v1/apps/{appId}/domains/verify` | external domains: re-check the TXT challenge |
+| "remove this domain from my app" | `DELETE /api/v1/apps/{appId}/domains` | detach only; the cloudflare registration remains until expiry |
+
+## Default flow
+
+```ts
+import { ElizaCloudClient } from "@elizaos/cloud-sdk";
+
+const cloud = new ElizaCloudClient({
+  apiKey: process.env.ELIZAOS_CLOUD_API_KEY,
+  // optional override for local dev / staging / preview deploys
+  baseUrl: process.env.ELIZA_CLOUD_BASE_URL,
+});
+
+// 1. find the domain (and the app it's attached to)
+const allDomains = await cloud.routes.getApiV1Domains();
+const target = allDomains.domains.find((d) => d.domain === "myapp.com");
+if (!target) {
+  // tell the user they don't own that domain
+  return;
+}
+const appId = target.appId; // the app the domain is attached to
+
+// 2. list current dns records (cloudflare-managed zones only)
+const records = await cloud.routes.getApiV1AppsByIdDomainsByDomainDns({
+  appId,
+  domain: "myapp.com",
+});
+
+// 3. add / edit / delete a record
+const created = await cloud.routes.postApiV1AppsByIdDomainsByDomainDns({
+  appId,
+  domain: "myapp.com",
+  json: { type: "A", name: "www", content: "203.0.113.5", ttl: 1, proxied: true },
+});
+
+const updated = await cloud.routes.patchApiV1AppsByIdDomainsByDomainDnsByRecordId({
+  appId,
+  domain: "myapp.com",
+  recordId: created.record.id,
+  json: { content: "203.0.113.99" },
+});
+
+await cloud.routes.deleteApiV1AppsByIdDomainsByDomainDnsByRecordId({
+  appId,
+  domain: "myapp.com",
+  recordId: created.record.id,
+});
+```
+
+## Where the boundaries are
+
+**Cloudflare-registered domains (registrar=cloudflare):** full CRUD on every record type (A, AAAA, CNAME, TXT, MX, SRV, CAA). Cloudflare is the nameserver, so changes propagate within ~minutes.
+
+**External domains (registrar=external):** read-only here. The user must edit those at the DNS provider where they originally bought the domain (Namecheap, Google Domains, etc.). The DNS endpoints return 409 with that explanation.
+
+## Read these references in order
+
+1. `references/api-shape.md` — exact request/response shapes
+2. `references/dns-records.md` — when to use which record type, ttl + proxied semantics
+3. `references/failure-modes.md` — the failures you'll actually hit
+
+## What this skill is NOT
+
+- **Not for buying a new domain.** Use `eliza-cloud-buy-domain`.
+- **Not for transferring a domain into Eliza Cloud.** Out of scope for v1.
+- **Not for renewing.** Cloudflare-registered domains auto-renew unless the user turned it off in the dashboard.
+- **Not a billing surface.** DNS edits are free; this skill does not debit credits.

--- a/skills/.defaults/eliza-cloud-manage-domain/references/api-shape.md
+++ b/skills/.defaults/eliza-cloud-manage-domain/references/api-shape.md
@@ -1,0 +1,110 @@
+# api shapes — manage-domain skill
+
+All endpoints assume `Authorization: Bearer <ELIZAOS_CLOUD_API_KEY>` and return `{ success: true, ... }` on the happy path; failures return `{ success: false, error: <message> }` with a 4xx/5xx status.
+
+## GET /api/v1/domains
+
+Org-wide list of every managed domain.
+
+Response:
+```json
+{
+  "success": true,
+  "domains": [
+    {
+      "id": "...",
+      "domain": "myapp.com",
+      "registrar": "cloudflare",            // or "external"
+      "status": "active",                    // pending | active | expired | suspended | transferring
+      "verified": true,
+      "sslStatus": "active",                 // pending | provisioning | active | error
+      "expiresAt": "2027-01-01T00:00:00Z",
+      "autoRenew": true,
+      "resourceType": "app",                 // app | container | agent | mcp | null (detached)
+      "appId": "...",
+      "containerId": null,
+      "agentId": null,
+      "mcpId": null,
+      "cloudflareZoneId": "..."
+    }
+  ]
+}
+```
+
+## GET /api/v1/apps/:appId/domains
+
+Per-app list. Same shape as the org-wide list but only domains attached to that app.
+
+## GET /api/v1/apps/:appId/domains/:domain/dns
+
+List dns records on a cloudflare-managed zone. Returns 409 for external-registrar domains.
+
+Response:
+```json
+{
+  "success": true,
+  "domain": "myapp.com",
+  "records": [
+    {
+      "id": "abc...",
+      "type": "A",
+      "name": "myapp.com",
+      "content": "203.0.113.5",
+      "ttl": 1,
+      "proxied": true,
+      "createdOn": "2026-...",
+      "modifiedOn": "2026-..."
+    }
+  ]
+}
+```
+
+## POST /api/v1/apps/:appId/domains/:domain/dns
+
+Add a record. Body:
+```json
+{
+  "type": "A",                  // A | AAAA | CNAME | TXT | MX | SRV | CAA
+  "name": "www",                // subdomain or "@" for apex
+  "content": "203.0.113.5",
+  "ttl": 1,                     // 1 = automatic
+  "proxied": true,              // false = grey cloud (DNS only)
+  "priority": 10                // MX records only
+}
+```
+Response: `{ success: true, record: { ...new record... } }` (status 201)
+
+## GET /api/v1/apps/:appId/domains/:domain/dns/:recordId
+
+Read one record. Same shape as the list entries above.
+
+## PATCH /api/v1/apps/:appId/domains/:domain/dns/:recordId
+
+Edit one record. Body is a partial — include only the fields you want to change.
+
+## DELETE /api/v1/apps/:appId/domains/:domain/dns/:recordId
+
+Remove a record. Response:
+```json
+{ "success": true, "recordId": "abc..." }
+```
+
+## POST /api/v1/apps/:appId/domains/sync
+
+Refresh registrar status into the managed_domains row from cloudflare.
+
+Body: `{ "domain": "myapp.com" }`
+
+Response: `{ success: true, domain, status, sslStatus, ... }`
+
+## POST /api/v1/apps/:appId/domains/verify
+
+For external domains only. Re-check the user's `_eliza-cloud-verify.<domain>` TXT record.
+
+Body: `{ "domain": "myapp.com" }`
+
+Response: `{ success: true, verified: boolean, ... }`
+
+## DELETE /api/v1/apps/:appId/domains
+
+Detach a domain from the app. Body: `{ "domain": "myapp.com" }`. The registration itself stays active until expiration.

--- a/skills/.defaults/eliza-cloud-manage-domain/references/dns-records.md
+++ b/skills/.defaults/eliza-cloud-manage-domain/references/dns-records.md
@@ -1,0 +1,34 @@
+# dns records — when to use which
+
+Default rule: if the user just wants their app to work at `myapp.com` and they bought the domain through us, the buy flow already created the right A/CNAME records pointing at the app's container. Don't add records unless asked.
+
+| Type | Use for | Common content |
+|---|---|---|
+| A | Point a name at an IPv4 | `203.0.113.5` |
+| AAAA | Point a name at an IPv6 | `2001:db8::1` |
+| CNAME | Alias one name to another | `app.elizacloud.ai` |
+| TXT | Verification, SPF, DKIM, arbitrary text | `v=spf1 include:_spf.google.com ~all` |
+| MX | Mail routing | `aspmx.l.google.com` (set priority) |
+| SRV | Service location (sip, xmpp, etc.) | `_proto._service.target` |
+| CAA | Restrict who can issue SSL certs | `0 issue "letsencrypt.org"` |
+
+## Naming conventions
+
+- Apex (`myapp.com` itself): `name: "@"` or `name: "myapp.com"`
+- Subdomain (`www.myapp.com`): `name: "www"` (cloudflare auto-appends the zone)
+- Wildcard (`*.myapp.com`): `name: "*"`
+
+## TTL
+
+Cloudflare's TTL field is in seconds. **`1` is special and means "automatic"** — cloudflare picks the TTL based on whether the record is proxied. Default to `1` unless the user has a reason for a fixed TTL.
+
+## proxied (orange cloud vs grey cloud)
+
+- `proxied: true` (orange cloud) — cloudflare's edge sits in front. SSL, DDoS protection, caching. Use for HTTP/HTTPS records pointing at an origin.
+- `proxied: false` (grey cloud, "DNS only") — bare DNS, no proxy. Use for records that need direct address resolution: MX, SRV, TXT, mail/IMAP A records, SSH targets, etc.
+
+If the user is not sure, default `true` for A/AAAA/CNAME on web subdomains and `false` for everything else.
+
+## priority
+
+Only MX records use `priority`. Lower number = higher priority. Common values: 1, 5, 10, 20.

--- a/skills/.defaults/eliza-cloud-manage-domain/references/failure-modes.md
+++ b/skills/.defaults/eliza-cloud-manage-domain/references/failure-modes.md
@@ -1,0 +1,21 @@
+# failure modes — manage-domain skill
+
+| Status | Meaning | Action |
+|---|---|---|
+| 400 | invalid payload (bad record type, name too long, empty patch) | echo the validation error to the user verbatim and ask for a corrected value |
+| 404 | domain not attached to this app, or app does not exist | re-check `appId` and `domain` strings; ensure the user actually owns this domain (call `GET /api/v1/domains` to confirm) |
+| 409 (on dns endpoints) | domain is `registrar=external` | the user owns this domain elsewhere; tell them to make the dns change at the provider where they bought it (e.g. Namecheap dashboard) |
+| 502 | cloudflare returned an error | retry once; if it persists, tell the user cloudflare is having an issue and to retry in a minute |
+| 500 | unexpected | log the error id; don't loop |
+
+## Detach is not delete
+
+`DELETE /api/v1/apps/:id/domains` only **detaches** the domain from the app. The cloudflare registration itself stays active until its expiration date. To "actually delete" a domain the user has to wait for expiry (or transfer it out of cloudflare). Be clear about this if the user thinks they cancelled and got their money back.
+
+## Patching a record that doesn't exist
+
+`PATCH /api/v1/apps/:id/domains/:domain/dns/:recordId` returns 404 if `recordId` was never on this zone or was already deleted. Always list records first to get fresh ids.
+
+## Sync after a manual cloudflare dashboard change
+
+If the user edited a record directly in the cloudflare dashboard (outside Eliza Cloud), the managed_domains row may be stale. Call `POST /api/v1/apps/:id/domains/sync` to refresh status into our DB. (DNS records themselves are read live from cloudflare, so the next list call is always current.)

--- a/skills/.defaults/eliza-cloud/SKILL.md
+++ b/skills/.defaults/eliza-cloud/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: eliza-cloud
-description: "Use when the task involves Eliza Cloud or elizaOS Cloud as a managed backend, app platform, deployment target, billing layer, or monetization surface. Covers app creation, `appId` usage, app auth flows, cloud-hosted APIs, analytics, credits, creator monetization, and custom Docker container deployments."
+description: "Use when the task involves Eliza Cloud or elizaOS Cloud as a managed backend, app platform, deployment target, billing layer, or monetization surface. The catch-all skill for any user request about THEIR existing apps / containers / earnings / credits / api-keys / analytics / billing — `list my apps`, `delete this app`, `change container size`, `what are my earnings`, `top up credits`, `regenerate api key`, `show analytics`. Covers app creation, `appId` usage, app auth flows, cloud-hosted APIs, analytics, credits, creator monetization, and custom Docker container deployments. For domain-specific ops defer to `eliza-cloud-buy-domain` / `eliza-cloud-manage-domain`."
 ---
 
 # Eliza Cloud
@@ -25,7 +25,12 @@ Treat Eliza Cloud as the default managed backend before inventing separate auth,
 
 ## Default Build Flow
 
-For most app work:
+For new agent-built apps, defer to `build-monetized-app`: register a Cloud app,
+build and push a container image, deploy that container, enable monetization,
+patch the app URL/origins, and then offer a custom domain. Static hosting is
+only for legacy/local apps or edits to an existing static app.
+
+For existing app work:
 
 1. create or reuse an Eliza Cloud app
 2. capture the app's `appId` and API key
@@ -34,6 +39,56 @@ For most app work:
 5. enable monetization if the app should earn
 6. deploy a container only if server-side code is required
 
+For static-hosted apps, do not deploy a container unless the app truly needs its
+own server. Register the public static URL as the Cloud app, store the returned
+`appId` in non-secret local config, and use a same-origin proxy to call Cloud
+APIs. The config's `cloudUrl` is the
+browser-facing Cloud frontend/OAuth base that serves `/app-auth/authorize`; it
+must come from `ELIZA_CLOUD_PUBLIC_URL`, then `ELIZA_CLOUD_URL`, then
+`ELIZA_CLOUD_BASE_URL` only when that same origin serves the frontend too. Do
+not point `cloudUrl` at an API-only local worker such as `:8787`, and do not
+silently mix a localhost API base with production OAuth. In local testing,
+`apiBase: http://localhost:8787/api/v1` pairs with `cloudUrl:
+http://127.0.0.1:3000`.
+
+AI inference apps are monetized apps by default. They must use app auth plus the
+app-specific chat endpoint:
+
+- Browser starts sign-in at `/app-auth/authorize` with `app_id`, `redirect_uri`, and `state`.
+- Browser stores only the returned user token, never an owner API key.
+- Browser calls the app's same-origin proxy with `x-user-token`.
+- Proxy forwards to `/api/v1/apps/{id}/chat` with `Authorization: Bearer <user_jwt>` and optional `x-affiliate-code`. The app id belongs in the route path, not in an `x-app-id` header.
+- Monetization uses `PUT /api/v1/apps/{id}/monetization` with markup/share fields.
+
 ## Important Reality Check
 
 Some older docs still describe generic per-request or per-token app pricing. In this repo's current implementation, the active app monetization controls are markup/share-based. Prefer the current schema, UI, and API behavior in this repo when prose docs conflict.
+
+## Management surface — what users can ask for
+
+This is the catch-all skill for any user request about apps they already own. Endpoints + intent map:
+
+| User says | Endpoint | Method |
+|---|---|---|
+| `list my apps` | `/api/v1/apps` | GET |
+| `show me my app X` / `app details` | `/api/v1/apps/{id}` | GET |
+| `rename my app` / `change app config` | `/api/v1/apps/{id}` | PATCH |
+| `delete this app` | `/api/v1/apps/{id}` | DELETE |
+| `list my containers` | `/api/v1/containers` | GET |
+| `change container tier / size` | `/api/v1/apps/{id}` (container fields) | PATCH |
+| `what are my earnings` | `/api/v1/apps/{id}/earnings` | GET |
+| `set markup percentage` | `/api/v1/apps/{id}/monetization` | PUT |
+| `show app analytics / usage` | `/api/v1/apps/{id}/analytics` | GET |
+| `regenerate my api key` | `/api/v1/apps/{id}/regenerate-api-key` | POST |
+| `manage app users` | `/api/v1/apps/{id}/users` | GET / POST |
+| `top up credits` | direct user to `/dashboard/billing` (Stripe checkout) |
+| `dashboard overview` | `/api/v1/dashboard` | GET |
+
+Always confirm before destructive actions (delete app, regenerate key) — show the user what's about to happen, ask for explicit yes.
+
+For domain-specific ops:
+- `eliza-cloud-buy-domain` — register a brand-new domain through cloudflare (paid from cloud credits)
+- `eliza-cloud-manage-domain` — list / edit dns records / detach domains
+
+For the build-and-monetize flow specifically:
+- `build-monetized-app` — ships a new app, then proactively offers a custom domain at the end

--- a/skills/.defaults/task-agent-eliza-bridge/SKILL.md
+++ b/skills/.defaults/task-agent-eliza-bridge/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: claude-subagent-eliza-bridge
+name: task-agent-eliza-bridge
 description: "Use when spawning a Claude Code, Codex, Gemini, Aider, or other CLI task agent whose work needs parent Eliza runtime context. Covers the read-only loopback bridge for character, room, memory, and active workspace state."
 ---
 
-# Claude/Codex Sub-Agent Eliza Bridge
+# Task-Agent Eliza Bridge
 
-Use this skill when a coding sub-agent needs context that lives in the parent Eliza runtime rather than in the checkout.
+Use this skill when a coding task agent needs context that lives in the parent Eliza runtime rather than in the checkout.
 
 The orchestrator injects a parent-runtime reference into each non-shell task agent's memory file. The child can curl these loopback-only, read-only endpoints with its session id:
 
@@ -15,7 +15,7 @@ The orchestrator injects a parent-runtime reference into each non-shell task age
 
 ## Parent Responsibilities
 
-Before delegating work that references parent context, make sure the spawned agent has the injected memory file. The bridge is for context reads only: character/persona, originating room, model preferences, memory search, and active workspace/task-agent status.
+Before delegating work that references parent context, make sure the spawned agent has the injected memory file. The bridge is for context reads only: character/persona, originating room, model preferences, memory search, and active workspace state.
 
 Do not give the child the parent's API key or a full memory dump. Cloud state belongs to the `eliza-cloud` skill; local runtime state belongs to this bridge.
 


### PR DESCRIPTION
This PR will be reviewed by an AI agent. Provide clear context to help it assess your changes.

Aesthetic/UI changes that don't improve agent capability are out of scope and will be rejected.

## Category
- [ ] Bug fix
- [ ] Security fix
- [ ] Performance improvement
- [x] New feature
- [x] Documentation
- [ ] Test coverage
- [ ] Other

## What

Updates the default app-build and Cloud skills so production app builds target Eliza Cloud containers, not personal `agent-home` hosting. It also makes AI app behavior explicit: use Eliza Cloud OAuth, app-scoped monetized chat endpoints, and ask for confirmation before buying a custom domain.

## Why

Normal Discord prompts like “build me an AI chat app” should not require the user to say “register with Cloud” or “use monetized endpoints.” The skills should teach the task agent to infer auth/AI/domain needs from the requested app while still requiring explicit user confirmation before purchases.

## How

- Adds/updates default skills for Cloud app builds, domain search/buy/manage, and the generic task-agent bridge.
- Renames the bridge away from Claude-specific language.
- Removes `agent-home` as the production default and documents it as legacy/local static hosting only.
- Uses app-scoped `/api/v1/apps/<appId>/chat` guidance for monetized AI apps.
- Keeps domain purchase wording as a confirmation question, not `reply with ...` command text.

## Testing

- `git diff --check`
- `rg` scans for stale `agent-home`, Claude-specific bridge names, `/api/v1/messages`, `postApiV1Messages`, `anthropic-version`, and stale `x-app-id` guidance.
- Normal Discord e2e verified the orchestrator can hand these instructions to Codex and get URL/appId/auth/monetization/domain-confirmation output from normie prompts.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Standardize cloud app build workflow with domain purchase and management skills
> - Adds two new skills, `eliza-cloud-buy-domain` and `eliza-cloud-manage-domain`, covering the full lifecycle of domain registration, DNS/SSL provisioning, and post-purchase management for Eliza Cloud apps.
> - Updates `build-monetized-app` and `eliza-cloud` skills to mandate Cloud-backed auth and the `/api/v1/apps/{id}/chat` endpoint for AI inference apps, and to always offer a custom domain after deployment.
> - Updates [sdk-flow.md](https://github.com/milady-ai/milady/pull/2100/files#diff-0524bbbfea094dd529104e7f6d786c5d807ce1e737770a83d6d7008531095159) to route chat requests through the app-specific endpoint (applying credits, markup, and analytics) and clarifies same-origin proxy patterns for user JWTs.
> - Renames the `claude-subagent-milady-bridge` skill to `task-agent-eliza-bridge` in skill definitions and agent documentation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cc7b564.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->