### PR TITLE
fix(app): avoid privileged vite hmr bind

### DIFF
--- a/apps/app/test/vite-dev-origin.test.ts
+++ b/apps/app/test/vite-dev-origin.test.ts
@@ -31,7 +31,8 @@ describe("resolveViteDevServerRuntime", () => {
       origin: "https://192.168.1.42",
       hmr: {
         host: "192.168.1.42",
-        port: 443,
+        port: 2138,
+        clientPort: 443,
         protocol: "wss",
       },
     });
@@ -50,7 +51,8 @@ describe("resolveViteDevServerRuntime", () => {
       origin: "http://10.0.0.2:9000",
       hmr: {
         host: "10.0.0.99",
-        port: 9000,
+        port: 2138,
+        clientPort: 9000,
         protocol: "ws",
       },
     });

--- a/apps/app/vite-dev-origin.ts
+++ b/apps/app/vite-dev-origin.ts
@@ -1,6 +1,7 @@
 export interface ViteHmrConfig {
   host?: string;
   port: number;
+  clientPort?: number;
   protocol?: "ws" | "wss";
 }
 
@@ -53,6 +54,20 @@ function resolveOriginPort(origin: URL, fallbackPort: number): number {
   return fallbackPort;
 }
 
+function withPublicClientPort(
+  hmr: ViteHmrConfig,
+  publicPort: number,
+): ViteHmrConfig {
+  if (publicPort === hmr.port) {
+    return hmr;
+  }
+
+  return {
+    ...hmr,
+    clientPort: publicPort,
+  };
+}
+
 export function resolveViteDevServerRuntime(
   env: Record<string, string | undefined>,
   uiPort: number,
@@ -71,11 +86,14 @@ export function resolveViteDevServerRuntime(
   if (explicitOrigin) {
     return {
       origin: explicitOrigin.origin,
-      hmr: {
-        host: explicitHmrHost || explicitOrigin.hostname,
-        port: resolveOriginPort(explicitOrigin, uiPort),
-        protocol: explicitOrigin.protocol === "https:" ? "wss" : "ws",
-      },
+      hmr: withPublicClientPort(
+        {
+          host: explicitHmrHost || explicitOrigin.hostname,
+          port: uiPort,
+          protocol: explicitOrigin.protocol === "https:" ? "wss" : "ws",
+        },
+        resolveOriginPort(explicitOrigin, uiPort),
+      ),
     };
   }
 


### PR DESCRIPTION
This PR will be reviewed by an AI agent. Provide clear context to help it assess your changes.

Aesthetic/UI changes that don't improve agent capability are out of scope and will be rejected.

## Category
- [x] Bug fix
- [ ] Security fix
- [ ] Performance improvement
- [ ] New feature
- [ ] Documentation
- [ ] Test coverage
- [ ] Other

## What

Separates Vite's local dev-server bind port from the public browser HMR client port.

## Why

When a public HTTPS origin is configured, the app should advertise the public `443` client port to browsers but still bind the local dev server to an unprivileged local port. Before this change, local runtime could try to bind privileged `:443` and fail with `EACCES`.

## How

Keeps the public-origin parsing for client HMR metadata, but resolves the actual dev-server bind port independently so local development does not attempt privileged binds.

## Testing

- Direct Bun assertion check against `apps/app/vite-dev-origin.ts` passed.
- Attempted direct Vitest path for `apps/app/test/vite-dev-origin.test.ts`; repo Vitest include config excludes that direct path, so the direct Bun assertion was used for focused verification.
- Live local Milady runtime no longer logs the privileged `:443` Vite bind failure after this change.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Vite HMR config to bind on `uiPort` instead of the public origin port
> When `MILADY_VITE_ORIGIN`/`ELIZA_VITE_ORIGIN` is set, the HMR server was binding on the public origin's port, which can be a privileged port (e.g. 443). The fix sets `hmr.port` to `uiPort` for the local bind and introduces `clientPort` in [`vite-dev-origin.ts`](https://github.com/milady-ai/milady/pull/2101/files#diff-6164c3727b4562712e4e03edf46c76058258f312683319f188b66c750334bef4) to expose the correct public-facing port to HMR clients when it differs from `uiPort`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 88adc2a.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->