### PR TITLE
fix(dev): prefer repo-local app-core script resolution by default

### DIFF
--- a/scripts/lib/resolve-eliza-app-core-script.mjs
+++ b/scripts/lib/resolve-eliza-app-core-script.mjs
@@ -2,14 +2,27 @@ import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { isLocalElizaDisabled } from "./eliza-package-mode.mjs";
+import {
+  LOCAL_UPSTREAM_SKIP_ENV_KEYS,
+  getExplicitElizaSourceMode,
+} from "./eliza-package-mode.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const defaultRepoRoot = path.resolve(__dirname, "..", "..");
 const requireFromHere = createRequire(import.meta.url);
 
 function localUpstreamsDisabled() {
-  return isLocalElizaDisabled();
+  const explicitMode = getExplicitElizaSourceMode();
+  if (explicitMode === "packages") {
+    return true;
+  }
+  if (explicitMode === "local") {
+    return false;
+  }
+
+  return LOCAL_UPSTREAM_SKIP_ENV_KEYS.some(
+    (key) => process.env[key] === "1",
+  );
 }
 
 function explicitAppCoreRoot() {

--- a/scripts/lib/resolve-eliza-app-core-script.mjs
+++ b/scripts/lib/resolve-eliza-app-core-script.mjs
@@ -3,8 +3,8 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
-  LOCAL_UPSTREAM_SKIP_ENV_KEYS,
   getExplicitElizaSourceMode,
+  LOCAL_UPSTREAM_SKIP_ENV_KEYS,
 } from "./eliza-package-mode.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -20,9 +20,7 @@ function localUpstreamsDisabled() {
     return false;
   }
 
-  return LOCAL_UPSTREAM_SKIP_ENV_KEYS.some(
-    (key) => process.env[key] === "1",
-  );
+  return LOCAL_UPSTREAM_SKIP_ENV_KEYS.some((key) => process.env[key] === "1");
 }
 
 function explicitAppCoreRoot() {


### PR DESCRIPTION
## Summary
- change `resolve-eliza-app-core-script` local-source preference logic to:
  - treat **explicit** `MILADY_ELIZA_SOURCE=packages` as package mode
  - treat **explicit** `MILADY_ELIZA_SOURCE=local` as local mode
  - otherwise only disable local-source preference when skip flags are set (`MILADY_SKIP_LOCAL_UPSTREAMS=1` / `ELIZA_SKIP_LOCAL_UPSTREAMS=1`)
- keep package-mode opt-out intact while making default developer command resolution prefer repo-local `eliza/packages/app-core` when available

## Why
This avoids the CI-breaking `workspace:*` manifest rewrite while still making day-to-day dev commands pick local elizaOS sources by default in local checkouts.

## Validation
- `node` smoke check importing `resolveElizaAppCoreScript` and resolving `dev-ui.mjs` successfully after the change


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `localUpstreamsDisabled` to prefer repo-local app-core script resolution by default
> Updates `localUpstreamsDisabled()` in [resolve-eliza-app-core-script.mjs](https://github.com/milady-ai/milady/pull/2106/files#diff-43e8b19a62c9d03dc706a3c274f27864113d2c479648bd8a6afc7a72b529d69e) to use `getExplicitElizaSourceMode()` for deterministic mode resolution. Returns `true` for explicit `"packages"` mode, `false` for explicit `"local"` mode, and falls back to checking whether any env var in `LOCAL_UPSTREAM_SKIP_ENV_KEYS` equals `"1"`. Previously, the default behavior skipped local resolution; now it prefers local unless explicitly overridden.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c7adb76.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->