### PR TITLE
fix(app): broken build — duplicate export + missing prefetchVrmToCache stub

### DIFF
--- a/apps/app/src/optional-eliza-app-stub.tsx
+++ b/apps/app/src/optional-eliza-app-stub.tsx
@@ -54,6 +54,8 @@ export function resolveCompanionInferenceNotice(): null {
   return null;
 }
 
+export async function prefetchVrmToCache(): Promise<void> {}
+
 // Stubs for @elizaos/app-wallet — the canonical wallet UI ships in
 // eliza/plugins/app-wallet, but the host app sometimes aliases the
 // whole package to this no-op stub (Capacitor / minimal builds without
@@ -489,16 +491,6 @@ export { THREE };
 // useOnboardingCallbacks and the wallet onboarding flow degrades to a
 // no-op RPC update. With `bun run eliza:local`, the alias auto-detect in
 // vite.config.ts routes through the real package instead.
-export function buildWalletRpcUpdateRequest(_args: unknown): {
-  credentials: Record<string, string>;
-  selections: Record<string, never>;
-} {
-  return { credentials: {}, selections: {} };
-}
-
-export function normalizeWalletRpcSelections(_selections: unknown): {} {
-  return {};
-}
 
 export function collectSelectedCredentialKeys(_selections: unknown): string[] {
   return [];


### PR DESCRIPTION
## Summary
- removes duplicate `buildWalletRpcUpdateRequest` export in `optional-eliza-app-stub.tsx` (defined at line 62 and again at 492, causing vite esbuild transform failure)
- adds missing `prefetchVrmToCache` stub — imported by `main.tsx` from `@elizaos/app-companion` which aliases to this stub in npm-package mode

build is currently broken on develop without this fix.

## Test plan
- [x] `bun run build` passes locally after this change (was failing before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix broken build by adding `prefetchVrmToCache` stub and removing duplicate exports
> Updates [optional-eliza-app-stub.tsx](https://github.com/milady-ai/milady/pull/2108/files#diff-a5cf8b609cdd9fd8cb4ef7a485b044d00a353b723b398feaa15b4a5744efcd1c) to fix a broken build caused by a missing stub and duplicate exports.
>
> - Adds a no-op async `prefetchVrmToCache` stub that returns a resolved `Promise<void>`
> - Removes `buildWalletRpcUpdateRequest` and `normalizeWalletRpcSelections` stubs, which were causing duplicate export errors
> - Risk: any code importing `buildWalletRpcUpdateRequest` or `normalizeWalletRpcSelections` from this stub will now fail to resolve
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5796e6a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->