### PR TITLE
fix(ci): guard agent-review auth build when eliza app-core is absent

### DIFF
--- a/.github/actions/setup-bun-workspace/action.yml
+++ b/.github/actions/setup-bun-workspace/action.yml
@@ -187,6 +187,10 @@ runs:
           echo "eliza checkout absent; skipping nested cloud submodule init"
           exit 0
         fi
+        if ! git -C eliza rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+          echo "eliza/ is not a git worktree; skipping cloud hydration."
+          exit 0
+        fi
         git -C eliza submodule update --init cloud
         test -d eliza/cloud/packages/sdk
         test -d eliza/cloud/packages/billing

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -155,8 +155,8 @@ jobs:
 
       - name: Build local eliza runtime plugins
         run: |
-          if [ ! -d eliza ]; then
-            echo "eliza checkout absent; skipping local runtime plugin builds"
+          if [ ! -d eliza/packages/core ]; then
+            echo "eliza app-core checkout absent; skipping local runtime plugin builds"
             exit 0
           fi
           if [ ! -f eliza/packages/core/dist/index.node.js ] || [ ! -f eliza/packages/core/dist/index.d.ts ]; then


### PR DESCRIPTION
## Summary\n- harden Agent Review Auth tests (P0 gate) workflow step Build local eliza runtime plugins\n- short-circuit when liza/packages/core is absent to avoid cd failure\n\n## Why\npull_request_target Agent Review jobs currently fail with:\n- cd: eliza/packages/core: No such file or directory\n\nThis is a workflow-path infra failure, not a product-code regression.\n\n## Validation\n- 
ode scripts/validate-ci-bootstrap-contract.mjs (pass)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard agent-review auth build and workspace hydration when eliza app-core is absent
> - In [agent-review.yml](.github/workflows/agent-review.yml), tightens the build guard to check for `eliza/packages/core` instead of just `eliza/`, skipping local runtime plugin builds when the app core directory is missing.
> - In [action.yml](.github/actions/setup-bun-workspace/action.yml), adds a pre-check that exits early if `eliza/` is not a valid git worktree before running `git submodule update --init cloud`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e43528c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->