### PR TITLE
fix(ci): restore auth gate command and stabilize package-mode auth smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,37 @@ jobs:
       - name: Run type checker
         run: bun run verify:typecheck
 
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Published-only CI restores required non-eliza submodules during setup.
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          install-command: bun install --ignore-scripts --no-frozen-lockfile
+          skip-cloud-submodule: "true"
+          skip-local-upstreams-postinstall: "true"
+
+      - name: Restore eliza workspace paths for repo scripts
+        run: node scripts/restore-local-eliza-workspace.mjs
+
+      - name: Align nested eliza package resolution
+        run: node scripts/align-eliza-ci-node-modules.mjs
+
+      - name: Run auth gate regression test
+        run: bun run test:auth
+
   build:
     name: Build
     runs-on: ubuntu-24.04
@@ -276,3 +307,30 @@ jobs:
         run: bun run build:web
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  all-tests-passed:
+    name: All Tests Passed
+    if: ${{ always() }}
+    runs-on: ubuntu-24.04
+    needs:
+      - pre-review
+      - lint
+      - typecheck
+      - unit-tests
+      - build
+    steps:
+      - name: Require all CI gates to pass
+        env:
+          PRE_REVIEW: ${{ needs.pre-review.result }}
+          LINT: ${{ needs.lint.result }}
+          TYPECHECK: ${{ needs.typecheck.result }}
+          UNIT_TESTS: ${{ needs.unit-tests.result }}
+          BUILD: ${{ needs.build.result }}
+        run: |
+          set -euo pipefail
+          for result in "$PRE_REVIEW" "$LINT" "$TYPECHECK" "$UNIT_TESTS" "$BUILD"; do
+            if [ "$result" != "success" ]; then
+              echo "Required CI gate did not pass: $result"
+              exit 1
+            fi
+          done

--- a/bun.lock
+++ b/bun.lock
@@ -65,6 +65,7 @@
         "drizzle-orm": "0.45.2",
         "ethers": "^6.16.0",
         "glob": "^13.0.6",
+        "jose": "^6.1.0",
         "json5": "^2.2.3",
         "lucide-react": "^0.577.0",
         "node-llama-cpp": "^3.18.1",

--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
     "lifeops:gmail:real-smoke": "node scripts/gmail-real-smoke.mjs",
     "lifeops:gmail:real-sweep": "node scripts/gmail-real-sweep.mjs",
     "scenarios:creds:pull": "node scripts/scenario-creds-pull.mjs",
+    "test:auth": "bun scripts/test-auth-gate.mjs",
     "test:selfcontrol:mobile:android": "node scripts/run-eliza-app-core-script.mjs run-mobile-build.mjs android",
     "test:selfcontrol:mobile:ios": "node scripts/run-eliza-app-core-script.mjs run-mobile-build.mjs ios",
     "test:live:browser-workspace": "node apps/app/scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts test/ui-smoke/browser-workspace.spec.ts",

--- a/package.json
+++ b/package.json
@@ -235,6 +235,7 @@
     "ethers": "^6.16.0",
     "glob": "^13.0.6",
     "json5": "^2.2.3",
+    "jose": "^6.1.0",
     "lucide-react": "^0.577.0",
     "clsx": "^2.1.1",
     "class-variance-authority": "^0.7.1",

--- a/scripts/smoke-oob.mjs
+++ b/scripts/smoke-oob.mjs
@@ -34,10 +34,12 @@
  */
 
 import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolveElizaAppCoreRoot } from "./lib/resolve-eliza-app-core-script.mjs";
 
 const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
 const READY_TIMEOUT_MS = 60_000;
@@ -55,6 +57,36 @@ function log(level, message) {
 
 function debugLog(message) {
   if (debug) log("debug", message);
+}
+
+function resolveDevServerEntry() {
+  const appCoreRoot = resolveElizaAppCoreRoot({ repoRoot: REPO_ROOT });
+  const candidates = [
+    join(appCoreRoot, "src", "runtime", "dev-server.ts"),
+    join(appCoreRoot, "src", "runtime", "dev-server.js"),
+    join(
+      appCoreRoot,
+      "packages",
+      "app-core",
+      "src",
+      "runtime",
+      "dev-server.ts",
+    ),
+    join(
+      appCoreRoot,
+      "packages",
+      "app-core",
+      "src",
+      "runtime",
+      "dev-server.js",
+    ),
+  ];
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+  throw new Error(
+    `Could not locate app-core dev-server entry under ${appCoreRoot}`,
+  );
 }
 
 async function pickFreePort() {
@@ -113,13 +145,17 @@ async function chat(baseUrl, prompt) {
   });
   const text = await res.text();
   if (!res.ok) {
-    throw new Error(`/v1/chat/completions HTTP ${res.status}: ${text.slice(0, 200)}`);
+    throw new Error(
+      `/v1/chat/completions HTTP ${res.status}: ${text.slice(0, 200)}`,
+    );
   }
   let body;
   try {
     body = JSON.parse(text);
   } catch {
-    throw new Error(`/v1/chat/completions returned non-JSON: ${text.slice(0, 200)}`);
+    throw new Error(
+      `/v1/chat/completions returned non-JSON: ${text.slice(0, 200)}`,
+    );
   }
   const reply = body?.choices?.[0]?.message?.content;
   if (typeof reply !== "string") {
@@ -152,7 +188,9 @@ async function reset(baseUrl) {
   });
   if (!res.ok && res.status !== 405) {
     const text = await res.text();
-    throw new Error(`/api/agent/reset HTTP ${res.status}: ${text.slice(0, 200)}`);
+    throw new Error(
+      `/api/agent/reset HTTP ${res.status}: ${text.slice(0, 200)}`,
+    );
   }
 }
 
@@ -171,26 +209,21 @@ async function main() {
   // state dir, known port. Boot exercises the same vault bootstrap,
   // SECRET_SALT persistence, and route registration paths a real boot
   // hits — just without the renderer/static-server side.
-  const devServerEntry =
-    "eliza/packages/app-core/src/runtime/dev-server.ts";
-  const child = spawn(
-    "bun",
-    [devServerEntry],
-    {
-      cwd: REPO_ROOT,
-      env: {
-        ...process.env,
-        MILADY_STATE_DIR: stateDir,
-        ELIZA_STATE_DIR: stateDir,
-        MILADY_API_PORT: String(port),
-        ELIZA_API_PORT: String(port),
-        ELIZA_HEADLESS: "1",
-        FORCE_COLOR: "0",
-      },
-      stdio: ["ignore", debug ? "inherit" : "pipe", debug ? "inherit" : "pipe"],
-      detached: process.platform !== "win32",
+  const devServerEntry = resolveDevServerEntry();
+  const child = spawn("bun", [devServerEntry], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      MILADY_STATE_DIR: stateDir,
+      ELIZA_STATE_DIR: stateDir,
+      MILADY_API_PORT: String(port),
+      ELIZA_API_PORT: String(port),
+      ELIZA_HEADLESS: "1",
+      FORCE_COLOR: "0",
     },
-  );
+    stdio: ["ignore", debug ? "inherit" : "pipe", debug ? "inherit" : "pipe"],
+    detached: process.platform !== "win32",
+  });
   // If we asked for piped stdio (non-debug), still capture stderr so
   // boot failures aren't silently swallowed.
   if (!debug && child.stderr) {

--- a/scripts/test-auth-gate.mjs
+++ b/scripts/test-auth-gate.mjs
@@ -36,7 +36,7 @@ async function main() {
   const verifyBootstrapToken = await loadVerifyBootstrapToken();
   const nowMs = Date.now();
   const nowSeconds = Math.floor(nowMs / 1000);
-  const issuer = "https://issuer.milady.local";
+  const issuer = `https://issuer.milady.local/${nowMs.toString(36)}`;
   const containerId = "container-1";
 
   const { privateKey, publicKey } = await generateKeyPair("RS256");

--- a/scripts/test-auth-gate.mjs
+++ b/scripts/test-auth-gate.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+
+import { createRequire } from "node:module";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { exportJWK, generateKeyPair, SignJWT } from "jose";
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function loadVerifyBootstrapToken() {
+  const require = createRequire(import.meta.url);
+  const packageJsonPath = require.resolve("@elizaos/app-core/package.json");
+  const appCoreRoot = path.dirname(packageJsonPath);
+  const modulePath = path.join(
+    appCoreRoot,
+    "packages",
+    "app-core",
+    "src",
+    "api",
+    "auth",
+    "bootstrap-token.js",
+  );
+  const moduleUrl = pathToFileURL(modulePath).href;
+  const module = await import(moduleUrl);
+  if (typeof module.verifyBootstrapToken !== "function") {
+    throw new Error("verifyBootstrapToken export is missing");
+  }
+  return module.verifyBootstrapToken;
+}
+
+async function main() {
+  const verifyBootstrapToken = await loadVerifyBootstrapToken();
+  const nowMs = Date.now();
+  const nowSeconds = Math.floor(nowMs / 1000);
+  const issuer = "https://issuer.milady.local";
+  const containerId = "container-1";
+
+  const { privateKey, publicKey } = await generateKeyPair("RS256");
+  const jwk = await exportJWK(publicKey);
+  jwk.kid = "smoke-key";
+  jwk.alg = "RS256";
+  jwk.use = "sig";
+
+  const token = await new SignJWT({
+    sub: "cloud-user-123",
+    containerId,
+    scope: "bootstrap",
+    jti: "jti-1",
+  })
+    .setProtectedHeader({ alg: "RS256", kid: "smoke-key" })
+    .setIssuer(issuer)
+    .setIssuedAt(nowSeconds)
+    .setExpirationTime(nowSeconds + 300)
+    .sign(privateKey);
+
+  const seen = new Set();
+  const authStore = {
+    async recordJtiSeen(jti) {
+      if (seen.has(jti)) return false;
+      seen.add(jti);
+      return true;
+    },
+  };
+
+  const fetchImpl = async () => ({
+    ok: true,
+    async json() {
+      return { keys: [jwk] };
+    },
+  });
+
+  const baseOptions = {
+    authStore,
+    fetchImpl,
+    now: () => nowMs,
+  };
+
+  const success = await verifyBootstrapToken(token, {
+    ...baseOptions,
+    env: {
+      ELIZA_CLOUD_ISSUER: issuer,
+      ELIZA_CLOUD_CONTAINER_ID: containerId,
+    },
+  });
+  assert(
+    success.ok === true,
+    `expected success, got ${JSON.stringify(success)}`,
+  );
+
+  const replay = await verifyBootstrapToken(token, {
+    ...baseOptions,
+    env: {
+      ELIZA_CLOUD_ISSUER: issuer,
+      ELIZA_CLOUD_CONTAINER_ID: containerId,
+    },
+  });
+  assert(
+    replay.ok === false && replay.reason === "replay",
+    `expected replay failure, got ${JSON.stringify(replay)}`,
+  );
+
+  const containerMismatch = await verifyBootstrapToken(token, {
+    ...baseOptions,
+    authStore: {
+      async recordJtiSeen() {
+        return true;
+      },
+    },
+    env: {
+      ELIZA_CLOUD_ISSUER: issuer,
+      ELIZA_CLOUD_CONTAINER_ID: "wrong-container",
+    },
+  });
+  assert(
+    containerMismatch.ok === false &&
+      containerMismatch.reason === "container_mismatch",
+    `expected container mismatch, got ${JSON.stringify(containerMismatch)}`,
+  );
+
+  console.log("[test-auth-gate] PASS");
+}
+
+main().catch((error) => {
+  console.error(
+    `[test-auth-gate] FAIL: ${
+      error instanceof Error ? error.message : String(error)
+    }`,
+  );
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- restore a concrete `test:auth` command so Agent Review auth gate no longer fails with "Script not found"
- add `scripts/test-auth-gate.mjs` that exercises bootstrap token verification contract (success, replay rejection, container mismatch) against installed `@elizaos/app-core`
- make `scripts/smoke-oob.mjs` resolve app-core runtime entry in both local-source and package-mode layouts (`src/runtime/*` and `packages/app-core/src/runtime/*`)

## Validation
- `bun run verify:lint`
- `bun run verify:typecheck`
- `bun run build`
- `bun run test:auth`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore auth gate command and stabilize CI with a unit-test job
> - Adds a `test:auth` script and a new `unit-tests` CI job in [ci.yml](https://github.com/milady-ai/milady/pull/2110/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f) that runs [scripts/test-auth-gate.mjs](https://github.com/milady-ai/milady/pull/2110/files#diff-290b49b2da925394dacc52a8a3cbba7f11ac5e8b1219fe433914d0e00c00e095) on every workflow run.
> - [test-auth-gate.mjs](https://github.com/milady-ai/milady/pull/2110/files#diff-290b49b2da925394dacc52a8a3cbba7f11ac5e8b1219fe433914d0e00c00e095) generates an RS256 keypair via `jose`, signs a JWT, and calls `verifyBootstrapToken` from `@elizaos/app-core` to verify success, replay detection, and container ID mismatch scenarios.
> - Adds an `all-tests-passed` gate job that fails the workflow if any required job (lint, typecheck, unit-tests, build) does not succeed.
> - Replaces the hardcoded dev-server entry path in [scripts/smoke-oob.mjs](https://github.com/milady-ai/milady/pull/2110/files#diff-2064b977f491c889554aa18646f09265aba31ec93020df09d57a5192d50d4ccb) with a dynamic resolver that checks multiple candidate paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e292f6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->