### PR TITLE
fix(app): preserve client IP through dev proxy

### DIFF
--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -2137,6 +2137,7 @@ export default defineConfig({
       "/api": {
         target: `http://127.0.0.1:${apiPort}`,
         changeOrigin: true,
+        xfwd: true,
         configure: (proxy) => {
           proxy.on("error", (_err, _req, res) => {
             if (!res.headersSent) {


### PR DESCRIPTION
> ## Merge sequencing (for the maintainer agent)
>
> - **Depends on:** nothing — single-line `xfwd: true` Vite proxy config change.
> - **Unblocks:** nothing else.
> - **Suggested merge order:** Phase 1 — independent, mergeable now (CLEAN, all checks green).
> - **Risk:** trivial. One Vite-proxy boolean.

## Summary
- enable Vite proxy forwarded headers for `/api` in the Milady app
- preserve the real client IP for loopback-sensitive API routes when the desktop/web UI proxies to the local API
- refresh the branch on current `develop` without changing the one-line behavior

## Validation
- `git diff --check origin/develop...HEAD`
- `bunx biome check apps/app/vite.config.ts`

## Notes
- This keeps public requests from being collapsed into `127.0.0.1` by the Vite proxy, which is required for pairing/auth routes that distinguish loopback access from remote clients.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve client IP in Vite dev server proxy for `/api` requests
> Adds `xfwd: true` to the `/api` proxy entry in [vite.config.ts](https://github.com/milady-ai/milady/pull/2111/files#diff-0d80c2713ea1483c55bbc803b5d5d6a1f75654501e99a33c5d306cdbddd511e4), so the dev proxy forwards `X-Forwarded-For`, `X-Forwarded-Port`, and `X-Forwarded-Proto` headers to the backend. Without this, the backend sees all dev requests as originating from localhost.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1b4ae2e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->