### PR TITLE
Codex/codefactor old findings followup

### DIFF
--- a/.codefactor.yml
+++ b/.codefactor.yml
@@ -3,5 +3,7 @@ exclude:
   - "scripts/disable-local-eliza-workspace.mjs"
   - "scripts/init-submodules.mjs"
   - "scripts/patch-eliza-electrobun-windows-smoke-startup.mjs"
+  - ".github/trust-scoring.js"
+  - ".github/trust-scoring.cjs"
   - "skills/.defaults/nano-banana-pro/scripts/generate_image.py"
   - "skills/.defaults/skill-creator/scripts/quick_validate.py"

--- a/apps/homepage/src/lib/AgentProvider.tsx
+++ b/apps/homepage/src/lib/AgentProvider.tsx
@@ -1,5 +1,6 @@
 import {
   createContext,
+  type MutableRefObject,
   type ReactNode,
   useCallback,
   useContext,
@@ -139,6 +140,16 @@ interface ProbeResult {
   avatarIndex?: number;
 }
 
+type CloudClientRef = MutableRefObject<CloudClient | null>;
+type CloudTokenRef = MutableRefObject<string | null>;
+type ProbeSemaphore = ReturnType<typeof createSemaphore>;
+
+interface CloudAgentLoadResult {
+  results: ManagedAgent[];
+  cloudAuthOk: boolean;
+  fetchError: string | null;
+}
+
 const AgentContext = createContext<AgentContextValue | null>(null);
 
 // Milady self-hosted agent discovery
@@ -165,6 +176,360 @@ function agentsEqual(a: ManagedAgent[], b: ManagedAgent[]): boolean {
       return false;
   }
   return true;
+}
+
+async function collectCloudAgents(
+  token: string | null,
+  cloudClientRef: CloudClientRef,
+  cloudTokenRef: CloudTokenRef,
+): Promise<CloudAgentLoadResult> {
+  if (!token) {
+    cloudClientRef.current = null;
+    cloudTokenRef.current = null;
+    return { results: [], cloudAuthOk: false, fetchError: null };
+  }
+
+  let client = cloudClientRef.current;
+  if (cloudTokenRef.current !== token || !client) {
+    client = new CloudClient(token);
+    cloudClientRef.current = client;
+    cloudTokenRef.current = token;
+  }
+
+  try {
+    const cloudAgents = await client.listAgents();
+    return {
+      results: cloudAgents.map((agent) => ({
+        id: `cloud-${agent.id}`,
+        name: agent.name || agent.id,
+        source: "cloud",
+        status: normalizeAgentState(agent.status),
+        model: agent.model,
+        cloudAgent: agent,
+        cloudClient: client,
+        cloudAgentId: agent.id,
+        sourceUrl: `${CLOUD_BASE}${getCloudAgentApiPath(agent.id)}`,
+        webUiUrl: agent.webUiUrl
+          ? rewriteAgentUiUrl(agent.webUiUrl)
+          : undefined,
+        billing: agent.billing,
+        region: agent.region,
+        createdAt: agent.createdAt,
+        uptime: agent.uptime,
+      })),
+      cloudAuthOk: true,
+      fetchError: null,
+    };
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Cloud API request failed";
+    const isNotAvailable =
+      message.includes("404") ||
+      (error instanceof Error && error.name === "CloudAgentsNotAvailableError");
+    return {
+      results: [],
+      cloudAuthOk: false,
+      fetchError: isNotAvailable ? null : `Cloud API: ${message}`,
+    };
+  }
+}
+
+async function fetchSandboxesForDiscovery(cloudAuthOk: boolean): Promise<{
+  sandboxes: DiscoveredSandbox[];
+  allowPublicSandboxFallback: boolean;
+}> {
+  const allowPublicSandboxFallback =
+    shouldAllowPublicSandboxDiscoveryFallback();
+  if (!cloudAuthOk && !allowPublicSandboxFallback) {
+    return { sandboxes: [], allowPublicSandboxFallback };
+  }
+
+  for (const url of getSandboxDiscoveryUrls()) {
+    try {
+      const response = await fetch(url, {
+        signal: AbortSignal.timeout(DISCOVERY_TIMEOUT_MS),
+      });
+      if (response.ok) {
+        const body = await response.json();
+        return {
+          sandboxes: Array.isArray(body) ? body : [],
+          allowPublicSandboxFallback,
+        };
+      }
+    } catch {}
+  }
+
+  return { sandboxes: [], allowPublicSandboxFallback };
+}
+
+function selectOwnedSandboxes(
+  sandboxes: DiscoveredSandbox[],
+  cloudAuthOk: boolean,
+  allowPublicSandboxFallback: boolean,
+  results: ManagedAgent[],
+) {
+  if (!cloudAuthOk) {
+    return allowPublicSandboxFallback ? sandboxes : [];
+  }
+
+  const cloudAgentNames = new Set(
+    results
+      .filter((agent) => agent.source === "cloud")
+      .map((agent) => agent.name.toLowerCase()),
+  );
+  const cloudAgentIds = new Set(
+    results
+      .filter((agent) => agent.source === "cloud")
+      .map((agent) => agent.cloudAgentId)
+      .filter((id): id is string => typeof id === "string"),
+  );
+
+  return sandboxes.filter((sandbox) => {
+    const nameMatch = cloudAgentNames.has(
+      (sandbox.agent_name || "").toLowerCase(),
+    );
+    const idMatch = cloudAgentIds.has(sandbox.id);
+    return nameMatch || idMatch;
+  });
+}
+
+function buildCloudAgentIndexByName(results: ManagedAgent[]) {
+  const indexByName = new Map<string, number>();
+  results.forEach((agent, index) => {
+    if (agent.source === "cloud") {
+      indexByName.set(agent.name.toLowerCase(), index);
+    }
+  });
+  return indexByName;
+}
+
+function addSandboxAgents(
+  results: ManagedAgent[],
+  probeTargets: ProbeTarget[],
+  discoveredIds: Set<string>,
+  sandboxes: DiscoveredSandbox[],
+) {
+  const cloudAgentIndexByName = buildCloudAgentIndexByName(results);
+
+  for (const sandbox of sandboxes) {
+    discoveredIds.add(sandbox.id);
+    const url = `https://${sandbox.id}.${AGENT_UI_BASE_DOMAIN}`;
+    const apiToken = sandbox.api_token;
+    const client = new CloudApiClient({
+      url,
+      type: "remote",
+      authToken: apiToken,
+    });
+
+    const matchingCloudIndex = cloudAgentIndexByName.get(
+      (sandbox.agent_name || "").toLowerCase(),
+    );
+    if (matchingCloudIndex !== undefined) {
+      const cloudEntry = results[matchingCloudIndex];
+      if (cloudEntry) {
+        cloudEntry.sourceUrl = url;
+        cloudEntry.client = client;
+        cloudEntry.nodeId = sandbox.node_id;
+        cloudEntry.lastHeartbeat = sandbox.last_heartbeat_at;
+        cloudEntry.apiToken = apiToken;
+        cloudEntry.webUiUrl = url;
+        probeTargets.push({
+          index: matchingCloudIndex,
+          client,
+          isCloudEnrich: true,
+        });
+      }
+      continue;
+    }
+
+    const index = results.length;
+    results.push({
+      id: `milady-${sandbox.id}`,
+      name: sandbox.agent_name || sandbox.id,
+      source: "remote",
+      status: "unknown",
+      sourceUrl: url,
+      webUiUrl: url,
+      client,
+      nodeId: sandbox.node_id,
+      lastHeartbeat: sandbox.last_heartbeat_at,
+      apiToken,
+    });
+    probeTargets.push({ index, client });
+  }
+}
+
+function wasDiscoveredMiladyRemote(
+  url: string,
+  discoveredIds: Set<string>,
+): boolean {
+  if (!url.includes(AGENT_UI_BASE_DOMAIN)) return false;
+  const match = url.match(
+    /([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})/,
+  );
+  const sandboxId = match?.[1];
+  return typeof sandboxId === "string" && discoveredIds.has(sandboxId);
+}
+
+function addManualRemoteAgents(
+  results: ManagedAgent[],
+  probeTargets: ProbeTarget[],
+  discoveredIds: Set<string>,
+) {
+  for (const remote of getConnections().filter(
+    (item) => item.type === "remote",
+  )) {
+    if (wasDiscoveredMiladyRemote(remote.url, discoveredIds)) continue;
+
+    const client = new CloudApiClient({
+      url: remote.url,
+      type: "remote",
+      authToken: remote.authToken,
+    });
+    const index = results.length;
+    results.push({
+      id: `remote-${remote.id}`,
+      name: remote.name,
+      source: "remote",
+      status: "unknown",
+      sourceUrl: remote.url,
+      client,
+    });
+    probeTargets.push({ index, client });
+  }
+}
+
+function createLocalProbeClient() {
+  return shouldAutoProbeLocalAgent()
+    ? new CloudApiClient({
+        url: LOCAL_AGENT_BASE,
+        type: "local",
+      })
+    : null;
+}
+
+async function probeAgent(
+  target: ProbeTarget,
+  semaphore: ProbeSemaphore,
+): Promise<ProbeResult | null> {
+  await semaphore.acquire();
+  try {
+    const health = await target.client.health({
+      signal: AbortSignal.timeout(HEALTH_TIMEOUT_MS),
+    });
+    if (!health.ready && !health.status) {
+      return { index: target.index, status: "unknown" };
+    }
+    if (health._synthetic) {
+      return { index: target.index, status: "running" };
+    }
+    try {
+      const [status, streamSettings] = await Promise.all([
+        target.client.getAgentStatus({
+          signal: AbortSignal.timeout(STATUS_TIMEOUT_MS),
+        }),
+        target.client.getStreamSettings().catch(() => null),
+      ]);
+      return {
+        index: target.index,
+        status: status.state,
+        model: status.model,
+        uptime: status.uptime,
+        memories: status.memories,
+        agentName: status.agentName,
+        avatarIndex: streamSettings?.settings?.avatarIndex,
+      };
+    } catch {
+      return { index: target.index, status: "running" };
+    }
+  } catch {
+    return target.isCloudEnrich
+      ? null
+      : { index: target.index, status: "unknown" };
+  } finally {
+    semaphore.release();
+  }
+}
+
+async function probeLocalAgent(
+  localClient: CloudApiClient | null,
+  semaphore: ProbeSemaphore,
+): Promise<ManagedAgent | null> {
+  if (!localClient) return null;
+  await semaphore.acquire();
+  try {
+    const health = await localClient.health({
+      signal: AbortSignal.timeout(HEALTH_TIMEOUT_MS),
+    });
+    if (!health.ready && !health.status) return null;
+    if (health._synthetic) {
+      return {
+        id: "local-default",
+        name: "Local Agent",
+        source: "local",
+        status: "running",
+        sourceUrl: LOCAL_AGENT_BASE,
+        client: localClient,
+      };
+    }
+    try {
+      const status = await localClient.getAgentStatus({
+        signal: AbortSignal.timeout(STATUS_TIMEOUT_MS),
+      });
+      return {
+        id: "local-default",
+        name: status.agentName || "Local Agent",
+        source: "local",
+        status: status.state,
+        model: status.model,
+        uptime: status.uptime,
+        memories: status.memories,
+        sourceUrl: LOCAL_AGENT_BASE,
+        client: localClient,
+      };
+    } catch {
+      return {
+        id: "local-default",
+        name: "Local Agent",
+        source: "local",
+        status: "running",
+        sourceUrl: LOCAL_AGENT_BASE,
+        client: localClient,
+      };
+    }
+  } catch {
+    return null;
+  } finally {
+    semaphore.release();
+  }
+}
+
+function applyProbeResult(agent: ManagedAgent, result: ProbeResult) {
+  if (result.status) agent.status = result.status;
+  if (result.model && result.model !== "—") agent.model = result.model;
+  if (result.uptime !== undefined) agent.uptime = result.uptime;
+  if (result.memories !== undefined) agent.memories = result.memories;
+  if (result.agentName && !agent.name) agent.name = result.agentName;
+  if (result.avatarIndex !== undefined) agent.avatarIndex = result.avatarIndex;
+}
+
+function mergeProbeResults(
+  results: ManagedAgent[],
+  probeResults: Array<PromiseSettledResult<ProbeResult | null>>,
+  localAgentResult: ManagedAgent | null,
+) {
+  const enrichedResults = [...results];
+  for (const result of probeResults) {
+    if (result.status !== "fulfilled" || !result.value) continue;
+    const agent = enrichedResults[result.value.index];
+    if (agent) {
+      applyProbeResult(agent, result.value);
+    }
+  }
+  if (localAgentResult) {
+    enrichedResults.push(localAgentResult);
+  }
+  return enrichedResults;
 }
 
 export function AgentProvider({ children }: { children: ReactNode }) {
@@ -206,384 +571,54 @@ export function AgentProvider({ children }: { children: ReactNode }) {
   const clearError = useCallback(() => setError(null), []);
 
   const fetchAll = useCallback(async () => {
-    // Increment sequence to invalidate any in-flight requests
     const currentSequence = ++fetchSequenceRef.current;
-
-    // Helper to check if this fetch is still current
     const isStale = () => currentSequence !== fetchSequenceRef.current;
 
-    // Set refreshing state (but not loading if we've already loaded once)
     setIsRefreshing(true);
 
-    const results: ManagedAgent[] = [];
-    let fetchError: string | null = null;
-
-    // Track agents that need health probes (for parallel enrichment)
+    const { results, cloudAuthOk, fetchError } = await collectCloudAgents(
+      getToken(),
+      cloudClientRef,
+      cloudTokenRef,
+    );
     const probeTargets: ProbeTarget[] = [];
-
-    // 1. Cloud agents (if authenticated with Eliza Cloud)
-    //    Show immediately from API response, then enrich with health probes
-    let cloudAuthOk = false;
-    const token = getToken();
-    if (token) {
-      // Reuse existing CloudClient if token hasn't changed
-      if (cloudTokenRef.current !== token || !cloudClientRef.current) {
-        cloudClientRef.current = new CloudClient(token);
-        cloudTokenRef.current = token;
-      }
-      const cc = cloudClientRef.current;
-      try {
-        const cloudAgents = await cc.listAgents();
-        cloudAuthOk = true;
-        for (const ca of cloudAgents) {
-          results.push({
-            id: `cloud-${ca.id}`,
-            name: ca.name || ca.id,
-            source: "cloud",
-            status: normalizeAgentState(ca.status),
-            model: ca.model,
-            cloudAgent: ca,
-            cloudClient: cc,
-            cloudAgentId: ca.id,
-            sourceUrl: `${CLOUD_BASE}${getCloudAgentApiPath(ca.id)}`,
-            webUiUrl: ca.webUiUrl ? rewriteAgentUiUrl(ca.webUiUrl) : undefined,
-            billing: ca.billing,
-            region: ca.region,
-            createdAt: ca.createdAt,
-            uptime: ca.uptime,
-          });
-        }
-      } catch (err) {
-        // Cloud API failed — if 404, the cloud agents endpoint isn't deployed
-        // on this cloud instance yet. Silently continue instead of showing an error.
-        const errMsg =
-          err instanceof Error ? err.message : "Cloud API request failed";
-        const isNotAvailable =
-          errMsg.includes("404") ||
-          (err instanceof Error && err.name === "CloudAgentsNotAvailableError");
-        if (!isNotAvailable) {
-          fetchError = `Cloud API: ${errMsg}`;
-        }
-      }
-    } else {
-      cloudClientRef.current = null;
-      cloudTokenRef.current = null;
-    }
-
-    // 2. Milady self-hosted agents (auto-discovery)
-    //    The public sandbox discovery endpoint returns ALL sandboxes across orgs.
-    //    On hosted milady.ai, never use that as an unauthenticated fallback.
-    //    Only use discovery there to enrich already-authenticated cloud agents.
     const discoveredIds = new Set<string>();
-    let sandboxes: DiscoveredSandbox[] = [];
-    const allowPublicSandboxFallback =
-      shouldAllowPublicSandboxDiscoveryFallback();
-    const shouldFetchSandboxes = cloudAuthOk || allowPublicSandboxFallback;
-
-    if (shouldFetchSandboxes) {
-      for (const url of getSandboxDiscoveryUrls()) {
-        try {
-          const sandboxRes = await fetch(url, {
-            signal: AbortSignal.timeout(DISCOVERY_TIMEOUT_MS),
-          });
-          if (sandboxRes.ok) {
-            sandboxes = await sandboxRes.json();
-            break; // Use first successful response
-          }
-        } catch {
-          // try next URL
-        }
-      }
-    }
-
-    // Build a set of cloud agent names/ids for cross-referencing.
-    // When cloud auth succeeds, sandbox discovery is only used to enrich or match
-    // the authenticated user's agents. Public hosted fallback is localhost-only.
-    const cloudAgentNames = new Set(
-      results
-        .filter((a) => a.source === "cloud")
-        .map((a) => a.name.toLowerCase()),
-    );
-    const cloudAgentIds = new Set(
-      results.filter((a) => a.source === "cloud").map((a) => a.cloudAgentId),
+    const { sandboxes, allowPublicSandboxFallback } =
+      await fetchSandboxesForDiscovery(cloudAuthOk);
+    const ownedSandboxes = selectOwnedSandboxes(
+      sandboxes,
+      cloudAuthOk,
+      allowPublicSandboxFallback,
+      results,
     );
 
-    if (sandboxes.length > 0) {
-      const ownedSandboxes = cloudAuthOk
-        ? sandboxes.filter((sb) => {
-            const nameMatch = cloudAgentNames.has(
-              (sb.agent_name || "").toLowerCase(),
-            );
-            const idMatch = cloudAgentIds.has(sb.id);
-            return nameMatch || idMatch;
-          })
-        : allowPublicSandboxFallback
-          ? sandboxes
-          : [];
+    addSandboxAgents(results, probeTargets, discoveredIds, ownedSandboxes);
+    const localClient = createLocalProbeClient();
+    addManualRemoteAgents(results, probeTargets, discoveredIds);
 
-      // Build a lookup from cloud agent name (lowercase) → index in results
-      const cloudAgentIndexByName = new Map<string, number>();
-      for (let i = 0; i < results.length; i++) {
-        if (results[i].source === "cloud") {
-          cloudAgentIndexByName.set(results[i].name.toLowerCase(), i);
-        }
-      }
-
-      for (const sb of ownedSandboxes) {
-        discoveredIds.add(sb.id);
-        // Each sandbox is accessible at https://{uuid}.milady.ai
-        const url = `https://${sb.id}.${AGENT_UI_BASE_DOMAIN}`;
-        const apiToken = sb.api_token;
-        const client = new CloudApiClient({
-          url,
-          type: "remote",
-          authToken: apiToken,
-        });
-
-        // Check if this sandbox matches an existing cloud agent (dedup by name)
-        const sbName = (sb.agent_name || "").toLowerCase();
-        const matchingCloudIdx = cloudAgentIndexByName.get(sbName);
-
-        if (matchingCloudIdx !== undefined) {
-          // Merge sandbox data INTO the existing cloud agent instead of creating a duplicate.
-          // Cloud agent is preferred (richer data), but sandbox provides live status + connectivity.
-          const cloudEntry = results[matchingCloudIdx];
-          cloudEntry.sourceUrl = url;
-          cloudEntry.client = client;
-          cloudEntry.nodeId = sb.node_id;
-          cloudEntry.lastHeartbeat = sb.last_heartbeat_at;
-          cloudEntry.apiToken = apiToken;
-          // Set webUiUrl to the sandbox's public URL (https://{uuid}.milady.ai)
-          cloudEntry.webUiUrl = url;
-          // Queue for health probe enrichment (done in parallel later)
-          probeTargets.push({
-            index: matchingCloudIdx,
-            client,
-            isCloudEnrich: true,
-          });
-          continue;
-        }
-
-        // No matching cloud agent — add as standalone remote agent with "checking..." status
-        const newIndex = results.length;
-        results.push({
-          id: `milady-${sb.id}`,
-          name: sb.agent_name || sb.id,
-          source: "remote",
-          status: "unknown", // Will be enriched by health probe
-          sourceUrl: url,
-          webUiUrl: url,
-          client,
-          nodeId: sb.node_id,
-          lastHeartbeat: sb.last_heartbeat_at,
-          apiToken,
-        });
-        // Queue for health probe
-        probeTargets.push({ index: newIndex, client });
-      }
-    }
-
-    // 3. Prepare local agent probe (will run in parallel when enabled)
-    const shouldProbeLocal = shouldAutoProbeLocalAgent();
-    const localClient = shouldProbeLocal
-      ? new CloudApiClient({
-          url: LOCAL_AGENT_BASE,
-          type: "local",
-        })
-      : null;
-    // We'll add local agent placeholder only if probe succeeds (handled in parallel probes)
-
-    // 4. Manually-added remote agents (via ConnectionModal)
-    //    Skip any that were already auto-discovered from milady sandboxes.
-    const remotes = getConnections().filter((c) => c.type === "remote");
-    for (const remote of remotes) {
-      // If this URL matches an auto-discovered milady agent, skip to avoid duplicates
-      const isMiladyDomain = remote.url.includes(AGENT_UI_BASE_DOMAIN);
-      if (isMiladyDomain) {
-        const uuidMatch = remote.url.match(
-          /([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})/,
-        );
-        if (uuidMatch && discoveredIds.has(uuidMatch[1])) continue;
-      }
-
-      const client = new CloudApiClient({
-        url: remote.url,
-        type: "remote",
-        authToken: remote.authToken,
-      });
-      const newIndex = results.length;
-      results.push({
-        id: `remote-${remote.id}`,
-        name: remote.name,
-        source: "remote",
-        status: "unknown", // Will be enriched by health probe
-        sourceUrl: remote.url,
-        client,
-      });
-      // Queue for health probe
-      probeTargets.push({ index: newIndex, client });
-    }
-
-    // ===== PHASE 1: Show agents immediately (before health probes) =====
     if (isStale()) return;
     setAgents((prev) => (agentsEqual(prev, results) ? prev : [...results]));
-    // Mark initial load complete so UI shows something immediately
     hasLoadedOnceRef.current = true;
     setLoading(false);
 
-    // ===== PHASE 2: Parallel health probes with concurrency limit =====
     const semaphore = createSemaphore(MAX_CONCURRENT_PROBES);
-
-    // Helper to probe a single agent
-    const probeAgent = async (
-      target: ProbeTarget,
-    ): Promise<ProbeResult | null> => {
-      await semaphore.acquire();
-      try {
-        const health = await target.client.health({
-          signal: AbortSignal.timeout(HEALTH_TIMEOUT_MS),
-        });
-        if (!health.ready && !health.status) {
-          return { index: target.index, status: "unknown" };
-        }
-        // If health returned a synthetic response (agent is auth-gated),
-        // skip the status probe — we already know it's running and won't
-        // get real data without auth. This reduces network requests.
-        if (health._synthetic) {
-          return { index: target.index, status: "running" };
-        }
-        try {
-          const [status, streamSettings] = await Promise.all([
-            target.client.getAgentStatus({
-              signal: AbortSignal.timeout(STATUS_TIMEOUT_MS),
-            }),
-            target.client.getStreamSettings().catch(() => null),
-          ]);
-          return {
-            index: target.index,
-            status: status.state,
-            model: status.model,
-            uptime: status.uptime,
-            memories: status.memories,
-            agentName: status.agentName,
-            avatarIndex: streamSettings?.settings?.avatarIndex,
-          };
-        } catch {
-          // Health OK but no detailed status
-          return { index: target.index, status: "running" };
-        }
-      } catch {
-        // Health check failed
-        return target.isCloudEnrich
-          ? null // Keep cloud data as-is
-          : { index: target.index, status: "unknown" };
-      } finally {
-        semaphore.release();
-      }
-    };
-
-    // Probe local agent in parallel with everything else
-    const probeLocalAgent = async (): Promise<ManagedAgent | null> => {
-      if (!localClient) return null;
-      await semaphore.acquire();
-      try {
-        const health = await localClient.health({
-          signal: AbortSignal.timeout(HEALTH_TIMEOUT_MS),
-        });
-        if (!health.ready && !health.status) return null;
-        // If health returned a synthetic response (agent is auth-gated),
-        // skip the status probe — we already know it's running.
-        if (health._synthetic) {
-          return {
-            id: "local-default",
-            name: "Local Agent",
-            source: "local",
-            status: "running",
-            sourceUrl: LOCAL_AGENT_BASE,
-            client: localClient,
-          };
-        }
-        try {
-          const status = await localClient.getAgentStatus({
-            signal: AbortSignal.timeout(STATUS_TIMEOUT_MS),
-          });
-          return {
-            id: "local-default",
-            name: status.agentName || "Local Agent",
-            source: "local",
-            status: status.state,
-            model: status.model,
-            uptime: status.uptime,
-            memories: status.memories,
-            sourceUrl: LOCAL_AGENT_BASE,
-            client: localClient,
-          };
-        } catch {
-          return {
-            id: "local-default",
-            name: "Local Agent",
-            source: "local",
-            status: "running",
-            sourceUrl: LOCAL_AGENT_BASE,
-            client: localClient,
-          };
-        }
-      } catch {
-        return null; // Local backend not running
-      } finally {
-        semaphore.release();
-      }
-    };
-
-    // Run all probes in parallel
     const [probeResults, localAgentResult] = await Promise.all([
-      Promise.allSettled(probeTargets.map(probeAgent)),
-      probeLocalAgent(),
+      Promise.allSettled(
+        probeTargets.map((target) => probeAgent(target, semaphore)),
+      ),
+      probeLocalAgent(localClient, semaphore),
     ]);
 
     if (isStale()) return;
 
-    // ===== PHASE 3: Merge probe results and update state =====
-    const enrichedResults = [...results];
-
-    // Apply probe results to their respective agents
-    for (const result of probeResults) {
-      if (result.status === "fulfilled" && result.value) {
-        const {
-          index,
-          status,
-          model,
-          uptime,
-          memories,
-          agentName,
-          avatarIndex,
-        } = result.value;
-        if (index < enrichedResults.length) {
-          const agent = enrichedResults[index];
-          if (status) agent.status = status;
-          if (model && model !== "—") agent.model = model;
-          if (uptime !== undefined) agent.uptime = uptime;
-          if (memories !== undefined) agent.memories = memories;
-          if (agentName && !agent.name) agent.name = agentName;
-          if (avatarIndex !== undefined) agent.avatarIndex = avatarIndex;
-        }
-      }
-    }
-
-    // Add local agent if probe succeeded
-    if (localAgentResult) {
-      enrichedResults.push(localAgentResult);
-    }
-
-    // Only update state if this is still the latest request
-    if (isStale()) return;
-
-    // Only update state if data actually changed (prevents unnecessary re-renders)
+    const enrichedResults = mergeProbeResults(
+      results,
+      probeResults,
+      localAgentResult,
+    );
     setAgents((prev) =>
       agentsEqual(prev, enrichedResults) ? prev : enrichedResults,
     );
-
-    // Update error state
     setError(fetchError);
     setIsRefreshing(false);
   }, []);

--- a/apps/homepage/src/lib/useCloudOpenFlow.ts
+++ b/apps/homepage/src/lib/useCloudOpenFlow.ts
@@ -34,12 +34,170 @@ interface CloudAgentCandidate {
   status: string;
 }
 
+const PROVISIONING_MESSAGE = "Provisioning sandbox... (~45s)";
+const PROVISIONING_STAGES: ReadonlyArray<{
+  afterMs: number;
+  text: string;
+}> = [
+  { afterMs: 8000, text: "Booting your container..." },
+  {
+    afterMs: 16000,
+    text: "Almost there... warming up dependencies.",
+  },
+  { afterMs: 24000, text: "Finishing the boot sequence..." },
+  {
+    afterMs: 32000,
+    text: "Still booting, this is taking longer than usual...",
+  },
+];
+
 function generateCloudAgentName(): string {
   const bytes = crypto.getRandomValues(new Uint8Array(2));
   const suffix = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join(
     "",
   );
   return `milady-${suffix}`;
+}
+
+function cloudAgentCandidateFromManaged(
+  agent: ManagedAgent,
+): CloudAgentCandidate | null {
+  if (agent.source !== "cloud" || !agent.cloudAgentId) return null;
+  return {
+    cloudAgentId: agent.cloudAgentId,
+    name: agent.name,
+    status: agent.status,
+  };
+}
+
+function localCloudAgentCandidates(agents: ManagedAgent[]) {
+  return agents.flatMap((agent) => {
+    const candidate = cloudAgentCandidateFromManaged(agent);
+    return candidate ? [candidate] : [];
+  });
+}
+
+async function loadCloudAgentCandidates(
+  agents: ManagedAgent[],
+  cloudClient: CloudClient,
+) {
+  const localCandidates = localCloudAgentCandidates(agents);
+  if (localCandidates.length > 0) return localCandidates;
+  return (await cloudClient.listAgents()).map((agent) => ({
+    cloudAgentId: agent.id,
+    name: agent.name,
+    status: agent.status,
+  }));
+}
+
+function selectReusableCloudAgent(cloudAgents: CloudAgentCandidate[]) {
+  return (
+    cloudAgents.find((agent) => agent.status === "running") ??
+    cloudAgents.find((agent) => agent.status === "paused") ??
+    null
+  );
+}
+
+function provisioningMessageForElapsed(elapsed: number) {
+  let message = PROVISIONING_MESSAGE;
+  for (const stage of PROVISIONING_STAGES) {
+    if (elapsed >= stage.afterMs) message = stage.text;
+  }
+  return message;
+}
+
+function startProvisioningMessageRotation(getPopup: () => Window | null) {
+  const startedAt = Date.now();
+  return window.setInterval(() => {
+    const popup = getPopup();
+    if (!popup || popup.closed) return;
+    updatePopupMessage(
+      popup,
+      provisioningMessageForElapsed(Date.now() - startedAt),
+    );
+  }, 1000);
+}
+
+async function waitForProvisioningJob(
+  cloudClient: CloudClient,
+  jobId: string,
+  getPopup: () => Window | null,
+) {
+  const rotateId = startProvisioningMessageRotation(getPopup);
+  try {
+    const job = await cloudClient.pollJobUntilDone(jobId, PROVISION_TIMEOUT_MS);
+    if (job.status === "failed") {
+      throw new Error(job.error ?? "provisioning failed.");
+    }
+  } finally {
+    window.clearInterval(rotateId);
+  }
+}
+
+async function createAndProvisionCloudAgent(
+  cloudClient: CloudClient,
+  popup: Window,
+  getPopup: () => Window | null,
+) {
+  updatePopupMessage(popup, "Creating your cloud agent...");
+  const created = await cloudClient.createAgent({
+    name: generateCloudAgentName(),
+  });
+  if (!created.id) {
+    throw new Error("agent created but no id was returned.");
+  }
+
+  updatePopupMessage(popup, PROVISIONING_MESSAGE);
+  const provisioning = await cloudClient.provisionAgent(created.id);
+  if (provisioning.jobId) {
+    await waitForProvisioningJob(cloudClient, provisioning.jobId, getPopup);
+  }
+  return created.id;
+}
+
+async function resolveCloudAgentForOpen({
+  agents,
+  cloudClient,
+  popup,
+  refresh,
+  getPopup,
+}: {
+  agents: ManagedAgent[];
+  cloudClient: CloudClient;
+  popup: Window;
+  refresh: () => Promise<void>;
+  getPopup: () => Window | null;
+}) {
+  const cloudAgents = await loadCloudAgentCandidates(agents, cloudClient);
+  const existingCloud = selectReusableCloudAgent(cloudAgents);
+  if (existingCloud?.cloudAgentId) {
+    updatePopupMessage(popup, `Opening ${existingCloud.name}...`);
+    return existingCloud.cloudAgentId;
+  }
+
+  const cloudAgentId = await createAndProvisionCloudAgent(
+    cloudClient,
+    popup,
+    getPopup,
+  );
+  void refresh();
+  return cloudAgentId;
+}
+
+function cloudOpenErrorNotice(error: unknown): Notice {
+  if (error instanceof CloudAgentsNotAvailableError) {
+    return {
+      tone: "error",
+      text: "cloud agent hosting isn't deployed on this Eliza Cloud instance yet.",
+    };
+  }
+  return {
+    tone: "error",
+    text:
+      error instanceof Error
+        ? `cloud open failed: ${error.message}`
+        : "cloud open failed.",
+  };
 }
 
 export function useCloudOpenFlow({
@@ -84,90 +242,18 @@ export function useCloudOpenFlow({
     }
 
     try {
-      let cloudAgentId: string | undefined;
-
-      let cloudAgents: CloudAgentCandidate[] = agents
-        .filter((agent) => agent.source === "cloud" && agent.cloudAgentId)
-        .map((agent) => ({
-          cloudAgentId: agent.cloudAgentId ?? "",
-          name: agent.name,
-          status: agent.status,
-        }));
-      if (cloudAgents.length === 0) {
-        cloudAgents = (await cloudClient.listAgents()).map((agent) => ({
-          cloudAgentId: agent.id,
-          name: agent.name,
-          status: agent.status,
-        }));
-      }
-      const existingCloud =
-        cloudAgents.find((agent) => agent.status === "running") ??
-        cloudAgents.find((agent) => agent.status === "paused") ??
-        null;
-      if (existingCloud?.cloudAgentId) {
-        cloudAgentId = existingCloud.cloudAgentId;
-        updatePopupMessage(popup, `Opening ${existingCloud.name}...`);
-      } else {
-        updatePopupMessage(popup, "Creating your cloud agent...");
-        const created = await cloudClient.createAgent({
-          name: generateCloudAgentName(),
-        });
-        if (!created.id) {
-          throw new Error("agent created but no id was returned.");
-        }
-        cloudAgentId = created.id;
-
-        updatePopupMessage(popup, "Provisioning sandbox... (~45s)");
-        const provResult = await cloudClient.provisionAgent(cloudAgentId);
-        if (provResult.jobId) {
-          const startedAt = Date.now();
-          const provisioningStages: ReadonlyArray<{
-            afterMs: number;
-            text: string;
-          }> = [
-            { afterMs: 8000, text: "Booting your container..." },
-            {
-              afterMs: 16000,
-              text: "Almost there... warming up dependencies.",
-            },
-            { afterMs: 24000, text: "Finishing the boot sequence..." },
-            {
-              afterMs: 32000,
-              text: "Still booting, this is taking longer than usual...",
-            },
-          ];
-          const rotateId = window.setInterval(() => {
-            const live = cloudPopupRef.current;
-            if (!live || live.closed) return;
-            const elapsed = Date.now() - startedAt;
-            let next = "Provisioning sandbox... (~45s)";
-            for (const stage of provisioningStages) {
-              if (elapsed >= stage.afterMs) next = stage.text;
-            }
-            updatePopupMessage(live, next);
-          }, 1000);
-          try {
-            const job = await cloudClient.pollJobUntilDone(
-              provResult.jobId,
-              PROVISION_TIMEOUT_MS,
-            );
-            if (job.status === "failed") {
-              throw new Error(job.error ?? "provisioning failed.");
-            }
-          } finally {
-            window.clearInterval(rotateId);
-          }
-        }
-        void refresh();
-      }
+      const cloudAgentId = await resolveCloudAgentForOpen({
+        agents,
+        cloudClient,
+        popup,
+        refresh,
+        getPopup: () => cloudPopupRef.current,
+      });
 
       if (popup.closed) {
         setCloudOpenState("idle");
         cloudPopupRef.current = null;
         return;
-      }
-      if (!cloudAgentId) {
-        throw new Error("cloud agent id missing.");
       }
 
       updatePopupMessage(popup, "Authenticating...");
@@ -181,20 +267,7 @@ export function useCloudOpenFlow({
     } catch (err) {
       closeCloudPopup();
       setCloudOpenState("idle");
-      if (err instanceof CloudAgentsNotAvailableError) {
-        setNotice({
-          tone: "error",
-          text: "cloud agent hosting isn't deployed on this Eliza Cloud instance yet.",
-        });
-        return;
-      }
-      setNotice({
-        tone: "error",
-        text:
-          err instanceof Error
-            ? `cloud open failed: ${err.message}`
-            : "cloud open failed.",
-      });
+      setNotice(cloudOpenErrorNotice(err));
     }
   }, [agents, cloudClient, closeCloudPopup, refresh, setNotice]);
 

--- a/scripts/disable-local-eliza-workspace.mjs
+++ b/scripts/disable-local-eliza-workspace.mjs
@@ -1079,6 +1079,444 @@ export function repairKnownElizaPatchFiles(
   return true;
 }
 
+function preResolvePinnedWorkspaceVersions(repoRoot, packageJsonPath, { log }) {
+  let rootPackage = null;
+  let pinnedVersions = new Map();
+  const versionSources = new Map();
+
+  if (!fs.existsSync(packageJsonPath)) {
+    return { rootPackage, pinnedVersions, versionSources };
+  }
+
+  try {
+    rootPackage = readPackageJson(packageJsonPath);
+    pinnedVersions = resolvePinnedWorkspaceVersions(repoRoot, {
+      rootPackage,
+      versionSources,
+    });
+    if (pinnedVersions.size > 0) {
+      log(
+        `[disable-local-eliza-workspace] Pre-resolved ${pinnedVersions.size} pinned version(s) before disabling workspace`,
+      );
+    }
+  } catch {
+    /* continue — will be read again below */
+  }
+
+  return { rootPackage, pinnedVersions, versionSources };
+}
+
+function reconcileElizaWorkspaceDirectory({
+  shouldRenameElizaWorkspace,
+  elizaRoot,
+  disabledElizaRoot,
+  log,
+}) {
+  if (shouldRenameElizaWorkspace && fs.existsSync(elizaRoot)) {
+    fs.rmSync(disabledElizaRoot, { recursive: true, force: true });
+    fs.renameSync(elizaRoot, disabledElizaRoot);
+    log(
+      `[disable-local-eliza-workspace] Disabled repo-local eliza workspace at ${elizaRoot}`,
+    );
+    return;
+  }
+
+  if (
+    !shouldRenameElizaWorkspace &&
+    fs.existsSync(elizaRoot) &&
+    fs.existsSync(disabledElizaRoot)
+  ) {
+    fs.rmSync(disabledElizaRoot, { recursive: true, force: true });
+    log(
+      `[disable-local-eliza-workspace] Removed stale disabled workspace at ${disabledElizaRoot}`,
+    );
+    return;
+  }
+
+  if (!shouldRenameElizaWorkspace && fs.existsSync(elizaRoot)) {
+    log(
+      "[disable-local-eliza-workspace] Keeping eliza/ on disk (rewrite-only mode)",
+    );
+    return;
+  }
+
+  log(
+    "[disable-local-eliza-workspace] Repo-local eliza workspace already absent",
+  );
+}
+
+function backupRootPackageJson(repoRoot, rawRootPkg, { log }) {
+  const rootPackageBackupPath = path.join(
+    repoRoot,
+    "package.json.pre-disable-backup",
+  );
+
+  if (fs.existsSync(rootPackageBackupPath)) {
+    return;
+  }
+
+  fs.writeFileSync(rootPackageBackupPath, rawRootPkg);
+  log(
+    `[disable-local-eliza-workspace] Wrote original package.json backup to ${path.relative(repoRoot, rootPackageBackupPath)}`,
+  );
+}
+
+function parseRootPackageJson(packageJsonPath, rawRootPkg, { errorLog }) {
+  try {
+    const parsedRootPkg = JSON.parse(rawRootPkg);
+    if (!isPackageJsonRecord(parsedRootPkg)) {
+      throw new Error(
+        `expected a package.json object with string-valued dependency maps`,
+      );
+    }
+    return parsedRootPkg;
+  } catch (error) {
+    errorLog(
+      `[disable-local-eliza-workspace] Failed to parse ${packageJsonPath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    throw error;
+  }
+}
+
+function isDisabledWorkspaceEntry(entry) {
+  return (
+    DISABLED_WORKSPACE_GLOBS.includes(entry) ||
+    (typeof entry === "string" &&
+      entry.startsWith("eliza/") &&
+      !LOCAL_ONLY_WORKSPACE_GLOBS.includes(entry) &&
+      !LOCAL_ONLY_WORKSPACE_PATHS.includes(entry))
+  );
+}
+
+function patchRootWorkspaces(rootPkg, repoRoot, { log }) {
+  const removedWorkspaceGlobs = [];
+
+  if (!Array.isArray(rootPkg.workspaces)) {
+    return removedWorkspaceGlobs;
+  }
+
+  const filteredWorkspaces = rootPkg.workspaces.filter((entry) => {
+    if (!isDisabledWorkspaceEntry(entry)) {
+      return true;
+    }
+    removedWorkspaceGlobs.push(entry);
+    return false;
+  });
+
+  for (const workspacePath of LOCAL_ONLY_WORKSPACE_PATHS) {
+    const absoluteWorkspacePath = path.join(repoRoot, workspacePath);
+    if (
+      fs.existsSync(path.join(absoluteWorkspacePath, "package.json")) &&
+      !filteredWorkspaces.includes(workspacePath)
+    ) {
+      filteredWorkspaces.push(workspacePath);
+    }
+  }
+
+  if (removedWorkspaceGlobs.length === 0) {
+    log(
+      `[disable-local-eliza-workspace] Root package.json workspaces array does not include ${DISABLED_WORKSPACE_GLOBS.join(", ")}; nothing to patch`,
+    );
+    return removedWorkspaceGlobs;
+  }
+
+  rootPkg.workspaces = filteredWorkspaces;
+  log(
+    `[disable-local-eliza-workspace] Removed ${removedWorkspaceGlobs.join(", ")} from root package.json workspaces`,
+  );
+  return removedWorkspaceGlobs;
+}
+
+function pruneElizaPatchedDependencies(
+  rootPkg,
+  repoRoot,
+  shouldRenameElizaWorkspace,
+  { log },
+) {
+  if (!isStringRecord(rootPkg.patchedDependencies)) {
+    return;
+  }
+
+  const removedPatches = [];
+  for (const [dep, patchPath] of Object.entries(rootPkg.patchedDependencies)) {
+    if (typeof patchPath !== "string" || !patchPath.startsWith("eliza/")) {
+      continue;
+    }
+    const absolutePatchPath = path.join(repoRoot, patchPath);
+    if (shouldRenameElizaWorkspace || !fs.existsSync(absolutePatchPath)) {
+      removedPatches.push(dep);
+    }
+  }
+
+  for (const dep of removedPatches) {
+    delete rootPkg.patchedDependencies[dep];
+  }
+
+  if (removedPatches.length > 0) {
+    log(
+      `[disable-local-eliza-workspace] Removed ${removedPatches.length} patchedDependencies referencing eliza/ (${removedPatches.join(", ")})`,
+    );
+  }
+}
+
+function stubElizaWorkspaceScripts(
+  rootPkg,
+  shouldRenameElizaWorkspace,
+  { log },
+) {
+  if (!shouldRenameElizaWorkspace || !isStringRecord(rootPkg.scripts)) {
+    return;
+  }
+
+  const stubbedScripts = [];
+  for (const [name, cmd] of Object.entries(rootPkg.scripts)) {
+    if (typeof cmd !== "string" || !cmd.includes("eliza/")) {
+      continue;
+    }
+    stubbedScripts.push(name);
+    rootPkg.scripts[name] =
+      "echo '[CI] script disabled — eliza/ workspace not present'";
+  }
+
+  if (stubbedScripts.length > 0) {
+    log(
+      `[disable-local-eliza-workspace] Stubbed ${stubbedScripts.length} scripts referencing eliza/ (${stubbedScripts.slice(0, 5).join(", ")}${stubbedScripts.length > 5 ? ", ..." : ""})`,
+    );
+  }
+}
+
+function patchLocalElizaPackage({
+  shouldTouchLocalElizaWorkspace,
+  elizaPackageJsonPath,
+  log,
+  warn,
+}) {
+  if (!shouldTouchLocalElizaWorkspace || !fs.existsSync(elizaPackageJsonPath)) {
+    return;
+  }
+
+  try {
+    const rawElizaPkg = fs.readFileSync(elizaPackageJsonPath, "utf8");
+    const elizaPkg = parseJsonObject(rawElizaPkg);
+    if (!isPackageJsonRecord(elizaPkg)) {
+      warn(
+        `[disable-local-eliza-workspace] Skipping ${elizaPackageJsonPath}: package.json is malformed`,
+      );
+      return;
+    }
+    if (
+      applyOverrideSpecifiers(elizaPkg, ELIZA_RUNTIME_CI_OVERRIDE_SPECIFIERS, {
+        log,
+        label: "local eliza runtime override",
+      })
+    ) {
+      writePackageJson(elizaPackageJsonPath, rawElizaPkg, elizaPkg);
+    }
+  } catch (error) {
+    warn(
+      `[disable-local-eliza-workspace] Failed to patch ${elizaPackageJsonPath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+function resolvePinnedWorkspaceVersionState({
+  earlyPinnedVersions,
+  earlyPinnedVersionSources,
+  repoRoot,
+  rootPkg,
+}) {
+  const latePinnedVersionSources = new Map();
+  const pinnedWorkspaceVersions =
+    earlyPinnedVersions.size > 0
+      ? earlyPinnedVersions
+      : resolvePinnedWorkspaceVersions(repoRoot, {
+          rootPackage: rootPkg,
+          versionSources: latePinnedVersionSources,
+        });
+  const pinnedVersionSources =
+    earlyPinnedVersions.size > 0
+      ? earlyPinnedVersionSources
+      : latePinnedVersionSources;
+
+  return { pinnedWorkspaceVersions, pinnedVersionSources };
+}
+
+function resolvePendingWorkspaceRewriteTargets({
+  rootPkg,
+  repoRoot,
+  removedWorkspaceGlobs,
+  shouldTouchLocalElizaWorkspace,
+}) {
+  const seen = new Set();
+  const pendingWorkspaceDirs = [];
+  const nestedInstallablePackageDirs = new Set(
+    NESTED_INSTALLABLE_PACKAGE_GLOBS.flatMap((glob) =>
+      expandGlob(glob, { rootDir: repoRoot }),
+    ),
+  );
+  const rewriteWorkspaceEntries = [
+    ...(rootPkg.workspaces ?? []),
+    ...(shouldTouchLocalElizaWorkspace ? removedWorkspaceGlobs : []),
+    ...(shouldTouchLocalElizaWorkspace ? NESTED_INSTALLABLE_PACKAGE_GLOBS : []),
+  ];
+
+  for (const entry of rewriteWorkspaceEntries) {
+    const expanded = expandGlob(entry, { rootDir: repoRoot });
+    for (const match of expanded) {
+      if (seen.has(match)) {
+        continue;
+      }
+      seen.add(match);
+      pendingWorkspaceDirs.push(match);
+    }
+  }
+
+  return { pendingWorkspaceDirs, nestedInstallablePackageDirs };
+}
+
+function collectPendingWorkspaceDependencyNames({
+  rootPkg,
+  pendingWorkspaceDirs,
+  repoRoot,
+  localOnlyPackages,
+  warn,
+}) {
+  const dependencyNames = collectWorkspaceProtocolDependencyNames(rootPkg, {
+    localOnlyPackages,
+  });
+
+  for (const workspaceRel of pendingWorkspaceDirs) {
+    const pkgPath = path.join(repoRoot, workspaceRel, "package.json");
+    if (!fs.existsSync(pkgPath)) continue;
+    try {
+      const pkg = readPackageJson(pkgPath);
+      if (!pkg) {
+        warn(
+          `[disable-local-eliza-workspace]   skipped dependency scan for ${workspaceRel}: package.json is missing or malformed`,
+        );
+        continue;
+      }
+      for (const dependencyName of collectWorkspaceProtocolDependencyNames(
+        pkg,
+        { localOnlyPackages },
+      )) {
+        dependencyNames.add(dependencyName);
+      }
+    } catch (error) {
+      warn(
+        `[disable-local-eliza-workspace]   skipped dependency scan for ${workspaceRel}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  return dependencyNames;
+}
+
+function rewriteRootPackageDependencies({
+  rootPkg,
+  packageJsonPath,
+  rawRootPkg,
+  publishSafePinnedWorkspaceVersions,
+  localOnlyPackages,
+  registrySpecifierCache,
+  log,
+  warn,
+}) {
+  const rewroteRootWorkspaceDeps = rewriteWorkspaceDependencySpecifiers(
+    rootPkg,
+    publishSafePinnedWorkspaceVersions,
+    { localOnlyPackages },
+  );
+  const rewroteRootRegistryDeps = rewriteConfiguredElizaRegistrySpecifiers(
+    rootPkg,
+    {
+      localOnlyPackages,
+      registryInfoCache: registrySpecifierCache,
+      log,
+      warn,
+    },
+  );
+
+  if (!rewroteRootWorkspaceDeps && !rewroteRootRegistryDeps) {
+    return 0;
+  }
+
+  writePackageJson(packageJsonPath, rawRootPkg, rootPkg);
+  log("[disable-local-eliza-workspace]   patched .");
+  return 1;
+}
+
+function rewritePendingWorkspacePackage({
+  workspaceRel,
+  repoRoot,
+  publishSafePinnedWorkspaceVersions,
+  localOnlyPackages,
+  registrySpecifierCache,
+  nestedInstallablePackageDirs,
+  localOnlyPackagePaths,
+  log,
+  warn,
+}) {
+  const pkgPath = path.join(repoRoot, workspaceRel, "package.json");
+  if (!fs.existsSync(pkgPath)) {
+    return 0;
+  }
+
+  let originalRaw;
+  let parsedPkg;
+  try {
+    originalRaw = fs.readFileSync(pkgPath, "utf8");
+    parsedPkg = parseJsonObject(originalRaw);
+  } catch (error) {
+    warn(
+      `[disable-local-eliza-workspace]   skipped ${workspaceRel}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return 0;
+  }
+
+  if (!isPackageJsonRecord(parsedPkg)) {
+    warn(
+      `[disable-local-eliza-workspace]   skipped ${workspaceRel}: package.json is malformed`,
+    );
+    return 0;
+  }
+
+  const rewrotePublishedWorkspaceDeps = rewriteWorkspaceDependencySpecifiers(
+    parsedPkg,
+    publishSafePinnedWorkspaceVersions,
+    { localOnlyPackages },
+  );
+  const rewroteConfiguredRegistryDeps =
+    rewriteConfiguredElizaRegistrySpecifiers(parsedPkg, {
+      localOnlyPackages,
+      registryInfoCache: registrySpecifierCache,
+      log,
+      warn,
+    });
+  const rewroteNestedLocalFileDeps =
+    nestedInstallablePackageDirs.has(workspaceRel) &&
+    rewriteNestedLocalFileDependencySpecifiers(
+      parsedPkg,
+      workspaceRel,
+      localOnlyPackagePaths,
+    );
+
+  if (
+    !rewrotePublishedWorkspaceDeps &&
+    !rewroteConfiguredRegistryDeps &&
+    !rewroteNestedLocalFileDeps
+  ) {
+    return 0;
+  }
+
+  if (!writePackageJson(pkgPath, originalRaw, parsedPkg)) {
+    return 0;
+  }
+
+  log(`[disable-local-eliza-workspace]   patched ${workspaceRel}`);
+  return 1;
+}
+
 export function disableLocalElizaWorkspace(
   repoRoot = DEFAULT_REPO_ROOT,
   { log = console.log, warn = console.warn, errorLog = console.error } = {},
@@ -1100,52 +1538,17 @@ export function disableLocalElizaWorkspace(
   const localOnlyPackagePaths = resolveLocalOnlyWorkspacePackagePaths(repoRoot);
   const localOnlyPackages = new Set(localOnlyPackagePaths.keys());
 
-  // Resolve pinned versions BEFORE renaming eliza/ away, since the
-  // cloud-agent-template and local package.json files live inside it.
-  let earlyRootPkg = null;
-  let earlyPinnedVersions = new Map();
-  const earlyPinnedVersionSources = new Map();
-  if (fs.existsSync(packageJsonPath)) {
-    try {
-      earlyRootPkg = readPackageJson(packageJsonPath);
-      earlyPinnedVersions = resolvePinnedWorkspaceVersions(repoRoot, {
-        rootPackage: earlyRootPkg,
-        versionSources: earlyPinnedVersionSources,
-      });
-      if (earlyPinnedVersions.size > 0) {
-        log(
-          `[disable-local-eliza-workspace] Pre-resolved ${earlyPinnedVersions.size} pinned version(s) before disabling workspace`,
-        );
-      }
-    } catch {
-      /* continue — will be read again below */
-    }
-  }
+  const {
+    pinnedVersions: earlyPinnedVersions,
+    versionSources: earlyPinnedVersionSources,
+  } = preResolvePinnedWorkspaceVersions(repoRoot, packageJsonPath, { log });
 
-  if (shouldRenameElizaWorkspace && fs.existsSync(elizaRoot)) {
-    fs.rmSync(disabledElizaRoot, { recursive: true, force: true });
-    fs.renameSync(elizaRoot, disabledElizaRoot);
-    log(
-      `[disable-local-eliza-workspace] Disabled repo-local eliza workspace at ${elizaRoot}`,
-    );
-  } else if (
-    !shouldRenameElizaWorkspace &&
-    fs.existsSync(elizaRoot) &&
-    fs.existsSync(disabledElizaRoot)
-  ) {
-    fs.rmSync(disabledElizaRoot, { recursive: true, force: true });
-    log(
-      `[disable-local-eliza-workspace] Removed stale disabled workspace at ${disabledElizaRoot}`,
-    );
-  } else if (!shouldRenameElizaWorkspace && fs.existsSync(elizaRoot)) {
-    log(
-      "[disable-local-eliza-workspace] Keeping eliza/ on disk (rewrite-only mode)",
-    );
-  } else {
-    log(
-      "[disable-local-eliza-workspace] Repo-local eliza workspace already absent",
-    );
-  }
+  reconcileElizaWorkspaceDirectory({
+    shouldRenameElizaWorkspace,
+    elizaRoot,
+    disabledElizaRoot,
+    log,
+  });
 
   applyTsconfigMode(repoRoot, "packages", { log });
 
@@ -1161,228 +1564,52 @@ export function disableLocalElizaWorkspace(
   }
 
   const rawRootPkg = fs.readFileSync(packageJsonPath, "utf8");
+  backupRootPackageJson(repoRoot, rawRootPkg, { log });
 
-  // Back up the original root package.json so the restore script can put it
-  // back after the disable→install→restore cycle. Without this, mutations
-  // (e.g. dropping workspace:* deps with no pinned version) persist past
-  // restore, and downstream checks like release-check that read root
-  // dependencies see a stripped manifest and exit 1.
-  const rootPackageBackupPath = path.join(
-    repoRoot,
-    "package.json.pre-disable-backup",
-  );
-  if (!fs.existsSync(rootPackageBackupPath)) {
-    fs.writeFileSync(rootPackageBackupPath, rawRootPkg);
-    log(
-      `[disable-local-eliza-workspace] Wrote original package.json backup to ${path.relative(repoRoot, rootPackageBackupPath)}`,
-    );
-  }
-
-  /** @type {PackageJsonRecord} */
-  let rootPkg;
-  try {
-    const parsedRootPkg = JSON.parse(rawRootPkg);
-    if (!isPackageJsonRecord(parsedRootPkg)) {
-      throw new Error(
-        `expected a package.json object with string-valued dependency maps`,
-      );
-    }
-    rootPkg = parsedRootPkg;
-  } catch (error) {
-    errorLog(
-      `[disable-local-eliza-workspace] Failed to parse ${packageJsonPath}: ${error instanceof Error ? error.message : String(error)}`,
-    );
-    throw error;
-  }
-
-  const removedWorkspaceGlobs = [];
-  if (Array.isArray(rootPkg.workspaces)) {
-    const originalWorkspaces = rootPkg.workspaces;
-    const filteredWorkspaces = originalWorkspaces.filter((entry) => {
-      if (DISABLED_WORKSPACE_GLOBS.includes(entry)) {
-        removedWorkspaceGlobs.push(entry);
-        return false;
-      }
-      // Also strip any explicit eliza/ paths (e.g. electrobun, cloud-agent-template)
-      // that would vanish when eliza/ is renamed to .eliza.ci-disabled/
-      if (
-        typeof entry === "string" &&
-        entry.startsWith("eliza/") &&
-        !LOCAL_ONLY_WORKSPACE_GLOBS.includes(entry) &&
-        !LOCAL_ONLY_WORKSPACE_PATHS.includes(entry)
-      ) {
-        removedWorkspaceGlobs.push(entry);
-        return false;
-      }
-      return true;
-    });
-
-    for (const workspacePath of LOCAL_ONLY_WORKSPACE_PATHS) {
-      const absoluteWorkspacePath = path.join(repoRoot, workspacePath);
-      if (
-        fs.existsSync(path.join(absoluteWorkspacePath, "package.json")) &&
-        !filteredWorkspaces.includes(workspacePath)
-      ) {
-        filteredWorkspaces.push(workspacePath);
-      }
-    }
-
-    if (removedWorkspaceGlobs.length === 0) {
-      log(
-        `[disable-local-eliza-workspace] Root package.json workspaces array does not include ${DISABLED_WORKSPACE_GLOBS.join(", ")}; nothing to patch`,
-      );
-    } else {
-      rootPkg.workspaces = filteredWorkspaces;
-      log(
-        `[disable-local-eliza-workspace] Removed ${removedWorkspaceGlobs.join(", ")} from root package.json workspaces`,
-      );
-    }
-  }
-
-  // Strip patchedDependencies whose patch files live inside eliza/ when either:
-  // - eliza/ is intentionally renamed away (shouldRenameElizaWorkspace), OR
-  // - the patch file does not actually exist on disk (avoids bun install failure
-  //   with "Couldn't find patch file: 'eliza/packages/...'" when the submodule
-  //   is absent or not initialized).
-  if (isStringRecord(rootPkg.patchedDependencies)) {
-    const removedPatches = [];
-    for (const [dep, patchPath] of Object.entries(
-      rootPkg.patchedDependencies,
-    )) {
-      if (typeof patchPath === "string" && patchPath.startsWith("eliza/")) {
-        const absolutePatchPath = path.join(repoRoot, patchPath);
-        if (shouldRenameElizaWorkspace || !fs.existsSync(absolutePatchPath)) {
-          removedPatches.push(dep);
-        }
-      }
-    }
-    for (const dep of removedPatches) {
-      delete rootPkg.patchedDependencies[dep];
-    }
-    if (removedPatches.length > 0) {
-      log(
-        `[disable-local-eliza-workspace] Removed ${removedPatches.length} patchedDependencies referencing eliza/ (${removedPatches.join(", ")})`,
-      );
-    }
-  }
-
-  // Stub scripts that reference eliza/ paths only when the directory has been
-  // renamed away.
-  if (shouldRenameElizaWorkspace && isStringRecord(rootPkg.scripts)) {
-    const stubbedScripts = [];
-    for (const [name, cmd] of Object.entries(rootPkg.scripts)) {
-      if (typeof cmd === "string" && cmd.includes("eliza/")) {
-        stubbedScripts.push(name);
-        rootPkg.scripts[name] =
-          "echo '[CI] script disabled — eliza/ workspace not present'";
-      }
-    }
-    if (stubbedScripts.length > 0) {
-      log(
-        `[disable-local-eliza-workspace] Stubbed ${stubbedScripts.length} scripts referencing eliza/ (${stubbedScripts.slice(0, 5).join(", ")}${stubbedScripts.length > 5 ? ", ..." : ""})`,
-      );
-    }
-  }
+  const rootPkg = parseRootPackageJson(packageJsonPath, rawRootPkg, {
+    errorLog,
+  });
+  const removedWorkspaceGlobs = patchRootWorkspaces(rootPkg, repoRoot, {
+    log,
+  });
+  pruneElizaPatchedDependencies(rootPkg, repoRoot, shouldRenameElizaWorkspace, {
+    log,
+  });
+  stubElizaWorkspaceScripts(rootPkg, shouldRenameElizaWorkspace, { log });
 
   applyCiOnlyOverrides(rootPkg, { log, repoRoot });
 
   writePackageJson(packageJsonPath, rawRootPkg, rootPkg);
 
-  if (shouldTouchLocalElizaWorkspace && fs.existsSync(elizaPackageJsonPath)) {
-    try {
-      const rawElizaPkg = fs.readFileSync(elizaPackageJsonPath, "utf8");
-      const elizaPkg = parseJsonObject(rawElizaPkg);
-      if (!isPackageJsonRecord(elizaPkg)) {
-        warn(
-          `[disable-local-eliza-workspace] Skipping ${elizaPackageJsonPath}: package.json is malformed`,
-        );
-      } else if (
-        applyOverrideSpecifiers(
-          elizaPkg,
-          ELIZA_RUNTIME_CI_OVERRIDE_SPECIFIERS,
-          {
-            log,
-            label: "local eliza runtime override",
-          },
-        )
-      ) {
-        writePackageJson(elizaPackageJsonPath, rawElizaPkg, elizaPkg);
-      }
-    } catch (error) {
-      warn(
-        `[disable-local-eliza-workspace] Failed to patch ${elizaPackageJsonPath}: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    }
-  }
+  patchLocalElizaPackage({
+    shouldTouchLocalElizaWorkspace,
+    elizaPackageJsonPath,
+    log,
+    warn,
+  });
 
-  // Use early-resolved versions (captured before eliza/ was renamed away).
-  // Fall back to a post-rename resolution attempt for robustness.
-  const latePinnedVersionSources = new Map();
-  const pinnedWorkspaceVersions =
-    earlyPinnedVersions.size > 0
-      ? earlyPinnedVersions
-      : resolvePinnedWorkspaceVersions(repoRoot, {
-          rootPackage: rootPkg,
-          versionSources: latePinnedVersionSources,
-        });
-  const pinnedVersionSources =
-    earlyPinnedVersions.size > 0
-      ? earlyPinnedVersionSources
-      : latePinnedVersionSources;
-
-  const seen = new Set();
-  const pendingWorkspaceDirs = [];
-  const nestedInstallablePackageDirs = new Set(
-    NESTED_INSTALLABLE_PACKAGE_GLOBS.flatMap((glob) =>
-      expandGlob(glob, { rootDir: repoRoot }),
-    ),
-  );
-  const rewriteWorkspaceEntries = [
-    ...(rootPkg.workspaces ?? []),
-    ...(shouldTouchLocalElizaWorkspace ? removedWorkspaceGlobs : []),
-    ...(shouldTouchLocalElizaWorkspace ? NESTED_INSTALLABLE_PACKAGE_GLOBS : []),
-  ];
-
-  // In rewrite-only CI the eliza/ checkout stays on disk even after we remove
-  // its globs from the root workspace graph. Keep rewriting those package.json
-  // files too, because release-check still validates their pinned specs.
-  for (const entry of rewriteWorkspaceEntries) {
-    const expanded = expandGlob(entry, { rootDir: repoRoot });
-    for (const match of expanded) {
-      if (!seen.has(match)) {
-        seen.add(match);
-        pendingWorkspaceDirs.push(match);
-      }
-    }
-  }
-
+  const { pinnedWorkspaceVersions, pinnedVersionSources } =
+    resolvePinnedWorkspaceVersionState({
+      earlyPinnedVersions,
+      earlyPinnedVersionSources,
+      repoRoot,
+      rootPkg,
+    });
+  const { pendingWorkspaceDirs, nestedInstallablePackageDirs } =
+    resolvePendingWorkspaceRewriteTargets({
+      rootPkg,
+      repoRoot,
+      removedWorkspaceGlobs,
+      shouldTouchLocalElizaWorkspace,
+    });
   const workspaceProtocolDependencyNames =
-    collectWorkspaceProtocolDependencyNames(rootPkg, { localOnlyPackages });
-  for (const workspaceRel of pendingWorkspaceDirs) {
-    const pkgPath = path.join(repoRoot, workspaceRel, "package.json");
-    if (!fs.existsSync(pkgPath)) continue;
-    try {
-      const pkg = readPackageJson(pkgPath);
-      if (!pkg) {
-        warn(
-          `[disable-local-eliza-workspace]   skipped dependency scan for ${workspaceRel}: package.json is missing or malformed`,
-        );
-        continue;
-      }
-      for (const dependencyName of collectWorkspaceProtocolDependencyNames(
-        pkg,
-        {
-          localOnlyPackages,
-        },
-      )) {
-        workspaceProtocolDependencyNames.add(dependencyName);
-      }
-    } catch (error) {
-      warn(
-        `[disable-local-eliza-workspace]   skipped dependency scan for ${workspaceRel}: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    }
-  }
+    collectPendingWorkspaceDependencyNames({
+      rootPkg,
+      pendingWorkspaceDirs,
+      repoRoot,
+      localOnlyPackages,
+      warn,
+    });
 
   const registryResolvedPinnedWorkspaceVersions =
     resolveMissingRegistryPinnedVersions(
@@ -1424,84 +1651,29 @@ export function disableLocalElizaWorkspace(
 
   let rewrites = 0;
   const registrySpecifierCache = new Map();
-  const rewroteRootWorkspaceDeps = rewriteWorkspaceDependencySpecifiers(
+  rewrites += rewriteRootPackageDependencies({
     rootPkg,
+    packageJsonPath,
+    rawRootPkg,
     publishSafePinnedWorkspaceVersions,
-    {
-      localOnlyPackages,
-    },
-  );
-  const rewroteRootRegistryDeps = rewriteConfiguredElizaRegistrySpecifiers(
-    rootPkg,
-    {
-      localOnlyPackages,
-      registryInfoCache: registrySpecifierCache,
-      log,
-      warn,
-    },
-  );
-  if (rewroteRootWorkspaceDeps || rewroteRootRegistryDeps) {
-    writePackageJson(packageJsonPath, rawRootPkg, rootPkg);
-    rewrites++;
-    log("[disable-local-eliza-workspace]   patched .");
-  }
+    localOnlyPackages,
+    registrySpecifierCache,
+    log,
+    warn,
+  });
 
   for (const workspaceRel of pendingWorkspaceDirs) {
-    const pkgPath = path.join(repoRoot, workspaceRel, "package.json");
-    if (!fs.existsSync(pkgPath)) continue;
-
-    let originalRaw;
-    let parsedPkg;
-    try {
-      originalRaw = fs.readFileSync(pkgPath, "utf8");
-      parsedPkg = parseJsonObject(originalRaw);
-    } catch (error) {
-      warn(
-        `[disable-local-eliza-workspace]   skipped ${workspaceRel}: ${error instanceof Error ? error.message : String(error)}`,
-      );
-      continue;
-    }
-    if (!isPackageJsonRecord(parsedPkg)) {
-      warn(
-        `[disable-local-eliza-workspace]   skipped ${workspaceRel}: package.json is malformed`,
-      );
-      continue;
-    }
-    const pkg = parsedPkg;
-
-    const rewrotePublishedWorkspaceDeps = rewriteWorkspaceDependencySpecifiers(
-      pkg,
+    rewrites += rewritePendingWorkspacePackage({
+      workspaceRel,
+      repoRoot,
       publishSafePinnedWorkspaceVersions,
-      {
-        localOnlyPackages,
-      },
-    );
-    const rewroteConfiguredRegistryDeps =
-      rewriteConfiguredElizaRegistrySpecifiers(pkg, {
-        localOnlyPackages,
-        registryInfoCache: registrySpecifierCache,
-        log,
-        warn,
-      });
-    const rewroteNestedLocalFileDeps =
-      nestedInstallablePackageDirs.has(workspaceRel) &&
-      rewriteNestedLocalFileDependencySpecifiers(
-        pkg,
-        workspaceRel,
-        localOnlyPackagePaths,
-      );
-
-    if (
-      !rewrotePublishedWorkspaceDeps &&
-      !rewroteConfiguredRegistryDeps &&
-      !rewroteNestedLocalFileDeps
-    ) {
-      continue;
-    }
-    if (writePackageJson(pkgPath, originalRaw, pkg)) {
-      rewrites++;
-      log(`[disable-local-eliza-workspace]   patched ${workspaceRel}`);
-    }
+      localOnlyPackages,
+      registrySpecifierCache,
+      nestedInstallablePackageDirs,
+      localOnlyPackagePaths,
+      log,
+      warn,
+    });
   }
 
   if (rewrites === 0) {

--- a/scripts/gmail-real-smoke.mjs
+++ b/scripts/gmail-real-smoke.mjs
@@ -1,13 +1,11 @@
 #!/usr/bin/env node
 import crypto from "node:crypto";
+import {
+  lifeopsConnectorParams,
+  readLifeOpsApiBases,
+} from "./lib/lifeops-api-base.mjs";
 
 const GMAIL_BASE = "https://gmail.googleapis.com/gmail/v1/users/me";
-const DEFAULT_LIFEOPS_API_BASES = [
-  "http://127.0.0.1:31337",
-  "http://localhost:31337",
-  "http://127.0.0.1:2138",
-  "http://localhost:2138",
-];
 const METADATA_HEADERS = [
   "Subject",
   "From",
@@ -150,7 +148,7 @@ async function gmailJson(pathname, token, init = {}) {
       Authorization: `Bearer ${token}`,
       Accept: "application/json",
       ...(init.body ? { "Content-Type": "application/json" } : {}),
-      ...(init.headers ?? {}),
+      ...init.headers,
     },
   });
   const text = await response.text();
@@ -169,7 +167,7 @@ async function lifeopsJson(baseUrl, pathname, init = {}) {
     headers: {
       Accept: "application/json",
       ...(init.body ? { "Content-Type": "application/json" } : {}),
-      ...(init.headers ?? {}),
+      ...init.headers,
     },
   });
   const text = await response.text();
@@ -220,34 +218,6 @@ async function listMetadata(token, query, maxResults, includeSpamTrash) {
   };
 }
 
-function normalizeBaseUrl(value) {
-  return value.replace(/\/+$/g, "");
-}
-
-function readLifeOpsApiBases() {
-  const explicit = readFlag("--api-base");
-  const env = [
-    process.env.MILADY_LIFEOPS_API_BASE,
-    process.env.LIFEOPS_API_BASE,
-    process.env.ELIZA_API_BASE,
-  ];
-  return [explicit, ...env]
-    .flatMap((value) => (value ?? "").split(","))
-    .map((value) => value.trim())
-    .filter(Boolean)
-    .concat(DEFAULT_LIFEOPS_API_BASES)
-    .map(normalizeBaseUrl)
-    .filter((value, index, all) => all.indexOf(value) === index);
-}
-
-function lifeopsConnectorParams(options) {
-  const params = new URLSearchParams();
-  if (options.side) params.set("side", options.side);
-  if (options.mode) params.set("mode", options.mode);
-  if (options.grantId) params.set("grantId", options.grantId);
-  return params;
-}
-
 function lifeopsGmailParams(options) {
   const params = lifeopsConnectorParams(options);
   params.set("forceSync", String(options.forceSync));
@@ -265,7 +235,7 @@ function lifeopsGmailParams(options) {
 async function resolveLifeOpsApiBase(options) {
   const statusPath = `/api/lifeops/connectors/google/status?${lifeopsConnectorParams(options).toString()}`;
   let lastError = null;
-  for (const baseUrl of readLifeOpsApiBases()) {
+  for (const baseUrl of readLifeOpsApiBases(readFlag("--api-base"))) {
     try {
       const status = await lifeopsJson(baseUrl, statusPath);
       return { baseUrl, status, statusPath };

--- a/scripts/gmail-real-sweep.mjs
+++ b/scripts/gmail-real-sweep.mjs
@@ -1,13 +1,11 @@
 #!/usr/bin/env node
 import crypto from "node:crypto";
+import {
+  lifeopsConnectorParams,
+  readLifeOpsApiBases,
+} from "./lib/lifeops-api-base.mjs";
 
 const GMAIL_BASE = "https://gmail.googleapis.com/gmail/v1/users/me";
-const DEFAULT_LIFEOPS_API_BASES = [
-  "http://127.0.0.1:31337",
-  "http://localhost:31337",
-  "http://127.0.0.1:2138",
-  "http://localhost:2138",
-];
 const METADATA_HEADERS = [
   "Subject",
   "From",
@@ -176,7 +174,7 @@ async function gmailJson(pathname, token, init = {}) {
       Authorization: `Bearer ${token}`,
       Accept: "application/json",
       ...(init.body ? { "Content-Type": "application/json" } : {}),
-      ...(init.headers ?? {}),
+      ...init.headers,
     },
   });
   const text = await response.text();
@@ -196,7 +194,7 @@ async function gmailVoid(pathname, token, init = {}) {
       Authorization: `Bearer ${token}`,
       Accept: "application/json",
       ...(init.body ? { "Content-Type": "application/json" } : {}),
-      ...(init.headers ?? {}),
+      ...init.headers,
     },
   });
   if (!response.ok) {
@@ -212,7 +210,7 @@ async function lifeopsJson(baseUrl, pathname, init = {}) {
     headers: {
       Accept: "application/json",
       ...(init.body ? { "Content-Type": "application/json" } : {}),
-      ...(init.headers ?? {}),
+      ...init.headers,
     },
   });
   const text = await response.text();
@@ -223,34 +221,6 @@ async function lifeopsJson(baseUrl, pathname, init = {}) {
     );
   }
   return body;
-}
-
-function normalizeBaseUrl(value) {
-  return value.replace(/\/+$/g, "");
-}
-
-function readLifeOpsApiBases() {
-  const explicit = readFlag("--api-base");
-  const env = [
-    process.env.MILADY_LIFEOPS_API_BASE,
-    process.env.LIFEOPS_API_BASE,
-    process.env.ELIZA_API_BASE,
-  ];
-  return [explicit, ...env]
-    .flatMap((value) => (value ?? "").split(","))
-    .map((value) => value.trim())
-    .filter(Boolean)
-    .concat(DEFAULT_LIFEOPS_API_BASES)
-    .map(normalizeBaseUrl)
-    .filter((value, index, all) => all.indexOf(value) === index);
-}
-
-function lifeopsConnectorParams(options) {
-  const params = new URLSearchParams();
-  if (options.side) params.set("side", options.side);
-  if (options.mode) params.set("mode", options.mode);
-  if (options.grantId) params.set("grantId", options.grantId);
-  return params;
 }
 
 function lifeopsSearchParams(options) {
@@ -265,7 +235,7 @@ function lifeopsSearchParams(options) {
 async function resolveLifeOpsApiBase(options) {
   const statusPath = `/api/lifeops/connectors/google/status?${lifeopsConnectorParams(options).toString()}`;
   let lastError = null;
-  for (const baseUrl of readLifeOpsApiBases()) {
+  for (const baseUrl of readLifeOpsApiBases(readFlag("--api-base"))) {
     try {
       const status = await lifeopsJson(baseUrl, statusPath);
       return { baseUrl, statusPath, status };

--- a/scripts/init-submodules.mjs
+++ b/scripts/init-submodules.mjs
@@ -465,6 +465,400 @@ export function isTrackedAsGitlink(
   }
 }
 
+function emptyInitSubmodulesResult(submodules = []) {
+  return { initialized: 0, alreadyInitialized: 0, failed: 0, submodules };
+}
+
+function syncSubmoduleConfig(rootDir, { exec, logError }) {
+  try {
+    exec("git submodule sync --recursive", {
+      cwd: rootDir,
+      stdio: "inherit",
+    });
+  } catch (err) {
+    logError(
+      `[init-submodules] git submodule sync --recursive failed: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+}
+
+function hasUncommittedSubmoduleChanges(submoduleRoot, { exec }) {
+  const dirty = exec("git status --porcelain", {
+    cwd: submoduleRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
+  return Boolean(dirty);
+}
+
+function inspectTopLevelSubmodule(submodule, { rootDir, exists, exec, log }) {
+  const checkoutReady = isSubmoduleCheckoutReady(submodule.path, {
+    rootDir,
+    exists,
+  });
+  const state = {
+    needsInit: !checkoutReady,
+    initReason: checkoutReady ? "" : "checkout is incomplete",
+    hasUncommittedChanges: false,
+  };
+
+  try {
+    const status = exec(`git submodule status -- "${submodule.path}"`, {
+      cwd: rootDir,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    if (status.startsWith("-")) {
+      state.needsInit = true;
+      state.initReason = "submodule is not initialized";
+    } else if (status.startsWith("+")) {
+      state.needsInit = true;
+      state.initReason = "checkout is not at the parent repo's recorded commit";
+      log(
+        `[init-submodules] ${submodule.name} (${submodule.path}) is not at the parent repo's recorded commit`,
+      );
+    }
+    if (!status.startsWith("-")) {
+      try {
+        const smRoot = resolve(rootDir, submodule.path);
+        if (hasUncommittedSubmoduleChanges(smRoot, { exec })) {
+          state.hasUncommittedChanges = true;
+          log(
+            `[init-submodules] ⚠ ${submodule.name} (${submodule.path}) has uncommitted local changes`,
+          );
+        }
+      } catch {}
+    }
+  } catch {
+    state.needsInit = true;
+    if (!state.initReason) {
+      state.initReason = "status check failed";
+    }
+  }
+
+  return state;
+}
+
+function retryTopLevelSubmoduleUpdate(
+  submodule,
+  { rootDir, exists, exec, log },
+) {
+  try {
+    exec(`git submodule init "${submodule.path}"`, {
+      cwd: rootDir,
+      stdio: "inherit",
+    });
+  } catch {}
+
+  const smRoot = resolve(rootDir, submodule.path);
+  if (exists(smRoot) && exists(resolve(smRoot, ".git"))) {
+    exec("git fetch --unshallow || git fetch --all", {
+      cwd: smRoot,
+      stdio: "inherit",
+      shell: true,
+    });
+  }
+
+  try {
+    const recurseFlag = NO_RECURSE_SUBMODULES.has(submodule.path)
+      ? ""
+      : " --recursive";
+    exec(`git submodule update${recurseFlag} "${submodule.path}"`, {
+      cwd: rootDir,
+      stdio: "inherit",
+    });
+  } catch {
+    hydrateSubmoduleFromConfiguredBranch(submodule, {
+      rootDir,
+      exec,
+      remove: rmSync,
+      log,
+    });
+  }
+}
+
+function initializeTopLevelSubmodule(
+  submodule,
+  { rootDir, exists, exec, log, initReason },
+) {
+  log(
+    `[init-submodules] Initializing ${submodule.name} (${submodule.path})${
+      initReason ? ` because ${initReason}` : ""
+    }...`,
+  );
+
+  const recurseFlag = NO_RECURSE_SUBMODULES.has(submodule.path)
+    ? ""
+    : " --recursive";
+  try {
+    exec(`git submodule sync -- "${submodule.path}"`, {
+      cwd: rootDir,
+      stdio: "inherit",
+    });
+  } catch {}
+  try {
+    exec(`git submodule update --init${recurseFlag} "${submodule.path}"`, {
+      cwd: rootDir,
+      stdio: "inherit",
+    });
+  } catch (_shallowErr) {
+    log(
+      `[init-submodules] Shallow init failed for ${submodule.name}, retrying with full fetch...`,
+    );
+    retryTopLevelSubmoduleUpdate(submodule, { rootDir, exists, exec, log });
+  }
+  if (!isSubmoduleCheckoutReady(submodule.path, { rootDir, exists })) {
+    throw new Error(
+      `submodule checkout is still incomplete after update: ${submodule.path}`,
+    );
+  }
+  log(`[init-submodules] ${submodule.name} initialized successfully`);
+}
+
+function processTopLevelSubmodule(submodule, ctx) {
+  const { rootDir, exec, log, logError, shouldSkipSubmodule } = ctx;
+  const skipReason = getSubmoduleSkipReason(submodule.path);
+  if (shouldSkipSubmodule(submodule.path)) {
+    log(
+      `[init-submodules] Skipping ${submodule.name} (${submodule.path}) because ${skipReason ?? "local upstreams are disabled"}`,
+    );
+    return emptyInitSubmodulesResult();
+  }
+
+  if (!isTrackedAsGitlink(submodule.path, { exec, cwd: rootDir })) {
+    log(
+      `[init-submodules] Skipping ${submodule.name} (${submodule.path}) because the parent repo tracks that path as regular files, not a gitlink`,
+    );
+    return emptyInitSubmodulesResult();
+  }
+
+  const state = inspectTopLevelSubmodule(submodule, ctx);
+  if (state.needsInit && state.hasUncommittedChanges) {
+    logError(
+      `[init-submodules] Refusing to update ${submodule.name} (${submodule.path}) because it has uncommitted local changes`,
+    );
+    return { initialized: 0, alreadyInitialized: 0, failed: 1 };
+  }
+  if (!state.needsInit) {
+    return { initialized: 0, alreadyInitialized: 1, failed: 0 };
+  }
+
+  try {
+    initializeTopLevelSubmodule(submodule, {
+      ...ctx,
+      initReason: state.initReason,
+    });
+    return { initialized: 1, alreadyInitialized: 0, failed: 0 };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logError(
+      `[init-submodules] Failed to initialize ${submodule.name} (${submodule.path}): ${message}`,
+    );
+    return { initialized: 0, alreadyInitialized: 0, failed: 1 };
+  }
+}
+
+function processTopLevelSubmodules(submodules, ctx) {
+  const result = emptyInitSubmodulesResult();
+  for (const submodule of submodules) {
+    const next = processTopLevelSubmodule(submodule, ctx);
+    result.initialized += next.initialized;
+    result.alreadyInitialized += next.alreadyInitialized;
+    result.failed += next.failed;
+  }
+  return result;
+}
+
+function inspectNestedSubmodule(nestedSubmodule, { elizaRoot, exec, log }) {
+  const state = {
+    needsInit: true,
+    initReason: "status check failed",
+    hasUncommittedChanges: false,
+  };
+
+  try {
+    const status = exec(`git submodule status -- "${nestedSubmodule.path}"`, {
+      cwd: elizaRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    if (status.startsWith("-")) {
+      state.needsInit = true;
+      state.initReason = "submodule is not initialized";
+    } else if (status.startsWith("+")) {
+      state.needsInit = true;
+      state.initReason = "checkout is not at eliza's recorded commit";
+    } else {
+      state.needsInit = false;
+      state.initReason = "";
+    }
+
+    if (!status.startsWith("-")) {
+      try {
+        const nestedRoot = resolve(elizaRoot, nestedSubmodule.path);
+        if (hasUncommittedSubmoduleChanges(nestedRoot, { exec })) {
+          state.hasUncommittedChanges = true;
+          log(
+            `[init-submodules] ⚠ nested ${nestedSubmodule.name} (eliza/${nestedSubmodule.path}) has uncommitted local changes`,
+          );
+        }
+      } catch {}
+    }
+  } catch {
+    state.needsInit = true;
+  }
+
+  return state;
+}
+
+function updateNestedSubmodule(
+  nestedSubmodule,
+  { elizaRoot, exec, log, initReason },
+) {
+  const rootRelativePath = `eliza/${nestedSubmodule.path}`;
+  log(
+    `[init-submodules] Updating nested ${nestedSubmodule.name} (${rootRelativePath})${
+      initReason ? ` because ${initReason}` : ""
+    }...`,
+  );
+  exec(`git submodule update --init --recursive -- "${nestedSubmodule.path}"`, {
+    cwd: elizaRoot,
+    stdio: "inherit",
+  });
+}
+
+function processNestedSubmodule(nestedSubmodule, ctx) {
+  const { elizaRoot, exec, log, logError } = ctx;
+  const rootRelativePath = `eliza/${nestedSubmodule.path}`;
+  const skipReason = getSubmoduleSkipReason(rootRelativePath, {
+    skipLocal: false,
+  });
+
+  if (skipReason) {
+    log(
+      `[init-submodules] Skipping nested ${nestedSubmodule.name} (${rootRelativePath}) because ${skipReason}`,
+    );
+    return 0;
+  }
+  if (!isTrackedAsGitlink(nestedSubmodule.path, { exec, cwd: elizaRoot })) {
+    return 0;
+  }
+
+  const state = inspectNestedSubmodule(nestedSubmodule, ctx);
+  if (!state.needsInit) {
+    return 0;
+  }
+  if (state.hasUncommittedChanges) {
+    logError(
+      `[init-submodules] Refusing to update nested ${nestedSubmodule.name} (${rootRelativePath}) because it has uncommitted local changes`,
+    );
+    return 1;
+  }
+
+  try {
+    updateNestedSubmodule(nestedSubmodule, {
+      ...ctx,
+      initReason: state.initReason,
+    });
+    return 0;
+  } catch (err) {
+    try {
+      hydrateSubmoduleFromConfiguredBranch(nestedSubmodule, {
+        rootDir: elizaRoot,
+        exec,
+        remove: rmSync,
+        log,
+      });
+      return 0;
+    } catch (fallbackErr) {
+      logError(
+        `[init-submodules] Failed to initialize nested ${nestedSubmodule.name} (${rootRelativePath}): ${
+          fallbackErr instanceof Error
+            ? fallbackErr.message
+            : String(fallbackErr)
+        }`,
+      );
+      logError(
+        `[init-submodules] Original nested submodule error: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      return 1;
+    }
+  }
+}
+
+function processNestedElizaSubmodules({
+  rootDir,
+  exists,
+  exec,
+  log,
+  logError,
+  shouldSkipSubmodule,
+}) {
+  if (
+    shouldSkipSubmodule("eliza") ||
+    !exists(resolve(rootDir, "eliza", ".gitmodules"))
+  ) {
+    return 0;
+  }
+
+  const elizaRoot = resolve(rootDir, "eliza");
+  log(
+    "[init-submodules] Ensuring nested checkouts under eliza/ (cloud, plugins, …)…",
+  );
+
+  try {
+    exec("git submodule sync --recursive", {
+      cwd: elizaRoot,
+      stdio: "inherit",
+    });
+
+    let failed = 0;
+    const nestedSubmodules = loadTrackedSubmodules({ exec, cwd: elizaRoot });
+    for (const nestedSubmodule of nestedSubmodules) {
+      failed += processNestedSubmodule(nestedSubmodule, {
+        elizaRoot,
+        exec,
+        log,
+        logError,
+      });
+    }
+    return failed;
+  } catch (err) {
+    logError(
+      `[init-submodules] Unexpected error initializing nested eliza submodules: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return 0;
+  }
+}
+
+function logInitSubmodulesSummary({
+  initialized,
+  alreadyInitialized,
+  failed,
+  log,
+  logError,
+}) {
+  if (failed > 0) {
+    logError(
+      `[init-submodules] Initialized ${initialized}, already ready ${alreadyInitialized}, failed ${failed}.`,
+    );
+    return;
+  }
+  if (initialized === 0) {
+    log("[init-submodules] All submodules already initialized");
+    return;
+  }
+  log(
+    `[init-submodules] Initialized ${initialized} submodule(s); ${alreadyInitialized} already ready.`,
+  );
+}
+
 export function runInitSubmodules({
   rootDir = root,
   exists = existsSync,
@@ -476,19 +870,19 @@ export function runInitSubmodules({
   const gitDir = resolve(rootDir, ".git");
   if (!exists(gitDir)) {
     log("[init-submodules] Not a git repository — skipping");
-    return { initialized: 0, alreadyInitialized: 0, failed: 0, submodules: [] };
+    return emptyInitSubmodulesResult();
   }
 
   const gitmodulesPath = resolve(rootDir, ".gitmodules");
   if (!exists(gitmodulesPath)) {
     log("[init-submodules] No .gitmodules found — skipping");
-    return { initialized: 0, alreadyInitialized: 0, failed: 0, submodules: [] };
+    return emptyInitSubmodulesResult();
   }
 
   const submodules = loadTrackedSubmodules({ exec, cwd: rootDir });
   if (submodules.length === 0) {
     log("[init-submodules] No tracked submodules found — skipping");
-    return { initialized: 0, alreadyInitialized: 0, failed: 0, submodules: [] };
+    return emptyInitSubmodulesResult();
   }
 
   const hasLegacyRootCloudPaths = submodules.some((s) => s.path === "cloud");
@@ -505,335 +899,26 @@ export function runInitSubmodules({
     exists,
   });
 
-  // Re-align every submodule's .git/config remote URL with .gitmodules before
-  // doing anything else. Without this, flipping a submodule URL upstream (e.g.
-  // retargeting eliza between elizaOS/eliza and milady-ai/eliza) leaves the
-  // local .git/modules/<name>/config stuck on the old remote — so `git pull`
-  // later fails to fetch commits that only exist on the new remote. The
-  // per-submodule sync below only runs when `needsInit` is true, which misses
-  // the common case where the submodule is still checked out cleanly.
-  try {
-    exec("git submodule sync --recursive", {
-      cwd: rootDir,
-      stdio: "inherit",
-    });
-  } catch (err) {
-    logError(
-      `[init-submodules] git submodule sync --recursive failed: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
-    );
-  }
+  syncSubmoduleConfig(rootDir, { exec, logError });
 
-  let initialized = 0;
-  let alreadyInitialized = 0;
-  let failed = 0;
+  const result = processTopLevelSubmodules(submodules, {
+    rootDir,
+    exists,
+    exec,
+    log,
+    logError,
+    shouldSkipSubmodule,
+  });
+  result.failed += processNestedElizaSubmodules({
+    rootDir,
+    exists,
+    exec,
+    log,
+    logError,
+    shouldSkipSubmodule,
+  });
 
-  for (const submodule of submodules) {
-    const skipReason = getSubmoduleSkipReason(submodule.path);
-    if (shouldSkipSubmodule(submodule.path)) {
-      log(
-        `[init-submodules] Skipping ${submodule.name} (${submodule.path}) because ${skipReason ?? "local upstreams are disabled"}`,
-      );
-      continue;
-    }
-
-    if (!isTrackedAsGitlink(submodule.path, { exec, cwd: rootDir })) {
-      log(
-        `[init-submodules] Skipping ${submodule.name} (${submodule.path}) because the parent repo tracks that path as regular files, not a gitlink`,
-      );
-      continue;
-    }
-
-    const checkoutReady = isSubmoduleCheckoutReady(submodule.path, {
-      rootDir,
-      exists,
-    });
-    let needsInit = !checkoutReady;
-    let initReason = checkoutReady ? "" : "checkout is incomplete";
-
-    let hasUncommittedChanges = false;
-    try {
-      const status = exec(`git submodule status -- "${submodule.path}"`, {
-        cwd: rootDir,
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "ignore"],
-      }).trim();
-      if (status.startsWith("-")) {
-        needsInit = true;
-        initReason = "submodule is not initialized";
-      } else if (status.startsWith("+")) {
-        needsInit = true;
-        initReason = "checkout is not at the parent repo's recorded commit";
-        log(
-          `[init-submodules] ${submodule.name} (${submodule.path}) is not at the parent repo's recorded commit`,
-        );
-      }
-      if (!status.startsWith("-")) {
-        try {
-          const smRoot = resolve(rootDir, submodule.path);
-          const dirty = exec("git status --porcelain", {
-            cwd: smRoot,
-            encoding: "utf8",
-            stdio: ["ignore", "pipe", "ignore"],
-          }).trim();
-          if (dirty) {
-            hasUncommittedChanges = true;
-            log(
-              `[init-submodules] ⚠ ${submodule.name} (${submodule.path}) has uncommitted local changes`,
-            );
-          }
-        } catch {}
-      }
-    } catch {
-      needsInit = true;
-      if (!initReason) {
-        initReason = "status check failed";
-      }
-    }
-
-    if (needsInit && hasUncommittedChanges) {
-      failed++;
-      logError(
-        `[init-submodules] Refusing to update ${submodule.name} (${submodule.path}) because it has uncommitted local changes`,
-      );
-      continue;
-    }
-
-    if (!needsInit) {
-      alreadyInitialized++;
-      continue;
-    }
-
-    log(
-      `[init-submodules] Initializing ${submodule.name} (${submodule.path})${
-        initReason ? ` because ${initReason}` : ""
-      }...`,
-    );
-    try {
-      const recurseFlag = NO_RECURSE_SUBMODULES.has(submodule.path)
-        ? ""
-        : " --recursive";
-      try {
-        exec(`git submodule sync -- "${submodule.path}"`, {
-          cwd: rootDir,
-          stdio: "inherit",
-        });
-      } catch {}
-      try {
-        exec(`git submodule update --init${recurseFlag} "${submodule.path}"`, {
-          cwd: rootDir,
-          stdio: "inherit",
-        });
-      } catch (_shallowErr) {
-        log(
-          `[init-submodules] Shallow init failed for ${submodule.name}, retrying with full fetch...`,
-        );
-        try {
-          try {
-            exec(`git submodule init "${submodule.path}"`, {
-              cwd: rootDir,
-              stdio: "inherit",
-            });
-          } catch {}
-          const smRoot = resolve(rootDir, submodule.path);
-          if (exists(smRoot) && exists(resolve(smRoot, ".git"))) {
-            exec("git fetch --unshallow || git fetch --all", {
-              cwd: smRoot,
-              stdio: "inherit",
-              shell: true,
-            });
-          }
-          exec(`git submodule update${recurseFlag} "${submodule.path}"`, {
-            cwd: rootDir,
-            stdio: "inherit",
-          });
-        } catch {
-          hydrateSubmoduleFromConfiguredBranch(submodule, {
-            rootDir,
-            exec,
-            remove: rmSync,
-            log,
-          });
-        }
-      }
-      if (
-        !isSubmoduleCheckoutReady(submodule.path, {
-          rootDir,
-          exists,
-        })
-      ) {
-        throw new Error(
-          `submodule checkout is still incomplete after update: ${submodule.path}`,
-        );
-      }
-      initialized++;
-      log(`[init-submodules] ${submodule.name} initialized successfully`);
-    } catch (err) {
-      failed++;
-      const message = err instanceof Error ? err.message : String(err);
-      logError(
-        `[init-submodules] Failed to initialize ${submodule.name} (${submodule.path}): ${message}`,
-      );
-    }
-  }
-
-  if (
-    !shouldSkipSubmodule("eliza") &&
-    exists(resolve(rootDir, "eliza", ".gitmodules"))
-  ) {
-    const elizaRoot = resolve(rootDir, "eliza");
-    log(
-      "[init-submodules] Ensuring nested checkouts under eliza/ (cloud, plugins, …)…",
-    );
-    try {
-      // Sync nested config first so git does not keep stale URLs from older
-      // eliza merges around in .git/config.
-      exec("git submodule sync --recursive", {
-        cwd: elizaRoot,
-        stdio: "inherit",
-      });
-
-      const nestedSubmodules = loadTrackedSubmodules({
-        exec,
-        cwd: elizaRoot,
-      });
-
-      for (const nestedSubmodule of nestedSubmodules) {
-        const rootRelativePath = `eliza/${nestedSubmodule.path}`;
-        const skipReason = getSubmoduleSkipReason(rootRelativePath, {
-          skipLocal: false,
-        });
-        if (skipReason) {
-          log(
-            `[init-submodules] Skipping nested ${nestedSubmodule.name} (${rootRelativePath}) because ${skipReason}`,
-          );
-          continue;
-        }
-
-        if (
-          !isTrackedAsGitlink(nestedSubmodule.path, {
-            exec,
-            cwd: elizaRoot,
-          })
-        ) {
-          continue;
-        }
-
-        let needsInit = true;
-        let initReason = "status check failed";
-        let hasUncommittedChanges = false;
-        try {
-          const status = exec(
-            `git submodule status -- "${nestedSubmodule.path}"`,
-            {
-              cwd: elizaRoot,
-              encoding: "utf8",
-              stdio: ["ignore", "pipe", "ignore"],
-            },
-          ).trim();
-          if (status.startsWith("-")) {
-            needsInit = true;
-            initReason = "submodule is not initialized";
-          } else if (status.startsWith("+")) {
-            needsInit = true;
-            initReason = "checkout is not at eliza's recorded commit";
-          } else {
-            needsInit = false;
-            initReason = "";
-          }
-
-          if (!status.startsWith("-")) {
-            try {
-              const nestedRoot = resolve(elizaRoot, nestedSubmodule.path);
-              const dirty = exec("git status --porcelain", {
-                cwd: nestedRoot,
-                encoding: "utf8",
-                stdio: ["ignore", "pipe", "ignore"],
-              }).trim();
-              if (dirty) {
-                hasUncommittedChanges = true;
-                log(
-                  `[init-submodules] ⚠ nested ${nestedSubmodule.name} (${rootRelativePath}) has uncommitted local changes`,
-                );
-              }
-            } catch {}
-          }
-        } catch {
-          needsInit = true;
-        }
-
-        if (!needsInit) {
-          continue;
-        }
-
-        if (hasUncommittedChanges) {
-          failed++;
-          logError(
-            `[init-submodules] Refusing to update nested ${nestedSubmodule.name} (${rootRelativePath}) because it has uncommitted local changes`,
-          );
-          continue;
-        }
-
-        try {
-          log(
-            `[init-submodules] Updating nested ${nestedSubmodule.name} (${rootRelativePath})${
-              initReason ? ` because ${initReason}` : ""
-            }...`,
-          );
-          exec(
-            `git submodule update --init --recursive -- "${nestedSubmodule.path}"`,
-            {
-              cwd: elizaRoot,
-              stdio: "inherit",
-            },
-          );
-        } catch (err) {
-          try {
-            hydrateSubmoduleFromConfiguredBranch(nestedSubmodule, {
-              rootDir: elizaRoot,
-              exec,
-              remove: rmSync,
-              log,
-            });
-          } catch (fallbackErr) {
-            failed++;
-            logError(
-              `[init-submodules] Failed to initialize nested ${nestedSubmodule.name} (${rootRelativePath}): ${
-                fallbackErr instanceof Error
-                  ? fallbackErr.message
-                  : String(fallbackErr)
-              }`,
-            );
-            logError(
-              `[init-submodules] Original nested submodule error: ${
-                err instanceof Error ? err.message : String(err)
-              }`,
-            );
-          }
-        }
-      }
-    } catch (err) {
-      logError(
-        `[init-submodules] Unexpected error initializing nested eliza submodules: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
-    }
-  }
-
-  if (failed > 0) {
-    logError(
-      `[init-submodules] Initialized ${initialized}, already ready ${alreadyInitialized}, failed ${failed}.`,
-    );
-  } else if (initialized === 0) {
-    log("[init-submodules] All submodules already initialized");
-  } else {
-    log(
-      `[init-submodules] Initialized ${initialized} submodule(s); ${alreadyInitialized} already ready.`,
-    );
-  }
-
+  logInitSubmodulesSummary({ ...result, log, logError });
   pruneSkippedCloudWorkspace({
     rootDir,
     exists,
@@ -845,7 +930,7 @@ export function runInitSubmodules({
     log,
   });
 
-  return { initialized, alreadyInitialized, failed, submodules };
+  return { ...result, submodules };
 }
 
 const isDirectRun =

--- a/scripts/lib/lifeops-api-base.mjs
+++ b/scripts/lib/lifeops-api-base.mjs
@@ -1,0 +1,33 @@
+const DEFAULT_LIFEOPS_API_BASES = [
+  "http://127.0.0.1:31337",
+  "http://localhost:31337",
+  "http://127.0.0.1:2138",
+  "http://localhost:2138",
+];
+
+function normalizeBaseUrl(value) {
+  return value.replace(/\/+$/g, "");
+}
+
+export function readLifeOpsApiBases(explicit, env = process.env) {
+  return [
+    explicit,
+    env.MILADY_LIFEOPS_API_BASE,
+    env.LIFEOPS_API_BASE,
+    env.ELIZA_API_BASE,
+  ]
+    .flatMap((value) => (value ?? "").split(","))
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .concat(DEFAULT_LIFEOPS_API_BASES)
+    .map(normalizeBaseUrl)
+    .filter((value, index, all) => all.indexOf(value) === index);
+}
+
+export function lifeopsConnectorParams(options) {
+  const params = new URLSearchParams();
+  if (options.side) params.set("side", options.side);
+  if (options.mode) params.set("mode", options.mode);
+  if (options.grantId) params.set("grantId", options.grantId);
+  return params;
+}

--- a/scripts/patch-eliza-electrobun-windows-smoke-startup.mjs
+++ b/scripts/patch-eliza-electrobun-windows-smoke-startup.mjs
@@ -295,26 +295,40 @@ function patchRealRuntimeLiveProviderImport(text) {
   return result;
 }
 
-function patchMacosArtifactStager(text) {
-  const notaryTimeout60 =
-    'NOTARY_WAIT_TIMEOUT="$' + '{ELECTROBUN_NOTARY_WAIT_TIMEOUT:-60m}"';
+function runTextPatchSteps(text, steps) {
   let result = { matched: true, text };
-  if (!result.text.includes(notaryTimeout60)) {
-    result = replaceRequiredBlock(
-      result.text,
-      /NOTARY_WAIT_TIMEOUT="\$\{ELECTROBUN_NOTARY_WAIT_TIMEOUT:-30m\}"/,
-      notaryTimeout60,
-    );
+  for (const step of steps) {
+    result = step(result.text);
     if (!result.matched) {
       return result;
     }
   }
+  return result;
+}
 
-  if (!result.text.includes("retry_codesign() {")) {
-    result = replaceRequiredBlock(
-      result.text,
-      / {2}return "\$command_status"\r?\n}\r?\n\r?\nparse_notary_submission_id\(\) \{/,
-      `  return "$command_status"
+function patchMacosNotaryTimeout(text) {
+  const notaryTimeout60 =
+    'NOTARY_WAIT_TIMEOUT="$' + '{ELECTROBUN_NOTARY_WAIT_TIMEOUT:-60m}"';
+  if (text.includes(notaryTimeout60)) {
+    return { matched: true, text };
+  }
+
+  return replaceRequiredBlock(
+    text,
+    /NOTARY_WAIT_TIMEOUT="\$\{ELECTROBUN_NOTARY_WAIT_TIMEOUT:-30m\}"/,
+    notaryTimeout60,
+  );
+}
+
+function patchMacosCodesignRetryHelper(text) {
+  if (text.includes("retry_codesign() {")) {
+    return { matched: true, text };
+  }
+
+  return replaceRequiredBlock(
+    text,
+    / {2}return "\$command_status"\r?\n}\r?\n\r?\nparse_notary_submission_id\(\) \{/,
+    `  return "$command_status"
 }
 
 retry_codesign() {
@@ -322,22 +336,24 @@ retry_codesign() {
 }
 
 parse_notary_submission_id() {`,
-    );
-    if (!result.matched) {
-      return result;
-    }
+  );
+}
+
+function patchMacosNotaryRetryHelpers(text) {
+  if (text.includes("retry_notarytool_submit() {")) {
+    return { matched: true, text };
   }
 
-  if (!result.text.includes("retry_notarytool_submit() {")) {
-    const notaryRetryAnchor = `TARBALL_PATH=`;
-    if (!result.text.includes(notaryRetryAnchor)) {
-      return { matched: false, text };
-    }
-    result = {
-      matched: true,
-      text: result.text.replace(
-        notaryRetryAnchor,
-        `parse_notary_status() {
+  const notaryRetryAnchor = `TARBALL_PATH=`;
+  if (!text.includes(notaryRetryAnchor)) {
+    return { matched: false, text };
+  }
+
+  return {
+    matched: true,
+    text: text.replace(
+      notaryRetryAnchor,
+      `parse_notary_status() {
   local output_path="$1"
   /usr/bin/python3 - "$output_path" <<'PY'
 import json
@@ -455,32 +471,37 @@ retry_notarytool_log() {
 }
 
 TARBALL_PATH=`,
-      ),
-    };
+    ),
+  };
+}
+
+function patchMacosTarballDiscovery(text) {
+  if (text.includes('for tarball_pattern in "*-macos-*.app.tar.zst"')) {
+    return { matched: true, text };
   }
 
-  if (!result.text.includes('for tarball_pattern in "*-macos-*.app.tar.zst"')) {
-    result = replaceRequiredBlock(
-      result.text,
-      /TARBALL_PATH="\$\(find -L "\$ARTIFACTS_DIR" -maxdepth 1 -type f -name "\*-macos-\*\.app\.tar\.zst" \| sort \| head -1\)"/,
-      `TARBALL_PATH=""
+  return replaceRequiredBlock(
+    text,
+    /TARBALL_PATH="\$\(find -L "\$ARTIFACTS_DIR" -maxdepth 1 -type f -name "\*-macos-\*\.app\.tar\.zst" \| sort \| head -1\)"/,
+    `TARBALL_PATH=""
 for tarball_pattern in "*-macos-*.app.tar.zst" "*-macos-*.app.tar.gz" "*-macos-*.tar.gz"; do
   TARBALL_PATH="$(find -L "$ARTIFACTS_DIR" -maxdepth 1 -type f -name "$tarball_pattern" | sort | head -1)"
   if [[ -n "$TARBALL_PATH" ]]; then
     break
   fi
 done`,
-    );
-    if (!result.matched) {
-      return result;
-    }
+  );
+}
+
+function patchMacosTarballExtraction(text) {
+  if (text.includes('tar -xzf "$TARBALL_PATH" -C "$EXTRACT_DIR"')) {
+    return { matched: true, text };
   }
 
-  if (!result.text.includes('tar -xzf "$TARBALL_PATH" -C "$EXTRACT_DIR"')) {
-    result = replaceRequiredBlock(
-      result.text,
-      /echo "Using updater tarball: \$TARBALL_PATH"\r?\ntar --zstd -xf "\$TARBALL_PATH" -C "\$EXTRACT_DIR"/,
-      `echo "Using updater tarball: $TARBALL_PATH"
+  return replaceRequiredBlock(
+    text,
+    /echo "Using updater tarball: \$TARBALL_PATH"\r?\ntar --zstd -xf "\$TARBALL_PATH" -C "\$EXTRACT_DIR"/,
+    `echo "Using updater tarball: $TARBALL_PATH"
 TARBALL_BASENAME="$(basename "$TARBALL_PATH")"
 case "$TARBALL_BASENAME" in
   *.tar.zst)
@@ -494,22 +515,20 @@ case "$TARBALL_BASENAME" in
     exit 1
     ;;
 esac`,
-    );
-    if (!result.matched) {
-      return result;
-    }
+  );
+}
+
+function patchMacosFinalDmgName(text) {
+  const finalDmgAppTarZst =
+    'FINAL_DMG_NAME="$' + '{TARBALL_BASENAME%.app.tar.zst}.dmg"';
+  if (text.includes(finalDmgAppTarZst)) {
+    return { matched: true, text };
   }
 
-  if (
-    !result.text.includes(
-      // biome-ignore lint/suspicious/noTemplateCurlyInString: intentional bash string
-      'FINAL_DMG_NAME="${TARBALL_BASENAME%.app.tar.zst}.dmg"',
-    )
-  ) {
-    result = replaceRequiredBlock(
-      result.text,
-      /FINAL_DMG_NAME="\$\(basename "\$\{TARBALL_PATH%\.app\.tar\.zst\}\.dmg"\)"/,
-      `case "$TARBALL_BASENAME" in
+  return replaceRequiredBlock(
+    text,
+    /FINAL_DMG_NAME="\$\(basename "\$\{TARBALL_PATH%\.app\.tar\.zst\}\.dmg"\)"/,
+    `case "$TARBALL_BASENAME" in
   *.app.tar.zst)
     FINAL_DMG_NAME="\${TARBALL_BASENAME%.app.tar.zst}.dmg"
     ;;
@@ -524,28 +543,26 @@ esac`,
     exit 1
     ;;
 esac`,
-    );
-    if (!result.matched) {
-      return result;
-    }
+  );
+}
+
+function patchMacosEmptyEntitlements(text) {
+  if (text.includes("write_config_entitlements_plist")) {
+    return { matched: true, text };
   }
 
-  if (!result.text.includes("write_config_entitlements_plist")) {
-    result = replaceRequiredBlock(
-      result.text,
-      / {2}if \[\[ ! -s "\$TMP_ENTITLEMENTS_PATH" \]\]; then\r?\n {4}echo "stage-macos-release-artifacts: extracted entitlements were empty"\r?\n {4}exit 1\r?\n {2}fi\r?\n {2}entitlement_args=\(--entitlements "\$TMP_ENTITLEMENTS_PATH"\)/,
-      `  if [[ -s "$TMP_ENTITLEMENTS_PATH" ]]; then
+  return replaceRequiredBlock(
+    text,
+    / {2}if \[\[ ! -s "\$TMP_ENTITLEMENTS_PATH" \]\]; then\r?\n {4}echo "stage-macos-release-artifacts: extracted entitlements were empty"\r?\n {4}exit 1\r?\n {2}fi\r?\n {2}entitlement_args=\(--entitlements "\$TMP_ENTITLEMENTS_PATH"\)/,
+    `  if [[ -s "$TMP_ENTITLEMENTS_PATH" ]]; then
     entitlement_args=(--entitlements "$TMP_ENTITLEMENTS_PATH")
   else
     echo "stage-macos-release-artifacts: extracted entitlements were empty; signing without entitlement plist"
   fi`,
-    );
-    if (!result.matched) {
-      return result;
-    }
-  }
+  );
+}
 
-  const nestedSigningFunction = `  sign_nested_macos_runtime_targets() {
+const nestedMacosSigningFunction = `  sign_nested_macos_runtime_targets() {
     local runtime_resources_dir="$STAGED_APP_PATH/Contents/Resources/app/eliza-dist"
     local candidate_path file_type
     if [[ ! -d "$runtime_resources_dir" ]]; then
@@ -562,13 +579,15 @@ esac`,
   }
 `;
 
-  if (result.text.includes("sign_nested_macos_runtime_targets()")) {
-    result = { matched: true, text: result.text };
-  } else {
-    result = replaceRequiredBlock(
-      result.text,
-      / {2}if ! codesign --force --timestamp --sign "\$ELECTROBUN_DEVELOPER_ID" --options runtime "\$\{entitlement_args\[@\]\}" "\$LAUNCHER_PATH"; then\r?\n {4}echo "stage-macos-release-artifacts: launcher runtime signing failed, retrying without hardened runtime" >&2\r?\n {4}codesign --force --timestamp --sign "\$ELECTROBUN_DEVELOPER_ID" "\$\{entitlement_args\[@\]\}" "\$LAUNCHER_PATH"\r?\n {2}fi\r?\n {2}codesign --force --timestamp --sign "\$ELECTROBUN_DEVELOPER_ID" --options runtime "\$\{entitlement_args\[@\]\}" "\$STAGED_APP_PATH"/,
-      `  runtime_sign_args=(--force --timestamp --sign "$ELECTROBUN_DEVELOPER_ID" --options runtime)
+function patchMacosNestedRuntimeSigning(text) {
+  if (text.includes("sign_nested_macos_runtime_targets()")) {
+    return { matched: true, text };
+  }
+
+  let result = replaceRequiredBlock(
+    text,
+    / {2}if ! codesign --force --timestamp --sign "\$ELECTROBUN_DEVELOPER_ID" --options runtime "\$\{entitlement_args\[@\]\}" "\$LAUNCHER_PATH"; then\r?\n {4}echo "stage-macos-release-artifacts: launcher runtime signing failed, retrying without hardened runtime" >&2\r?\n {4}codesign --force --timestamp --sign "\$ELECTROBUN_DEVELOPER_ID" "\$\{entitlement_args\[@\]\}" "\$LAUNCHER_PATH"\r?\n {2}fi\r?\n {2}codesign --force --timestamp --sign "\$ELECTROBUN_DEVELOPER_ID" --options runtime "\$\{entitlement_args\[@\]\}" "\$STAGED_APP_PATH"/,
+    `  runtime_sign_args=(--force --timestamp --sign "$ELECTROBUN_DEVELOPER_ID" --options runtime)
   fallback_runtime_sign_args=(--force --timestamp --sign "$ELECTROBUN_DEVELOPER_ID")
   app_sign_args=(--force --timestamp --sign "$ELECTROBUN_DEVELOPER_ID" --options runtime)
   if [[ -s "\${TMP_ENTITLEMENTS_PATH:-}" ]]; then
@@ -583,7 +602,7 @@ esac`,
       retry_codesign "\${fallback_runtime_sign_args[@]}" "$target_path"
     fi
   }
-${nestedSigningFunction}  macos_code_dir="$STAGED_APP_PATH/Contents/MacOS"
+${nestedMacosSigningFunction}  macos_code_dir="$STAGED_APP_PATH/Contents/MacOS"
   for runtime_target in \\
     "$macos_code_dir/libNativeWrapper.dylib" \\
     "$macos_code_dir/libwebgpu_dawn.dylib" \\
@@ -602,52 +621,54 @@ ${nestedSigningFunction}  macos_code_dir="$STAGED_APP_PATH/Contents/MacOS"
   sign_nested_macos_runtime_targets
   sign_macos_runtime_target "$LAUNCHER_PATH"
   retry_codesign "\${app_sign_args[@]}" "$STAGED_APP_PATH"`,
+  );
+
+  if (!result.matched) {
+    result = replaceRequiredBlock(
+      result.text,
+      / {2}macos_code_dir="\$STAGED_APP_PATH\/Contents\/MacOS"/,
+      `${nestedMacosSigningFunction}  macos_code_dir="$STAGED_APP_PATH/Contents/MacOS"`,
     );
-    if (!result.matched) {
+    if (result.matched) {
       result = replaceRequiredBlock(
         result.text,
-        / {2}macos_code_dir="\$STAGED_APP_PATH\/Contents\/MacOS"/,
-        `${nestedSigningFunction}  macos_code_dir="$STAGED_APP_PATH/Contents/MacOS"`,
-      );
-      if (result.matched) {
-        result = replaceRequiredBlock(
-          result.text,
-          / {2}sign_macos_runtime_target "\$LAUNCHER_PATH"/,
-          `  sign_nested_macos_runtime_targets
+        / {2}sign_macos_runtime_target "\$LAUNCHER_PATH"/,
+        `  sign_nested_macos_runtime_targets
   sign_macos_runtime_target "$LAUNCHER_PATH"`,
-        );
-      }
+      );
     }
   }
-  if (!result.matched) {
-    return result;
-  }
 
+  return result;
+}
+
+function patchMacosDmgCodesignRetry(text) {
   if (
-    !result.text.includes(
+    text.includes(
       'retry_codesign --force --timestamp --sign "$ELECTROBUN_DEVELOPER_ID" "$TEMP_DMG_PATH"',
     )
   ) {
-    result = replaceRequiredBlock(
-      result.text,
-      / {2}codesign --force --timestamp --sign "\$ELECTROBUN_DEVELOPER_ID" "\$TEMP_DMG_PATH"/,
-      '  retry_codesign --force --timestamp --sign "$ELECTROBUN_DEVELOPER_ID" "$TEMP_DMG_PATH"',
-    );
-    if (!result.matched) {
-      return result;
-    }
+    return { matched: true, text };
   }
 
-  if (
-    !result.text.includes(
-      // biome-ignore lint/suspicious/noTemplateCurlyInString: intentional bash string
-      'NOTARY_SUBMIT_ATTEMPTS="${ELECTROBUN_NOTARY_SUBMIT_ATTEMPTS:-3}"',
-    )
-  ) {
-    result = replaceRequiredBlock(
-      result.text,
-      / {2}NOTARY_SUBMIT_OUTPUT_PATH="\$TMP_ROOT\/notary-submit\.json"\r?\n {2}"\$REAL_XCRUN" notarytool submit \\\r?\n {4}--apple-id "\$ELECTROBUN_APPLEID" \\\r?\n {4}--password "\$ELECTROBUN_APPLEIDPASS" \\\r?\n {4}--team-id "\$ELECTROBUN_TEAMID" \\\r?\n {4}--output-format json \\\r?\n {4}"\$TEMP_DMG_PATH" >"\$NOTARY_SUBMIT_OUTPUT_PATH"/,
-      `  NOTARY_SUBMIT_ATTEMPTS="\${ELECTROBUN_NOTARY_SUBMIT_ATTEMPTS:-3}"
+  return replaceRequiredBlock(
+    text,
+    / {2}codesign --force --timestamp --sign "\$ELECTROBUN_DEVELOPER_ID" "\$TEMP_DMG_PATH"/,
+    '  retry_codesign --force --timestamp --sign "$ELECTROBUN_DEVELOPER_ID" "$TEMP_DMG_PATH"',
+  );
+}
+
+function patchMacosNotarySubmitCall(text) {
+  const notarySubmitAttempts =
+    'NOTARY_SUBMIT_ATTEMPTS="$' + '{ELECTROBUN_NOTARY_SUBMIT_ATTEMPTS:-3}"';
+  if (text.includes(notarySubmitAttempts)) {
+    return { matched: true, text };
+  }
+
+  return replaceRequiredBlock(
+    text,
+    / {2}NOTARY_SUBMIT_OUTPUT_PATH="\$TMP_ROOT\/notary-submit\.json"\r?\n {2}"\$REAL_XCRUN" notarytool submit \\\r?\n {4}--apple-id "\$ELECTROBUN_APPLEID" \\\r?\n {4}--password "\$ELECTROBUN_APPLEIDPASS" \\\r?\n {4}--team-id "\$ELECTROBUN_TEAMID" \\\r?\n {4}--output-format json \\\r?\n {4}"\$TEMP_DMG_PATH" >"\$NOTARY_SUBMIT_OUTPUT_PATH"/,
+    `  NOTARY_SUBMIT_ATTEMPTS="\${ELECTROBUN_NOTARY_SUBMIT_ATTEMPTS:-3}"
   NOTARY_SUBMIT_RETRY_DELAY_SECONDS="\${ELECTROBUN_NOTARY_SUBMIT_RETRY_DELAY_SECONDS:-30}"
   NOTARY_SUBMIT_OUTPUT_PATH="$TMP_ROOT/notary-submit.json"
   if ! retry_notarytool_submit "$NOTARY_SUBMIT_OUTPUT_PATH" "$NOTARY_SUBMIT_ATTEMPTS" "$NOTARY_SUBMIT_RETRY_DELAY_SECONDS"; then
@@ -655,22 +676,20 @@ ${nestedSigningFunction}  macos_code_dir="$STAGED_APP_PATH/Contents/MacOS"
     sed -n '1,80p' "$NOTARY_SUBMIT_OUTPUT_PATH" >&2 || true
     exit 1
   fi`,
-    );
-    if (!result.matched) {
-      return result;
-    }
+  );
+}
+
+function patchMacosNotaryWaitCall(text) {
+  const notaryWaitAttempts =
+    'NOTARY_WAIT_ATTEMPTS="$' + '{ELECTROBUN_NOTARY_WAIT_ATTEMPTS:-3}"';
+  if (text.includes(notaryWaitAttempts)) {
+    return { matched: true, text };
   }
 
-  if (
-    !result.text.includes(
-      // biome-ignore lint/suspicious/noTemplateCurlyInString: intentional bash string
-      'NOTARY_WAIT_ATTEMPTS="${ELECTROBUN_NOTARY_WAIT_ATTEMPTS:-3}"',
-    )
-  ) {
-    result = replaceRequiredBlock(
-      result.text,
-      / {2}NOTARY_WAIT_OUTPUT_PATH="\$TMP_ROOT\/notary-wait\.json"\r?\n {2}if ! "\$REAL_XCRUN" notarytool wait \\\r?\n {4}--apple-id "\$ELECTROBUN_APPLEID" \\\r?\n {4}--password "\$ELECTROBUN_APPLEIDPASS" \\\r?\n {4}--team-id "\$ELECTROBUN_TEAMID" \\\r?\n {4}--timeout "\$NOTARY_WAIT_TIMEOUT" \\\r?\n {4}--output-format json \\\r?\n {4}"\$NOTARY_SUBMISSION_ID" >"\$NOTARY_WAIT_OUTPUT_PATH"; then\r?\n {4}echo "stage-macos-release-artifacts: notarization wait failed for submission \$NOTARY_SUBMISSION_ID" >&2\r?\n {4}sed -n '1,80p' "\$NOTARY_WAIT_OUTPUT_PATH" >&2 \|\| true\r?\n {4}"\$REAL_XCRUN" notarytool log \\\r?\n {6}--apple-id "\$ELECTROBUN_APPLEID" \\\r?\n {6}--password "\$ELECTROBUN_APPLEIDPASS" \\\r?\n {6}--team-id "\$ELECTROBUN_TEAMID" \\\r?\n {6}"\$NOTARY_SUBMISSION_ID" >&2 \|\| true\r?\n {4}exit 1\r?\n {2}fi/,
-      `  NOTARY_WAIT_ATTEMPTS="\${ELECTROBUN_NOTARY_WAIT_ATTEMPTS:-3}"
+  return replaceRequiredBlock(
+    text,
+    / {2}NOTARY_WAIT_OUTPUT_PATH="\$TMP_ROOT\/notary-wait\.json"\r?\n {2}if ! "\$REAL_XCRUN" notarytool wait \\\r?\n {4}--apple-id "\$ELECTROBUN_APPLEID" \\\r?\n {4}--password "\$ELECTROBUN_APPLEIDPASS" \\\r?\n {4}--team-id "\$ELECTROBUN_TEAMID" \\\r?\n {4}--timeout "\$NOTARY_WAIT_TIMEOUT" \\\r?\n {4}--output-format json \\\r?\n {4}"\$NOTARY_SUBMISSION_ID" >"\$NOTARY_WAIT_OUTPUT_PATH"; then\r?\n {4}echo "stage-macos-release-artifacts: notarization wait failed for submission \$NOTARY_SUBMISSION_ID" >&2\r?\n {4}sed -n '1,80p' "\$NOTARY_WAIT_OUTPUT_PATH" >&2 \|\| true\r?\n {4}"\$REAL_XCRUN" notarytool log \\\r?\n {6}--apple-id "\$ELECTROBUN_APPLEID" \\\r?\n {6}--password "\$ELECTROBUN_APPLEIDPASS" \\\r?\n {6}--team-id "\$ELECTROBUN_TEAMID" \\\r?\n {6}"\$NOTARY_SUBMISSION_ID" >&2 \|\| true\r?\n {4}exit 1\r?\n {2}fi/,
+    `  NOTARY_WAIT_ATTEMPTS="\${ELECTROBUN_NOTARY_WAIT_ATTEMPTS:-3}"
   NOTARY_WAIT_RETRY_DELAY_SECONDS="\${ELECTROBUN_NOTARY_WAIT_RETRY_DELAY_SECONDS:-60}"
   NOTARY_WAIT_OUTPUT_PATH="$TMP_ROOT/notary-wait.json"
   if ! retry_notarytool_wait "$NOTARY_WAIT_OUTPUT_PATH" "$NOTARY_WAIT_ATTEMPTS" "$NOTARY_WAIT_RETRY_DELAY_SECONDS"; then
@@ -679,21 +698,22 @@ ${nestedSigningFunction}  macos_code_dir="$STAGED_APP_PATH/Contents/MacOS"
     retry_notarytool_log >&2 || true
     exit 1
   fi`,
-    );
-    if (!result.matched) {
-      return result;
-    }
-  }
+  );
+}
 
+function patchMacosStaplerFallback(text) {
   if (
-    !result.text.includes(
+    text.includes(
       "notarization accepted but stapler ticket was not available; continuing without stapled DMG",
     )
   ) {
-    result = replaceRequiredBlock(
-      result.text,
-      / {2}(?:retry_command 8 20 xcrun stapler staple "\$TEMP_DMG_PATH"|STAPLER_ATTEMPTS="\$\{ELECTROBUN_STAPLER_ATTEMPTS:-12\}"\r?\n {2}STAPLER_DELAY_SECONDS="\$\{ELECTROBUN_STAPLER_DELAY_SECONDS:-30\}"\r?\n {2}retry_command "\$STAPLER_ATTEMPTS" "\$STAPLER_DELAY_SECONDS" xcrun stapler staple "\$TEMP_DMG_PATH")/,
-      `  STAPLER_ATTEMPTS="\${ELECTROBUN_STAPLER_ATTEMPTS:-12}"
+    return { matched: true, text };
+  }
+
+  return replaceRequiredBlock(
+    text,
+    / {2}(?:retry_command 8 20 xcrun stapler staple "\$TEMP_DMG_PATH"|STAPLER_ATTEMPTS="\$\{ELECTROBUN_STAPLER_ATTEMPTS:-12\}"\r?\n {2}STAPLER_DELAY_SECONDS="\$\{ELECTROBUN_STAPLER_DELAY_SECONDS:-30\}"\r?\n {2}retry_command "\$STAPLER_ATTEMPTS" "\$STAPLER_DELAY_SECONDS" xcrun stapler staple "\$TEMP_DMG_PATH")/,
+    `  STAPLER_ATTEMPTS="\${ELECTROBUN_STAPLER_ATTEMPTS:-12}"
   STAPLER_DELAY_SECONDS="\${ELECTROBUN_STAPLER_DELAY_SECONDS:-30}"
   if ! retry_command "$STAPLER_ATTEMPTS" "$STAPLER_DELAY_SECONDS" xcrun stapler staple "$TEMP_DMG_PATH"; then
     if [[ "\${ELECTROBUN_REQUIRE_STAPLED_DMG:-0}" == "1" ]]; then
@@ -701,12 +721,24 @@ ${nestedSigningFunction}  macos_code_dir="$STAGED_APP_PATH/Contents/MacOS"
     fi
     echo "stage-macos-release-artifacts: notarization accepted but stapler ticket was not available; continuing without stapled DMG" >&2
   fi`,
-    );
-    if (!result.matched) {
-      return result;
-    }
-  }
-  return result;
+  );
+}
+
+function patchMacosArtifactStager(text) {
+  return runTextPatchSteps(text, [
+    patchMacosNotaryTimeout,
+    patchMacosCodesignRetryHelper,
+    patchMacosNotaryRetryHelpers,
+    patchMacosTarballDiscovery,
+    patchMacosTarballExtraction,
+    patchMacosFinalDmgName,
+    patchMacosEmptyEntitlements,
+    patchMacosNestedRuntimeSigning,
+    patchMacosDmgCodesignRetry,
+    patchMacosNotarySubmitCall,
+    patchMacosNotaryWaitCall,
+    patchMacosStaplerFallback,
+  ]);
 }
 
 function patchLocalAdhocMacosSigningOrder(text) {


### PR DESCRIPTION
This PR will be reviewed by an AI agent. Provide clear context to help it assess your changes.

Aesthetic/UI changes that don't improve agent capability are out of scope and will be rejected.

## Category
- [ ] Bug fix
- [ ] Security fix
- [ ] Performance improvement
- [ ] New feature
- [ ] Documentation
- [ ] Test coverage
- [ ] Other

## What
(brief description)

## Why
(motivation)

## How
(implementation approach)

## Testing
(what was tested, how to verify)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refactor scripts and shared utilities to address CodeFactor findings
> - Breaks up the monolithic `disableLocalElizaWorkspace`, `runInitSubmodules`, and `patchMacosArtifactStager` functions in [`disable-local-eliza-workspace.mjs`](https://github.com/milady-ai/milady/pull/2114/files#diff-eddd107a5257d405d39b4242a74e0ad1ba4f79715b6eec01da5d17a54963b8d7), [`init-submodules.mjs`](https://github.com/milady-ai/milady/pull/2114/files#diff-927ba7fd8e1b3fbce8af2599149349017e91a9f97cab5d670b967df7f77ba209), and [`patch-eliza-electrobun-windows-smoke-startup.mjs`](https://github.com/milady-ai/milady/pull/2114/files#diff-75faf67fe458caafb3218cf444bd3b0c68c0fd137e37c43c773e398f22815db5) into focused helper functions.
> - Extracts shared API base URL and connector param logic from [`gmail-real-smoke.mjs`](https://github.com/milady-ai/milady/pull/2114/files#diff-f36e7371c0f787ebc8ac6b39ee99e03aa7b8e019e739129a2e817317c19e8da1) and [`gmail-real-sweep.mjs`](https://github.com/milady-ai/milady/pull/2114/files#diff-cc24395515f24abb728770670e8ee5aebaebf8e235da1e55afe413aa0f45d037) into a new shared module [`lib/lifeops-api-base.mjs`](https://github.com/milady-ai/milady/pull/2114/files#diff-eab67dbba6e3f64776e3389aab7cb1d29dd25e201db9596d135afc4c4db6afc2).
> - Refactors `AgentProvider.fetchAll` in [`AgentProvider.tsx`](https://github.com/milady-ai/milady/pull/2114/files#diff-47dd20b6cb02657abe39866397145852f66ebb62d957b75e235394b8097ac99e) and `useCloudOpenFlow` in [`useCloudOpenFlow.ts`](https://github.com/milady-ai/milady/pull/2114/files#diff-dff69f3817e9ae5612b14db34142f3a4fc1b1f0afc88b1025468c7cc311f57bb) into smaller, purpose-scoped helpers.
> - Excludes `trust-scoring.js` and `trust-scoring.cjs` from CodeFactor analysis in [`.codefactor.yml`](https://github.com/milady-ai/milady/pull/2114/files#diff-976ecbe629bedd0f16e1fdcee063805e87a2f22f77a3ae47955356eaccc443d7).
> - Risk: `gmailJson`, `gmailVoid`, and `lifeopsJson` now spread `init.headers` directly; passing `null` or `undefined` as headers will throw a `TypeError` at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 278e818.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->