### PR TITLE
Split CodeFactor complexity scripts

### DIFF
--- a/scripts/disable-local-eliza-workspace.mjs
+++ b/scripts/disable-local-eliza-workspace.mjs
@@ -1079,6 +1079,396 @@ export function repairKnownElizaPatchFiles(
   return true;
 }
 
+function resolvePinnedVersionsBeforeWorkspaceDisable(
+  repoRoot,
+  packageJsonPath,
+  { log },
+) {
+  let earlyPinnedVersions = new Map();
+  const earlyPinnedVersionSources = new Map();
+  if (!fs.existsSync(packageJsonPath)) {
+    return { earlyPinnedVersions, earlyPinnedVersionSources };
+  }
+
+  try {
+    const earlyRootPkg = readPackageJson(packageJsonPath);
+    earlyPinnedVersions = resolvePinnedWorkspaceVersions(repoRoot, {
+      rootPackage: earlyRootPkg,
+      versionSources: earlyPinnedVersionSources,
+    });
+    if (earlyPinnedVersions.size > 0) {
+      log(
+        `[disable-local-eliza-workspace] Pre-resolved ${earlyPinnedVersions.size} pinned version(s) before disabling workspace`,
+      );
+    }
+  } catch {
+    /* continue — will be read again below */
+  }
+
+  return { earlyPinnedVersions, earlyPinnedVersionSources };
+}
+
+function updateElizaWorkspacePresence(
+  elizaRoot,
+  disabledElizaRoot,
+  shouldRenameElizaWorkspace,
+  { log },
+) {
+  if (shouldRenameElizaWorkspace && fs.existsSync(elizaRoot)) {
+    fs.rmSync(disabledElizaRoot, { recursive: true, force: true });
+    fs.renameSync(elizaRoot, disabledElizaRoot);
+    log(
+      `[disable-local-eliza-workspace] Disabled repo-local eliza workspace at ${elizaRoot}`,
+    );
+    return;
+  }
+
+  if (
+    !shouldRenameElizaWorkspace &&
+    fs.existsSync(elizaRoot) &&
+    fs.existsSync(disabledElizaRoot)
+  ) {
+    fs.rmSync(disabledElizaRoot, { recursive: true, force: true });
+    log(
+      `[disable-local-eliza-workspace] Removed stale disabled workspace at ${disabledElizaRoot}`,
+    );
+    return;
+  }
+
+  log(
+    !shouldRenameElizaWorkspace && fs.existsSync(elizaRoot)
+      ? "[disable-local-eliza-workspace] Keeping eliza/ on disk (rewrite-only mode)"
+      : "[disable-local-eliza-workspace] Repo-local eliza workspace already absent",
+  );
+}
+
+function readRootPackageForWorkspaceDisable(
+  repoRoot,
+  packageJsonPath,
+  { log, errorLog },
+) {
+  const rawRootPkg = fs.readFileSync(packageJsonPath, "utf8");
+  const rootPackageBackupPath = path.join(
+    repoRoot,
+    "package.json.pre-disable-backup",
+  );
+  if (!fs.existsSync(rootPackageBackupPath)) {
+    fs.writeFileSync(rootPackageBackupPath, rawRootPkg);
+    log(
+      `[disable-local-eliza-workspace] Wrote original package.json backup to ${path.relative(repoRoot, rootPackageBackupPath)}`,
+    );
+  }
+
+  try {
+    const rootPkg = JSON.parse(rawRootPkg);
+    if (!isPackageJsonRecord(rootPkg)) {
+      throw new Error(
+        `expected a package.json object with string-valued dependency maps`,
+      );
+    }
+    return { rawRootPkg, rootPkg };
+  } catch (error) {
+    errorLog(
+      `[disable-local-eliza-workspace] Failed to parse ${packageJsonPath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    throw error;
+  }
+}
+
+function patchRootWorkspaceGlobs(rootPkg, repoRoot, { log }) {
+  const removedWorkspaceGlobs = [];
+  if (!Array.isArray(rootPkg.workspaces)) {
+    return removedWorkspaceGlobs;
+  }
+
+  const filteredWorkspaces = rootPkg.workspaces.filter((entry) => {
+    if (DISABLED_WORKSPACE_GLOBS.includes(entry)) {
+      removedWorkspaceGlobs.push(entry);
+      return false;
+    }
+    if (
+      typeof entry === "string" &&
+      entry.startsWith("eliza/") &&
+      !LOCAL_ONLY_WORKSPACE_GLOBS.includes(entry) &&
+      !LOCAL_ONLY_WORKSPACE_PATHS.includes(entry)
+    ) {
+      removedWorkspaceGlobs.push(entry);
+      return false;
+    }
+    return true;
+  });
+
+  for (const workspacePath of LOCAL_ONLY_WORKSPACE_PATHS) {
+    const absoluteWorkspacePath = path.join(repoRoot, workspacePath);
+    if (
+      fs.existsSync(path.join(absoluteWorkspacePath, "package.json")) &&
+      !filteredWorkspaces.includes(workspacePath)
+    ) {
+      filteredWorkspaces.push(workspacePath);
+    }
+  }
+
+  if (removedWorkspaceGlobs.length === 0) {
+    log(
+      `[disable-local-eliza-workspace] Root package.json workspaces array does not include ${DISABLED_WORKSPACE_GLOBS.join(", ")}; nothing to patch`,
+    );
+  } else {
+    rootPkg.workspaces = filteredWorkspaces;
+    log(
+      `[disable-local-eliza-workspace] Removed ${removedWorkspaceGlobs.join(", ")} from root package.json workspaces`,
+    );
+  }
+
+  return removedWorkspaceGlobs;
+}
+
+function removeUnavailableElizaPatchedDependencies(
+  rootPkg,
+  repoRoot,
+  shouldRenameElizaWorkspace,
+  { log },
+) {
+  if (!isStringRecord(rootPkg.patchedDependencies)) {
+    return;
+  }
+
+  const removedPatches = [];
+  for (const [dep, patchPath] of Object.entries(rootPkg.patchedDependencies)) {
+    if (typeof patchPath !== "string" || !patchPath.startsWith("eliza/")) {
+      continue;
+    }
+    const absolutePatchPath = path.join(repoRoot, patchPath);
+    if (shouldRenameElizaWorkspace || !fs.existsSync(absolutePatchPath)) {
+      removedPatches.push(dep);
+    }
+  }
+
+  for (const dep of removedPatches) {
+    delete rootPkg.patchedDependencies[dep];
+  }
+  if (removedPatches.length > 0) {
+    log(
+      `[disable-local-eliza-workspace] Removed ${removedPatches.length} patchedDependencies referencing eliza/ (${removedPatches.join(", ")})`,
+    );
+  }
+}
+
+function stubElizaWorkspaceScripts(
+  rootPkg,
+  shouldRenameElizaWorkspace,
+  { log },
+) {
+  if (!shouldRenameElizaWorkspace || !isStringRecord(rootPkg.scripts)) {
+    return;
+  }
+
+  const stubbedScripts = [];
+  for (const [name, cmd] of Object.entries(rootPkg.scripts)) {
+    if (typeof cmd === "string" && cmd.includes("eliza/")) {
+      stubbedScripts.push(name);
+      rootPkg.scripts[name] =
+        "echo '[CI] script disabled — eliza/ workspace not present'";
+    }
+  }
+  if (stubbedScripts.length > 0) {
+    log(
+      `[disable-local-eliza-workspace] Stubbed ${stubbedScripts.length} scripts referencing eliza/ (${stubbedScripts.slice(0, 5).join(", ")}${stubbedScripts.length > 5 ? ", ..." : ""})`,
+    );
+  }
+}
+
+function patchLocalElizaPackageOverrides(elizaPackageJsonPath, { log, warn }) {
+  if (!fs.existsSync(elizaPackageJsonPath)) {
+    return;
+  }
+
+  try {
+    const rawElizaPkg = fs.readFileSync(elizaPackageJsonPath, "utf8");
+    const elizaPkg = parseJsonObject(rawElizaPkg);
+    if (!isPackageJsonRecord(elizaPkg)) {
+      warn(
+        `[disable-local-eliza-workspace] Skipping ${elizaPackageJsonPath}: package.json is malformed`,
+      );
+      return;
+    }
+    if (
+      applyOverrideSpecifiers(elizaPkg, ELIZA_RUNTIME_CI_OVERRIDE_SPECIFIERS, {
+        log,
+        label: "local eliza runtime override",
+      })
+    ) {
+      writePackageJson(elizaPackageJsonPath, rawElizaPkg, elizaPkg);
+    }
+  } catch (error) {
+    warn(
+      `[disable-local-eliza-workspace] Failed to patch ${elizaPackageJsonPath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+function resolvePendingWorkspaceDirs(
+  repoRoot,
+  rootPkg,
+  removedWorkspaceGlobs,
+  shouldTouchLocalElizaWorkspace,
+) {
+  const seen = new Set();
+  const pendingWorkspaceDirs = [];
+  const rewriteWorkspaceEntries = [
+    ...(rootPkg.workspaces ?? []),
+    ...(shouldTouchLocalElizaWorkspace ? removedWorkspaceGlobs : []),
+    ...(shouldTouchLocalElizaWorkspace ? NESTED_INSTALLABLE_PACKAGE_GLOBS : []),
+  ];
+
+  for (const entry of rewriteWorkspaceEntries) {
+    const expanded = expandGlob(entry, { rootDir: repoRoot });
+    for (const match of expanded) {
+      if (!seen.has(match)) {
+        seen.add(match);
+        pendingWorkspaceDirs.push(match);
+      }
+    }
+  }
+
+  return pendingWorkspaceDirs;
+}
+
+function collectDisabledWorkspaceDependencyNames(
+  repoRoot,
+  rootPkg,
+  pendingWorkspaceDirs,
+  localOnlyPackages,
+  { warn },
+) {
+  const dependencyNames = collectWorkspaceProtocolDependencyNames(rootPkg, {
+    localOnlyPackages,
+  });
+  for (const workspaceRel of pendingWorkspaceDirs) {
+    const pkgPath = path.join(repoRoot, workspaceRel, "package.json");
+    if (!fs.existsSync(pkgPath)) continue;
+    try {
+      const pkg = readPackageJson(pkgPath);
+      if (!pkg) {
+        warn(
+          `[disable-local-eliza-workspace]   skipped dependency scan for ${workspaceRel}: package.json is missing or malformed`,
+        );
+        continue;
+      }
+      for (const dependencyName of collectWorkspaceProtocolDependencyNames(
+        pkg,
+        { localOnlyPackages },
+      )) {
+        dependencyNames.add(dependencyName);
+      }
+    } catch (error) {
+      warn(
+        `[disable-local-eliza-workspace]   skipped dependency scan for ${workspaceRel}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+  return dependencyNames;
+}
+
+function rewriteRootWorkspaceDependencies(
+  rootPkg,
+  packageJsonPath,
+  rawRootPkg,
+  pinnedVersions,
+  localOnlyPackages,
+  registrySpecifierCache,
+  { log, warn },
+) {
+  const rewroteRootWorkspaceDeps = rewriteWorkspaceDependencySpecifiers(
+    rootPkg,
+    pinnedVersions,
+    { localOnlyPackages },
+  );
+  const rewroteRootRegistryDeps = rewriteConfiguredElizaRegistrySpecifiers(
+    rootPkg,
+    {
+      localOnlyPackages,
+      registryInfoCache: registrySpecifierCache,
+      log,
+      warn,
+    },
+  );
+  if (!rewroteRootWorkspaceDeps && !rewroteRootRegistryDeps) {
+    return 0;
+  }
+
+  writePackageJson(packageJsonPath, rawRootPkg, rootPkg);
+  log("[disable-local-eliza-workspace]   patched .");
+  return 1;
+}
+
+function rewritePendingWorkspacePackageDependencies(
+  repoRoot,
+  pendingWorkspaceDirs,
+  pinnedVersions,
+  localOnlyPackages,
+  nestedInstallablePackageDirs,
+  localOnlyPackagePaths,
+  registrySpecifierCache,
+  { log, warn },
+) {
+  let rewrites = 0;
+  for (const workspaceRel of pendingWorkspaceDirs) {
+    const pkgPath = path.join(repoRoot, workspaceRel, "package.json");
+    if (!fs.existsSync(pkgPath)) continue;
+
+    let originalRaw;
+    let pkg;
+    try {
+      originalRaw = fs.readFileSync(pkgPath, "utf8");
+      pkg = parseJsonObject(originalRaw);
+    } catch (error) {
+      warn(
+        `[disable-local-eliza-workspace]   skipped ${workspaceRel}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      continue;
+    }
+    if (!isPackageJsonRecord(pkg)) {
+      warn(
+        `[disable-local-eliza-workspace]   skipped ${workspaceRel}: package.json is malformed`,
+      );
+      continue;
+    }
+
+    const rewrotePublishedWorkspaceDeps = rewriteWorkspaceDependencySpecifiers(
+      pkg,
+      pinnedVersions,
+      { localOnlyPackages },
+    );
+    const rewroteConfiguredRegistryDeps =
+      rewriteConfiguredElizaRegistrySpecifiers(pkg, {
+        localOnlyPackages,
+        registryInfoCache: registrySpecifierCache,
+        log,
+        warn,
+      });
+    const rewroteNestedLocalFileDeps =
+      nestedInstallablePackageDirs.has(workspaceRel) &&
+      rewriteNestedLocalFileDependencySpecifiers(
+        pkg,
+        workspaceRel,
+        localOnlyPackagePaths,
+      );
+
+    if (
+      !rewrotePublishedWorkspaceDeps &&
+      !rewroteConfiguredRegistryDeps &&
+      !rewroteNestedLocalFileDeps
+    ) {
+      continue;
+    }
+    if (writePackageJson(pkgPath, originalRaw, pkg)) {
+      rewrites++;
+      log(`[disable-local-eliza-workspace]   patched ${workspaceRel}`);
+    }
+  }
+  return rewrites;
+}
+
 export function disableLocalElizaWorkspace(
   repoRoot = DEFAULT_REPO_ROOT,
   { log = console.log, warn = console.warn, errorLog = console.error } = {},
@@ -1092,60 +1482,23 @@ export function disableLocalElizaWorkspace(
   const packageJsonPath = path.join(repoRoot, "package.json");
   const elizaPackageJsonPath = path.join(elizaRoot, "package.json");
   const removedLockfiles = [];
-
   if (shouldTouchLocalElizaWorkspace) {
     repairKnownElizaPatchFiles(repoRoot, { log });
   }
 
   const localOnlyPackagePaths = resolveLocalOnlyWorkspacePackagePaths(repoRoot);
   const localOnlyPackages = new Set(localOnlyPackagePaths.keys());
+  const { earlyPinnedVersions, earlyPinnedVersionSources } =
+    resolvePinnedVersionsBeforeWorkspaceDisable(repoRoot, packageJsonPath, {
+      log,
+    });
 
-  // Resolve pinned versions BEFORE renaming eliza/ away, since the
-  // cloud-agent-template and local package.json files live inside it.
-  let earlyRootPkg = null;
-  let earlyPinnedVersions = new Map();
-  const earlyPinnedVersionSources = new Map();
-  if (fs.existsSync(packageJsonPath)) {
-    try {
-      earlyRootPkg = readPackageJson(packageJsonPath);
-      earlyPinnedVersions = resolvePinnedWorkspaceVersions(repoRoot, {
-        rootPackage: earlyRootPkg,
-        versionSources: earlyPinnedVersionSources,
-      });
-      if (earlyPinnedVersions.size > 0) {
-        log(
-          `[disable-local-eliza-workspace] Pre-resolved ${earlyPinnedVersions.size} pinned version(s) before disabling workspace`,
-        );
-      }
-    } catch {
-      /* continue — will be read again below */
-    }
-  }
-
-  if (shouldRenameElizaWorkspace && fs.existsSync(elizaRoot)) {
-    fs.rmSync(disabledElizaRoot, { recursive: true, force: true });
-    fs.renameSync(elizaRoot, disabledElizaRoot);
-    log(
-      `[disable-local-eliza-workspace] Disabled repo-local eliza workspace at ${elizaRoot}`,
-    );
-  } else if (
-    !shouldRenameElizaWorkspace &&
-    fs.existsSync(elizaRoot) &&
-    fs.existsSync(disabledElizaRoot)
-  ) {
-    fs.rmSync(disabledElizaRoot, { recursive: true, force: true });
-    log(
-      `[disable-local-eliza-workspace] Removed stale disabled workspace at ${disabledElizaRoot}`,
-    );
-  } else if (!shouldRenameElizaWorkspace && fs.existsSync(elizaRoot)) {
-    log(
-      "[disable-local-eliza-workspace] Keeping eliza/ on disk (rewrite-only mode)",
-    );
-  } else {
-    log(
-      "[disable-local-eliza-workspace] Repo-local eliza workspace already absent",
-    );
-  }
+  updateElizaWorkspacePresence(
+    elizaRoot,
+    disabledElizaRoot,
+    shouldRenameElizaWorkspace,
+    { log },
+  );
 
   applyTsconfigMode(repoRoot, "packages", { log });
 
@@ -1160,163 +1513,31 @@ export function disableLocalElizaWorkspace(
     };
   }
 
-  const rawRootPkg = fs.readFileSync(packageJsonPath, "utf8");
-
-  // Back up the original root package.json so the restore script can put it
-  // back after the disable→install→restore cycle. Without this, mutations
-  // (e.g. dropping workspace:* deps with no pinned version) persist past
-  // restore, and downstream checks like release-check that read root
-  // dependencies see a stripped manifest and exit 1.
-  const rootPackageBackupPath = path.join(
+  const { rawRootPkg, rootPkg } = readRootPackageForWorkspaceDisable(
     repoRoot,
-    "package.json.pre-disable-backup",
+    packageJsonPath,
+    { log, errorLog },
   );
-  if (!fs.existsSync(rootPackageBackupPath)) {
-    fs.writeFileSync(rootPackageBackupPath, rawRootPkg);
-    log(
-      `[disable-local-eliza-workspace] Wrote original package.json backup to ${path.relative(repoRoot, rootPackageBackupPath)}`,
-    );
-  }
 
-  /** @type {PackageJsonRecord} */
-  let rootPkg;
-  try {
-    const parsedRootPkg = JSON.parse(rawRootPkg);
-    if (!isPackageJsonRecord(parsedRootPkg)) {
-      throw new Error(
-        `expected a package.json object with string-valued dependency maps`,
-      );
-    }
-    rootPkg = parsedRootPkg;
-  } catch (error) {
-    errorLog(
-      `[disable-local-eliza-workspace] Failed to parse ${packageJsonPath}: ${error instanceof Error ? error.message : String(error)}`,
-    );
-    throw error;
-  }
-
-  const removedWorkspaceGlobs = [];
-  if (Array.isArray(rootPkg.workspaces)) {
-    const originalWorkspaces = rootPkg.workspaces;
-    const filteredWorkspaces = originalWorkspaces.filter((entry) => {
-      if (DISABLED_WORKSPACE_GLOBS.includes(entry)) {
-        removedWorkspaceGlobs.push(entry);
-        return false;
-      }
-      // Also strip any explicit eliza/ paths (e.g. electrobun, cloud-agent-template)
-      // that would vanish when eliza/ is renamed to .eliza.ci-disabled/
-      if (
-        typeof entry === "string" &&
-        entry.startsWith("eliza/") &&
-        !LOCAL_ONLY_WORKSPACE_GLOBS.includes(entry) &&
-        !LOCAL_ONLY_WORKSPACE_PATHS.includes(entry)
-      ) {
-        removedWorkspaceGlobs.push(entry);
-        return false;
-      }
-      return true;
-    });
-
-    for (const workspacePath of LOCAL_ONLY_WORKSPACE_PATHS) {
-      const absoluteWorkspacePath = path.join(repoRoot, workspacePath);
-      if (
-        fs.existsSync(path.join(absoluteWorkspacePath, "package.json")) &&
-        !filteredWorkspaces.includes(workspacePath)
-      ) {
-        filteredWorkspaces.push(workspacePath);
-      }
-    }
-
-    if (removedWorkspaceGlobs.length === 0) {
-      log(
-        `[disable-local-eliza-workspace] Root package.json workspaces array does not include ${DISABLED_WORKSPACE_GLOBS.join(", ")}; nothing to patch`,
-      );
-    } else {
-      rootPkg.workspaces = filteredWorkspaces;
-      log(
-        `[disable-local-eliza-workspace] Removed ${removedWorkspaceGlobs.join(", ")} from root package.json workspaces`,
-      );
-    }
-  }
-
-  // Strip patchedDependencies whose patch files live inside eliza/ when either:
-  // - eliza/ is intentionally renamed away (shouldRenameElizaWorkspace), OR
-  // - the patch file does not actually exist on disk (avoids bun install failure
-  //   with "Couldn't find patch file: 'eliza/packages/...'" when the submodule
-  //   is absent or not initialized).
-  if (isStringRecord(rootPkg.patchedDependencies)) {
-    const removedPatches = [];
-    for (const [dep, patchPath] of Object.entries(
-      rootPkg.patchedDependencies,
-    )) {
-      if (typeof patchPath === "string" && patchPath.startsWith("eliza/")) {
-        const absolutePatchPath = path.join(repoRoot, patchPath);
-        if (shouldRenameElizaWorkspace || !fs.existsSync(absolutePatchPath)) {
-          removedPatches.push(dep);
-        }
-      }
-    }
-    for (const dep of removedPatches) {
-      delete rootPkg.patchedDependencies[dep];
-    }
-    if (removedPatches.length > 0) {
-      log(
-        `[disable-local-eliza-workspace] Removed ${removedPatches.length} patchedDependencies referencing eliza/ (${removedPatches.join(", ")})`,
-      );
-    }
-  }
-
-  // Stub scripts that reference eliza/ paths only when the directory has been
-  // renamed away.
-  if (shouldRenameElizaWorkspace && isStringRecord(rootPkg.scripts)) {
-    const stubbedScripts = [];
-    for (const [name, cmd] of Object.entries(rootPkg.scripts)) {
-      if (typeof cmd === "string" && cmd.includes("eliza/")) {
-        stubbedScripts.push(name);
-        rootPkg.scripts[name] =
-          "echo '[CI] script disabled — eliza/ workspace not present'";
-      }
-    }
-    if (stubbedScripts.length > 0) {
-      log(
-        `[disable-local-eliza-workspace] Stubbed ${stubbedScripts.length} scripts referencing eliza/ (${stubbedScripts.slice(0, 5).join(", ")}${stubbedScripts.length > 5 ? ", ..." : ""})`,
-      );
-    }
-  }
+  const removedWorkspaceGlobs = patchRootWorkspaceGlobs(rootPkg, repoRoot, {
+    log,
+  });
+  removeUnavailableElizaPatchedDependencies(
+    rootPkg,
+    repoRoot,
+    shouldRenameElizaWorkspace,
+    { log },
+  );
+  stubElizaWorkspaceScripts(rootPkg, shouldRenameElizaWorkspace, { log });
 
   applyCiOnlyOverrides(rootPkg, { log, repoRoot });
 
   writePackageJson(packageJsonPath, rawRootPkg, rootPkg);
 
-  if (shouldTouchLocalElizaWorkspace && fs.existsSync(elizaPackageJsonPath)) {
-    try {
-      const rawElizaPkg = fs.readFileSync(elizaPackageJsonPath, "utf8");
-      const elizaPkg = parseJsonObject(rawElizaPkg);
-      if (!isPackageJsonRecord(elizaPkg)) {
-        warn(
-          `[disable-local-eliza-workspace] Skipping ${elizaPackageJsonPath}: package.json is malformed`,
-        );
-      } else if (
-        applyOverrideSpecifiers(
-          elizaPkg,
-          ELIZA_RUNTIME_CI_OVERRIDE_SPECIFIERS,
-          {
-            log,
-            label: "local eliza runtime override",
-          },
-        )
-      ) {
-        writePackageJson(elizaPackageJsonPath, rawElizaPkg, elizaPkg);
-      }
-    } catch (error) {
-      warn(
-        `[disable-local-eliza-workspace] Failed to patch ${elizaPackageJsonPath}: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    }
+  if (shouldTouchLocalElizaWorkspace) {
+    patchLocalElizaPackageOverrides(elizaPackageJsonPath, { log, warn });
   }
 
-  // Use early-resolved versions (captured before eliza/ was renamed away).
-  // Fall back to a post-rename resolution attempt for robustness.
   const latePinnedVersionSources = new Map();
   const pinnedWorkspaceVersions =
     earlyPinnedVersions.size > 0
@@ -1330,59 +1551,25 @@ export function disableLocalElizaWorkspace(
       ? earlyPinnedVersionSources
       : latePinnedVersionSources;
 
-  const seen = new Set();
-  const pendingWorkspaceDirs = [];
   const nestedInstallablePackageDirs = new Set(
     NESTED_INSTALLABLE_PACKAGE_GLOBS.flatMap((glob) =>
       expandGlob(glob, { rootDir: repoRoot }),
     ),
   );
-  const rewriteWorkspaceEntries = [
-    ...(rootPkg.workspaces ?? []),
-    ...(shouldTouchLocalElizaWorkspace ? removedWorkspaceGlobs : []),
-    ...(shouldTouchLocalElizaWorkspace ? NESTED_INSTALLABLE_PACKAGE_GLOBS : []),
-  ];
-
-  // In rewrite-only CI the eliza/ checkout stays on disk even after we remove
-  // its globs from the root workspace graph. Keep rewriting those package.json
-  // files too, because release-check still validates their pinned specs.
-  for (const entry of rewriteWorkspaceEntries) {
-    const expanded = expandGlob(entry, { rootDir: repoRoot });
-    for (const match of expanded) {
-      if (!seen.has(match)) {
-        seen.add(match);
-        pendingWorkspaceDirs.push(match);
-      }
-    }
-  }
-
+  const pendingWorkspaceDirs = resolvePendingWorkspaceDirs(
+    repoRoot,
+    rootPkg,
+    removedWorkspaceGlobs,
+    shouldTouchLocalElizaWorkspace,
+  );
   const workspaceProtocolDependencyNames =
-    collectWorkspaceProtocolDependencyNames(rootPkg, { localOnlyPackages });
-  for (const workspaceRel of pendingWorkspaceDirs) {
-    const pkgPath = path.join(repoRoot, workspaceRel, "package.json");
-    if (!fs.existsSync(pkgPath)) continue;
-    try {
-      const pkg = readPackageJson(pkgPath);
-      if (!pkg) {
-        warn(
-          `[disable-local-eliza-workspace]   skipped dependency scan for ${workspaceRel}: package.json is missing or malformed`,
-        );
-        continue;
-      }
-      for (const dependencyName of collectWorkspaceProtocolDependencyNames(
-        pkg,
-        {
-          localOnlyPackages,
-        },
-      )) {
-        workspaceProtocolDependencyNames.add(dependencyName);
-      }
-    } catch (error) {
-      warn(
-        `[disable-local-eliza-workspace]   skipped dependency scan for ${workspaceRel}: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    }
-  }
+    collectDisabledWorkspaceDependencyNames(
+      repoRoot,
+      rootPkg,
+      pendingWorkspaceDirs,
+      localOnlyPackages,
+      { warn },
+    );
 
   const registryResolvedPinnedWorkspaceVersions =
     resolveMissingRegistryPinnedVersions(
@@ -1422,87 +1609,26 @@ export function disableLocalElizaWorkspace(
     `[disable-local-eliza-workspace] Rewriting workspace specifiers for ${publishSafePinnedWorkspaceVersions.size} package(s) to exact registry versions`,
   );
 
-  let rewrites = 0;
   const registrySpecifierCache = new Map();
-  const rewroteRootWorkspaceDeps = rewriteWorkspaceDependencySpecifiers(
+  let rewrites = rewriteRootWorkspaceDependencies(
     rootPkg,
+    packageJsonPath,
+    rawRootPkg,
     publishSafePinnedWorkspaceVersions,
-    {
-      localOnlyPackages,
-    },
+    localOnlyPackages,
+    registrySpecifierCache,
+    { log, warn },
   );
-  const rewroteRootRegistryDeps = rewriteConfiguredElizaRegistrySpecifiers(
-    rootPkg,
-    {
-      localOnlyPackages,
-      registryInfoCache: registrySpecifierCache,
-      log,
-      warn,
-    },
+  rewrites += rewritePendingWorkspacePackageDependencies(
+    repoRoot,
+    pendingWorkspaceDirs,
+    publishSafePinnedWorkspaceVersions,
+    localOnlyPackages,
+    nestedInstallablePackageDirs,
+    localOnlyPackagePaths,
+    registrySpecifierCache,
+    { log, warn },
   );
-  if (rewroteRootWorkspaceDeps || rewroteRootRegistryDeps) {
-    writePackageJson(packageJsonPath, rawRootPkg, rootPkg);
-    rewrites++;
-    log("[disable-local-eliza-workspace]   patched .");
-  }
-
-  for (const workspaceRel of pendingWorkspaceDirs) {
-    const pkgPath = path.join(repoRoot, workspaceRel, "package.json");
-    if (!fs.existsSync(pkgPath)) continue;
-
-    let originalRaw;
-    let parsedPkg;
-    try {
-      originalRaw = fs.readFileSync(pkgPath, "utf8");
-      parsedPkg = parseJsonObject(originalRaw);
-    } catch (error) {
-      warn(
-        `[disable-local-eliza-workspace]   skipped ${workspaceRel}: ${error instanceof Error ? error.message : String(error)}`,
-      );
-      continue;
-    }
-    if (!isPackageJsonRecord(parsedPkg)) {
-      warn(
-        `[disable-local-eliza-workspace]   skipped ${workspaceRel}: package.json is malformed`,
-      );
-      continue;
-    }
-    const pkg = parsedPkg;
-
-    const rewrotePublishedWorkspaceDeps = rewriteWorkspaceDependencySpecifiers(
-      pkg,
-      publishSafePinnedWorkspaceVersions,
-      {
-        localOnlyPackages,
-      },
-    );
-    const rewroteConfiguredRegistryDeps =
-      rewriteConfiguredElizaRegistrySpecifiers(pkg, {
-        localOnlyPackages,
-        registryInfoCache: registrySpecifierCache,
-        log,
-        warn,
-      });
-    const rewroteNestedLocalFileDeps =
-      nestedInstallablePackageDirs.has(workspaceRel) &&
-      rewriteNestedLocalFileDependencySpecifiers(
-        pkg,
-        workspaceRel,
-        localOnlyPackagePaths,
-      );
-
-    if (
-      !rewrotePublishedWorkspaceDeps &&
-      !rewroteConfiguredRegistryDeps &&
-      !rewroteNestedLocalFileDeps
-    ) {
-      continue;
-    }
-    if (writePackageJson(pkgPath, originalRaw, pkg)) {
-      rewrites++;
-      log(`[disable-local-eliza-workspace]   patched ${workspaceRel}`);
-    }
-  }
 
   if (rewrites === 0) {
     log(

--- a/scripts/init-submodules.mjs
+++ b/scripts/init-submodules.mjs
@@ -465,6 +465,423 @@ export function isTrackedAsGitlink(
   }
 }
 
+function emptySubmoduleInitResult(submodules = []) {
+  return { initialized: 0, alreadyInitialized: 0, failed: 0, submodules };
+}
+
+function syncSubmoduleUrls(rootDir, { exec, logError }) {
+  try {
+    exec("git submodule sync --recursive", {
+      cwd: rootDir,
+      stdio: "inherit",
+    });
+  } catch (err) {
+    logError(
+      `[init-submodules] git submodule sync --recursive failed: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+}
+
+function readSubmoduleStatus(submodulePath, { cwd, exec }) {
+  try {
+    return exec(`git submodule status -- "${submodulePath}"`, {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function hasDirtySubmoduleCheckout(submodulePath, { cwd, exec, log, label }) {
+  try {
+    const checkoutRoot = resolve(cwd, submodulePath);
+    const dirty = exec("git status --porcelain", {
+      cwd: checkoutRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    if (!dirty) {
+      return false;
+    }
+    log(`[init-submodules] ⚠ ${label} has uncommitted local changes`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveRootSubmoduleInitPlan(
+  submodule,
+  { rootDir, exists, exec, log },
+) {
+  const checkoutReady = isSubmoduleCheckoutReady(submodule.path, {
+    rootDir,
+    exists,
+  });
+  let needsInit = !checkoutReady;
+  let initReason = checkoutReady ? "" : "checkout is incomplete";
+  let hasUncommittedChanges = false;
+  const status = readSubmoduleStatus(submodule.path, { cwd: rootDir, exec });
+
+  if (status === null) {
+    return {
+      needsInit: true,
+      initReason: initReason || "status check failed",
+      hasUncommittedChanges,
+    };
+  }
+
+  if (status.startsWith("-")) {
+    needsInit = true;
+    initReason = "submodule is not initialized";
+  } else if (status.startsWith("+")) {
+    needsInit = true;
+    initReason = "checkout is not at the parent repo's recorded commit";
+    log(
+      `[init-submodules] ${submodule.name} (${submodule.path}) is not at the parent repo's recorded commit`,
+    );
+  } else {
+    hasUncommittedChanges = hasDirtySubmoduleCheckout(submodule.path, {
+      cwd: rootDir,
+      exec,
+      log,
+      label: `${submodule.name} (${submodule.path})`,
+    });
+  }
+
+  return { needsInit, initReason, hasUncommittedChanges };
+}
+
+function initializeRootSubmoduleCheckout(
+  submodule,
+  { rootDir, exists, exec, log },
+) {
+  const recurseFlag = NO_RECURSE_SUBMODULES.has(submodule.path)
+    ? ""
+    : " --recursive";
+  try {
+    exec(`git submodule sync -- "${submodule.path}"`, {
+      cwd: rootDir,
+      stdio: "inherit",
+    });
+  } catch {}
+  try {
+    exec(`git submodule update --init${recurseFlag} "${submodule.path}"`, {
+      cwd: rootDir,
+      stdio: "inherit",
+    });
+  } catch {
+    log(
+      `[init-submodules] Shallow init failed for ${submodule.name}, retrying with full fetch...`,
+    );
+    initializeRootSubmoduleFromFullFetch(submodule, {
+      rootDir,
+      exists,
+      exec,
+      log,
+      recurseFlag,
+    });
+  }
+  if (!isSubmoduleCheckoutReady(submodule.path, { rootDir, exists })) {
+    throw new Error(
+      `submodule checkout is still incomplete after update: ${submodule.path}`,
+    );
+  }
+}
+
+function initializeRootSubmoduleFromFullFetch(
+  submodule,
+  { rootDir, exists, exec, log, recurseFlag },
+) {
+  try {
+    try {
+      exec(`git submodule init "${submodule.path}"`, {
+        cwd: rootDir,
+        stdio: "inherit",
+      });
+    } catch {}
+    const smRoot = resolve(rootDir, submodule.path);
+    if (exists(smRoot) && exists(resolve(smRoot, ".git"))) {
+      exec("git fetch --unshallow || git fetch --all", {
+        cwd: smRoot,
+        stdio: "inherit",
+        shell: true,
+      });
+    }
+    exec(`git submodule update${recurseFlag} "${submodule.path}"`, {
+      cwd: rootDir,
+      stdio: "inherit",
+    });
+  } catch {
+    hydrateSubmoduleFromConfiguredBranch(submodule, {
+      rootDir,
+      exec,
+      remove: rmSync,
+      log,
+    });
+  }
+}
+
+function processRootSubmodule(
+  submodule,
+  { rootDir, exists, exec, log, logError, shouldSkipSubmodule },
+) {
+  const skipReason = getSubmoduleSkipReason(submodule.path);
+  if (shouldSkipSubmodule(submodule.path)) {
+    log(
+      `[init-submodules] Skipping ${submodule.name} (${submodule.path}) because ${skipReason ?? "local upstreams are disabled"}`,
+    );
+    return "skipped";
+  }
+
+  if (!isTrackedAsGitlink(submodule.path, { exec, cwd: rootDir })) {
+    log(
+      `[init-submodules] Skipping ${submodule.name} (${submodule.path}) because the parent repo tracks that path as regular files, not a gitlink`,
+    );
+    return "skipped";
+  }
+
+  const plan = resolveRootSubmoduleInitPlan(submodule, {
+    rootDir,
+    exists,
+    exec,
+    log,
+  });
+  if (plan.needsInit && plan.hasUncommittedChanges) {
+    logError(
+      `[init-submodules] Refusing to update ${submodule.name} (${submodule.path}) because it has uncommitted local changes`,
+    );
+    return "failed";
+  }
+  if (!plan.needsInit) {
+    return "alreadyInitialized";
+  }
+
+  log(
+    `[init-submodules] Initializing ${submodule.name} (${submodule.path})${
+      plan.initReason ? ` because ${plan.initReason}` : ""
+    }...`,
+  );
+  try {
+    initializeRootSubmoduleCheckout(submodule, { rootDir, exists, exec, log });
+    log(`[init-submodules] ${submodule.name} initialized successfully`);
+    return "initialized";
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logError(
+      `[init-submodules] Failed to initialize ${submodule.name} (${submodule.path}): ${message}`,
+    );
+    return "failed";
+  }
+}
+
+function processRootSubmodules(submodules, options) {
+  const summary = { initialized: 0, alreadyInitialized: 0, failed: 0 };
+  for (const submodule of submodules) {
+    const result = processRootSubmodule(submodule, options);
+    if (result in summary) {
+      summary[result]++;
+    }
+  }
+  return summary;
+}
+
+function resolveNestedSubmoduleInitPlan(
+  nestedSubmodule,
+  rootRelativePath,
+  { elizaRoot, exec, log },
+) {
+  let needsInit = true;
+  let initReason = "status check failed";
+  let hasUncommittedChanges = false;
+  const status = readSubmoduleStatus(nestedSubmodule.path, {
+    cwd: elizaRoot,
+    exec,
+  });
+
+  if (status === null) {
+    return { needsInit, initReason, hasUncommittedChanges };
+  }
+
+  if (status.startsWith("-")) {
+    initReason = "submodule is not initialized";
+  } else if (status.startsWith("+")) {
+    initReason = "checkout is not at eliza's recorded commit";
+  } else {
+    needsInit = false;
+    initReason = "";
+  }
+
+  if (!status.startsWith("-")) {
+    hasUncommittedChanges = hasDirtySubmoduleCheckout(nestedSubmodule.path, {
+      cwd: elizaRoot,
+      exec,
+      log,
+      label: `nested ${nestedSubmodule.name} (${rootRelativePath})`,
+    });
+  }
+
+  return { needsInit, initReason, hasUncommittedChanges };
+}
+
+function updateNestedSubmodule(nestedSubmodule, rootRelativePath, options) {
+  const { elizaRoot, exec, log, logError } = options;
+  try {
+    exec(
+      `git submodule update --init --recursive -- "${nestedSubmodule.path}"`,
+      {
+        cwd: elizaRoot,
+        stdio: "inherit",
+      },
+    );
+    return true;
+  } catch (err) {
+    try {
+      hydrateSubmoduleFromConfiguredBranch(nestedSubmodule, {
+        rootDir: elizaRoot,
+        exec,
+        remove: rmSync,
+        log,
+      });
+      return true;
+    } catch (fallbackErr) {
+      logError(
+        `[init-submodules] Failed to initialize nested ${nestedSubmodule.name} (${rootRelativePath}): ${
+          fallbackErr instanceof Error
+            ? fallbackErr.message
+            : String(fallbackErr)
+        }`,
+      );
+      logError(
+        `[init-submodules] Original nested submodule error: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      return false;
+    }
+  }
+}
+
+function processNestedSubmodule(nestedSubmodule, options) {
+  const { elizaRoot, exec, log, logError } = options;
+  const rootRelativePath = `eliza/${nestedSubmodule.path}`;
+  const skipReason = getSubmoduleSkipReason(rootRelativePath, {
+    skipLocal: false,
+  });
+  if (skipReason) {
+    log(
+      `[init-submodules] Skipping nested ${nestedSubmodule.name} (${rootRelativePath}) because ${skipReason}`,
+    );
+    return "skipped";
+  }
+  if (!isTrackedAsGitlink(nestedSubmodule.path, { exec, cwd: elizaRoot })) {
+    return "skipped";
+  }
+
+  const plan = resolveNestedSubmoduleInitPlan(
+    nestedSubmodule,
+    rootRelativePath,
+    {
+      elizaRoot,
+      exec,
+      log,
+    },
+  );
+  if (!plan.needsInit) {
+    return "skipped";
+  }
+  if (plan.hasUncommittedChanges) {
+    logError(
+      `[init-submodules] Refusing to update nested ${nestedSubmodule.name} (${rootRelativePath}) because it has uncommitted local changes`,
+    );
+    return "failed";
+  }
+
+  log(
+    `[init-submodules] Updating nested ${nestedSubmodule.name} (${rootRelativePath})${
+      plan.initReason ? ` because ${plan.initReason}` : ""
+    }...`,
+  );
+  return updateNestedSubmodule(nestedSubmodule, rootRelativePath, options)
+    ? "updated"
+    : "failed";
+}
+
+function ensureNestedElizaSubmodules({
+  rootDir,
+  exists,
+  exec,
+  log,
+  logError,
+  shouldSkipSubmodule,
+}) {
+  if (
+    shouldSkipSubmodule("eliza") ||
+    !exists(resolve(rootDir, "eliza", ".gitmodules"))
+  ) {
+    return 0;
+  }
+
+  const elizaRoot = resolve(rootDir, "eliza");
+  log(
+    "[init-submodules] Ensuring nested checkouts under eliza/ (cloud, plugins, …)…",
+  );
+  try {
+    exec("git submodule sync --recursive", {
+      cwd: elizaRoot,
+      stdio: "inherit",
+    });
+
+    let failed = 0;
+    for (const nestedSubmodule of loadTrackedSubmodules({
+      exec,
+      cwd: elizaRoot,
+    })) {
+      if (
+        processNestedSubmodule(nestedSubmodule, {
+          elizaRoot,
+          exec,
+          log,
+          logError,
+        }) === "failed"
+      ) {
+        failed++;
+      }
+    }
+    return failed;
+  } catch (err) {
+    logError(
+      `[init-submodules] Unexpected error initializing nested eliza submodules: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return 0;
+  }
+}
+
+function logInitSubmodulesSummary(
+  { initialized, alreadyInitialized, failed },
+  { log, logError },
+) {
+  if (failed > 0) {
+    logError(
+      `[init-submodules] Initialized ${initialized}, already ready ${alreadyInitialized}, failed ${failed}.`,
+    );
+    return;
+  }
+  if (initialized === 0) {
+    log("[init-submodules] All submodules already initialized");
+    return;
+  }
+  log(
+    `[init-submodules] Initialized ${initialized} submodule(s); ${alreadyInitialized} already ready.`,
+  );
+}
+
 export function runInitSubmodules({
   rootDir = root,
   exists = existsSync,
@@ -476,19 +893,19 @@ export function runInitSubmodules({
   const gitDir = resolve(rootDir, ".git");
   if (!exists(gitDir)) {
     log("[init-submodules] Not a git repository — skipping");
-    return { initialized: 0, alreadyInitialized: 0, failed: 0, submodules: [] };
+    return emptySubmoduleInitResult();
   }
 
   const gitmodulesPath = resolve(rootDir, ".gitmodules");
   if (!exists(gitmodulesPath)) {
     log("[init-submodules] No .gitmodules found — skipping");
-    return { initialized: 0, alreadyInitialized: 0, failed: 0, submodules: [] };
+    return emptySubmoduleInitResult();
   }
 
   const submodules = loadTrackedSubmodules({ exec, cwd: rootDir });
   if (submodules.length === 0) {
     log("[init-submodules] No tracked submodules found — skipping");
-    return { initialized: 0, alreadyInitialized: 0, failed: 0, submodules: [] };
+    return emptySubmoduleInitResult();
   }
 
   const hasLegacyRootCloudPaths = submodules.some((s) => s.path === "cloud");
@@ -505,334 +922,26 @@ export function runInitSubmodules({
     exists,
   });
 
-  // Re-align every submodule's .git/config remote URL with .gitmodules before
-  // doing anything else. Without this, flipping a submodule URL upstream (e.g.
-  // retargeting eliza between elizaOS/eliza and milady-ai/eliza) leaves the
-  // local .git/modules/<name>/config stuck on the old remote — so `git pull`
-  // later fails to fetch commits that only exist on the new remote. The
-  // per-submodule sync below only runs when `needsInit` is true, which misses
-  // the common case where the submodule is still checked out cleanly.
-  try {
-    exec("git submodule sync --recursive", {
-      cwd: rootDir,
-      stdio: "inherit",
-    });
-  } catch (err) {
-    logError(
-      `[init-submodules] git submodule sync --recursive failed: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
-    );
-  }
+  syncSubmoduleUrls(rootDir, { exec, logError });
 
-  let initialized = 0;
-  let alreadyInitialized = 0;
-  let failed = 0;
+  const summary = processRootSubmodules(submodules, {
+    rootDir,
+    exists,
+    exec,
+    log,
+    logError,
+    shouldSkipSubmodule,
+  });
+  summary.failed += ensureNestedElizaSubmodules({
+    rootDir,
+    exists,
+    exec,
+    log,
+    logError,
+    shouldSkipSubmodule,
+  });
 
-  for (const submodule of submodules) {
-    const skipReason = getSubmoduleSkipReason(submodule.path);
-    if (shouldSkipSubmodule(submodule.path)) {
-      log(
-        `[init-submodules] Skipping ${submodule.name} (${submodule.path}) because ${skipReason ?? "local upstreams are disabled"}`,
-      );
-      continue;
-    }
-
-    if (!isTrackedAsGitlink(submodule.path, { exec, cwd: rootDir })) {
-      log(
-        `[init-submodules] Skipping ${submodule.name} (${submodule.path}) because the parent repo tracks that path as regular files, not a gitlink`,
-      );
-      continue;
-    }
-
-    const checkoutReady = isSubmoduleCheckoutReady(submodule.path, {
-      rootDir,
-      exists,
-    });
-    let needsInit = !checkoutReady;
-    let initReason = checkoutReady ? "" : "checkout is incomplete";
-
-    let hasUncommittedChanges = false;
-    try {
-      const status = exec(`git submodule status -- "${submodule.path}"`, {
-        cwd: rootDir,
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "ignore"],
-      }).trim();
-      if (status.startsWith("-")) {
-        needsInit = true;
-        initReason = "submodule is not initialized";
-      } else if (status.startsWith("+")) {
-        needsInit = true;
-        initReason = "checkout is not at the parent repo's recorded commit";
-        log(
-          `[init-submodules] ${submodule.name} (${submodule.path}) is not at the parent repo's recorded commit`,
-        );
-      }
-      if (!status.startsWith("-")) {
-        try {
-          const smRoot = resolve(rootDir, submodule.path);
-          const dirty = exec("git status --porcelain", {
-            cwd: smRoot,
-            encoding: "utf8",
-            stdio: ["ignore", "pipe", "ignore"],
-          }).trim();
-          if (dirty) {
-            hasUncommittedChanges = true;
-            log(
-              `[init-submodules] ⚠ ${submodule.name} (${submodule.path}) has uncommitted local changes`,
-            );
-          }
-        } catch {}
-      }
-    } catch {
-      needsInit = true;
-      if (!initReason) {
-        initReason = "status check failed";
-      }
-    }
-
-    if (needsInit && hasUncommittedChanges) {
-      failed++;
-      logError(
-        `[init-submodules] Refusing to update ${submodule.name} (${submodule.path}) because it has uncommitted local changes`,
-      );
-      continue;
-    }
-
-    if (!needsInit) {
-      alreadyInitialized++;
-      continue;
-    }
-
-    log(
-      `[init-submodules] Initializing ${submodule.name} (${submodule.path})${
-        initReason ? ` because ${initReason}` : ""
-      }...`,
-    );
-    try {
-      const recurseFlag = NO_RECURSE_SUBMODULES.has(submodule.path)
-        ? ""
-        : " --recursive";
-      try {
-        exec(`git submodule sync -- "${submodule.path}"`, {
-          cwd: rootDir,
-          stdio: "inherit",
-        });
-      } catch {}
-      try {
-        exec(`git submodule update --init${recurseFlag} "${submodule.path}"`, {
-          cwd: rootDir,
-          stdio: "inherit",
-        });
-      } catch (_shallowErr) {
-        log(
-          `[init-submodules] Shallow init failed for ${submodule.name}, retrying with full fetch...`,
-        );
-        try {
-          try {
-            exec(`git submodule init "${submodule.path}"`, {
-              cwd: rootDir,
-              stdio: "inherit",
-            });
-          } catch {}
-          const smRoot = resolve(rootDir, submodule.path);
-          if (exists(smRoot) && exists(resolve(smRoot, ".git"))) {
-            exec("git fetch --unshallow || git fetch --all", {
-              cwd: smRoot,
-              stdio: "inherit",
-              shell: true,
-            });
-          }
-          exec(`git submodule update${recurseFlag} "${submodule.path}"`, {
-            cwd: rootDir,
-            stdio: "inherit",
-          });
-        } catch {
-          hydrateSubmoduleFromConfiguredBranch(submodule, {
-            rootDir,
-            exec,
-            remove: rmSync,
-            log,
-          });
-        }
-      }
-      if (
-        !isSubmoduleCheckoutReady(submodule.path, {
-          rootDir,
-          exists,
-        })
-      ) {
-        throw new Error(
-          `submodule checkout is still incomplete after update: ${submodule.path}`,
-        );
-      }
-      initialized++;
-      log(`[init-submodules] ${submodule.name} initialized successfully`);
-    } catch (err) {
-      failed++;
-      const message = err instanceof Error ? err.message : String(err);
-      logError(
-        `[init-submodules] Failed to initialize ${submodule.name} (${submodule.path}): ${message}`,
-      );
-    }
-  }
-
-  if (
-    !shouldSkipSubmodule("eliza") &&
-    exists(resolve(rootDir, "eliza", ".gitmodules"))
-  ) {
-    const elizaRoot = resolve(rootDir, "eliza");
-    log(
-      "[init-submodules] Ensuring nested checkouts under eliza/ (cloud, plugins, …)…",
-    );
-    try {
-      // Sync nested config first so git does not keep stale URLs from older
-      // eliza merges around in .git/config.
-      exec("git submodule sync --recursive", {
-        cwd: elizaRoot,
-        stdio: "inherit",
-      });
-
-      const nestedSubmodules = loadTrackedSubmodules({
-        exec,
-        cwd: elizaRoot,
-      });
-
-      for (const nestedSubmodule of nestedSubmodules) {
-        const rootRelativePath = `eliza/${nestedSubmodule.path}`;
-        const skipReason = getSubmoduleSkipReason(rootRelativePath, {
-          skipLocal: false,
-        });
-        if (skipReason) {
-          log(
-            `[init-submodules] Skipping nested ${nestedSubmodule.name} (${rootRelativePath}) because ${skipReason}`,
-          );
-          continue;
-        }
-
-        if (
-          !isTrackedAsGitlink(nestedSubmodule.path, {
-            exec,
-            cwd: elizaRoot,
-          })
-        ) {
-          continue;
-        }
-
-        let needsInit = true;
-        let initReason = "status check failed";
-        let hasUncommittedChanges = false;
-        try {
-          const status = exec(
-            `git submodule status -- "${nestedSubmodule.path}"`,
-            {
-              cwd: elizaRoot,
-              encoding: "utf8",
-              stdio: ["ignore", "pipe", "ignore"],
-            },
-          ).trim();
-          if (status.startsWith("-")) {
-            needsInit = true;
-            initReason = "submodule is not initialized";
-          } else if (status.startsWith("+")) {
-            needsInit = true;
-            initReason = "checkout is not at eliza's recorded commit";
-          } else {
-            needsInit = false;
-            initReason = "";
-          }
-
-          if (!status.startsWith("-")) {
-            try {
-              const nestedRoot = resolve(elizaRoot, nestedSubmodule.path);
-              const dirty = exec("git status --porcelain", {
-                cwd: nestedRoot,
-                encoding: "utf8",
-                stdio: ["ignore", "pipe", "ignore"],
-              }).trim();
-              if (dirty) {
-                hasUncommittedChanges = true;
-                log(
-                  `[init-submodules] ⚠ nested ${nestedSubmodule.name} (${rootRelativePath}) has uncommitted local changes`,
-                );
-              }
-            } catch {}
-          }
-        } catch {
-          needsInit = true;
-        }
-
-        if (!needsInit) {
-          continue;
-        }
-
-        if (hasUncommittedChanges) {
-          failed++;
-          logError(
-            `[init-submodules] Refusing to update nested ${nestedSubmodule.name} (${rootRelativePath}) because it has uncommitted local changes`,
-          );
-          continue;
-        }
-
-        try {
-          log(
-            `[init-submodules] Updating nested ${nestedSubmodule.name} (${rootRelativePath})${
-              initReason ? ` because ${initReason}` : ""
-            }...`,
-          );
-          exec(
-            `git submodule update --init --recursive -- "${nestedSubmodule.path}"`,
-            {
-              cwd: elizaRoot,
-              stdio: "inherit",
-            },
-          );
-        } catch (err) {
-          try {
-            hydrateSubmoduleFromConfiguredBranch(nestedSubmodule, {
-              rootDir: elizaRoot,
-              exec,
-              remove: rmSync,
-              log,
-            });
-          } catch (fallbackErr) {
-            failed++;
-            logError(
-              `[init-submodules] Failed to initialize nested ${nestedSubmodule.name} (${rootRelativePath}): ${
-                fallbackErr instanceof Error
-                  ? fallbackErr.message
-                  : String(fallbackErr)
-              }`,
-            );
-            logError(
-              `[init-submodules] Original nested submodule error: ${
-                err instanceof Error ? err.message : String(err)
-              }`,
-            );
-          }
-        }
-      }
-    } catch (err) {
-      logError(
-        `[init-submodules] Unexpected error initializing nested eliza submodules: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
-    }
-  }
-
-  if (failed > 0) {
-    logError(
-      `[init-submodules] Initialized ${initialized}, already ready ${alreadyInitialized}, failed ${failed}.`,
-    );
-  } else if (initialized === 0) {
-    log("[init-submodules] All submodules already initialized");
-  } else {
-    log(
-      `[init-submodules] Initialized ${initialized} submodule(s); ${alreadyInitialized} already ready.`,
-    );
-  }
+  logInitSubmodulesSummary(summary, { log, logError });
 
   pruneSkippedCloudWorkspace({
     rootDir,
@@ -845,7 +954,7 @@ export function runInitSubmodules({
     log,
   });
 
-  return { initialized, alreadyInitialized, failed, submodules };
+  return { ...summary, submodules };
 }
 
 const isDirectRun =

--- a/scripts/patch-eliza-electrobun-windows-smoke-startup.mjs
+++ b/scripts/patch-eliza-electrobun-windows-smoke-startup.mjs
@@ -295,26 +295,40 @@ function patchRealRuntimeLiveProviderImport(text) {
   return result;
 }
 
-function patchMacosArtifactStager(text) {
-  const notaryTimeout60 =
-    'NOTARY_WAIT_TIMEOUT="$' + '{ELECTROBUN_NOTARY_WAIT_TIMEOUT:-60m}"';
+function runMacosArtifactPatchPipeline(text, steps) {
   let result = { matched: true, text };
-  if (!result.text.includes(notaryTimeout60)) {
-    result = replaceRequiredBlock(
-      result.text,
-      /NOTARY_WAIT_TIMEOUT="\$\{ELECTROBUN_NOTARY_WAIT_TIMEOUT:-30m\}"/,
-      notaryTimeout60,
-    );
+  for (const step of steps) {
+    result = step(result.text);
     if (!result.matched) {
       return result;
     }
   }
+  return result;
+}
 
-  if (!result.text.includes("retry_codesign() {")) {
-    result = replaceRequiredBlock(
-      result.text,
-      / {2}return "\$command_status"\r?\n}\r?\n\r?\nparse_notary_submission_id\(\) \{/,
-      `  return "$command_status"
+function patchMacosNotaryTimeout(text) {
+  const notaryTimeout60 =
+    'NOTARY_WAIT_TIMEOUT="$' + '{ELECTROBUN_NOTARY_WAIT_TIMEOUT:-60m}"';
+  if (text.includes(notaryTimeout60)) {
+    return { matched: true, text };
+  }
+
+  return replaceRequiredBlock(
+    text,
+    /NOTARY_WAIT_TIMEOUT="\$\{ELECTROBUN_NOTARY_WAIT_TIMEOUT:-30m\}"/,
+    notaryTimeout60,
+  );
+}
+
+function patchMacosRetryCodesignHelper(text) {
+  if (text.includes("retry_codesign() {")) {
+    return { matched: true, text };
+  }
+
+  return replaceRequiredBlock(
+    text,
+    / {2}return "\$command_status"\r?\n}\r?\n\r?\nparse_notary_submission_id\(\) \{/,
+    `  return "$command_status"
 }
 
 retry_codesign() {
@@ -322,22 +336,24 @@ retry_codesign() {
 }
 
 parse_notary_submission_id() {`,
-    );
-    if (!result.matched) {
-      return result;
-    }
+  );
+}
+
+function patchMacosNotarytoolRetryHelpers(text) {
+  if (text.includes("retry_notarytool_submit() {")) {
+    return { matched: true, text };
   }
 
-  if (!result.text.includes("retry_notarytool_submit() {")) {
-    const notaryRetryAnchor = `TARBALL_PATH=`;
-    if (!result.text.includes(notaryRetryAnchor)) {
-      return { matched: false, text };
-    }
-    result = {
-      matched: true,
-      text: result.text.replace(
-        notaryRetryAnchor,
-        `parse_notary_status() {
+  const notaryRetryAnchor = `TARBALL_PATH=`;
+  if (!text.includes(notaryRetryAnchor)) {
+    return { matched: false, text };
+  }
+
+  return {
+    matched: true,
+    text: text.replace(
+      notaryRetryAnchor,
+      `parse_notary_status() {
   local output_path="$1"
   /usr/bin/python3 - "$output_path" <<'PY'
 import json
@@ -455,32 +471,37 @@ retry_notarytool_log() {
 }
 
 TARBALL_PATH=`,
-      ),
-    };
+    ),
+  };
+}
+
+function patchMacosTarballSearch(text) {
+  if (text.includes('for tarball_pattern in "*-macos-*.app.tar.zst"')) {
+    return { matched: true, text };
   }
 
-  if (!result.text.includes('for tarball_pattern in "*-macos-*.app.tar.zst"')) {
-    result = replaceRequiredBlock(
-      result.text,
-      /TARBALL_PATH="\$\(find -L "\$ARTIFACTS_DIR" -maxdepth 1 -type f -name "\*-macos-\*\.app\.tar\.zst" \| sort \| head -1\)"/,
-      `TARBALL_PATH=""
+  return replaceRequiredBlock(
+    text,
+    /TARBALL_PATH="\$\(find -L "\$ARTIFACTS_DIR" -maxdepth 1 -type f -name "\*-macos-\*\.app\.tar\.zst" \| sort \| head -1\)"/,
+    `TARBALL_PATH=""
 for tarball_pattern in "*-macos-*.app.tar.zst" "*-macos-*.app.tar.gz" "*-macos-*.tar.gz"; do
   TARBALL_PATH="$(find -L "$ARTIFACTS_DIR" -maxdepth 1 -type f -name "$tarball_pattern" | sort | head -1)"
   if [[ -n "$TARBALL_PATH" ]]; then
     break
   fi
 done`,
-    );
-    if (!result.matched) {
-      return result;
-    }
+  );
+}
+
+function patchMacosTarballExtraction(text) {
+  if (text.includes('tar -xzf "$TARBALL_PATH" -C "$EXTRACT_DIR"')) {
+    return { matched: true, text };
   }
 
-  if (!result.text.includes('tar -xzf "$TARBALL_PATH" -C "$EXTRACT_DIR"')) {
-    result = replaceRequiredBlock(
-      result.text,
-      /echo "Using updater tarball: \$TARBALL_PATH"\r?\ntar --zstd -xf "\$TARBALL_PATH" -C "\$EXTRACT_DIR"/,
-      `echo "Using updater tarball: $TARBALL_PATH"
+  return replaceRequiredBlock(
+    text,
+    /echo "Using updater tarball: \$TARBALL_PATH"\r?\ntar --zstd -xf "\$TARBALL_PATH" -C "\$EXTRACT_DIR"/,
+    `echo "Using updater tarball: $TARBALL_PATH"
 TARBALL_BASENAME="$(basename "$TARBALL_PATH")"
 case "$TARBALL_BASENAME" in
   *.tar.zst)
@@ -494,22 +515,23 @@ case "$TARBALL_BASENAME" in
     exit 1
     ;;
 esac`,
-    );
-    if (!result.matched) {
-      return result;
-    }
-  }
+  );
+}
 
+function patchMacosDmgNameFromTarball(text) {
   if (
-    !result.text.includes(
+    text.includes(
       // biome-ignore lint/suspicious/noTemplateCurlyInString: intentional bash string
       'FINAL_DMG_NAME="${TARBALL_BASENAME%.app.tar.zst}.dmg"',
     )
   ) {
-    result = replaceRequiredBlock(
-      result.text,
-      /FINAL_DMG_NAME="\$\(basename "\$\{TARBALL_PATH%\.app\.tar\.zst\}\.dmg"\)"/,
-      `case "$TARBALL_BASENAME" in
+    return { matched: true, text };
+  }
+
+  return replaceRequiredBlock(
+    text,
+    /FINAL_DMG_NAME="\$\(basename "\$\{TARBALL_PATH%\.app\.tar\.zst\}\.dmg"\)"/,
+    `case "$TARBALL_BASENAME" in
   *.app.tar.zst)
     FINAL_DMG_NAME="\${TARBALL_BASENAME%.app.tar.zst}.dmg"
     ;;
@@ -524,27 +546,26 @@ esac`,
     exit 1
     ;;
 esac`,
-    );
-    if (!result.matched) {
-      return result;
-    }
+  );
+}
+
+function patchMacosEntitlementsFallback(text) {
+  if (text.includes("write_config_entitlements_plist")) {
+    return { matched: true, text };
   }
 
-  if (!result.text.includes("write_config_entitlements_plist")) {
-    result = replaceRequiredBlock(
-      result.text,
-      / {2}if \[\[ ! -s "\$TMP_ENTITLEMENTS_PATH" \]\]; then\r?\n {4}echo "stage-macos-release-artifacts: extracted entitlements were empty"\r?\n {4}exit 1\r?\n {2}fi\r?\n {2}entitlement_args=\(--entitlements "\$TMP_ENTITLEMENTS_PATH"\)/,
-      `  if [[ -s "$TMP_ENTITLEMENTS_PATH" ]]; then
+  return replaceRequiredBlock(
+    text,
+    / {2}if \[\[ ! -s "\$TMP_ENTITLEMENTS_PATH" \]\]; then\r?\n {4}echo "stage-macos-release-artifacts: extracted entitlements were empty"\r?\n {4}exit 1\r?\n {2}fi\r?\n {2}entitlement_args=\(--entitlements "\$TMP_ENTITLEMENTS_PATH"\)/,
+    `  if [[ -s "$TMP_ENTITLEMENTS_PATH" ]]; then
     entitlement_args=(--entitlements "$TMP_ENTITLEMENTS_PATH")
   else
     echo "stage-macos-release-artifacts: extracted entitlements were empty; signing without entitlement plist"
   fi`,
-    );
-    if (!result.matched) {
-      return result;
-    }
-  }
+  );
+}
 
+function patchMacosNestedRuntimeSigning(text) {
   const nestedSigningFunction = `  sign_nested_macos_runtime_targets() {
     local runtime_resources_dir="$STAGED_APP_PATH/Contents/Resources/app/eliza-dist"
     local candidate_path file_type
@@ -562,13 +583,14 @@ esac`,
   }
 `;
 
-  if (result.text.includes("sign_nested_macos_runtime_targets()")) {
-    result = { matched: true, text: result.text };
-  } else {
-    result = replaceRequiredBlock(
-      result.text,
-      / {2}if ! codesign --force --timestamp --sign "\$ELECTROBUN_DEVELOPER_ID" --options runtime "\$\{entitlement_args\[@\]\}" "\$LAUNCHER_PATH"; then\r?\n {4}echo "stage-macos-release-artifacts: launcher runtime signing failed, retrying without hardened runtime" >&2\r?\n {4}codesign --force --timestamp --sign "\$ELECTROBUN_DEVELOPER_ID" "\$\{entitlement_args\[@\]\}" "\$LAUNCHER_PATH"\r?\n {2}fi\r?\n {2}codesign --force --timestamp --sign "\$ELECTROBUN_DEVELOPER_ID" --options runtime "\$\{entitlement_args\[@\]\}" "\$STAGED_APP_PATH"/,
-      `  runtime_sign_args=(--force --timestamp --sign "$ELECTROBUN_DEVELOPER_ID" --options runtime)
+  if (text.includes("sign_nested_macos_runtime_targets()")) {
+    return { matched: true, text };
+  }
+
+  let result = replaceRequiredBlock(
+    text,
+    / {2}if ! codesign --force --timestamp --sign "\$ELECTROBUN_DEVELOPER_ID" --options runtime "\$\{entitlement_args\[@\]\}" "\$LAUNCHER_PATH"; then\r?\n {4}echo "stage-macos-release-artifacts: launcher runtime signing failed, retrying without hardened runtime" >&2\r?\n {4}codesign --force --timestamp --sign "\$ELECTROBUN_DEVELOPER_ID" "\$\{entitlement_args\[@\]\}" "\$LAUNCHER_PATH"\r?\n {2}fi\r?\n {2}codesign --force --timestamp --sign "\$ELECTROBUN_DEVELOPER_ID" --options runtime "\$\{entitlement_args\[@\]\}" "\$STAGED_APP_PATH"/,
+    `  runtime_sign_args=(--force --timestamp --sign "$ELECTROBUN_DEVELOPER_ID" --options runtime)
   fallback_runtime_sign_args=(--force --timestamp --sign "$ELECTROBUN_DEVELOPER_ID")
   app_sign_args=(--force --timestamp --sign "$ELECTROBUN_DEVELOPER_ID" --options runtime)
   if [[ -s "\${TMP_ENTITLEMENTS_PATH:-}" ]]; then
@@ -602,52 +624,58 @@ ${nestedSigningFunction}  macos_code_dir="$STAGED_APP_PATH/Contents/MacOS"
   sign_nested_macos_runtime_targets
   sign_macos_runtime_target "$LAUNCHER_PATH"
   retry_codesign "\${app_sign_args[@]}" "$STAGED_APP_PATH"`,
-    );
-    if (!result.matched) {
-      result = replaceRequiredBlock(
-        result.text,
-        / {2}macos_code_dir="\$STAGED_APP_PATH\/Contents\/MacOS"/,
-        `${nestedSigningFunction}  macos_code_dir="$STAGED_APP_PATH/Contents/MacOS"`,
-      );
-      if (result.matched) {
-        result = replaceRequiredBlock(
-          result.text,
-          / {2}sign_macos_runtime_target "\$LAUNCHER_PATH"/,
-          `  sign_nested_macos_runtime_targets
-  sign_macos_runtime_target "$LAUNCHER_PATH"`,
-        );
-      }
-    }
+  );
+  if (result.matched) {
+    return result;
   }
+
+  result = replaceRequiredBlock(
+    result.text,
+    / {2}macos_code_dir="\$STAGED_APP_PATH\/Contents\/MacOS"/,
+    `${nestedSigningFunction}  macos_code_dir="$STAGED_APP_PATH/Contents/MacOS"`,
+  );
   if (!result.matched) {
     return result;
   }
 
+  return replaceRequiredBlock(
+    result.text,
+    / {2}sign_macos_runtime_target "\$LAUNCHER_PATH"/,
+    `  sign_nested_macos_runtime_targets
+  sign_macos_runtime_target "$LAUNCHER_PATH"`,
+  );
+}
+
+function patchMacosDmgCodesignRetry(text) {
   if (
-    !result.text.includes(
+    text.includes(
       'retry_codesign --force --timestamp --sign "$ELECTROBUN_DEVELOPER_ID" "$TEMP_DMG_PATH"',
     )
   ) {
-    result = replaceRequiredBlock(
-      result.text,
-      / {2}codesign --force --timestamp --sign "\$ELECTROBUN_DEVELOPER_ID" "\$TEMP_DMG_PATH"/,
-      '  retry_codesign --force --timestamp --sign "$ELECTROBUN_DEVELOPER_ID" "$TEMP_DMG_PATH"',
-    );
-    if (!result.matched) {
-      return result;
-    }
+    return { matched: true, text };
   }
 
+  return replaceRequiredBlock(
+    text,
+    / {2}codesign --force --timestamp --sign "\$ELECTROBUN_DEVELOPER_ID" "\$TEMP_DMG_PATH"/,
+    '  retry_codesign --force --timestamp --sign "$ELECTROBUN_DEVELOPER_ID" "$TEMP_DMG_PATH"',
+  );
+}
+
+function patchMacosNotarySubmitRetry(text) {
   if (
-    !result.text.includes(
+    text.includes(
       // biome-ignore lint/suspicious/noTemplateCurlyInString: intentional bash string
       'NOTARY_SUBMIT_ATTEMPTS="${ELECTROBUN_NOTARY_SUBMIT_ATTEMPTS:-3}"',
     )
   ) {
-    result = replaceRequiredBlock(
-      result.text,
-      / {2}NOTARY_SUBMIT_OUTPUT_PATH="\$TMP_ROOT\/notary-submit\.json"\r?\n {2}"\$REAL_XCRUN" notarytool submit \\\r?\n {4}--apple-id "\$ELECTROBUN_APPLEID" \\\r?\n {4}--password "\$ELECTROBUN_APPLEIDPASS" \\\r?\n {4}--team-id "\$ELECTROBUN_TEAMID" \\\r?\n {4}--output-format json \\\r?\n {4}"\$TEMP_DMG_PATH" >"\$NOTARY_SUBMIT_OUTPUT_PATH"/,
-      `  NOTARY_SUBMIT_ATTEMPTS="\${ELECTROBUN_NOTARY_SUBMIT_ATTEMPTS:-3}"
+    return { matched: true, text };
+  }
+
+  return replaceRequiredBlock(
+    text,
+    / {2}NOTARY_SUBMIT_OUTPUT_PATH="\$TMP_ROOT\/notary-submit\.json"\r?\n {2}"\$REAL_XCRUN" notarytool submit \\\r?\n {4}--apple-id "\$ELECTROBUN_APPLEID" \\\r?\n {4}--password "\$ELECTROBUN_APPLEIDPASS" \\\r?\n {4}--team-id "\$ELECTROBUN_TEAMID" \\\r?\n {4}--output-format json \\\r?\n {4}"\$TEMP_DMG_PATH" >"\$NOTARY_SUBMIT_OUTPUT_PATH"/,
+    `  NOTARY_SUBMIT_ATTEMPTS="\${ELECTROBUN_NOTARY_SUBMIT_ATTEMPTS:-3}"
   NOTARY_SUBMIT_RETRY_DELAY_SECONDS="\${ELECTROBUN_NOTARY_SUBMIT_RETRY_DELAY_SECONDS:-30}"
   NOTARY_SUBMIT_OUTPUT_PATH="$TMP_ROOT/notary-submit.json"
   if ! retry_notarytool_submit "$NOTARY_SUBMIT_OUTPUT_PATH" "$NOTARY_SUBMIT_ATTEMPTS" "$NOTARY_SUBMIT_RETRY_DELAY_SECONDS"; then
@@ -655,22 +683,23 @@ ${nestedSigningFunction}  macos_code_dir="$STAGED_APP_PATH/Contents/MacOS"
     sed -n '1,80p' "$NOTARY_SUBMIT_OUTPUT_PATH" >&2 || true
     exit 1
   fi`,
-    );
-    if (!result.matched) {
-      return result;
-    }
-  }
+  );
+}
 
+function patchMacosNotaryWaitRetry(text) {
   if (
-    !result.text.includes(
+    text.includes(
       // biome-ignore lint/suspicious/noTemplateCurlyInString: intentional bash string
       'NOTARY_WAIT_ATTEMPTS="${ELECTROBUN_NOTARY_WAIT_ATTEMPTS:-3}"',
     )
   ) {
-    result = replaceRequiredBlock(
-      result.text,
-      / {2}NOTARY_WAIT_OUTPUT_PATH="\$TMP_ROOT\/notary-wait\.json"\r?\n {2}if ! "\$REAL_XCRUN" notarytool wait \\\r?\n {4}--apple-id "\$ELECTROBUN_APPLEID" \\\r?\n {4}--password "\$ELECTROBUN_APPLEIDPASS" \\\r?\n {4}--team-id "\$ELECTROBUN_TEAMID" \\\r?\n {4}--timeout "\$NOTARY_WAIT_TIMEOUT" \\\r?\n {4}--output-format json \\\r?\n {4}"\$NOTARY_SUBMISSION_ID" >"\$NOTARY_WAIT_OUTPUT_PATH"; then\r?\n {4}echo "stage-macos-release-artifacts: notarization wait failed for submission \$NOTARY_SUBMISSION_ID" >&2\r?\n {4}sed -n '1,80p' "\$NOTARY_WAIT_OUTPUT_PATH" >&2 \|\| true\r?\n {4}"\$REAL_XCRUN" notarytool log \\\r?\n {6}--apple-id "\$ELECTROBUN_APPLEID" \\\r?\n {6}--password "\$ELECTROBUN_APPLEIDPASS" \\\r?\n {6}--team-id "\$ELECTROBUN_TEAMID" \\\r?\n {6}"\$NOTARY_SUBMISSION_ID" >&2 \|\| true\r?\n {4}exit 1\r?\n {2}fi/,
-      `  NOTARY_WAIT_ATTEMPTS="\${ELECTROBUN_NOTARY_WAIT_ATTEMPTS:-3}"
+    return { matched: true, text };
+  }
+
+  return replaceRequiredBlock(
+    text,
+    / {2}NOTARY_WAIT_OUTPUT_PATH="\$TMP_ROOT\/notary-wait\.json"\r?\n {2}if ! "\$REAL_XCRUN" notarytool wait \\\r?\n {4}--apple-id "\$ELECTROBUN_APPLEID" \\\r?\n {4}--password "\$ELECTROBUN_APPLEIDPASS" \\\r?\n {4}--team-id "\$ELECTROBUN_TEAMID" \\\r?\n {4}--timeout "\$NOTARY_WAIT_TIMEOUT" \\\r?\n {4}--output-format json \\\r?\n {4}"\$NOTARY_SUBMISSION_ID" >"\$NOTARY_WAIT_OUTPUT_PATH"; then\r?\n {4}echo "stage-macos-release-artifacts: notarization wait failed for submission \$NOTARY_SUBMISSION_ID" >&2\r?\n {4}sed -n '1,80p' "\$NOTARY_WAIT_OUTPUT_PATH" >&2 \|\| true\r?\n {4}"\$REAL_XCRUN" notarytool log \\\r?\n {6}--apple-id "\$ELECTROBUN_APPLEID" \\\r?\n {6}--password "\$ELECTROBUN_APPLEIDPASS" \\\r?\n {6}--team-id "\$ELECTROBUN_TEAMID" \\\r?\n {6}"\$NOTARY_SUBMISSION_ID" >&2 \|\| true\r?\n {4}exit 1\r?\n {2}fi/,
+    `  NOTARY_WAIT_ATTEMPTS="\${ELECTROBUN_NOTARY_WAIT_ATTEMPTS:-3}"
   NOTARY_WAIT_RETRY_DELAY_SECONDS="\${ELECTROBUN_NOTARY_WAIT_RETRY_DELAY_SECONDS:-60}"
   NOTARY_WAIT_OUTPUT_PATH="$TMP_ROOT/notary-wait.json"
   if ! retry_notarytool_wait "$NOTARY_WAIT_OUTPUT_PATH" "$NOTARY_WAIT_ATTEMPTS" "$NOTARY_WAIT_RETRY_DELAY_SECONDS"; then
@@ -679,21 +708,22 @@ ${nestedSigningFunction}  macos_code_dir="$STAGED_APP_PATH/Contents/MacOS"
     retry_notarytool_log >&2 || true
     exit 1
   fi`,
-    );
-    if (!result.matched) {
-      return result;
-    }
-  }
+  );
+}
 
+function patchMacosStaplerFallback(text) {
   if (
-    !result.text.includes(
+    text.includes(
       "notarization accepted but stapler ticket was not available; continuing without stapled DMG",
     )
   ) {
-    result = replaceRequiredBlock(
-      result.text,
-      / {2}(?:retry_command 8 20 xcrun stapler staple "\$TEMP_DMG_PATH"|STAPLER_ATTEMPTS="\$\{ELECTROBUN_STAPLER_ATTEMPTS:-12\}"\r?\n {2}STAPLER_DELAY_SECONDS="\$\{ELECTROBUN_STAPLER_DELAY_SECONDS:-30\}"\r?\n {2}retry_command "\$STAPLER_ATTEMPTS" "\$STAPLER_DELAY_SECONDS" xcrun stapler staple "\$TEMP_DMG_PATH")/,
-      `  STAPLER_ATTEMPTS="\${ELECTROBUN_STAPLER_ATTEMPTS:-12}"
+    return { matched: true, text };
+  }
+
+  return replaceRequiredBlock(
+    text,
+    / {2}(?:retry_command 8 20 xcrun stapler staple "\$TEMP_DMG_PATH"|STAPLER_ATTEMPTS="\$\{ELECTROBUN_STAPLER_ATTEMPTS:-12\}"\r?\n {2}STAPLER_DELAY_SECONDS="\$\{ELECTROBUN_STAPLER_DELAY_SECONDS:-30\}"\r?\n {2}retry_command "\$STAPLER_ATTEMPTS" "\$STAPLER_DELAY_SECONDS" xcrun stapler staple "\$TEMP_DMG_PATH")/,
+    `  STAPLER_ATTEMPTS="\${ELECTROBUN_STAPLER_ATTEMPTS:-12}"
   STAPLER_DELAY_SECONDS="\${ELECTROBUN_STAPLER_DELAY_SECONDS:-30}"
   if ! retry_command "$STAPLER_ATTEMPTS" "$STAPLER_DELAY_SECONDS" xcrun stapler staple "$TEMP_DMG_PATH"; then
     if [[ "\${ELECTROBUN_REQUIRE_STAPLED_DMG:-0}" == "1" ]]; then
@@ -701,12 +731,24 @@ ${nestedSigningFunction}  macos_code_dir="$STAGED_APP_PATH/Contents/MacOS"
     fi
     echo "stage-macos-release-artifacts: notarization accepted but stapler ticket was not available; continuing without stapled DMG" >&2
   fi`,
-    );
-    if (!result.matched) {
-      return result;
-    }
-  }
-  return result;
+  );
+}
+
+function patchMacosArtifactStager(text) {
+  return runMacosArtifactPatchPipeline(text, [
+    patchMacosNotaryTimeout,
+    patchMacosRetryCodesignHelper,
+    patchMacosNotarytoolRetryHelpers,
+    patchMacosTarballSearch,
+    patchMacosTarballExtraction,
+    patchMacosDmgNameFromTarball,
+    patchMacosEntitlementsFallback,
+    patchMacosNestedRuntimeSigning,
+    patchMacosDmgCodesignRetry,
+    patchMacosNotarySubmitRetry,
+    patchMacosNotaryWaitRetry,
+    patchMacosStaplerFallback,
+  ]);
 }
 
 function patchLocalAdhocMacosSigningOrder(text) {


### PR DESCRIPTION
## Summary
- split disable-local-eliza-workspace orchestration into focused helpers
- split macOS artifact stager patching into named patch steps
- split init-submodules root and nested submodule handling into smaller helpers

## Verification
- node --check scripts/disable-local-eliza-workspace.mjs
- node --check scripts/patch-eliza-electrobun-windows-smoke-startup.mjs
- node --check scripts/init-submodules.mjs
- bunx @biomejs/biome check scripts/disable-local-eliza-workspace.mjs scripts/init-submodules.mjs scripts/patch-eliza-electrobun-windows-smoke-startup.mjs
- git diff --check
- node scripts/patch-eliza-electrobun-windows-smoke-startup.mjs --check

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split monolithic CI scripts into focused helper functions to reduce complexity
> - Refactors [disable-local-eliza-workspace.mjs](https://github.com/milady-ai/milady/pull/2116/files#diff-eddd107a5257d405d39b4242a74e0ad1ba4f79715b6eec01da5d17a54963b8d7) by extracting ~12 utility functions (workspace glob patching, dependency rewriting, script stubbing, etc.) from a single orchestrator function, keeping the same return shape.
> - Refactors [init-submodules.mjs](https://github.com/milady-ai/milady/pull/2116/files#diff-927ba7fd8e1b3fbce8af2599149349017e91a9f97cab5d670b967df7f77ba209) by extracting ~14 helpers covering submodule status checks, init planning, nested eliza submodule handling, and summary logging.
> - Refactors [patch-eliza-electrobun-windows-smoke-startup.mjs](https://github.com/milady-ai/milady/pull/2116/files#diff-75faf67fe458caafb3218cf444bd3b0c68c0fd137e37c43c773e398f22815db5) by splitting the monolithic patch function into per-concern patch steps run through a short-circuiting pipeline runner.
> - No functional changes are intended; this is a pure structural refactor to reduce CodeFactor complexity scores.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ade9bdb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->