### PR TITLE
docs(homepage): simplify troubleshooting path literals

### DIFF
--- a/apps/homepage/src/docs/content/beginner/troubleshooting.mdx
+++ b/apps/homepage/src/docs/content/beginner/troubleshooting.mdx
@@ -87,7 +87,7 @@ Fresh slate:
 
 <Steps>
   <li>Quit Milady.</li>
-  <li>Rename <code>{"~/.milady"}</code> to <code>{"~/.milady.old"}</code>. That keeps your old data around in case you want to pull something out of it.</li>
+  <li>Rename <code>&#126;/.milady</code> to <code>&#126;/.milady.old</code>. That keeps your old data around in case you want to pull something out of it.</li>
   <li>Launch Milady. It'll behave like a brand-new install and walk you through onboarding again.</li>
 </Steps>
 


### PR DESCRIPTION
## Summary
- Replace JSX string expressions for the troubleshooting home-directory path literals with HTML entities that render the same `~` text.
- Keeps the MDX valid under the homepage docs build while avoiding unnecessary JSX expression syntax in prose.

## Tests
- `git diff --check`
- `bun run --cwd apps/homepage build`
- `bunx @biomejs/biome check apps/homepage/src/docs/content/beginner/troubleshooting.mdx` (not applicable: repo Biome config ignores this MDX path)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Simplify path literals in troubleshooting docs
> Replaces MDX expression syntax (`{"~/.milady"}`) with plain HTML entities for the `~/.milady` and `~/.milady.old` paths in [troubleshooting.mdx](https://github.com/milady-ai/milady/pull/2117/files#diff-d0656dae8752e7a87a84e18ecb96e308d388625c5a797f7c3db05bdb76741d9b).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 93de72d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->