### PR TITLE
docs(homepage): avoid stale source branch wording

### DIFF
--- a/apps/homepage/src/docs/content/beginner/install.mdx
+++ b/apps/homepage/src/docs/content/beginner/install.mdx
@@ -11,7 +11,7 @@ The homepage points to the current stable Milady release. That's the default for
 | Option | Who it's for | Link |
 | --- | --- | --- |
 | **Stable release** | Everyone, by default. | [Latest stable release](https://github.com/milady-ai/milady/releases/latest) |
-| **Source (GitHub)** | Developers who want to read the code, file issues, or build from `main` themselves. | [github.com/milady-ai/milady](https://github.com/milady-ai/milady) |
+| **Source (GitHub)** | Developers who want to read the code, file issues, or build from the default branch. | [github.com/milady-ai/milady](https://github.com/milady-ai/milady) |
 
 Stable release tags look like `v1.4.0` with no prerelease suffix. The big download buttons on [milady.ai](https://milady.ai) resolve to that stable release.
 


### PR DESCRIPTION
> ## Merge sequencing (for the maintainer agent)
>
> - **Depends on:** #2124 to clear `Lint & Format`, `Type Check`, `Targeted Tests` — those fail on the `Install submodule verification dependencies` workflow step which doesn't apply to this docs/setup change but red-bars the PR.
> - **Unblocks:** nothing else.
> - **Suggested merge order:** Phase 3 — after #2124 lands. `Build`, `Auth tests (P0 gate)`, `CodeFactor`, `review-pr` all pass already.
> - **Risk:** trivial — single-file docs/setup change, exactly what title says.

## Summary
- update beginner install docs so the source checkout option says to build from the repository default branch instead of hard-coding `main`

## Validation
- `bun run --cwd apps/homepage lint`
- `bun run --cwd apps/homepage build`
- `git diff --check`

## Check Status
- Branch was rebased onto current `milady-ai/milady:develop` and force-pushed.
- Normal upstream CI jobs are green.
- Duplicate `CI (Fork)` jobs are red in this repo setup; they fail before exercising this docs change because the fork workflow expects paths/commands that are not present for this checkout shape.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update install docs to reference the default branch instead of `main`
> Changes the wording in [install.mdx](https://github.com/milady-ai/milady/pull/2118/files#diff-84ed41c2aded5f3da612408d86dfbb266883f5476d3ae366a75d75be592b199d) to avoid hardcoding `main` as the source branch, using "default branch" instead to stay accurate if the branch name changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6517450.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->