### PR TITLE
fix(setup): prefer local eliza links in source mode

### DIFF
--- a/scripts/setup-upstreams.mjs
+++ b/scripts/setup-upstreams.mjs
@@ -1181,7 +1181,7 @@ export function ensurePluginDependencyLinks(
   pluginsRoot = getRepoPluginsRoot(repoRoot),
 ) {
   let linkedDependencies = 0;
-  const searchRoots = [repoRoot, getRepoElizaRoot(repoRoot)];
+  const searchRoots = [getRepoElizaRoot(repoRoot), repoRoot];
 
   for (const packageDir of discoverPluginPackageDirs(pluginsRoot)) {
     const packageJson = readPackageJson(packageDir);
@@ -1247,7 +1247,7 @@ export function ensureMiladySingletonDependencyLinks(
   repoRoot = DEFAULT_REPO_ROOT,
 ) {
   let linkedDependencies = 0;
-  const searchRoots = [repoRoot, getRepoElizaRoot(repoRoot)];
+  const searchRoots = [getRepoElizaRoot(repoRoot), repoRoot];
 
   for (const {
     packageDir: relativePackageDir,


### PR DESCRIPTION
> ## Merge sequencing (for the maintainer agent)
>
> - **Depends on:** #2124 to clear `Lint & Format`, `Type Check`, `Targeted Tests` — those fail on the `Install submodule verification dependencies` workflow step which doesn't apply to this docs/setup change but red-bars the PR.
> - **Unblocks:** nothing else.
> - **Suggested merge order:** Phase 3 — after #2124 lands. `Build`, `Auth tests (P0 gate)`, `CodeFactor`, `review-pr` all pass already.
> - **Risk:** trivial — single-file docs/setup change, exactly what title says.

## Summary
- prefer the repo-local `eliza` checkout before the root package tree when relinking `@elizaos` plugin dependencies in local source mode
- apply the same local-first precedence to Milady singleton dependency relinks

## Why
When local source mode uses a current elizaOS checkout, plugin builds can otherwise resolve older root packages first. This keeps local source mode linked against the matching local `eliza` tree.

## Validation
- inline Node fixture verifying `setup-upstreams` plugin and singleton dependency links resolve to `eliza/node_modules` before root `node_modules`
- `bunx vitest run --environment node scripts/standalone-eliza-package-contract.test.ts`

## Check Status
- Branch is on top of current `milady-ai/milady:develop`.
- Normal upstream CI, release workflow contract, CodeFactor, and agent review checks are green/neutral.
- Duplicate `CI (Fork)` jobs are red in this repo setup; logs show they fail before this PR code is exercised because the workflow tries commands in an absent `eliza` directory / checkout shape.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix dependency linking to prefer local Eliza packages in source mode
> In [setup-upstreams.mjs](https://github.com/milady-ai/milady/pull/2119/files#diff-61d81dba031f233c46c15e4239a053eb2d3c374a926939e24aba9abbf8c7df91), `ensurePluginDependencyLinks` and `ensureMiladySingletonDependencyLinks` now search the Eliza repo root before the main repo root when resolving local package links. Previously the order was reversed, causing the main repo's packages to take precedence over the local Eliza source.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c702ad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->