### PR TITLE
docs: update cloud wallet provider wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Install from the Skills Marketplace in the app, or ask your agent to install it.
 
 ### Wallet
 
-Milady auto-generates EVM and Solana wallet addresses on startup. For BSC trading you need to import your own private key (see above). If connected to **Eliza Cloud**, managed wallets via Privy are available without local key management.
+Milady auto-generates EVM and Solana wallet addresses on startup. For BSC trading you need to import your own private key (see above). If connected to **Eliza Cloud**, managed wallets via Steward are available without local key management.
 
 View your agent's wallet addresses in the Settings tab or ask: *"what's my wallet address?"*
 


### PR DESCRIPTION
> ## Merge sequencing (for the maintainer agent)
>
> - **Depends on:** #2124 to clear `Lint & Format`, `Type Check`, `Targeted Tests` — those fail on the `Install submodule verification dependencies` workflow step which doesn't apply to this docs/setup change but red-bars the PR.
> - **Unblocks:** nothing else.
> - **Suggested merge order:** Phase 3 — after #2124 lands. `Build`, `Auth tests (P0 gate)`, `CodeFactor`, `review-pr` all pass already.
> - **Risk:** trivial — single-file docs/setup change, exactly what title says.

## Summary
- update README wallet wording to reference Steward instead of the outdated Privy provider name for Eliza Cloud managed wallets

## Validation
- `git diff --check`
- `rg -n "Privy" README.md docs apps/homepage/src/docs apps/app/README.md` returned no matches
- `bun run verify:format:changed` was not applicable because `README.md` is ignored by Biome, so no files were processed

## Check Status
- Branch is on top of current `milady-ai/milady:develop`.
- CodeFactor and agent review checks are green/neutral.
- Duplicate `CI (Fork)` jobs are red in this repo setup; they fail before exercising this README-only change because the fork workflow expects paths/commands that are not present for this checkout shape.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update cloud wallet provider name from 'Privy' to 'Steward' in README
> Updates the wallet provider name in [README.md](https://github.com/milady-ai/milady/pull/2120/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) to reflect the current provider used for managed wallets on Eliza Cloud.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3851ac2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->