### PR TITLE
fix(ci): hydrate eliza runtime in fork workflow

### DIFF
--- a/.github/actions/setup-bun-workspace/action.yml
+++ b/.github/actions/setup-bun-workspace/action.yml
@@ -133,15 +133,23 @@ runs:
       env:
         MILADY_SKIP_CLOUD_SUBMODULE: ${{ inputs.skip-cloud-submodule == 'true' && '1' || '' }}
 
-    # Some review jobs still execute local eliza runtime scripts after the
-    # published-only install rewrite. Hydrate eliza only for those jobs; normal
-    # published-only CI resolves @elizaos/* versions from npm dist-tags.
-    - name: Shallow-init eliza submodule for version resolution
-      if: ${{ inputs.disable-local-eliza-workspace == 'true' && inputs.prepare-local-eliza-runtime == 'true' }}
+    # Some jobs execute repo-local eliza runtime scripts even when checkout
+    # omits submodules, such as fork CI and review jobs. Hydrate eliza only
+    # for those jobs; normal published-only CI resolves @elizaos/* versions
+    # from npm dist-tags.
+    - name: Hydrate local eliza runtime checkout
+      if: ${{ inputs.prepare-local-eliza-runtime == 'true' }}
       shell: bash
       run: |
         if [ ! -f eliza/package.json ]; then
           git clone --depth=1 --branch "${MILADY_ELIZA_BRANCH:-develop}" https://github.com/elizaOS/eliza.git eliza
+        fi
+        if [ "${{ inputs.skip-cloud-submodule }}" = "true" ]; then
+          MILADY_SKIP_CLOUD_SUBMODULE=1 node --input-type=module <<'NODE'
+        import { pruneSkippedCloudWorkspace } from "./scripts/init-submodules.mjs";
+
+        pruneSkippedCloudWorkspace({ rootDir: process.cwd() });
+        NODE
         fi
 
     - name: Apply elizaOS source CI patches
@@ -259,6 +267,17 @@ runs:
       env:
         npm_config_python: ${{ env.pythonLocation }}/bin/python3
 
+    - name: Install local eliza runtime dependencies
+      if: ${{ inputs.prepare-local-eliza-runtime == 'true' && hashFiles('eliza/package.json') != '' }}
+      shell: bash
+      run: |
+        bun install --cwd eliza --no-frozen-lockfile --ignore-scripts
+
+    - name: Hydrate local eliza Bun package postinstall
+      if: ${{ inputs.prepare-local-eliza-runtime == 'true' && hashFiles('eliza/node_modules/bun/install.js') != '' }}
+      shell: bash
+      run: cd eliza/node_modules/bun && node install.js
+
     - name: Generate local eliza protobuf types
       if: ${{ inputs.prepare-local-eliza-runtime == 'true' }}
       shell: bash
@@ -290,14 +309,8 @@ runs:
         MILADY_NO_VISION_DEPS: ${{ inputs.no-vision-deps == 'true' && '1' || '' }}
         MILADY_SKIP_LOCAL_UPSTREAMS: ${{ (inputs.disable-local-eliza-workspace == 'true' || inputs.skip-local-upstreams-postinstall == 'true') && '1' || '' }}
 
-    - name: Install local eliza runtime dependencies
-      if: ${{ inputs.prepare-local-eliza-runtime == 'true' && inputs.disable-local-eliza-workspace == 'true' }}
-      shell: bash
-      run: |
-        bun install --cwd eliza --no-frozen-lockfile --ignore-scripts
-
     - name: Generate local eliza keyword data
-      if: ${{ inputs.prepare-local-eliza-runtime == 'true' && inputs.disable-local-eliza-workspace == 'true' }}
+      if: ${{ inputs.prepare-local-eliza-runtime == 'true' && hashFiles('eliza/package.json') != '' }}
       shell: bash
       run: |
         if [ -f eliza/packages/shared/scripts/generate-keywords.mjs ]; then

--- a/.github/workflows/ci-fork.yml
+++ b/.github/workflows/ci-fork.yml
@@ -30,14 +30,11 @@ jobs:
         with:
           bun-version: ${{ env.BUN_VERSION }}
           install-command: bun install --ignore-scripts --no-frozen-lockfile
+          prepare-local-eliza-runtime: "true"
+          skip-cloud-submodule: "true"
 
       - name: Restore eliza workspace paths for repo scripts
         run: node scripts/restore-local-eliza-workspace.mjs
-
-      - name: Install submodule verification dependencies
-        run: |
-          bun install --cwd eliza --no-frozen-lockfile --ignore-scripts
-          bun install --cwd eliza/cloud --no-frozen-lockfile --ignore-scripts
 
       - name: Biome lint
         run: bun run verify:lint
@@ -62,14 +59,11 @@ jobs:
         with:
           bun-version: ${{ env.BUN_VERSION }}
           install-command: bun install --ignore-scripts --no-frozen-lockfile
+          prepare-local-eliza-runtime: "true"
+          skip-cloud-submodule: "true"
 
       - name: Restore eliza workspace paths for repo scripts
         run: node scripts/restore-local-eliza-workspace.mjs
-
-      - name: Install submodule verification dependencies
-        run: |
-          bun install --cwd eliza --no-frozen-lockfile --ignore-scripts
-          bun install --cwd eliza/cloud --no-frozen-lockfile --ignore-scripts
 
       - name: Run type checker
         run: bun run verify:typecheck
@@ -91,6 +85,8 @@ jobs:
         with:
           bun-version: ${{ env.BUN_VERSION }}
           install-command: bun install --ignore-scripts --no-frozen-lockfile
+          prepare-local-eliza-runtime: "true"
+          skip-cloud-submodule: "true"
 
       - name: Restore eliza workspace paths for repo scripts
         run: node scripts/restore-local-eliza-workspace.mjs
@@ -117,6 +113,8 @@ jobs:
         with:
           bun-version: ${{ env.BUN_VERSION }}
           install-command: bun install --ignore-scripts --no-frozen-lockfile
+          prepare-local-eliza-runtime: "true"
+          skip-cloud-submodule: "true"
 
       - name: Restore eliza workspace paths for repo scripts
         run: node scripts/restore-local-eliza-workspace.mjs

--- a/scripts/apply-eliza-ci-patches.mjs
+++ b/scripts/apply-eliza-ci-patches.mjs
@@ -360,6 +360,13 @@ function patchN8nCharacterKnowledge(raw) {
   );
 }
 
+function patchSqlRawConnectionReturnType(raw, managerTypeName) {
+  return raw.replace(
+    "  getRawConnection() {\n    return this.manager.getConnection();\n  }",
+    `  getRawConnection(): ReturnType<${managerTypeName}["getConnection"]> {\n    return this.manager.getConnection();\n  }`,
+  );
+}
+
 function applyReleaseSourcePatches() {
   replaceFileText(
     path.join(
@@ -514,6 +521,45 @@ function applyReleaseSourcePatches() {
     ),
     patchN8nCharacterKnowledge,
     "agent n8n explicit knowledge gate",
+  );
+
+  replaceFileText(
+    path.join(
+      elizaDir,
+      "plugins",
+      "plugin-sql",
+      "typescript",
+      "pg",
+      "adapter.ts",
+    ),
+    (raw) => patchSqlRawConnectionReturnType(raw, "PostgresConnectionManager"),
+    "plugin-sql pg raw connection return type",
+  );
+
+  replaceFileText(
+    path.join(
+      elizaDir,
+      "plugins",
+      "plugin-sql",
+      "typescript",
+      "pglite",
+      "adapter.ts",
+    ),
+    (raw) => patchSqlRawConnectionReturnType(raw, "PGliteClientManager"),
+    "plugin-sql pglite raw connection return type",
+  );
+
+  replaceFileText(
+    path.join(
+      elizaDir,
+      "plugins",
+      "plugin-sql",
+      "typescript",
+      "neon",
+      "adapter.ts",
+    ),
+    (raw) => patchSqlRawConnectionReturnType(raw, "NeonConnectionManager"),
+    "plugin-sql neon raw connection return type",
   );
 }
 

--- a/scripts/ci-bootstrap-contract.test.ts
+++ b/scripts/ci-bootstrap-contract.test.ts
@@ -59,6 +59,7 @@ describe("CI bootstrap contract", () => {
 
   it("does not run nested eliza workspace installs inside CI jobs", () => {
     const ci = workflow("ci.yml");
+    const ciFork = workflow("ci-fork.yml");
 
     expect(ci).not.toContain(
       "bun install --cwd eliza --no-frozen-lockfile --ignore-scripts",
@@ -66,6 +67,21 @@ describe("CI bootstrap contract", () => {
     expect(ci).not.toContain(
       "bun install --cwd eliza/cloud --no-frozen-lockfile --ignore-scripts",
     );
+    expect(ciFork).not.toContain(
+      "bun install --cwd eliza --no-frozen-lockfile --ignore-scripts",
+    );
+    expect(ciFork).not.toContain(
+      "bun install --cwd eliza/cloud --no-frozen-lockfile --ignore-scripts",
+    );
+  });
+
+  it("prepares local eliza runtime paths explicitly in fork CI", () => {
+    const ciFork = workflow("ci-fork.yml");
+
+    expect(ciFork.match(/prepare-local-eliza-runtime: "true"/g)).toHaveLength(
+      4,
+    );
+    expect(ciFork.match(/skip-cloud-submodule: "true"/g)).toHaveLength(4);
   });
 
   it("builds elizaOS core before bundled skills", () => {
@@ -96,15 +112,24 @@ describe("CI bootstrap contract", () => {
       "utf8",
     );
     const installDependencies = "- name: Install dependencies";
+    const hydrateElizaBun =
+      "- name: Hydrate local eliza Bun package postinstall";
     const generateProtobuf = "- name: Generate local eliza protobuf types";
     const postinstallPatches = "- name: Run repository postinstall patches";
 
     expect(setupAction).toContain(generateProtobuf);
+    expect(setupAction).toContain(hydrateElizaBun);
+    expect(setupAction).toContain(
+      "cd eliza/node_modules/bun && node install.js",
+    );
     expect(setupAction).toContain(
       "inputs.prepare-local-eliza-runtime == 'true'",
     );
     expect(setupAction).toContain("bunx @bufbuild/buf@1.67.0 generate");
     expect(setupAction.indexOf(installDependencies)).toBeLessThan(
+      setupAction.indexOf(hydrateElizaBun),
+    );
+    expect(setupAction.indexOf(hydrateElizaBun)).toBeLessThan(
       setupAction.indexOf(generateProtobuf),
     );
     expect(setupAction.indexOf(generateProtobuf)).toBeLessThan(
@@ -173,6 +198,31 @@ describe("CI bootstrap contract", () => {
     expect(agentReview.indexOf(align)).toBeLessThan(
       agentReview.indexOf(runAuthSuite),
     );
+  });
+
+  it("patches plugin-sql raw connection declarations for nested eliza CI builds", () => {
+    const patchScript = fs.readFileSync(
+      "scripts/apply-eliza-ci-patches.mjs",
+      "utf8",
+    );
+
+    expect(patchScript).toContain("patchSqlRawConnectionReturnType");
+    expect(patchScript).toContain("ReturnType<");
+    expect(patchScript).toContain("managerTypeName");
+    expect(patchScript).toContain('["getConnection"]>');
+    for (const token of [
+      "plugin-sql",
+      "typescript",
+      "pg",
+      "pglite",
+      "neon",
+      "adapter.ts",
+      "PostgresConnectionManager",
+      "PGliteClientManager",
+      "NeonConnectionManager",
+    ]) {
+      expect(patchScript).toContain(token);
+    }
   });
 
   it("links elizaOS runtime plugins and ambient UI types for local eliza checks", () => {

--- a/scripts/validate-ci-bootstrap-contract.mjs
+++ b/scripts/validate-ci-bootstrap-contract.mjs
@@ -142,6 +142,30 @@ assertContainsNone(
   ],
   failures,
 );
+const ciForkWorkflowText = readText(".github/workflows/ci-fork.yml", failures);
+assertContainsNone(
+  ciForkWorkflowText,
+  ".github/workflows/ci-fork.yml",
+  [
+    "bun install --cwd eliza --no-frozen-lockfile --ignore-scripts",
+    "bun install --cwd eliza/cloud --no-frozen-lockfile --ignore-scripts",
+  ],
+  failures,
+);
+assertCount(
+  ciForkWorkflowText,
+  ".github/workflows/ci-fork.yml",
+  'prepare-local-eliza-runtime: "true"',
+  4,
+  failures,
+);
+assertCount(
+  ciForkWorkflowText,
+  ".github/workflows/ci-fork.yml",
+  'skip-cloud-submodule: "true"',
+  4,
+  failures,
+);
 assertContainsAll(actionText, files.action, requiredActionSnippets, failures);
 assertContainsNone(actionText, files.action, forbiddenActionSnippets, failures);
 assertContainsAll(
@@ -155,6 +179,8 @@ assertOrdered(
   files.action,
   [
     "name: Install dependencies",
+    "name: Install local eliza runtime dependencies",
+    "name: Hydrate local eliza Bun package postinstall",
     "name: Generate local eliza protobuf types",
     "run: bash scripts/install-published-workspace-fallback-deps.sh",
     "run: node scripts/build-local-eliza-ci-overrides.mjs",
@@ -310,6 +336,21 @@ function assertContainsNone(text, relativePath, snippets, targetFailures) {
         `${relativePath} still contains forbidden bootstrap snippet: ${snippet}`,
       );
     }
+  }
+}
+
+function assertCount(
+  text,
+  relativePath,
+  snippet,
+  expectedCount,
+  targetFailures,
+) {
+  const actualCount = text.split(snippet).length - 1;
+  if (actualCount !== expectedCount) {
+    targetFailures.push(
+      `${relativePath} expected ${expectedCount} occurrence(s) of ${snippet}, found ${actualCount}`,
+    );
   }
 }
 


### PR DESCRIPTION
> ## Merge sequencing (for the maintainer agent)
>
> - **Depends on:** nothing in scope. This PR's own CI is currently red on the very gates it's trying to fix — that's expected (workflow comes from `develop` until merged), not a regression in the diff. Build/Analyze/CodeFactor pass cleanly.
> - **Recommend:** merge #2128 (Release Workflow Contract fix) first to remove unrelated noise from this PR's check status.
> - **Unblocks:** the `Install submodule verification dependencies` red on **every** fork-CI docs/setup PR — #2118, #2119, #2120, #2125. After this lands their `Lint & Format`, `Type Check`, and `Targeted Tests` checks should all turn green.
> - **Suggested merge order:** Phase 1 — merge with #2128 (independent of each other) and #2111.
> - **Risk:** low. The only behavioral change is replacing fragile raw `bun install --cwd eliza` calls with the shared setup-action's hydration path; non-eliza-CI workflows are untouched.

## Summary
- hydrate the local eliza runtime checkout through the shared setup action whenever a job explicitly requests `prepare-local-eliza-runtime`
- remove raw fork-CI `bun install --cwd eliza` assumptions that fail when checkout omits the `eliza/` path
- install the hydrated eliza dependencies and run Bun's package postinstall before protobuf generation or nested release checks
- keep existing eliza CI patch overlays responsible for release-source compatibility, including explicit `plugin-sql` raw connection return types needed by nested declaration builds
- add CI bootstrap contract checks so fork CI keeps using the shared setup path and correct ordering

## Validation
- `git diff --check`
- `bunx biome check --write scripts/apply-eliza-ci-patches.mjs scripts/ci-bootstrap-contract.test.ts scripts/validate-ci-bootstrap-contract.mjs`
- `node scripts/validate-ci-bootstrap-contract.mjs`
- `bunx vitest run --environment node scripts/ci-bootstrap-contract.test.ts scripts/standalone-eliza-package-contract.test.ts`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix eliza runtime hydration in fork CI workflow
> - Updates [ci-fork.yml](.github/workflows/ci-fork.yml) to pass `prepare-local-eliza-runtime: "true"` and `skip-cloud-submodule: "true"` to the setup action across all jobs, replacing ad-hoc inline `bun install` steps.
> - Widens the hydration condition in [setup-bun-workspace/action.yml](.github/actions/setup-bun-workspace/action.yml) to trigger on `prepare-local-eliza-runtime` alone (previously also required `disable-local-eliza-workspace`), and adds steps to install eliza dependencies and run Bun's postinstall.
> - Adds `patchSqlRawConnectionReturnType` to [apply-eliza-ci-patches.mjs](scripts/apply-eliza-ci-patches.mjs) to patch `getRawConnection()` return types in `plugin-sql` adapters for `pg`, `pglite`, and `neon`.
> - Extends CI bootstrap contract tests and validation script to enforce no nested eliza installs in fork jobs and to assert correct step ordering.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d6f1d6d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->