### PR TITLE
fix(app): align local eliza package boundaries

### DIFF
--- a/apps/app/capacitor.config.ts
+++ b/apps/app/capacitor.config.ts
@@ -2,7 +2,7 @@ import type { CapacitorConfig } from "@capacitor/cli";
 import {
   parseAllowedHostEnv,
   toCapacitorAllowNavigation,
-} from "@elizaos/app-core/config/allowed-hosts";
+} from "@elizaos/shared/config/allowed-hosts";
 import appConfig from "./app.config";
 
 type CapacitorAllowNavigation = NonNullable<

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import {
   parseAllowedHostEnv,
   toViteAllowedHosts,
-} from "@elizaos/app-core/config/allowed-hosts";
+} from "@elizaos/shared/config/allowed-hosts";
 import { colorizeDevSettingsStartupBanner } from "@elizaos/shared/dev-settings-banner-style";
 import { prependDevSubsystemFigletHeading } from "@elizaos/shared/dev-settings-figlet-heading";
 import {
@@ -43,6 +43,7 @@ const optionalElizaAppStubEntry = path.join(
   "src/optional-eliza-app-stub.tsx",
 );
 const nativePluginStubEntry = path.join(here, "src/native-plugin-stubs.ts");
+const localElizaRoot = path.join(miladyRoot, "eliza");
 
 function requireResolve(id: string): string {
   try {
@@ -56,19 +57,39 @@ function requireResolve(id: string): string {
 }
 
 function shouldUseLocalElizaSource(): boolean {
-  const sourceMode = (
-    process.env.MILADY_ELIZA_SOURCE ??
-    process.env.ELIZA_SOURCE ??
-    "packages"
-  ).toLowerCase();
+  const explicitSourceMode = (
+    process.env.MILADY_ELIZA_SOURCE ?? process.env.ELIZA_SOURCE
+  )
+    ?.trim()
+    .toLowerCase();
+  if (explicitSourceMode) {
+    return ["local", "source", "workspace"].includes(explicitSourceMode);
+  }
+  if (
+    process.env.MILADY_SKIP_LOCAL_UPSTREAMS === "1" ||
+    process.env.ELIZA_SKIP_LOCAL_UPSTREAMS === "1"
+  ) {
+    return false;
+  }
   return (
-    ["local", "source", "workspace"].includes(sourceMode) ||
     process.env.MILADY_FORCE_LOCAL_UPSTREAMS === "1" ||
-    process.env.ELIZA_FORCE_LOCAL_UPSTREAMS === "1"
+    process.env.ELIZA_FORCE_LOCAL_UPSTREAMS === "1" ||
+    resolvesInsideLocalElizaWorkspace("@elizaos/app-core/package.json")
   );
 }
 
-const localElizaRoot = path.join(miladyRoot, "eliza");
+function resolvesInsideLocalElizaWorkspace(id: string): boolean {
+  try {
+    const localRoot = fs.realpathSync(localElizaRoot);
+    const resolved = fs.realpathSync(_require.resolve(id));
+    return (
+      resolved === localRoot || resolved.startsWith(`${localRoot}${path.sep}`)
+    );
+  } catch {
+    return false;
+  }
+}
+
 const hasLocalElizaWorkspace =
   shouldUseLocalElizaSource() &&
   fs.existsSync(path.join(localElizaRoot, "package.json"));
@@ -77,8 +98,11 @@ const appCoreSrcRoot = hasLocalElizaWorkspace
   ? path.join(localElizaRoot, "packages/app-core/src")
   : null;
 const appCoreNativePluginEntrypoints = appCoreSrcRoot
-  ? path.join(appCoreSrcRoot, "platform/native-plugin-entrypoints.ts")
-  : requireResolve("@elizaos/app-core/platform/native-plugin-entrypoints");
+  ? path.join(
+      localElizaRoot,
+      "packages/ui/src/platform/native-plugin-entrypoints.ts",
+    )
+  : requireResolve("@elizaos/ui/platform/native-plugin-entrypoints");
 const emptyNodeModuleEntry = appCoreSrcRoot
   ? path.join(appCoreSrcRoot, "platform/empty-node-module.ts")
   : requireResolve("@elizaos/app-core/platform/empty-node-module");
@@ -268,11 +292,32 @@ function resolveLocalElizaAppAliases(): Alias[] {
       return null;
     }
     const record = value as Record<string, unknown>;
-    for (const condition of ["source", "types", "import", "default"]) {
+    for (const condition of ["source", "import", "default", "types"]) {
       const target = record[condition];
       if (typeof target === "string") return target;
     }
     return null;
+  }
+
+  function resolveRuntimeTarget(pkgDir: string, exportTarget: string): string {
+    if (exportTarget.startsWith("./dist/")) {
+      const sourceTarget = exportTarget
+        .replace(/^\.\/dist\//, "./src/")
+        .replace(/\.js$/, ".ts");
+      const sourcePath = resolveExistingUiSourceModule(
+        path.resolve(pkgDir, sourceTarget),
+      );
+      if (fs.existsSync(sourcePath)) {
+        return sourcePath;
+      }
+    }
+
+    const distPath = path.resolve(pkgDir, exportTarget);
+    if (fs.existsSync(distPath)) {
+      return distPath;
+    }
+
+    return distPath;
   }
 
   const aliases: Alias[] = [];
@@ -308,7 +353,7 @@ function resolveLocalElizaAppAliases(): Alias[] {
           key === "." ? pkgName : `${pkgName}/${key.replace(/^\.\//, "")}`;
         aliases.push({
           find: new RegExp(`^${escapeRegExp(aliasKey)}$`),
-          replacement: path.resolve(pkgDir, exportTarget),
+          replacement: resolveRuntimeTarget(pkgDir, exportTarget),
         });
       }
 
@@ -400,9 +445,73 @@ function resolveLocalAppCoreAliases(): Alias[] {
   }
 
   const uiSource = path.join(appCoreSrcRoot, "ui");
+  const uiPkgSrcRoot = uiPkgRoot ? path.join(uiPkgRoot, "src") : null;
+  const legacyAppCoreUiAliases: Alias[] = uiPkgSrcRoot
+    ? [
+        {
+          find: /^@elizaos\/app-core$/,
+          replacement: appCoreBrowserEntry,
+        },
+        {
+          find: /^@elizaos\/app-core\.js$/,
+          replacement: appCoreBrowserEntry,
+        },
+        {
+          find: /^@elizaos\/app-core\/styles\/(.*)$/,
+          replacement: `${uiPkgSrcRoot}/styles/$1`,
+        },
+        {
+          find: /^@elizaos\/app-core\/api$/,
+          replacement: path.join(uiPkgSrcRoot, "api/index.ts"),
+        },
+        {
+          find: /^@elizaos\/app-core\/components\/character\/CharacterEditor$/,
+          replacement: path.join(
+            uiPkgSrcRoot,
+            "components/character/CharacterEditor.tsx",
+          ),
+        },
+        {
+          find: /^@elizaos\/app-core\/components\/chat\/widgets\/types$/,
+          replacement: path.join(
+            uiPkgSrcRoot,
+            "components/chat/widgets/types.ts",
+          ),
+        },
+        {
+          find: /^@elizaos\/app-core\/components\/(.+)$/,
+          replacement: `${uiPkgSrcRoot}/components/$1`,
+          customResolver: resolveExistingUiSourceModule,
+        },
+        {
+          find: /^@elizaos\/app-core\/platform$/,
+          replacement: path.join(uiPkgSrcRoot, "platform/index.ts"),
+        },
+        {
+          find: /^@elizaos\/app-core\/state\/(.+)$/,
+          replacement: `${uiPkgSrcRoot}/state/$1.ts`,
+          customResolver: resolveExistingUiSourceModule,
+        },
+        {
+          find: /^@elizaos\/app-core\/utils$/,
+          replacement: path.join(uiPkgSrcRoot, "utils/index.ts"),
+        },
+        {
+          find: /^@elizaos\/app-core\/utils\/(.+)$/,
+          replacement: `${uiPkgSrcRoot}/utils/$1.ts`,
+          customResolver: resolveExistingUiSourceModule,
+        },
+        {
+          find: /^@elizaos\/app-core\/widgets\/(.+)$/,
+          replacement: `${uiPkgSrcRoot}/widgets/$1.ts`,
+          customResolver: resolveExistingUiSourceModule,
+        },
+      ]
+    : [];
 
   return [
     ...generatedAliases,
+    ...legacyAppCoreUiAliases,
     {
       find: /^@elizaos\/app-core\/(.+)$/,
       replacement: `${appCorePkgDir}/src/$1`,
@@ -608,18 +717,24 @@ function elizaCoreAlphaPrerelease(dir: string): number {
 }
 
 function resolveExistingUiSourceModule(id: string) {
-  if (fs.existsSync(id)) {
-    return id;
+  const candidates = [id];
+  if (id.endsWith(".tsx")) {
+    candidates.push(`${id.slice(0, -4)}.ts`);
+  } else if (id.endsWith(".ts")) {
+    candidates.push(`${id.slice(0, -3)}.tsx`);
+  } else if (!path.extname(id)) {
+    candidates.push(
+      `${id}.ts`,
+      `${id}.tsx`,
+      path.join(id, "index.ts"),
+      path.join(id, "index.tsx"),
+    );
   }
 
-  const alternate = id.endsWith(".tsx")
-    ? `${id.slice(0, -4)}.ts`
-    : id.endsWith(".ts")
-      ? `${id.slice(0, -3)}.tsx`
-      : null;
-
-  if (alternate && fs.existsSync(alternate)) {
-    return alternate;
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
   }
 
   return id;


### PR DESCRIPTION
> ## Merge sequencing (for the maintainer agent)
>
> - **Depends on:** #2124 to clear the `Build` red (it dies in the same `Install submodule verification dependencies` step that #2124 fixes).
> - **Unblocks:** nothing else.
> - **Suggested merge order:** Phase 3 — after #2124 lands.
> - **Risk:** low. 2-file diff (`apps/app/capacitor.config.ts` + `apps/app/vite.config.ts`); only adjusts package-resolution logic for local-eliza source mode and re-points imports to where they moved upstream.

## Summary
- import allowed-host helpers from `@elizaos/shared/config/allowed-hosts` after the helper moved out of app-core
- resolve native plugin entrypoints from `@elizaos/ui/platform/native-plugin-entrypoints` when using local Eliza source
- enable local-source aliases automatically when installed `@elizaos/app-core` resolves into the repo-local `eliza/` checkout, while preserving explicit package-mode opt-outs
- make local-source Vite aliases prefer matching app/plugin `src` exports over stale `dist` artifacts
- bridge legacy `@elizaos/app-core` UI subpaths to the current `@elizaos/ui` source package and resolve normal extensionless TS/TSX source modules

## Validation
- `git diff --check`
- `bunx @biomejs/biome check apps/app/capacitor.config.ts apps/app/vite.config.ts`
- `bun run --cwd apps/app lint`
- `bun run --cwd apps/app build:web` in the live checkout with nested `eliza/`

## Notes
- The clean PR worktree does not include a nested `eliza/` checkout, so the local-Eliza web build was validated in `/home/milady/iqlabs/milady` with the same `apps/app` changes applied.
- This PR is scoped to app config/package-boundary resolution for local Eliza source mode; it does not attempt to solve unrelated broad app typecheck baseline issues.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Align local Eliza package boundaries in Vite and Capacitor configs
> - Moves `parseAllowedHostEnv` and `toViteAllowedHosts`/`toCapacitorAllowNavigation` imports from `@elizaos/app-core/config/allowed-hosts` to `@elizaos/shared/config/allowed-hosts` in [vite.config.ts](https://github.com/milady-ai/milady/pull/2125/files#diff-0d80c2713ea1483c55bbc803b5d5d6a1f75654501e99a33c5d306cdbddd511e4) and [capacitor.config.ts](https://github.com/milady-ai/milady/pull/2125/files#diff-220f2f2597bafdae9600af3fe9db178a0961bbc74796e474fd8259c6e081b0dc).
> - Rewrites `shouldUseLocalElizaSource` to honor explicit `MILADY_ELIZA_SOURCE`/`ELIZA_SOURCE` env values (`local`, `source`, `workspace`), skip/force flags, and auto-detect workspace membership via a new `resolvesInsideLocalElizaWorkspace` helper.
> - When a local UI package source root exists, `resolveLocalAppCoreAliases` now remaps `@elizaos/app-core` and its subpaths (platform, api, components, state, utils, widgets) to corresponding sources under the UI package `src` tree.
> - `resolveLocalElizaAppAliases` now prefers `dist`-to-`src` mapping for export targets when the source file exists, with fallback to the built file.
> - Behavioral Change: native plugin entrypoints now resolve from `@elizaos/ui` instead of `@elizaos/app-core` when not using local sources.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 61259b7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->