### PR TITLE
fix(apps/app): wire window.ElizaNative bearer prefetch + 90s watchdog into bootstrap

### DIFF
--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -360,6 +360,27 @@ try {
       if (saved) bootstrapToken = saved;
     } catch {}
   }
+  // On AOSP/Milady the agent runs in the same APK and exposes its
+  // per-boot bearer through `window.ElizaNative.getLocalAgentToken()`
+  // (see `os/android/.../ElizaNativeBridge.java`). Pull it before the
+  // first auth-status poll so the React shell never hits PairingView
+  // for the loopback case where the device IS the agent.
+  if (!bootstrapToken) {
+    try {
+      const native = (
+        window as unknown as {
+          ElizaNative?: { getLocalAgentToken?: () => string | null };
+        }
+      ).ElizaNative;
+      const nativeToken = native?.getLocalAgentToken?.()?.trim();
+      if (nativeToken) {
+        bootstrapToken = nativeToken;
+        try {
+          window.localStorage.setItem(SELF_HOSTED_TOKEN_KEY, nativeToken);
+        } catch {}
+      }
+    } catch {}
+  }
   if (bootstrapToken) {
     appBootConfig.apiToken = bootstrapToken;
     appBootConfig.apiBase ??= window.location.origin;
@@ -369,6 +390,44 @@ try {
   }
 } catch {}
 setBootConfig(appBootConfig);
+
+// On AOSP/Milady, ElizaNativeBridge.getLocalAgentToken() returns null
+// for the first ~30-50s of app launch — the on-device agent process is
+// still booting and hasn't written its per-boot bearer to its volatile
+// static yet. The synchronous bootstrap above fires BEFORE the agent is
+// up, so it sees null and the React shell falls into PairingView even
+// though the bearer is in fact about to be available.
+//
+// Poll the bridge for up to 90s after launch; the first non-null read
+// applies the bearer to the client + localStorage and stops. Stock
+// Capacitor builds never expose `window.ElizaNative` so the watchdog
+// exits immediately.
+(function installOnDeviceBearerWatchdog() {
+  if (typeof window === "undefined") return;
+  const bridge = (
+    window as unknown as {
+      ElizaNative?: { getLocalAgentToken?: () => string | null };
+    }
+  ).ElizaNative;
+  if (!bridge?.getLocalAgentToken) return;
+
+  const deadline = Date.now() + 90_000;
+  const tick = () => {
+    try {
+      if (client.hasToken()) return;
+      const token = bridge.getLocalAgentToken?.()?.trim();
+      if (token) {
+        client.setToken(token);
+        try {
+          window.localStorage.setItem(SELF_HOSTED_TOKEN_KEY, token);
+        } catch {}
+        return;
+      }
+    } catch {}
+    if (Date.now() < deadline) setTimeout(tick, 500);
+  };
+  setTimeout(tick, 500);
+})();
 
 function getShareQueue(): ShareTargetPayload[] {
   const appWindow = getAppWindow();


### PR DESCRIPTION
## Problem

On AOSP/Milady builds the agent runs in the same APK as the WebView and exposes its per-boot bearer through \`window.ElizaNative.getLocalAgentToken()\` (see \`os/android/.../ElizaNativeBridge.java\`). The current bootstrap-token chain in \`main.tsx\` only checks the URL fragment and \`localStorage\` — it never asks the native bridge. Result: on a fresh-install AOSP boot the React shell does not see the bearer and drops the user into \`PairingView\`, even though the device IS the agent.

There is a second window where the prefetch can't help: \`ElizaNativeBridge.getLocalAgentToken()\` returns \`null\` for the first ~30–50 s of app launch because the on-device agent process is still booting and hasn't written its bearer to its volatile static yet. The bootstrap is synchronous, so it fires before the bearer exists and would strand the shell in PairingView even with the prefetch wired in.

## Fix

Two changes, both in \`apps/app/src/main.tsx\`:

1. **Synchronous prefetch** — after the existing \`localStorage[SELF_HOSTED_TOKEN_KEY]\` read in the bootstrap chain, try \`window.ElizaNative?.getLocalAgentToken()\`. If we get a non-empty token, plant it back in \`localStorage\` so later reloads short-circuit the bridge.

2. **90s watchdog after \`setBootConfig\`** — if the bridge exists but the bearer isn't ready yet, poll every 500 ms for up to 90 s. First non-null token gets applied via \`client.setToken(...)\` + persisted to \`localStorage\`, then the loop exits.

No behavior change on stock Capacitor / iOS / Electrobun / web — \`window.ElizaNative\` is undefined there, so the synchronous block short-circuits and the watchdog returns before its first \`setTimeout\`.

## Verification

- Tested on Pixel 6a with the current milady debug APK: cold launch from a fresh install reaches the chat surface (Eliza greeting) without a PairingView round-trip. Watchdog applies the bearer ~35 s after launch when the on-device bun runtime first writes it.
- Stock Capacitor build (no ElizaNativeBridge): no measurable difference — \`getLocalAgentToken\` is undefined, both blocks no-op.
- Biome check: clean on the modified file.

## Relationship to #2130

This PR is the trimmed-down bearer-bootstrap piece from #2130, which got auto-closed by the agent-review workflow when both AI reviewers failed (API outage, not a code rejection). Refiling as a focused single-file PR so the review surface is just the bootstrap chain and the watchdog — no patches/scripts/skill churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wire `window.ElizaNative` bearer token prefetch and 90s watchdog into app bootstrap
> - During bootstrap in [main.tsx](https://github.com/milady-ai/milady/pull/2132/files#diff-daadf90e7c659872f2d40ccafd9ee93306e0d519e96acb61016e83722e6f129a), if no token is found from the URL fragment or localStorage, the app now synchronously calls `window.ElizaNative.getLocalAgentToken()` and persists the result under `SELF_HOSTED_TOKEN_KEY` before applying the boot config.
> - If the synchronous prefetch yields no token, a 500ms polling watchdog runs for up to 90s, applying the native token to the client and localStorage as soon as it becomes available.
> - The watchdog exits immediately if a token is already set on the client, or if `window.ElizaNative` is unavailable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b14ad34.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->