### PR TITLE
fix(apps/app): import allowed-hosts from @elizaos/shared (closes #2134)

### DIFF
--- a/apps/app/capacitor.config.ts
+++ b/apps/app/capacitor.config.ts
@@ -1,8 +1,15 @@
 import type { CapacitorConfig } from "@capacitor/cli";
+// Import directly from @elizaos/shared (the canonical owner of the
+// allowed-hosts helper) so the import resolves identically in both
+// MILADY_ELIZA_SOURCE=packages (npm-published @elizaos/*) and
+// MILADY_ELIZA_SOURCE=local (workspace-linked eliza/packages/*) modes.
+// @elizaos/app-core re-exports this subpath in published builds but not
+// in the local source's package.json exports map, which would otherwise
+// break `bun run build:android` under local mode.
 import {
   parseAllowedHostEnv,
   toCapacitorAllowNavigation,
-} from "@elizaos/app-core/config/allowed-hosts";
+} from "@elizaos/shared/config/allowed-hosts";
 import appConfig from "./app.config";
 
 type CapacitorAllowNavigation = NonNullable<


### PR DESCRIPTION
## Problem

\`apps/app/capacitor.config.ts\` imports the \`allowed-hosts\` helper from \`@elizaos/app-core/config/allowed-hosts\`. That subpath only exists in the **npm-published** \`@elizaos/app-core\` (where it's re-exported for caller convenience) and is **not** in the local source's package.json exports map.

Under \`MILADY_ELIZA_SOURCE=local\` (i.e. workspace-linked source mode, used when patching elizaOS upstream alongside Milady), \`bun run build:android\` fails at the Capacitor sync step before gradle even starts:

\`\`\`
[error] Parsing capacitor.config.ts failed.
        ResolveMessage: Cannot find module '@elizaos/app-core/config/allowed-hosts'
        from '/home/.../milady/apps/app/capacitor.config.ts'
\`\`\`

Filed as #2134 with full repro.

## Fix

Import the helper directly from \`@elizaos/shared/config/allowed-hosts\` — the canonical owner. \`shared/package.json\` declares the subpath in its exports map for both CJS and ESM, so resolution works identically in local and packages modes:

\`\`\`json
"./config/allowed-hosts": {
  "import": "./dist/config/allowed-hosts.js",
  "default": "./dist/config/allowed-hosts.js",
  "types": "./dist/config/allowed-hosts.d.ts"
}
\`\`\`

No behavioral change — \`@elizaos/app-core\` re-exports the same functions from \`@elizaos/shared\` under the hood. The change mirrors how \`vite.config.ts\` (post-#2131 cleanups) already imports several other helpers directly from \`@elizaos/shared/*\`.

## Compat

- **MILADY_ELIZA_SOURCE=local**: now resolves. Verified with \`bun run build:android\` proceeding past the Capacitor sync step to gradle.
- **MILADY_ELIZA_SOURCE=packages** (default): unchanged — \`@elizaos/shared/config/allowed-hosts\` was already exported from the npm package.
- **Functional**: \`parseAllowedHostEnv\` + \`toCapacitorAllowNavigation\` are the same functions; this is a single import path swap.

## Closes

#2134

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix allowed-hosts import source in `capacitor.config.ts` to use `@elizaos/shared`
> Changes the import of `parseAllowedHostEnv` and `toCapacitorAllowNavigation` in [capacitor.config.ts](https://github.com/milady-ai/milady/pull/2135/files#diff-220f2f2597bafdae9600af3fe9db178a0961bbc74796e474fd8259c6e081b0dc) from `@elizaos/app-core/config/allowed-hosts` to `@elizaos/shared/config/allowed-hosts` to support different source modes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3a2dc46.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->