### PR TITLE
fix(lint): biome format vite.config.ts (unblocks develop CI + #2133 #2135)

### DIFF
--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -465,12 +465,11 @@ function resolveLocalAppCoreAliases(): Alias[] {
       const uiCssPath = uiPkgRoot
         ? path.join(uiPkgRoot, "src/styles", baseName)
         : null;
-      const resolvedPath =
-        fs.existsSync(distCssPath)
-          ? distCssPath
-          : uiCssPath && fs.existsSync(uiCssPath)
-            ? uiCssPath
-            : null;
+      const resolvedPath = fs.existsSync(distCssPath)
+        ? distCssPath
+        : uiCssPath && fs.existsSync(uiCssPath)
+          ? uiCssPath
+          : null;
       if (resolvedPath) {
         generatedAliases.push({
           find: new RegExp(`^${escapeRegExp(aliasKey)}$`),
@@ -525,9 +524,7 @@ function resolveLocalAppCoreAliases(): Alias[] {
   // Wave A moved several components/types from @elizaos/app-core to @elizaos/ui.
   // The catch-all maps to app-core/src/* which may not have them. Use a custom
   // resolver to fall back to the ui source when the app-core path doesn't exist.
-  const uiComponentsSourceDir = uiPkgRoot
-    ? path.join(uiPkgRoot, "src")
-    : null;
+  const uiComponentsSourceDir = uiPkgRoot ? path.join(uiPkgRoot, "src") : null;
 
   function resolveAppCoreWithUiFallback(id: string): string {
     if (fs.existsSync(id)) return id;


### PR DESCRIPTION
## Problem

The last 3 ci.yml runs on `develop` are failing on the **Lint & Format** check:

```
apps/app/vite.config.ts format
× Formatter would have printed the following content:
```

Biome formatter drift introduced by recent vite.config.ts work (`855d96c83`, `19b3a7b1e`, `3e4750528`, etc.) — two ternary expressions need collapsing. The CI failure on develop is also blocking downstream PRs that rebase against the latest develop:

- #2133 (capacitor-llama + core patches) — lint fails on this same line
- #2135 (allowed-hosts import fix) — lint fails on this same line

Both PRs touch unrelated files but lint runs workspace-wide, so they inherit develop's broken state.

## Fix

`biome format --write apps/app/vite.config.ts`. Pure formatter output, zero behavioral change.

## Verification

```
$ bunx biome check apps/app/vite.config.ts
Checked 1 file. No fixes applied.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix biome formatting in `vite.config.ts` to unblock develop CI
> Reformats nested ternary expressions in [vite.config.ts](https://github.com/milady-ai/milady/pull/2137/files#diff-0d80c2713ea1483c55bbc803b5d5d6a1f75654501e99a33c5d306cdbddd511e4) to satisfy biome lint rules. No logic, conditions, or values are changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6cf0242.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->