### PR TITLE
fix(vite): respect MILADY_SKIP_LOCAL_UPSTREAMS=1 in source-mode detection

### DIFF
--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -61,6 +61,16 @@ function shouldUseLocalElizaSource(): boolean {
   if (["package", "packages", "published", "npm"].includes(sourceMode)) {
     return false;
   }
+  // Legacy skip flag — set by CI when running in packages mode (e.g. the
+  // setup-bun-workspace action with disable-local-eliza-workspace=true).
+  // Mirrors isLocalElizaDisabled() in scripts/lib/eliza-package-mode.mjs so
+  // vite agrees with the rest of the toolchain about which mode it is in.
+  if (
+    process.env.MILADY_SKIP_LOCAL_UPSTREAMS === "1" ||
+    process.env.ELIZA_SKIP_LOCAL_UPSTREAMS === "1"
+  ) {
+    return false;
+  }
   if (
     process.env.MILADY_FORCE_LOCAL_UPSTREAMS === "1" ||
     process.env.ELIZA_FORCE_LOCAL_UPSTREAMS === "1"


### PR DESCRIPTION
## Problem

The Release workflow's `npm package build`, `Cloud app image build`, and `Electrobun matrix` jobs have been failing intermittently with:

\`\`\`
[UNRESOLVED_IMPORT] Could not resolve '../dist/index.js' in
../../eliza/packages/app-core/src/browser.ts
\`\`\`

Examples on develop:
- PR #2137: https://github.com/milady-ai/milady/actions/runs/25732889407
- PR #2129 merge: https://github.com/milady-ai/milady/actions/runs/25688497919

## Root cause

`setup-bun-workspace` (when called with `disable-local-eliza-workspace: "true"`) sets `MILADY_SKIP_LOCAL_UPSTREAMS=1` to opt the job into packages mode. The job then clones the eliza source for unrelated reasons (i18n keyword data generation, packaging asset copies, script delegation), leaving `eliza/packages/app-core/src/` on disk.

`apps/app/vite.config.ts`'s `shouldUseLocalElizaSource()` doesn't honor the legacy skip flag — it only checks `MILADY_ELIZA_SOURCE`, `MILADY_FORCE_LOCAL_UPSTREAMS`, and then auto-detects via filesystem. So when the eliza source is present, it flips vite into local mode and tries to bundle from `eliza/packages/app-core/src/browser.ts`, which re-exports from `../dist/index.js` that was never built (no \`bun run build\` ran in \`eliza/packages/app-core\`).

This is structurally similar to the docker fix moon already landed in 283986629 (\`ci(docker): build @elizaos/app-core before vite step\`), but the underlying issue is a logic mismatch between vite and the rest of the toolchain — not a missing build step. Build-docker's fix is also correct (defense in depth), but several jobs in agent-release.yml and build-cloud-image.yml don't pre-build app-core and would still hit this.

## Fix

Make \`shouldUseLocalElizaSource()\` return \`false\` when \`MILADY_SKIP_LOCAL_UPSTREAMS=1\` (or the \`ELIZA_\` variant) is set, mirroring the canonical helper \`isLocalElizaDisabled()\` in [scripts/lib/eliza-package-mode.mjs](../blob/develop/scripts/lib/eliza-package-mode.mjs):

\`\`\`ts
if (
  process.env.MILADY_SKIP_LOCAL_UPSTREAMS === \"1\" ||
  process.env.ELIZA_SKIP_LOCAL_UPSTREAMS === \"1\"
) {
  return false;
}
\`\`\`

Vite now agrees with the rest of the toolchain about which mode it is in.

## Compat

No behavior change in:
- \`MILADY_ELIZA_SOURCE=local\` mode — explicit source mode still wins (checked first)
- \`MILADY_ELIZA_SOURCE=packages\` mode — explicit packages mode still wins (checked first)
- Local dev with no env set + no eliza/ checkout — auto-detect returns false (unchanged)
- Local dev with no env set + eliza/ checkout — auto-detect returns true (unchanged)
- \`bun run eliza:local\` then \`bun run build\` — \`scripts/eliza-source-mode.mjs\` sets \`MILADY_SKIP_LOCAL_UPSTREAMS=''\` (empty string, not \"1\"), so the skip flag is not active

Only changes the CI case where setup-bun-workspace explicitly opts into packages mode (\`disable-local-eliza-workspace=true\` → \`MILADY_SKIP_LOCAL_UPSTREAMS=1\`) but the eliza source is still present on disk for non-vite reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Respect `MILADY_SKIP_LOCAL_UPSTREAMS` and `ELIZA_SKIP_LOCAL_UPSTREAMS` in `shouldUseLocalElizaSource`
> In [vite.config.ts](https://github.com/milady-ai/milady/pull/2138/files#diff-0d80c2713ea1483c55bbc803b5d5d6a1f75654501e99a33c5d306cdbddd511e4), `shouldUseLocalElizaSource` now returns `false` early when either `MILADY_SKIP_LOCAL_UPSTREAMS` or `ELIZA_SKIP_LOCAL_UPSTREAMS` is set to `"1"`, forcing package mode instead of local source mode.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e0d76ad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->