### PR TITLE
ci(sweeper): skip nightly run on forks, allow manual dispatch

### DIFF
--- a/.github/workflows/e2e-orphan-sweeper.yml
+++ b/.github/workflows/e2e-orphan-sweeper.yml
@@ -31,6 +31,12 @@ env:
 
 jobs:
   sweep:
+    # The sweeper needs MILADY_E2E_* secrets scoped to the canonical org.
+    # On forks the secrets are absent and every matrix entry fails on every
+    # cron tick, generating daily noise. Manual workflow_dispatch from a
+    # fork still works for the operator who triggered it (they can supply
+    # the secrets via their own org/repo settings).
+    if: github.repository_owner == 'milady-ai' || github.event_name == 'workflow_dispatch'
     name: Sweep ${{ matrix.service }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Problem

The \`E2E Orphan Sweeper\` workflow runs nightly at 04:00 UTC on every fork of \`milady-ai/milady\`. It needs ~25 \`MILADY_E2E_*\` secrets (Gmail OAuth, Discord, Telegram, Twitter, Signal, iMessage / BlueBubbles, GitHub PAT, Twilio, Selfcontrol) scoped to the canonical org. On any fork those secrets are absent, so every matrix entry of every cron tick fails — generating daily failure notifications to the fork owner with no actionable signal.

Example on a fork: https://github.com/dutchiono/milady/actions/workflows/e2e-orphan-sweeper.yml — same SHA failing every day for months.

## Fix

Gate the job to \`repository_owner == 'milady-ai'\` for scheduled runs. \`workflow_dispatch\` still works on forks so an operator who has supplied their own secrets can run the sweeper manually.

\`\`\`yaml
jobs:
  sweep:
    if: github.repository_owner == 'milady-ai' || github.event_name == 'workflow_dispatch'
\`\`\`

## Compat

- \`milady-ai/milady\` scheduled runs: unchanged
- \`milady-ai/milady\` manual dispatch: unchanged
- Fork scheduled runs: skipped (no more daily failure spam)
- Fork manual dispatch: unchanged (operator can supply their own secrets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip nightly e2e orphan sweeper run on forks, allow manual dispatch
> Adds an `if` condition to the `sweep` job in [e2e-orphan-sweeper.yml](.github/workflows/e2e-orphan-sweeper.yml) so it only runs when the repository owner is `milady-ai` or when triggered via `workflow_dispatch`. This prevents the job from running on forks during scheduled nightly runs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ed80da9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->