### PR TITLE
feat(apps/app): wire desktop-injected apiBase into bootstrap + reset stale dev pairings

### DIFF
--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -323,11 +323,66 @@ const appBootConfig: AppBootConfig = {
 // (#token=...), so it never reaches the server, access log, or Referer
 // headers. Once read, it persists in localStorage scoped to this origin.
 const SELF_HOSTED_TOKEN_KEY = "milady:self-hosted-api-token";
+const ACTIVE_SERVER_STORAGE_KEY = "elizaos:active-server";
+const API_BASE_STORAGE_KEY = "elizaos_api_base";
 const STALE_BOOTSTRAP_KEYS = [
   "elizaos:agent-profiles",
-  "elizaos:active-server",
+  ACTIVE_SERVER_STORAGE_KEY,
   MOBILE_RUNTIME_MODE_STORAGE_KEY,
 ] as const;
+
+function isLoopbackApiBase(value: unknown): boolean {
+  if (typeof value !== "string" || !value.trim()) return false;
+  try {
+    const host = new URL(value).hostname.toLowerCase();
+    return host === "127.0.0.1" || host === "localhost" || host === "::1";
+  } catch {
+    return false;
+  }
+}
+
+// In desktop dev, persisted active-server pairings from a previous session
+// can point at a remote agent (cloud, a different machine, or a packaged
+// build on the same host). On a fresh `bun run dev:desktop` we want the
+// renderer to talk to the local agent that orchestrator just spawned, not
+// re-resume a stale pairing. Reset to the local embedded server unless
+// the persisted value is already local/loopback.
+//
+// DEV-only + desktop-only by design. Production desktop and web bundles
+// preserve user pairings as-is.
+function forceDesktopDevLocalActiveServer(): void {
+  if (!import.meta.env.DEV || !isDesktopPlatform()) return;
+
+  try {
+    const raw = window.localStorage.getItem(ACTIVE_SERVER_STORAGE_KEY);
+    if (!raw) return;
+    const activeServer = JSON.parse(raw) as {
+      kind?: unknown;
+      apiBase?: unknown;
+    };
+    if (
+      activeServer?.kind === "local" ||
+      isLoopbackApiBase(activeServer?.apiBase)
+    ) {
+      return;
+    }
+
+    window.localStorage.setItem(
+      ACTIVE_SERVER_STORAGE_KEY,
+      JSON.stringify({
+        id: "local:embedded",
+        kind: "local",
+        label: "This device",
+      }),
+    );
+    window.localStorage.removeItem(API_BASE_STORAGE_KEY);
+    window.sessionStorage.removeItem(API_BASE_STORAGE_KEY);
+    client.setBaseUrl(null);
+    console.warn(
+      `${APP_LOG_PREFIX} Desktop dev ignored stale remote active server; using local agent.`,
+    );
+  } catch {}
+}
 try {
   const url = new URL(window.location.href);
   const hash = url.hash.startsWith("#") ? url.hash.slice(1) : url.hash;
@@ -389,7 +444,20 @@ try {
     } catch {}
   }
 } catch {}
+// On desktop, the Electrobun shell injects the local agent's HTTP origin
+// (e.g. `http://127.0.0.1:31337`) onto window before the renderer mounts.
+// Push it into the boot config so the React shell talks to that origin
+// rather than falling back to `window.location.origin` (which on
+// Electrobun is a custom scheme like `electrobun://`).
+// `getInjectedAppApiBase()` reads all four canonical window globals
+// (`__ELIZA_APP_API_BASE__`, the branded key, `__ELIZA{,OS}_APP_BOOT_CONFIG__`,
+// and legacy `__ELIZA_API_BASE__`) with the correct priority.
+if (isDesktopPlatform()) {
+  const desktopApiBase = getInjectedAppApiBase();
+  if (desktopApiBase) appBootConfig.apiBase ??= desktopApiBase;
+}
 setBootConfig(appBootConfig);
+forceDesktopDevLocalActiveServer();
 
 // On AOSP/Milady, ElizaNativeBridge.getLocalAgentToken() returns null
 // for the first ~30-50s of app launch — the on-device agent process is


### PR DESCRIPTION
Two related changes to the renderer boot in `apps/app/src/main.tsx`.

## 1. Desktop-injected apiBase into the boot config

The Electrobun shell injects the local agent's HTTP origin (e.g. `http://127.0.0.1:31337`) onto `window` before the renderer mounts, via the canonical `__ELIZA_APP_API_BASE__` / branded-key / `__ELIZA{,OS}_APP_BOOT_CONFIG__` / legacy `__ELIZA_API_BASE__` globals.

Before this PR, that injection only flowed into the cloud-only branding decision (via `getInjectedAppApiBase()` at line 206). The boot config still defaulted to `window.location.origin` when no bootstrap token was present. On Electrobun, `location.origin` is a custom scheme (`electrobun://...`), so the React shell would talk to a non-existent backend until the user manually paired.

Now, on desktop platforms we push `getInjectedAppApiBase()` (the existing canonical-priority helper) into `appBootConfig.apiBase` before `setBootConfig` finalizes:

```ts
if (isDesktopPlatform()) {
  const desktopApiBase = getInjectedAppApiBase();
  if (desktopApiBase) appBootConfig.apiBase ??= desktopApiBase;
}
setBootConfig(appBootConfig);
```

Web bundles preserve prior behavior — the guard is `isDesktopPlatform()`-scoped and the assignment uses `??=` so anything already set (bootstrap token branch, branded boot config) wins.

## 2. Reset stale dev pairings on desktop dev boot

In `bun run dev:desktop` the renderer can persist an active-server pairing across runs. If the persisted server points at a remote agent (cloud, a different machine, a packaged build on the same host), a fresh `dev:desktop` would still try to resume that pairing instead of talking to the local agent the orchestrator just spawned.

`forceDesktopDevLocalActiveServer()` runs after `setBootConfig` and resets the active server to `local:embedded` whenever the persisted value isn't already local/loopback:

- DEV-only (`import.meta.env.DEV`) + desktop-only (`isDesktopPlatform()`)
- Preserves anything already pointing at `127.0.0.1` / `localhost` / `::1` or with `kind === \"local\"`
- Clears `elizaos_api_base` from both localStorage and sessionStorage
- Calls `client.setBaseUrl(null)` so the in-memory client is reset too
- Logs a single `console.warn` with `APP_LOG_PREFIX` so the reset is visible in the dev console

Production desktop and web bundles never enter this function.

## Touched

- `apps/app/src/main.tsx` only — no new files
- No new `window` globals introduced; the existing `__ELIZA_APP_API_BASE__` injection point and `getInjectedAppApiBase()` helper are reused as-is
- Two new module-scope constants for the magic strings (`ACTIVE_SERVER_STORAGE_KEY`, `API_BASE_STORAGE_KEY`) — `STALE_BOOTSTRAP_KEYS` updated to use the constant

## Compat

| Platform / Mode | Before | After |
|---|---|---|
| Desktop dev (no token, host-injected apiBase) | Used `electrobun://` origin → broken | Uses injected `http://127.0.0.1:port` ✅ |
| Desktop dev (stale remote active server) | Resumed remote pairing | Resets to local embedded ✅ |
| Desktop prod | Unchanged | Unchanged |
| Web (any) | Unchanged | Unchanged |
| Capacitor mobile | Unchanged | Unchanged |
| Bootstrap-token self-hosted flow | Unchanged (`??=` preserves the token-path apiBase) | Unchanged |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wire desktop-injected `apiBase` into bootstrap and reset stale dev server pairings
> - On desktop, `getInjectedAppApiBase()` is called during boot and assigned to `appBootConfig.apiBase` if it is not already set, ensuring the desktop-injected API base takes effect.
> - Adds `forceDesktopDevLocalActiveServer()`, which runs only in desktop dev builds: if the persisted active server is not a local/loopback server, it resets the active server to the local embedded descriptor, clears `elizaos_api_base` from storage, and resets the client base URL to null.
> - Behavioral Change: In desktop dev builds, any stale remote server pairing stored in `localStorage` is silently overwritten to `local:embedded` on every startup.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c21212.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->