### PR TITLE
fix(vite): add has + getOwnPropertyDescriptor traps to node-builtin stub

### DIFF
--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -1225,7 +1225,27 @@ function generateNodeBuiltinStub(moduleId: string, req = _require): string {
   const lines = [
     // noop: returns itself (for chained calls like createRequire(url)(id)),
     // and is a valid class base (so `class X extends noop` works).
-    "const handler = { get(t, p) { if (typeof p === 'symbol') return undefined; if (p === '__esModule') return true; if (p === 'default') return t; if (p === 'prototype') return {}; if (p in t) return t[p]; return noop; }, set(t, p, v) { try { t[p] = v; } catch {} return true; }, apply() { return noop; }, construct() { return noop; }, defineProperty(t, p, d) { try { Object.defineProperty(t, p, { configurable: true, writable: true, enumerable: true, ...d }); } catch {} return true; } };",
+    //
+    // Traps:
+    //   get/set/apply/construct/defineProperty — handle attribute access,
+    //     mutation, invocation, instantiation, and defineProperty on the
+    //     stub.
+    //   has/getOwnPropertyDescriptor — close reflection holes so
+    //     `'foo' in noop` and `Object.getOwnPropertyDescriptor(noop, 'foo')`
+    //     return predictable values. Without these, consumer code that
+    //     probes the stub (feature detection, fs-extra's top-level
+    //     `typeof fs.realpath.native === 'function'` check, esbuild
+    //     interop helpers) can throw `Cannot read properties of undefined`
+    //     at IIFE evaluation time before React mounts.
+    //     `getOwnPropertyDescriptor` falls through to the target's real
+    //     descriptor when the key exists on it — required to satisfy the
+    //     Proxy invariant that non-configurable target keys must be
+    //     reported with matching descriptors. `ownKeys` is intentionally
+    //     omitted: the default behavior already yields
+    //     `Object.keys(noop) === []` (target keys are non-enumerable) and
+    //     a custom trap would risk violating the invariant that
+    //     non-configurable target keys must appear in the result.
+    "const handler = { get(t, p) { if (typeof p === 'symbol') return undefined; if (p === '__esModule') return true; if (p === 'default') return t; if (p === 'prototype') return {}; if (p in t) return t[p]; return noop; }, set(t, p, v) { try { t[p] = v; } catch {} return true; }, apply() { return noop; }, construct() { return noop; }, defineProperty(t, p, d) { try { Object.defineProperty(t, p, { configurable: true, writable: true, enumerable: true, ...d }); } catch {} return true; }, has() { return true; }, getOwnPropertyDescriptor(t, p) { var own = Object.getOwnPropertyDescriptor(t, p); if (own) return own; return { configurable: true, enumerable: true, writable: true, value: noop }; } };",
     "const noop = new Proxy(function noop(){}, handler);",
     "const stub = new Proxy({}, handler);",
     "export default stub;",


### PR DESCRIPTION
## Problem

The browser-bundle stub for node-builtin imports (`node:fs`, `node:path`, etc.) uses a `Proxy(function noop(){}, handler)` so chained access, callability, and `class extends noop` all work in the renderer for code paths that are dead in the browser.

Until this PR the handler had only `get`/`set`/`apply`/`construct`/`defineProperty` traps. Consumer code that **reflects** over the stub (rather than just calling/accessing it) hit holes — most notably the inlined fs-extra in `@elizaos/core@2.0.0-alpha.537`, which evaluates this at module load time:

```js
typeof fs.realpath.native === 'function'
  ? sI.realpath.native = ...
  : emitWarning(...);
```

When `fs.realpath` is the bare stub, `.native` lookup returns `noop` (via the `get` trap), but downstream reflection probes (e.g. fs-extra's later `if ('native' in fs.realpath)` style checks) return `false` because the `in` operator goes through the `has` trap, which we didn't have.

#2133's `@elizaos/core` patch fixes this at the consumer end. This PR fixes it at the stub end so the next published version of `@elizaos/core` (and any other consumer with similar probes) doesn't need a patch.

## Fix

Added two reflection traps to the Proxy handler:

**`has() { return true; }`**

Every probed key reports as existing. Combined with `get` returning `noop` for unknown keys, feature-detection branches consistently take the \"method exists\" path and invoke `noop`, instead of falling through to alternative code paths that don't exist in the renderer.

**`getOwnPropertyDescriptor(t, p)`**

Falls through to the target's real descriptor when the key exists on it — **required** by the Proxy invariant that non-configurable target keys (like `prototype` on a Function) must be reported with matching descriptors. For all other keys, returns a synthetic data descriptor with `value: noop`.

## `ownKeys` is intentionally NOT trapped

My first cut had `ownKeys() { return []; }`. That **crashes** the moment any consumer runs `Object.keys(noop)`:

```
TypeError: 'ownKeys' on proxy: trap result did not include 'prototype'
```

The Proxy invariant requires non-configurable target keys (`prototype` on a function) to appear in the trap's result. The default `[[OwnPropertyKeys]]` behavior already yields `Object.keys(noop) === []` because the function's `length`/`name`/`prototype` are all non-enumerable, so a custom trap is unnecessary AND risky.

## Verification

Validated by directly executing the generated stub with these probes:

| Probe | Before | After |
|---|---|---|
| `typeof noop.bind === 'function'` | ✓ | ✓ |
| `typeof fakeFs.realpath.native === 'function'` (the fs-extra check) | depends on probe ordering | ✓ |
| `'foo' in noop` | `false` | `true` |
| `Object.keys(noop).length === 0` | ✓ | ✓ |
| `for...in noop` completes without throwing | ✓ | ✓ |
| `Object.getOwnPropertyDescriptor(noop, 'prototype').configurable` | `false` (target's actual) | `false` (target's actual, invariant honored) |
| `class Sub extends noop {}` compiles + instantiates | ✓ | ✓ |
| `stub.foo.bar.baz()` chains and returns noop | ✓ | ✓ |

## Touched

- `apps/app/vite.config.ts` only — handler string in `generateNodeBuiltinStub`
- One added doc block, two added traps in the handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `has` and `getOwnPropertyDescriptor` traps to node-builtin browser stub
> The `generateNodeBuiltinStub` function in [vite.config.ts](https://github.com/milady-ai/milady/pull/2141/files#diff-0d80c2713ea1483c55bbc803b5d5d6a1f75654501e99a33c5d306cdbddd511e4) generates a Proxy-based ESM stub for Node built-ins in the browser. The new `has` trap returns `true` for all property checks (`in` operator), and `getOwnPropertyDescriptor` returns the real descriptor when present, or a configurable/enumerable/writable descriptor with a `noop` value for missing keys. This prevents errors in consumer code that reflects on the stub via `in` checks or `Object.getOwnPropertyDescriptor`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c97e14d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->