### PR TITLE
ci(cloud): guard `cd eliza/packages/schemas` against upstream restructure

### DIFF
--- a/.github/workflows/build-cloud-agent.yml
+++ b/.github/workflows/build-cloud-agent.yml
@@ -252,11 +252,17 @@ jobs:
       - name: Build @elizaos/core
         run: |
           export PATH="$GITHUB_WORKSPACE/eliza/node_modules/.bin:$GITHUB_WORKSPACE/eliza/packages/schemas/node_modules/.bin:$PATH"
-          # Proto generation
-          cd eliza/packages/schemas
-          buf dep update && buf generate
+          # Proto generation — eliza/packages/schemas was removed from
+          # upstream eliza in a recent restructure. Guard against its
+          # absence so the cloud agent build works against current eliza
+          # develop. The pattern mirrors build-docker.yml's guard.
+          if [ -d eliza/packages/schemas ] && [ -f eliza/packages/schemas/buf.gen.yaml ]; then
+            (cd eliza/packages/schemas && buf dep update && buf generate)
+          else
+            echo "eliza/packages/schemas not present in this eliza checkout — skipping proto generation"
+          fi
           # i18n keyword generation (needs @elizaos/shared scripts)
-          cd ../core
+          cd eliza/packages/core
           node ../shared/scripts/generate-keywords.mjs --target ts 2>/dev/null || echo "keyword gen skipped"
           # Build core
           bun run build.ts 2>&1 || echo "core build had errors"

--- a/.github/workflows/build-cloud-image.yml
+++ b/.github/workflows/build-cloud-image.yml
@@ -158,9 +158,16 @@ jobs:
       - name: Build @elizaos/core (includes agent-orchestrator)
         run: |
           export PATH="$GITHUB_WORKSPACE/eliza/node_modules/.bin:$GITHUB_WORKSPACE/eliza/packages/schemas/node_modules/.bin:$PATH"
-          cd eliza/packages/schemas
-          buf dep update && buf generate
-          cd ../core
+          # Proto generation — eliza/packages/schemas was removed from
+          # upstream eliza in a recent restructure. Guard against its
+          # absence so the cloud image build works against current eliza
+          # develop. The pattern mirrors build-docker.yml's guard.
+          if [ -d eliza/packages/schemas ] && [ -f eliza/packages/schemas/buf.gen.yaml ]; then
+            (cd eliza/packages/schemas && buf dep update && buf generate)
+          else
+            echo "eliza/packages/schemas not present in this eliza checkout — skipping proto generation"
+          fi
+          cd eliza/packages/core
           node ../shared/scripts/generate-keywords.mjs --target ts 2>/dev/null || echo "keyword gen skipped"
           bun run build:node
 


### PR DESCRIPTION
## Problem

\`eliza/packages/schemas\` was removed from upstream \`elizaOS/eliza\` in a recent restructure. The package list on the upstream default branch now reads:

> agent · app · app-core · benchmarks · browser-bridge · bun-ios-runtime · cloud-routing · core · docs · elizaos · examples · homepage · inference · native-plugins · os · prompts · registry · scenario-runner · scenario-schema · shared

No \`schemas\` between them.

Two workflows in this repo do an unconditional \`cd eliza/packages/schemas\` and now fail at that step on every fresh eliza clone:

- \`.github/workflows/build-cloud-image.yml\`
- \`.github/workflows/build-cloud-agent.yml\`

Error from the latest develop Release run (PR #2138's post-merge run, [run 25736357563](https://github.com/milady-ai/milady/actions/runs/25736357563)):

\`\`\`
/home/runner/work/_temp/...sh: line 2: cd: eliza/packages/schemas: No such file or directory
##[error]Process completed with exit code 1.
\`\`\`

This kills \`Cloud app image build\` and cascades into \`Release gate\` on every Release run.

## Fix

Three sibling workflows (\`ci.yml\`, \`agent-review.yml\`, \`build-docker.yml\`) already guard this access pattern:

\`\`\`bash
if [ -d eliza/packages/schemas ] && [ -f eliza/packages/schemas/buf.gen.yaml ]; then
  cd eliza/packages/schemas
  buf generate
fi
\`\`\`

Apply the same guard in \`build-cloud-image.yml\` and \`build-cloud-agent.yml\`. When schemas isn't present, proto generation is skipped — the downstream core build either picks up checked-in generated types or doesn't need them (same behavior already shipping in \`build-docker.yml\`).

Also moves the subsequent \`cd ../core\` to an absolute-style \`cd eliza/packages/core\` so the keyword gen + core build run from the correct directory regardless of whether the schemas block ran.

## Compat

| eliza checkout | Before | After |
|---|---|---|
| Upstream develop (no \`schemas/\`) | Build fails on \`cd\` | Skips proto gen, runs core build ✅ |
| Pinned older eliza (has \`schemas/\`) | Works | Unchanged — guard short-circuits to \`true\` ✅ |

## Verification

The build-docker.yml workflow uses this exact pattern and is currently passing on develop ([Build Agent Image runs](https://github.com/milady-ai/milady/actions/workflows/build-docker.yml)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard `cd eliza/packages/schemas` against upstream restructure in cloud CI workflows
> - Replaces unconditional `cd eliza/packages/schemas && buf dep update && buf generate` with a conditional check for the directory and `buf.gen.yaml` before running protobuf generation in both [build-cloud-agent.yml](.github/workflows/build-cloud-agent.yml) and [build-cloud-image.yml](.github/workflows/build-cloud-image.yml).
> - When the schemas directory is absent, the step logs a skip message and continues without failing.
> - Fixes the subsequent directory change from the relative `cd ../core` to the absolute `cd eliza/packages/core` for reliability.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 78cc160.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->