### PR TITLE
Fix for Useless assignment to local variable

### DIFF
--- a/native/ios-bun-port/polyfill/src/modules/http.ts
+++ b/native/ios-bun-port/polyfill/src/modules/http.ts
@@ -173,7 +173,6 @@ export function request(
   else if (optsOrCb && typeof optsOrCb === "object") {
     if (typeof optsOrUrl === "string" || optsOrUrl instanceof URL) {
       const base = normalizeRequestOptions(optsOrUrl);
-      opts = { ...optsOrCb, ...base } as RequestOptions;
       const merged: RequestOptions = {
         ...optsOrCb,
         protocol: undefined,


### PR DESCRIPTION
The best fix is to remove the unused assignment to `opts` at line 176, since it is immediately overwritten and never observed. This preserves current runtime behavior while eliminating dead code and satisfying the CodeQL rule.

In `native/ios-bun-port/polyfill/src/modules/http.ts`, within `request(...)`, in the branch:

- `else if (optsOrCb && typeof optsOrCb === "object") {`
- nested `if (typeof optsOrUrl === "string" || optsOrUrl instanceof URL) { ... }`

delete the line:

- `opts = { ...optsOrCb, ...base } as RequestOptions;`

No imports, new methods, or additional definitions are needed for this specific CodeQL finding.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove useless variable assignment in `http.request`
> Removes an early object spread assignment (`opts = { ...optsOrCb, ...base }`) in [http.ts](https://github.com/milady-ai/milady/pull/2143/files#diff-83d0673b9dc131cd2cb27eb6f86d58253cb44e63bf25ae491aa8757845dc9d2d) that was immediately overwritten and never used. The function now proceeds directly to constructing the `merged` object.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6a2af18.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->