### PR TITLE
fix(apps/app): rename MILADY_DEFAULT_THEME → ELIZA_DEFAULT_THEME (unbreaks bun run build:android)

### DIFF
--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -14,7 +14,7 @@ import {
   isElectrobunRuntime,
 } from "@elizaos/app-core";
 import type { BrandingConfig } from "@elizaos/app-core";
-import { MILADY_DEFAULT_THEME } from "@elizaos/shared";
+import { ELIZA_DEFAULT_THEME } from "@elizaos/shared";
 import {
   type AppBootConfig,
   getBootConfig,
@@ -199,7 +199,7 @@ function getInjectedAppApiBase(): string | undefined {
 
 const APP_BRANDING: Partial<BrandingConfig> = {
   ...APP_BRANDING_BASE,
-  theme: MILADY_DEFAULT_THEME,
+  theme: ELIZA_DEFAULT_THEME,
   // The hosted web bundle stays cloud-only in production. Desktop shells and
   // other hosts inject an explicit API base before React boots, and that host
   // backend should control onboarding capabilities instead.


### PR DESCRIPTION
## Summary

`@elizaos/shared` renamed the export `MILADY_DEFAULT_THEME` → `ELIZA_DEFAULT_THEME` during the theme-picker removal. `packages/shared/src/themes/presets.ts` now exports `ELIZA_DEFAULT_THEME` and the legacy alias is gone. Milady's `apps/app/src/main.tsx` still imports the old name, breaking every Vite-driven build on a fresh develop checkout:

```
src/main.tsx (17:0): "MILADY_DEFAULT_THEME" is not exported by
"../../eliza/packages/shared/dist/index.js", imported by "src/main.tsx".
```

Two-line rename, no semantic change.

## Verification

`bun run build:android` (with `MILADY_ELIZA_SOURCE=local` and the `@elizaos/shared` workspace-symlink fix) now reaches `BUILD SUCCESSFUL` in 1m 11s on the milady root. APK is 494 MB at `apps/app/android/app/build/outputs/apk/debug/app-debug.apk`, embeds the on-device agent runtime (libeliza_bun.so + libllama-cpp-arm64.so + companions).

```
> Task :app:assembleDebug
BUILD SUCCESSFUL in 1m 11s
227 actionable tasks: 54 executed, 173 up-to-date
```

Same fix was applied independently in a separate test session today; codifying here so every contributor's fresh build picks it up cleanly.

## Provenance

This is the trivial follow-up to the upstream `@elizaos/shared` rename. If maintainers want to keep a `MILADY_DEFAULT_THEME` alias for backward compatibility, the alternative would be to re-export it from `@elizaos/shared/dist/themes/presets.js` instead — either lands the same way for `main.tsx`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ELIZA_DEFAULT_THEME` rename in `APP_BRANDING` to unbreak Android build
> Replaces the stale `MILADY_DEFAULT_THEME` import with `ELIZA_DEFAULT_THEME` from `@elizaos/shared` in [main.tsx](https://github.com/milady-ai/milady/pull/2148/files#diff-daadf90e7c659872f2d40ccafd9ee93306e0d519e96acb61016e83722e6f129a). The old name no longer exists, causing `bun run build:android` to fail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized adadcb1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->