### PR TITLE
fix(ci): guard auth gate package-mode builds

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -155,6 +155,10 @@ jobs:
 
       - name: Build local eliza runtime plugins
         run: |
+          if [ ! -d eliza/packages/core ]; then
+            echo "eliza checkout is absent; skipping local runtime plugin build"
+            exit 0
+          fi
           if [ ! -f eliza/packages/core/dist/index.node.js ] || [ ! -f eliza/packages/core/dist/index.d.ts ]; then
             (cd eliza/packages/core && bun run build)
           fi


### PR DESCRIPTION
## Summary

Adds a small guard to the agent-review Auth P0 workflow so package-mode PR checkouts skip the local Eliza runtime plugin build when the nested `eliza/packages/core` checkout is absent.

## Why

Several package-mode Milady PRs can fail before their actual auth tests because the `pull_request_target` workflow assumes `eliza/packages/core` exists and then runs:

```sh
(cd eliza/packages/core && bun run build)
```

That directory is only present in local-source/nested-Eliza checkouts. In package-mode checkouts the workflow should skip this optional local runtime plugin prebuild instead of failing with `cd: eliza/packages/core: No such file or directory`.

This is intentionally split from the larger Android APK/runtime PR so maintainers can land the base workflow fix independently.

## Validation

```sh
git diff --check
node scripts/validate-ci-bootstrap-contract.mjs
```

Both passed locally.

## Notes

Because this workflow runs under `pull_request_target`, GitHub evaluates the workflow file from the base branch. This PR may not be able to make its own Auth P0 run observe the guard until the change lands on `develop`; the value here is unblocking subsequent PR checks once merged.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip local eliza runtime plugin build when `eliza/packages/core` is absent
> Adds a directory existence check at the start of the 'Build local eliza runtime plugins' step in [agent-review.yml](.github/workflows/agent-review.yml). If `eliza/packages/core` is missing, the step prints a message and exits successfully instead of running build commands that would fail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f777b4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->