### PR TITLE
fix(restore-local-eliza-workspace): skip stale omnivoice.cpp submodule by default

### DIFF
--- a/scripts/restore-local-eliza-workspace.mjs
+++ b/scripts/restore-local-eliza-workspace.mjs
@@ -8,7 +8,18 @@ import { applyCiOnlyOverrides } from "./disable-local-eliza-workspace.mjs";
 import { applyTsconfigMode } from "./lib/tsconfig-mode.mjs";
 
 function getNestedElizaSubmoduleSkipArgs() {
-  const skipped = ["plugin-openrouter"];
+  // Skip nested submodules whose upstream refs are unreachable or that we
+  // don't need locally. `name` is the submodule name from eliza/.gitmodules.
+  const skipped = [
+    "plugin-openrouter",
+    // omnivoice.cpp is voice-only; the elizaOS/omnivoice.cpp fork has
+    // force-pushed master so the tracked ref in eliza/develop is no longer
+    // reachable. Skipping unblocks local desktop builds that don't need
+    // voice. Re-enable by setting MILADY_FORCE_OMNIVOICE_SUBMODULE=1.
+    ...(process.env.MILADY_FORCE_OMNIVOICE_SUBMODULE === "1"
+      ? []
+      : ["plugins/plugin-local-inference/native/omnivoice.cpp"]),
+  ];
   if (
     process.env.MILADY_SKIP_CLOUD_SUBMODULE === "1" ||
     process.env.ELIZA_SKIP_CLOUD_SUBMODULE === "1"


### PR DESCRIPTION
## why

`bun run eliza:local` fails on a fresh windows checkout with:

```
restore-local-eliza-workspace: failed to initialize nested eliza submodules: Command failed: git -c submodule.plugin-openrouter.update=none submodule update --init --recursive
fatal: remote error: upload-pack: not our ref 10c14238ad26520236d4e392202347866984ea2f
fatal: Fetched in submodule path 'plugins/plugin-local-inference/native/omnivoice.cpp', but it did not contain 10c14238ad26520236d4e392202347866984ea2f. Direct fetching of that commit failed.
```

`eliza/develop`'s `.gitmodules` tracks ref `10c14238ad26520236d4e392202347866984ea2f` for `plugins/plugin-local-inference/native/omnivoice.cpp` (origin `https://github.com/elizaOS/omnivoice.cpp.git`, branch `master`), but that ref is no longer reachable on the upstream — `master` has been force-pushed. every text-only local-dev workflow gets blocked on a voice-only submodule.

## what

extend the existing `getNestedElizaSubmoduleSkipArgs` helper in `scripts/restore-local-eliza-workspace.mjs` to skip `plugins/plugin-local-inference/native/omnivoice.cpp` by default. opt back in with `MILADY_FORCE_OMNIVOICE_SUBMODULE=1` when working on voice.

mirrors the existing pattern for cloud (`MILADY_SKIP_CLOUD_SUBMODULE=1`).

## verified

`bun run eliza:local` now completes cleanly on a fresh windows checkout (348 packages linked, "local elizaOS source mode is ready.").

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip stale `omnivoice.cpp` submodule by default in restore-local-eliza-workspace
> In [restore-local-eliza-workspace.mjs](https://github.com/milady-ai/milady/pull/2165/files#diff-64f12dc4c1140282c6a043e6ee7414f35bb48fa1dcedff68851c99e70b602370), the `getNestedElizaSubmoduleSkipArgs` function now includes `plugins/plugin-local-inference/native/omnivoice.cpp` in the default skip list alongside `plugin-openrouter`. Set `MILADY_FORCE_OMNIVOICE_SUBMODULE=1` to override and force the submodule to be checked out.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0d8bec8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->