### PR TITLE
fix(ci): retry bare non-frozen bun installs (transient github: dep flake)

### DIFF
--- a/.github/workflows/agent-fix-ci.yml
+++ b/.github/workflows/agent-fix-ci.yml
@@ -214,7 +214,9 @@ jobs:
           node scripts/disable-local-eliza-workspace.mjs
 
       - name: Install dependencies
-        run: bun install --ignore-scripts
+        # Retry once: github: deps (e.g. node-llama-cpp) can hit transient
+        # GitHub resolution/rate-limit failures on non-frozen installs.
+        run: bun install --ignore-scripts || (sleep 5 && bun install --ignore-scripts)
         env:
           NPM_CONFIG_REGISTRY: 'https://registry.npmjs.org'
 

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -70,7 +70,9 @@ jobs:
         run: node scripts/disable-local-eliza-workspace.mjs
 
       - name: Install dependencies
-        run: bun install --ignore-scripts
+        # Retry once: github: deps (e.g. node-llama-cpp) can hit transient
+        # GitHub resolution/rate-limit failures on non-frozen installs.
+        run: bun install --ignore-scripts || (sleep 5 && bun install --ignore-scripts)
 
       - name: Generate release metadata
         env:

--- a/.github/workflows/task-agent-cross-platform-review.yml
+++ b/.github/workflows/task-agent-cross-platform-review.yml
@@ -66,7 +66,9 @@ jobs:
 
       - name: Install dependencies
         shell: bash
-        run: bun install --ignore-scripts
+        # Retry once: github: deps (e.g. node-llama-cpp) can hit transient
+        # GitHub resolution/rate-limit failures on non-frozen installs.
+        run: bun install --ignore-scripts || (sleep 5 && bun install --ignore-scripts)
 
       - name: Run repository postinstall
         run: bun run postinstall


### PR DESCRIPTION
## Diagnosis

`bun install --ignore-scripts` failed in CI with `node-llama-cpp@github:milady-ai/node-llama-cpp#v3.18.1-milady.3 failed to resolve`, after 6046 packages already resolved. That signature = a **transient GitHub resolution flake** on a github: dependency, not a dead pin:

- The repo `milady-ai/node-llama-cpp` was **transferred to `elizaOS`**; GitHub 301-redirects it. The tag exists → `git ls-remote` resolves it to SHA `b044d4a` for both orgs; `codeload` returns 200; `bun.lock` already pins that SHA.
- milady's **default** install is `--frozen-lockfile` (uses the locked SHA, no re-resolution). The failing command was **non-frozen**, which re-resolves the github: tag and can flake.

**Repointing the org is not viable:** the transitive `@elizaos/plugin-local-embedding` (pulled by `@elizaos/agent`) hardcodes the `milady-ai` spec in its *published* package — milady can't edit it.

## Fix

The repo already retries this exact flake in `setup-bun-workspace` (2 attempts + cache clean), `release-electrobun.yml` (3 attempts), and `apple-store-release.yml` (`|| retry`). Three **bare** non-frozen `bun install --ignore-scripts` steps lacked any retry — add the established retry-with-backoff:
- `deploy-web.yml`
- `task-agent-cross-platform-review.yml`
- `agent-fix-ci.yml`

Retry is strictly safe: no change on success; one extra attempt (after 5s) on the transient failure.

## Verification
All three workflows parse as valid YAML (js-yaml); `run` value confirmed correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retry `bun install` once on failure in CI workflows to handle transient GitHub dependency flakes
> Adds a single retry with a short sleep to the `bun install --ignore-scripts` step in three CI workflows: [agent-fix-ci.yml](https://github.com/milady-ai/milady/pull/2174/files#diff-eaacfc0cacde36a870476fd2864e9bfe5602e585849d1d2a89ecab8e9ed04e51), [deploy-web.yml](https://github.com/milady-ai/milady/pull/2174/files#diff-875a32a9bd9123a01ecb0b1802809c712a8a04f695e979c262eb9380e6359efc), and [task-agent-cross-platform-review.yml](https://github.com/milady-ai/milady/pull/2174/files#diff-565f196f26fdb8e0cb593d3fc3b5970315c2b868692d4eee464ff5b9302cdbdc). This guards against transient network failures when fetching dependencies from GitHub.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff51bb7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->