### PR TITLE
fix(build): externalize @elizaos/vault in tsdown node bundles (kill UNRESOLVED_IMPORT warnings)

### DIFF
--- a/tsdown.config.mjs
+++ b/tsdown.config.mjs
@@ -103,8 +103,16 @@ const optionalAppExternal = /^@elizaos\/app-/;
 // of them — always external; rolldown can't bundle the .node binary.
 const nodeRsExternal = /^@node-rs\//;
 const napiRsExternal = /^@napi-rs\//;
+// @elizaos/vault is a runtime-loaded workspace service (secrets manager),
+// declared as a workspace:* dependency and resolved from node_modules at
+// runtime. Unlike @elizaos/core / @elizaos/shared (intentionally inlined into
+// the node bundle), rolldown cannot cleanly bundle it, so it was being
+// implicitly externalized with an UNRESOLVED_IMPORT warning. List it explicitly
+// so the externalization is intentional and the warning goes away.
+const vaultExternal = "@elizaos/vault";
 const allExternals = [
   ...nativeExternals,
+  vaultExternal,
   pluginExternal,
   optionalAppExternal,
   nodeRsExternal,


### PR DESCRIPTION
## Problem
Every node build logged `[UNRESOLVED_IMPORT] Could not resolve '@elizaos/vault' ... treating it as an external dependency` for `secrets-manager-routes.ts`, `vault-mirror.ts`, `secrets-manager-installer.ts`, `secrets-inventory-routes.ts`.

## Root cause (committable, here in milady)
`tsdown.config.mjs` bundles app-core's node entries and lists explicit externals (`@elizaos/plugin-*`, `@elizaos/app-*`, native, `@node-rs`/`@napi-rs`) — but **not `@elizaos/vault`**. With an explicit `external` array, rolldown tries to bundle everything else; `@elizaos/core`/`@elizaos/shared` inline fine, but `@elizaos/vault` (a `workspace:*` runtime service it can't cleanly inline) fell back to an **implicit** external **plus a warning** on every build.

## Fix
List `@elizaos/vault` in `allExternals` so the externalization is intentional. **No runtime change** — vault was already external and resolves from `node_modules` (it's a declared `workspace:*` dep). This just removes the noise.

## Verification
`bunx tsdown` → 4 entries `✔ Build complete`, **0** `Could not resolve '@elizaos/vault'` warnings; biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Externalize `@elizaos/vault` in tsdown node bundles to fix UNRESOLVED_IMPORT warnings
> Adds `@elizaos/vault` to the externals list in [tsdown.config.mjs](https://github.com/milady-ai/milady/pull/2175/files#diff-c85f4a4d19abf058f7a061ab1df9c8a03c1bb6f3a96dd236521a248a7e4839d9) so the bundler treats it as an external dependency rather than attempting to bundle it, eliminating UNRESOLVED_IMPORT build warnings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c1144f8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->