### PR TITLE
build(app): suppress known-benign vite build warnings (pglite eval + intentional dynamic/static)

### DIFF
--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -2977,6 +2977,27 @@ export default defineConfig({
       output: {
         manualChunks: resolveManualChunk,
       },
+      // Suppress known-benign build noise so the log stays signal-rich.
+      // Anything not matched here still surfaces via the default handler.
+      onwarn(warning, defaultHandler) {
+        const message = warning.message ?? "";
+        const where = warning.id ?? warning.loc?.file ?? message;
+        // @electric-sql/pglite ships Emscripten/WASM glue that uses eval().
+        if (warning.code === "EVAL" && /pglite/i.test(where)) return;
+        // Modules imported both dynamically and statically: the dynamic imports
+        // are intentional (the @elizaos/ui DynamicViewLoader string-keyed module
+        // registry and plugin-browser lazy-loading), and the modules stay
+        // statically reachable in the main chunk. Informational — not a defect;
+        // converting either side would break the registry/lazy load.
+        if (
+          warning.plugin === "vite:reporter" &&
+          /dynamically imported by[\s\S]*but also statically imported by/.test(
+            message,
+          )
+        )
+          return;
+        defaultHandler(warning);
+      },
     },
     commonjsOptions: {
       include: [/node_modules/],


### PR DESCRIPTION
## What
A surgical `build.rollupOptions.onwarn` in `apps/app/vite.config.ts` that silences two **known-benign, non-actionable** warning categories; everything else still surfaces via the default handler.

- **pglite `EVAL`** — `@electric-sql/pglite` ships Emscripten/WASM glue that uses `eval()`. Third-party; can't change.
- **dynamic+static import mixing** (`vite:reporter`) — the dynamic `import()`s are *intentional architecture*: the `@elizaos/ui` `DynamicViewLoader` string-keyed module registry and plugin-browser lazy-loading. The modules are also statically reachable, so they stay in the main chunk. Converting either side would break the registry/lazy-load — these are informational, not defects (confirmed by reading the source).

## Why suppress (not "fix")
The roots are intentional patterns + a third-party dep; there is no correctness fix. This keeps the build log signal-rich without altering behavior.

## Verification
`apps/app` vite build: `✓ built`, exit 0. pglite EVAL warnings → **0**, dynamic/static warnings → **0**, no real warnings suppressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Suppress known-benign Vite build warnings for pglite eval and mixed imports
> Adds a Rollup `onwarn` handler in [vite.config.ts](https://github.com/milady-ai/milady/pull/2176/files#diff-0d80c2713ea1483c55bbc803b5d5d6a1f75654501e99a33c5d306cdbddd511e4) that silences two noisy but harmless warning types: `EVAL` warnings from `@electric-sql/pglite` artifacts, and `vite:reporter` warnings about modules being both dynamically and statically imported. All other warnings are passed through to the default handler.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 21d6060.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->