### PR TITLE
fix(app/dev): exclude @elizaos/agent runtime from renderer dep-prebundle

### DIFF
--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -2900,6 +2900,12 @@ export default defineConfig({
       // Contains native-only pty-state-capture / pty-console imports; skip pre-bundling.
       "@elizaos/plugin-agent-orchestrator",
       "pty-console",
+      // @elizaos/agent is server-side and the published alpha lags develop
+      // (missing newer subpaths like runtime/plugin-collector). esbuild
+      // dep-prebundling resolves it from the stale published package and
+      // crashes ("Missing ./runtime/plugin-collector specifier"); excluding it
+      // lets resolve.alias map @elizaos/agent[/*] to local source instead.
+      "@elizaos/agent",
       // Built-in secrets live in @elizaos/core features; Vite must not externalize them as a separate package.
       // Node-only HTTP client — crashes in browser, stub via nativeModuleStubPlugin
       "undici",

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -1464,7 +1464,7 @@ function generateNodeBuiltinStub(moduleId: string, req = _require): string {
     //   * mutation traps (set / defineProperty) don't throw under strict mode
     //   * `instanceof`, `default`, `__esModule` resolve sensibly for ESM<->CJS
     "function noopFn() { return noop; }",
-    "const handler = { get(t, p) { if (typeof p === 'symbol') return undefined; if (p === '__esModule') return true; if (p === 'default') return noop; if (p === 'prototype') return {}; if (p in t) return t[p]; return noop; }, set(t, p, v) { try { t[p] = v; } catch {} return true; }, has() { return true; }, ownKeys() { return []; }, getOwnPropertyDescriptor() { return { configurable: true, enumerable: true }; }, apply() { return noop; }, construct() { return noop; }, defineProperty(t, p, d) { try { Object.defineProperty(t, p, { configurable: true, writable: true, enumerable: true, ...d }); } catch {} return true; } };",
+    "const handler = { get(t, p) { if (typeof p === 'symbol') return undefined; if (p === '__esModule') return true; if (p === 'default') return noop; if (p === 'prototype') return {}; if (p in t) return t[p]; return noop; }, set(t, p, v) { try { t[p] = v; } catch {} return true; }, has() { return true; }, ownKeys(t) { return Reflect.ownKeys(t); }, getOwnPropertyDescriptor(t, p) { return Reflect.getOwnPropertyDescriptor(t, p) || { configurable: true, enumerable: true }; }, apply() { return noop; }, construct() { return noop; }, defineProperty(t, p, d) { try { Object.defineProperty(t, p, { configurable: true, writable: true, enumerable: true, ...d }); } catch {} return true; } };",
     "const noop = new Proxy(noopFn, handler);",
     "const stub = noop;",
     "const asyncNoop = () => Promise.resolve();",

--- a/docs/superpowers/plans/2026-05-30-milady-whitelabel-phase1.md
+++ b/docs/superpowers/plans/2026-05-30-milady-whitelabel-phase1.md
@@ -1,0 +1,386 @@
+# Milady Whitelabel — Phase 1 (Design System + Own Startup) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give Milady its own executive identity (flat velvet black, champagne/cream gold, condensed-display + mono type) and its own startup splash, replacing the inherited elizaOS gold theme + blue "elizaOS" splash — lightning-fast (no startup video/webfont on the critical path).
+
+**Architecture:** Milady stays the `apps/app` client. Phase 1 is the design-system + identity foundation: a self-contained `milady-executive.css` token sheet replaces the `brand-gold.css` import (token-driven shared UI reskins automatically), self-hosted subset fonts, and a Milady-owned `MiladyStartupShell` supplied through a new `startupShell` boot-config slot. The slot + a committable splash recolor + a Milady favicon make the front door on-brand even before the upstream slot reaches packaged builds.
+
+**Tech Stack:** Vite + React + TypeScript; Tailwind `@theme inline` over CSS custom properties; Electrobun desktop shell; bun.
+
+**Ownership constraint:** Only `apps/app/**`, `scripts/**`, `docs/**` are committable here. `eliza/**` is the gitignored upstream clone — edits there take effect in local-mode dev only and must also ship as an elizaOS PR (Task 10). Each file below is marked COMMITTABLE or UPSTREAM (local-dev).
+
+**Verification reality:** CSS/asset/React-component frontend work — verification is `bun run verify` (typecheck + lint), `bun run --cwd apps/app build`, and a desktop dev render + perf check, not unit-test TDD. A focused component test is included where it adds value.
+
+---
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `apps/app/design.md` | Create · COMMITTABLE | Design-system source of truth (DESIGN.md format) |
+| `apps/app/src/styles/fonts/saira-condensed-latin.woff2` | Create · COMMITTABLE | Display font (condensed grotesque), latin subset |
+| `apps/app/src/styles/fonts/jetbrains-mono-latin.woff2` | Create · COMMITTABLE | Mono/label font, latin subset |
+| `apps/app/src/styles/milady-executive.css` | Create · COMMITTABLE | Theme: font-face + :root tokens + dark tokens + first-run + velvet + splash recolor stopgap |
+| `apps/app/src/main.tsx` | Modify · COMMITTABLE | Swap brand-gold to milady-executive import; pass startupShell slot |
+| `apps/app/index.html` | Modify · COMMITTABLE | Preload the 2 fonts; point favicons at the Milady mark |
+| `apps/app/src/ui/shell/MiladyStartupShell.tsx` | Create · COMMITTABLE | Milady's own velvet splash |
+| `apps/app/src/ui/shell/MiladyStartupShell.test.tsx` | Create · COMMITTABLE | Renders wordmark + status |
+| `apps/app/public/brand/favicons/favicon.svg` | Replace · COMMITTABLE | Milady mark (splash logo + tab icon) |
+| `eliza/packages/ui/src/config/boot-config-store.ts` | Modify · UPSTREAM (local-dev) | Add startupShell? to AppBootConfig + getter |
+| `eliza/packages/ui/src/App.tsx` (~:1593) | Modify · UPSTREAM (local-dev) | Render bootConfig.startupShell ?? StartupScreen |
+
+---
+
+## Task 1: Author the design system (apps/app/design.md)
+
+**Files:** Create `apps/app/design.md` — COMMITTABLE
+
+- [ ] **Step 1:** Write `apps/app/design.md` in DESIGN.md format (YAML token front-matter + prose). Tokens mirror milady-executive.css :root.
+  - colors: bg #0a0a0b, bgElevated #151518, card #121214, surface #17171a, text #ece7df, textStrong #f6f2ea, muted #8d877c, border rgba(236,231,223,0.08), accent #c9b38c, accentHover #e8dcc0, accentForeground #0a0a0b
+  - typography: display "Saira Condensed" 600; mono "JetBrains Mono" (uppercase+tracked labels); body system sans
+  - radius sm 4 / md 8 / lg 14; elevation: single radial glow rgba(201,179,140,0.06), one low soft shadow, matte
+  - prose sections (canonical order): Overview · Colors · Typography · Layout · Elevation & Depth · Shapes · Components · Do's and Don'ts. Rules: velvet near-blacks never pure #000; champagne gold sparing (accent/hairline/wordmark dot), never bright #f0b90b; mono uppercase tracked labels; no blue; no gloss/hard shadows; no video on startup critical path.
+- [ ] **Step 2: Commit**
+```
+git add apps/app/design.md
+git commit -m "docs(app): add Milady executive design.md (design-system source of truth)"
+```
+
+---
+
+## Task 2: Vendor self-hosted subset fonts
+
+**Files:** Create the two woff2 under `apps/app/src/styles/fonts/` — COMMITTABLE. Both SIL OFL.
+
+- [ ] **Step 1:** Fetch prebuilt latin woff2 from @fontsource (no runtime dep):
+```
+cd /Users/home/Documents/milady
+mkdir -p apps/app/src/styles/fonts
+npm pack @fontsource/saira-condensed@latest --pack-destination /tmp >/dev/null 2>&1
+npm pack @fontsource/jetbrains-mono@latest --pack-destination /tmp >/dev/null 2>&1
+tar -xzf /tmp/fontsource-saira-condensed-*.tgz -C /tmp
+tar -xzf /tmp/fontsource-jetbrains-mono-*.tgz -C /tmp
+cp /tmp/package/files/saira-condensed-latin-600-normal.woff2 apps/app/src/styles/fonts/saira-condensed-latin.woff2
+cp /tmp/package/files/jetbrains-mono-latin-500-normal.woff2 apps/app/src/styles/fonts/jetbrains-mono-latin.woff2
+ls -la apps/app/src/styles/fonts/
+```
+Expected: two .woff2, each well under ~40KB. If names differ by version: `ls /tmp/package/files/ | grep latin` and pick latin-600-normal (Saira) + latin-500-normal (JetBrains).
+- [ ] **Step 2: Commit**
+```
+git add apps/app/src/styles/fonts/
+git commit -m "feat(app): vendor self-hosted Saira Condensed + JetBrains Mono (latin subset, OFL)"
+```
+
+---
+
+## Task 3: Create the executive theme sheet (milady-executive.css)
+
+**Files:** Create `apps/app/src/styles/milady-executive.css` — COMMITTABLE. Self-contained replacement for brand-gold.css.
+
+- [ ] **Step 1:** Write `apps/app/src/styles/milady-executive.css`:
+```css
+/* Milady executive design system — velvet black + champagne gold.
+ * Replaces @elizaos/app-core/styles/brand-gold.css. Source of truth: design.md. */
+
+@font-face {
+  font-family: "Saira Condensed";
+  font-style: normal; font-weight: 600; font-display: swap;
+  src: url("./fonts/saira-condensed-latin.woff2") format("woff2");
+}
+@font-face {
+  font-family: "JetBrains Mono";
+  font-style: normal; font-weight: 500; font-display: swap;
+  src: url("./fonts/jetbrains-mono-latin.woff2") format("woff2");
+}
+
+:root {
+  --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-display: "Saira Condensed", "Arial Narrow", system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  --jet-black: #08080a; --rich-black: #0a0a0b; --charcoal: #121214;
+  --deep-gold: #a8946b; --classic-gold: #c9b38c; --highlight-gold: #e8dcc0;
+  --champagne-gold: #ece7df; --burnished-gold: #b9a173;
+  --dark-silver: #2a2a2e; --steel: #8d877c; --bright-silver: #b8b2a6;
+  --chrome-highlight: #ece7df; --gunmetal: #17171a;
+  --gold-glow: rgba(201,179,140,0.10); --soft-white-glow: rgba(236,231,223,0.05);
+  --inner-shadow: rgba(0,0,0,0.55);
+
+  --accent: var(--classic-gold); --accent-rgb: 201,179,140;
+  --accent-hover: var(--highlight-gold); --accent-muted: var(--deep-gold);
+  --accent-subtle: rgba(201,179,140,0.10); --accent-foreground: #0a0a0b;
+  --primary: var(--classic-gold); --primary-foreground: #0a0a0b;
+  --ring: rgba(201,179,140,0.55); --border-hover: var(--classic-gold);
+  --warn: var(--burnished-gold); --warn-muted: rgba(185,161,115,0.7);
+  --warn-subtle: rgba(185,161,115,0.14); --focus: rgba(201,179,140,0.16);
+  --focus-ring: 0 0 0 2px rgba(201,179,140,0.30);
+  --link-color: var(--classic-gold); --link-hover-color: var(--highlight-gold);
+}
+
+[data-theme="dark"], .dark {
+  font-family: var(--font-sans);
+  --bg: #0a0a0b; --bg-accent: #101012; --bg-elevated: #151518;
+  --bg-hover: #1d1d22; --bg-muted: #101012;
+  --card: #121214; --card-foreground: #e7e2d9; --surface: #17171a;
+  --text: #ece7df; --text-strong: #f6f2ea; --chat-text: #ece7df;
+  --muted: #8d877c; --muted-strong: #ada69a;
+  --border: rgba(236,231,223,0.08); --border-strong: rgba(236,231,223,0.14);
+  --border-subtle: rgba(236,231,223,0.05); --input: #1b1b1f;
+  --accent-foreground: #0a0a0b; --primary-foreground: #0a0a0b;
+  --header-bar-bg: #08080a; --header-bar-fg: #ece7df;
+  --section-bar-bg: #0a0a0b; --section-bar-fg: #ece7df;
+}
+
+/* Velvet card sheen — a single diffuse top glow, matte. */
+.card, [class*="bg-card"] {
+  background-image: radial-gradient(120% 80% at 50% 0%, rgba(201,179,140,0.045), transparent 60%);
+}
+
+/* First-run / onboarding palette -> executive velvet. */
+.first-run-screen {
+  position: fixed; inset: 0; width: 100%; height: 100dvh;
+  overflow: hidden; overscroll-behavior: none; background: transparent;
+  --text: #ece7df; --muted: #8d877c; --border: rgba(236,231,223,0.10);
+  --card: rgba(23,23,26,0.72); --ok: #7fbf9b;
+  --accent: var(--classic-gold); --accent-foreground: #0a0a0b;
+  --first-run-text-strong: rgba(246,242,234,0.98);
+  --first-run-text-primary: rgba(236,231,223,0.96);
+  --first-run-text-subtle: rgba(236,231,223,0.80);
+  --first-run-text-muted: rgba(173,166,154,0.86);
+  --first-run-card-bg: rgba(23,23,26,0.72);
+  --first-run-card-border-strong: rgba(201,179,140,0.32);
+  --first-run-recommended-bg: rgba(201,179,140,0.12);
+  --first-run-recommended-border: rgba(201,179,140,0.28);
+  --first-run-accent-bg: rgba(201,179,140,0.16);
+  --first-run-accent-border: rgba(201,179,140,0.28);
+  --first-run-accent-foreground: #0a0a0b;
+  --first-run-input-bg: rgba(10,10,11,0.7);
+  --first-run-link: var(--highlight-gold);
+}
+
+/* Splash recolor STOPGAP — until MiladyStartupShell ships via the slot (Task 7).
+ * Overrides StartupShell hardcoded elizaOS literal-hex classes. FRAGILE; retired by slot. */
+[data-testid="startup-shell-loading"],
+[data-testid="startup-shell-loading"] [class*="bg-[#F7F9FF]"] {
+  background-color: #0a0a0b !important; color: #ece7df !important;
+}
+[data-testid="startup-shell-loading"] [class*="text-[#0B35F1]"] { color: #ece7df !important; }
+[data-testid="startup-shell-loading"] [class*="bg-white"]       { background-color: #17171a !important; }
+[data-testid="startup-shell-loading"] [class*="bg-[#0B35F1]"]   { background-color: rgba(201,179,140,0.45) !important; }
+[data-testid="startup-shell-loading"] [class*="ring-[#0B35F1]"] { box-shadow: 0 0 0 1px rgba(201,179,140,0.20) !important; }
+
+/* Functional, brand-neutral blocks carried over from brand-gold.css. */
+:root {
+  --memory-type-messages-bg: rgba(99,102,241,0.15); --memory-type-messages-fg: rgb(99,102,241);
+  --memory-type-memories-bg: rgba(168,85,247,0.15); --memory-type-memories-fg: rgb(168,85,247);
+  --memory-type-facts-bg: rgba(34,197,94,0.15); --memory-type-facts-fg: rgb(34,197,94);
+  --memory-type-documents-bg: rgba(245,158,11,0.15); --memory-type-documents-fg: rgb(245,158,11);
+  --memory-type-unknown-bg: rgba(156,163,175,0.15); --memory-type-unknown-fg: rgb(156,163,175);
+}
+.memory-type-badge-messages { background-color: var(--memory-type-messages-bg); color: var(--memory-type-messages-fg); }
+.memory-type-badge-memories { background-color: var(--memory-type-memories-bg); color: var(--memory-type-memories-fg); }
+.memory-type-badge-facts { background-color: var(--memory-type-facts-bg); color: var(--memory-type-facts-fg); }
+.memory-type-badge-documents { background-color: var(--memory-type-documents-bg); color: var(--memory-type-documents-fg); }
+.memory-type-badge-unknown { background-color: var(--memory-type-unknown-bg); color: var(--memory-type-unknown-fg); }
+.memory-type-dot-messages { background-color: var(--memory-type-messages-fg); }
+.memory-type-dot-memories { background-color: var(--memory-type-memories-fg); }
+.memory-type-dot-facts { background-color: var(--memory-type-facts-fg); }
+.memory-type-dot-documents { background-color: var(--memory-type-documents-fg); }
+.memory-type-dot-unknown { background-color: var(--memory-type-unknown-fg); }
+```
+- [ ] **Step 2: Commit**
+```
+git add apps/app/src/styles/milady-executive.css
+git commit -m "feat(app): add milady-executive.css (velvet/champagne theme + splash recolor stopgap)"
+```
+
+---
+
+## Task 4: Swap the theme import in main.tsx
+
+**Files:** Modify `apps/app/src/main.tsx:3` — COMMITTABLE
+- [ ] **Step 1:** Replace line 3 `import "@elizaos/app-core/styles/brand-gold.css";` with:
+```
+// Milady executive theme — replaces the upstream elizaOS gold theme.
+import "./styles/milady-executive.css";
+```
+Leave line 2 (styles.css base) in place.
+- [ ] **Step 2:** `bun run --cwd apps/app build`. Expected: succeeds; the two woff2 emit into the production output (`find apps/app -path '*assets*woff2' -not -path '*node_modules*'`).
+- [ ] **Step 3: Commit**
+```
+git add apps/app/src/main.tsx
+git commit -m "feat(app): use milady-executive theme instead of brand-gold"
+```
+
+---
+
+## Task 5: Preload the fonts in index.html
+
+**Files:** Modify `apps/app/index.html` — COMMITTABLE. font-display: swap already prevents FOIT.
+- [ ] **Step 1:** In `<head>` near the `<link rel="icon">` block (~line 67) add:
+```
+<link rel="preload" as="font" type="font/woff2" href="/src/styles/fonts/saira-condensed-latin.woff2" crossorigin />
+```
+If the literal path 404s in the production output, drop the preload and rely on font-display: swap. Do NOT add an external font CDN (CSP is font-src 'self').
+- [ ] **Step 2:** `bun run --cwd apps/app build`. Expected: succeeds.
+- [ ] **Step 3: Commit**
+```
+git add apps/app/index.html
+git commit -m "perf(app): preload Milady display font; swap fallback paints instantly"
+```
+
+---
+
+## Task 6: Milady's own startup splash component
+
+**Files:** Create `apps/app/src/ui/shell/MiladyStartupShell.tsx` + `.test.tsx` — COMMITTABLE. Hardcodes "Milady", minimal props, pure-CSS velvet gradient.
+- [ ] **Step 1:** Write `apps/app/src/ui/shell/MiladyStartupShell.test.tsx`:
+```tsx
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { MiladyStartupShell } from "./MiladyStartupShell";
+
+describe("MiladyStartupShell", () => {
+  it("renders the Milady wordmark and the status", () => {
+    render(<MiladyStartupShell phase="starting" status="Starting agent" />);
+    expect(screen.getByText("Milady")).toBeInTheDocument();
+    expect(screen.getByText("Starting agent")).toBeInTheDocument();
+  });
+  it("renders without a status", () => {
+    render(<MiladyStartupShell />);
+    expect(screen.getByText("Milady")).toBeInTheDocument();
+  });
+});
+```
+- [ ] **Step 2:** (from apps/app) `bunx vitest run src/ui/shell/MiladyStartupShell.test.tsx`. Expected: FAIL (cannot resolve ./MiladyStartupShell).
+- [ ] **Step 3:** Write `apps/app/src/ui/shell/MiladyStartupShell.tsx`:
+```tsx
+/** Milady's own startup splash, supplied to elizaOS App via the startupShell
+ * boot-config slot. Pure-CSS velvet gradient — no video, no critical-path webfont. */
+export interface MiladyStartupShellProps { phase?: string; status?: string; }
+
+export function MiladyStartupShell({ phase, status }: MiladyStartupShellProps) {
+  return (
+    <div
+      data-testid="milady-startup-shell"
+      data-startup-phase={phase}
+      role="status" aria-live="polite" aria-busy="true"
+      className="fixed inset-0 flex items-center justify-center overflow-hidden"
+      style={{
+        background: "radial-gradient(120% 80% at 50% 0%, #17171a 0%, #0a0a0b 55%, #08080a 100%)",
+        color: "#ece7df",
+        fontFamily: "var(--font-display, 'Arial Narrow', system-ui, sans-serif)",
+      }}
+    >
+      <div className="relative z-10 flex w-full max-w-[24rem] flex-col items-center gap-5 px-6 text-center">
+        <div className="flex items-center justify-center gap-3">
+          <span aria-hidden="true" style={{ width: 10, height: 10, borderRadius: 9999, background: "#c9b38c", boxShadow: "0 0 18px rgba(201,179,140,0.45)" }} />
+          <span style={{ fontSize: "2.5rem", fontWeight: 600, letterSpacing: "0.02em", lineHeight: 1 }}>Milady</span>
+        </div>
+        {status ? (
+          <p className="min-h-5 text-sm animate-pulse motion-reduce:animate-none"
+             style={{ color: "rgba(236,231,223,0.7)", fontFamily: "var(--font-mono, ui-monospace, monospace)", textTransform: "uppercase", letterSpacing: "0.12em" }}>
+            {status}
+          </p>
+        ) : null}
+        <div className="flex w-full max-w-[18rem] flex-col gap-2" aria-hidden>
+          <div className="h-2.5 w-full rounded-sm animate-pulse motion-reduce:animate-none" style={{ background: "rgba(201,179,140,0.18)" }} />
+          <div className="h-2.5 w-3/4 self-center rounded-sm animate-pulse motion-reduce:animate-none" style={{ background: "rgba(201,179,140,0.12)" }} />
+          <div className="h-2.5 w-1/2 self-center rounded-sm animate-pulse motion-reduce:animate-none" style={{ background: "rgba(201,179,140,0.08)" }} />
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+- [ ] **Step 4:** (from apps/app) `bunx vitest run src/ui/shell/MiladyStartupShell.test.tsx`. Expected: PASS (2 tests).
+- [ ] **Step 5: Commit**
+```
+git add apps/app/src/ui/shell/MiladyStartupShell.tsx apps/app/src/ui/shell/MiladyStartupShell.test.tsx
+git commit -m "feat(app): MiladyStartupShell — own velvet splash (no video, CSS gradient)"
+```
+
+---
+
+## Task 7: Wire the startupShell slot
+
+### 7a — UPSTREAM (local-dev): add the slot to AppBootConfig
+Modify `eliza/packages/ui/src/config/boot-config-store.ts`. Add to AppBootConfig (near companionShell, ~:227-299):
+```ts
+  /** Host-supplied startup/splash shell, rendered while the agent boots. */
+  startupShell?: import("react").ComponentType<{ phase?: string; status?: string }>;
+```
+Expose via the same getter pattern as the other slots (mirror companionShell's getter).
+
+### 7b — UPSTREAM (local-dev): render the slot in App.tsx (~:1593)
+Modify `eliza/packages/ui/src/App.tsx`. Resolve `const StartupShellSlot = bootConfig.startupShell;`, then in the non-ready startup gate replace `<StartupScreen />` with:
+```tsx
+{StartupShellSlot ? (
+  <StartupShellSlot phase={startupCoordinator.phase} status={startupCoordinator.statusLabel} />
+) : (
+  <StartupScreen />
+)}
+```
+Use whatever status string the controller exposes; if none, pass only phase=.
+
+### 7c — COMMITTABLE: pass the slot from Milady
+Modify `apps/app/src/main.tsx`:
+- [ ] add import `import { MiladyStartupShell } from "./ui/shell/MiladyStartupShell";`
+- [ ] add to the appBootConfig object literal: `startupShell: MiladyStartupShell,`
+Harmless on stale alpha (unknown fields ignored); activates when the slot ships. Until then the Task 3 recolor holds.
+- [ ] **Verify (local mode):** `bun run dev:desktop` — splash is the Milady velvet shell (Milady wordmark, champagne dot, no blue, no cloud video).
+- [ ] **Commit (committable part only):**
+```
+git add apps/app/src/main.tsx
+git commit -m "feat(app): supply MiladyStartupShell via the startupShell boot-config slot"
+```
+The eliza/** edits (7a/7b) are NOT committed here — local-mode dev + the upstream PR (Task 10).
+
+---
+
+## Task 8: Milady favicon mark
+
+**Files:** Replace `apps/app/public/brand/favicons/favicon.svg` — COMMITTABLE.
+- [ ] **Step 1:** Write `apps/app/public/brand/favicons/favicon.svg`:
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Milady">
+  <rect width="64" height="64" rx="14" fill="#0a0a0b"/>
+  <circle cx="32" cy="32" r="9" fill="#c9b38c"/>
+  <circle cx="32" cy="32" r="9" fill="none" stroke="#e8dcc0" stroke-opacity="0.35" stroke-width="2"/>
+</svg>
+```
+- [ ] **Step 2:** `bun run --cwd apps/app build`; open the splash or inspect the emitted favicon.svg. Expected: champagne dot on velvet, no elizaOS face.
+- [ ] **Step 3: Commit**
+```
+git add apps/app/public/brand/favicons/favicon.svg
+git commit -m "feat(app): Milady favicon mark (champagne dot on velvet) replacing elizaOS face"
+```
+Note: root PNG favicons in index.html are still elizaOS-rendered — regenerating from the mark is a small follow-up; the SVG covers the splash + modern-browser tab.
+
+---
+
+## Task 9: Performance + final verification
+- [ ] `bun run verify` — PASS for touched apps/app files.
+- [ ] `bun run --cwd apps/app build`; record the two woff2 sizes + the css size (each woff2 < ~40KB; css small). Large bundle regression blocks done.
+- [ ] `bun run dev:desktop` (local mode), then probe dev observability:
+```
+curl -s "http://127.0.0.1:31337/api/dev/console-log?maxLines=200"
+curl -s http://127.0.0.1:31337/api/dev/cursor-screenshot -o /tmp/milady-splash.png && ls -la /tmp/milady-splash.png
+```
+Expected: no font/CSP errors; screenshot shows velvet executive look + Milady splash; no Clouds_Loop_*.mp4 on the startup path.
+- [ ] `git push`.
+
+---
+
+## Task 10: Upstream PR for the startupShell slot (handoff)
+**Files:** the eliza/** edits from 7a/7b — UPSTREAM (elizaOS PR).
+- [ ] Open a PR against elizaOS/eliza adding the startupShell boot-config slot (7a + 7b). Small, generally-useful extension of the existing slot pattern. Durable path so the Milady splash reaches packaged builds after the next alpha republish; until then the Task 3 recolor + Task 8 favicon hold. Track in the upstream connectivity backlog.
+
+---
+
+## Self-Review
+- **Spec coverage:** design.md (T1) · theme replacing brand-gold (T3-4) · subset fonts + preload/swap (T2,5) · MiladyStartupShell via slot + recolor + favicon stopgap (T6-8) · lightning-fast: no startup video, swap fallback, thin component, bundle budget (T6,9 + CSS) · ownership marked per file · verify/build/render+perf (T9). All covered.
+- **Placeholders:** none — full CSS, full component, full SVG, exact edits + commands.
+- **Type consistency:** MiladyStartupShellProps { phase?, status? } identical across component, test, slot type (7a), App render (7b). Slot field `startupShell` consistent across 7a/7b/7c.
+- **Risks:** splash recolor couples to upstream class strings (stopgap, retired by slot); upstream slot gated for packaged builds; preload path may drop to swap-only if 404.

--- a/docs/superpowers/specs/2026-05-30-milady-whitelabel-client-design.md
+++ b/docs/superpowers/specs/2026-05-30-milady-whitelabel-client-design.md
@@ -1,179 +1,207 @@
-# Milady Whitelabel Client — Executive Design System (Foundation Pass)
+# Milady Whitelabel Client — Own Frontend Layer + Executive Design System
 
 **Date:** 2026-05-30
-**Status:** Approved design — ready for implementation plan
-**Scope:** Foundation + chrome. Per-screen editorial re-layout is a later pass.
+**Status:** Approved direction — ready for Phase 1 implementation plan
+**Driving constraint:** **Clear, distinct architectural separation** between Milady's
+frontend and the base elizaOS UI. Milady must own its identity layer, not be a
+recolored elizaOS under the paint.
 
 ## Problem
 
-`apps/app` is already the Milady client (its own `app.config.ts`, namespace, env
-aliases, character catalog, `appName: "Milady"`), but it still *looks* like
-elizaOS: it consumes the shared `@elizaos/app-core` + `@elizaos/ui` and inherits
-their chrome. The most visible offender is the startup splash, which hardcodes
-elizaOS blue-on-white and the literal string `"elizaOS"`. The user wants Milady
-to read as **its own white-labeled version** with an **executive** identity —
-flat velvet black, soft smooth textures, warm champagne/cream gold accents,
-condensed-display + monospace typography — in the spirit of the `.cache`
-gift-card reference, codified in a `design.md` (google-labs `DESIGN.md` format).
+`apps/app` is Milady's own, committable client, but today it is a thin shell
+(4 source files) that renders elizaOS's `<App>` from `@elizaos/app-core`. So it
+*looks* and *is structured* like elizaOS — same chrome, same startup screen
+(hardcoded elizaOS blue + the literal string `"elizaOS"`), same navigation. The
+user wants Milady to read as **its own version** with an **executive** identity
+(flat velvet black, soft smooth textures, warm champagne/cream gold accents,
+condensed-display + monospace type, `.cache`-spirit editorial layout), codified
+in a `design.md` (google-labs `DESIGN.md` format).
 
-## Decisions (locked with the user)
+## Architecture findings (researched, with evidence)
 
-1. **Whitelabel depth:** brand + theme layer. Keep consuming the shared runtime
-   UI; ship Milady's own complete design system + branding that reskins every
-   surface; close the spots where upstream hardcodes elizaOS. No fork.
-2. **Theme strategy:** replace. The executive look becomes *the* Milady identity;
-   retire the current `brand-gold.css` import. No theme switcher.
-3. **First increment:** foundation + chrome (design.md + theme tokens + branded
-   splash/chrome that renders Milady). Per-screen polish follows.
-4. **Fonts:** bundle self-hosted, open-licensed (offline-capable, fits
-   local-first/desktop).
+- **`App` is a 1743-line monolith** — `eliza/packages/ui/src/App.tsx`. It is a
+  switch on `tab` and exports only `App` itself (`App.tsx:1116`).
+- **Shell chrome is NOT injectable.** The boot-config slot system
+  (`companionShell`, `characterEditor`, `codingAgentTasksPanel`, `stewardLogo`,
+  `lifeOpsPageView`, … in `config/boot-config-store.ts`) injects only *leaf
+  feature widgets*. The Header (`components/shell/Header.tsx`), conversations
+  sidebar, desktop tab bar, layout frame, view-router, and **startup screen** are
+  hardwired inside `App`. A theme can recolor them but can never make them
+  Milady's — **so theme-only ≠ separation.**
+- **The pieces are modular files**, not inlined: `components/pages/ChatView.tsx`,
+  `SettingsView.tsx`, `HomeView.tsx`, `StreamView.tsx`, `shell/Header.tsx`,
+  `conversations/ConversationsSidebar.tsx` each stand alone. They are simply not
+  on the package's public barrel (`index.ts` does `export * from "./App"`, which
+  surfaces only `App`).
+- **Startup render seam:** `App.tsx:1593` — inside
+  `if (startupCoordinator.phase !== "ready" || !firstRunComplete)` it returns
+  `<CloudVideoBackground><div data-testid="pre-agent-cloud-shell"><StartupScreen/></div>…`.
+  This is the exact insertion point for a host-supplied startup shell.
+- **Theming (CSS vars) is the one already-clean seam** — `styles.css` defines a
+  Tailwind `@theme inline` map over CSS custom properties; `brand-gold.css`
+  overrides `:root`. `AppContext.tsx:230-234` applies a `BrandingConfig.theme`
+  `ThemeDefinition` inline **only when `branding.theme` is set** (`if (!brandTheme)
+  return;`), and `applyThemeToDocument` (`themes/apply-theme.ts`) sets inline
+  `:root` props that beat stylesheets. Milady will not set `branding.theme`, so a
+  static sheet stays authoritative — exactly as `brand-gold.css` is today.
 
-## Key architecture finding — the CSS-variable cascade (the spine)
+## Chosen architecture
 
-`@elizaos/ui` is fully token-driven: `styles.css` defines a Tailwind
-`@theme inline` map over CSS custom properties (`--bg`, `--accent`, `--card`,
-`--text`, `--border`, `--radius`, `--shadow-*`, fonts…); changing the vars
-reskins every component. There are two ways those vars get set:
-
-- **Static stylesheet** — `brand-gold.css` imported in `main.tsx` sets `:root`
-  tokens (it is already a flat-black + gold sheet; the gold is a *bright* yellow
-  `#f0b90b` and the font is Poppins).
-- **Inline at boot** — `AppContext.tsx:230-234` runs
-  `applyThemeToDocument(branding.theme, uiTheme)` **only when
-  `branding.theme` is set** (`if (!brandTheme) return;`). `applyThemeToDocument`
-  (`themes/apply-theme.ts`) sets **inline** `root.style.setProperty(...)`, which
-  beats any stylesheet `:root{}` rule for every token in `THEME_CSS_VAR_MAP`.
-
-**Consequence:** because Milady will **not** set `branding.theme`, nothing
-applies inline token overrides at boot — so a static stylesheet remains
-authoritative, exactly as `brand-gold.css` is today. We therefore deliver the
-Milady theme as **one CSS sheet**, not a parallel `ThemeDefinition` object. This
-is the least-complicated coherent design and keeps a single source of truth.
-
-> Trade-off considered: expressing colors as a `ThemeDefinition` via
-> `branding.theme`. Rejected for the foundation pass — it would force colors into
-> the inline path and split the brand across a TS object + a CSS sheet for the
-> non-token bits (velvet gradients, letter-spacing, `@font-face`), with no
-> benefit while we are *replacing* (not offering a user-pickable variant).
-
-## Architecture
+**Milady owns its own shell/identity layer and composes elizaOS feature *views* as
+content. It does NOT fork the 1743-line monolith.**
 
 ```
-apps/app/                      ← the Milady client (committable)
-  design.md                    ← NEW. Source of truth (DESIGN.md format)
-  src/main.tsx                 ← swap brand-gold.css import → milady-executive.css
-  src/styles/
-    milady-executive.css       ← NEW. The whole theme: :root tokens + @font-face
-                                  + velvet textures + letter-spacing + splash recolor
-    fonts/                      ← NEW. self-hosted woff2 (condensed display + mono)
+apps/app/                          ← Milady client (committable)
+  design.md                        ← NEW. Design system source of truth (DESIGN.md format)
+  src/
+    main.tsx                       ← mounts MiladyApp instead of <App>; swaps theme import
+    ui/                            ← NEW. Milady-owned frontend layer
+      MiladyApp.tsx                ← own shell: startup gate + chrome + router (Phase 2)
+      shell/
+        MiladyStartupShell.tsx     ← own startup/splash (Phase 1)
+        MiladyHeader.tsx           ← own top bar / nav (Phase 2)
+        MiladySidebar.tsx          ← (Phase 2/3)
+      router/                      ← dispatches tabs → composed elizaOS views (Phase 2)
+    styles/
+      milady-executive.css         ← NEW. Executive theme: :root tokens + @font-face + textures
+      fonts/                       ← NEW. self-hosted woff2 (condensed display + mono)
   public/brand/favicons/
-    favicon.svg                ← REPLACE elizaOS face → minimal Milady mark
+    favicon.svg                    ← REPLACE elizaOS face → Milady mark
 
-eliza/packages/ui/             ← upstream (non-committable here)
-  …/shell/StartupShell.tsx     ← targeted upstream PR: read useBranding().appName
-                                  + theme tokens instead of hardcoded hex + "elizaOS"
+eliza/packages/ (upstream — non-committable here; small, low-risk PRs)
+  ui/src/App.tsx                   ← render bootConfig.startupShell ?? <StartupScreen/> at :1593
+  ui/src/index.ts                  ← export the feature views + state hooks (useApp,
+                                     useBootConfig, useBranding) so apps/app can compose them
 ```
 
-The whitelabel rides three existing, already-wired levers — no new app
-architecture:
+- **Owns** (identity surfaces): startup/splash, header/nav, sidebar, layout frame,
+  view-router — built on the executive design system.
+- **Composes** (functionality): elizaOS feature views (`ChatView`, `SettingsView`,
+  `HomeView`, …) + the elizaOS state layer (`AppProvider`/`useApp`/`useBootConfig`)
+  — imported, not rebuilt. Chat/settings/etc. stay shared and keep working.
+- **The seam** is "own the shell + export the views," not "copy the monolith." The
+  only upstream work is a `startupShell` slot + barrel exports of already-standalone
+  files — small and low-risk.
 
-1. `BrandingConfig.appName` — already `"Milady"`; `{{appName}}` chrome already
-   says Milady via `useBranding()` / `appNameInterpolationVars`.
-2. The token-driven UI — one `:root` sheet reskins all body components.
-3. `<AppProvider branding={APP_BRANDING}>` is already passed in `main.tsx`.
+> Rejected alternatives: **theme-only** (no real separation — shares all chrome);
+> **fork the monolith** (copy 1743 LOC into `apps/app` — brittle, must track
+> upstream); **slot-only** (impossible — chrome is hardwired, not slot-fed). The
+> own-shell-compose-views path is the minimal change that achieves genuine
+> separation while keeping the elizaOS feature ecosystem.
 
 ## The design system (`apps/app/design.md`)
 
 google-labs `DESIGN.md` format: YAML token front-matter (keyed to the real
-`ThemeColorSet` / CSS-var names) + prose sections in canonical order: **Overview ·
-Colors · Typography · Layout · Elevation & Depth · Shapes · Components · Do's &
-Don'ts**. `milady-executive.css` is the literal implementation of these tokens;
-they are kept in sync by review (no codegen step in this pass — YAGNI).
+`ThemeColorSet` / CSS-var names) + prose in canonical order: **Overview · Colors ·
+Typography · Layout · Elevation & Depth · Shapes · Components · Do's & Don'ts**.
+`milady-executive.css` is the literal implementation; kept in sync by review (no
+codegen this pass — YAGNI).
 
-### Colors (executive velvet, indicative — finalized in design.md)
+### Colors (executive velvet — indicative; finalized in design.md)
 
 | Role | Value | Notes |
 |---|---|---|
 | `--bg` | `#0a0a0b` | velvet near-black, never pure `#000` |
 | `--bg-elevated` / `--card` | `#121214` → `#17171a` | smooth step up |
-| `--surface` glow | radial `rgba(201,179,140,0.06)` | the "velvet" sheen on cards |
+| surface glow | radial `rgba(201,179,140,0.06)` | the "velvet" sheen |
 | `--text` | `#ece7df` | warm cream-white |
 | `--muted` | `#8d877c` | warm grey |
 | `--border` | `rgba(236,231,223,0.08)` | low-contrast hairline |
-| `--accent` | `#c9b38c` | **champagne/cream gold**, not bright `#f0b90b` |
+| `--accent` | `#c9b38c` | champagne/cream gold (not bright `#f0b90b`) |
 | `--accent-hover` | `#e8dcc0` | lighter champagne (resting→lighter, never →black) |
 | `--accent-foreground` | `#0a0a0b` | text on accent |
 
-Accent is **sparing** — editorial, not gilded. (Note: this brand is intentionally
-warm-gold; the cloud-frontend "no blue / orange-accent" rule in CLAUDE.md governs
-`packages/cloud-frontend`, a different surface, and does not bind this desktop
-client. Flag for confirmation if cloud-frontend must share the palette.)
+Accent is sparing — editorial, not gilded. (The cloud-frontend "no blue /
+orange-accent" rule in CLAUDE.md governs `packages/cloud-frontend`, a separate
+surface; this desktop client is intentionally warm-champagne. Treated as distinct
+brands unless told otherwise.)
 
 ### Typography
-
-- **Display/headers:** self-hosted condensed grotesque (candidate: *Saira
-  Condensed* / *Archivo Narrow* — OFL). Drives `--font-display`.
-- **Labels/meta:** self-hosted monospace (candidate: *IBM Plex Mono* /
-  *JetBrains Mono* — OFL), uppercase + tracked for section labels (`01 / 03`,
-  `LIVE PREVIEW`). Drives `--font-mono`.
-- **Body:** keep a clean grotesque (mono or a neutral sans) per design.md.
-- Final family choices live in design.md; files bundled under `src/styles/fonts/`.
+- **Display:** self-hosted condensed grotesque (candidate *Saira Condensed* /
+  *Archivo Narrow*, OFL) → `--font-display`.
+- **Labels/meta:** self-hosted monospace (candidate *IBM Plex Mono* /
+  *JetBrains Mono*, OFL), uppercase + tracked → `--font-mono`.
+- **Body:** clean neutral grotesque per design.md. Replaces Poppins.
+- Files bundled under `src/styles/fonts/`; exact families finalized in design.md.
 
 ### Elevation & textures ("soft velvet smooth")
+One low soft shadow + a single diffuse light-source glow per card; large radii;
+smooth gradients; matte, no gloss.
 
-Single low, soft shadow + one diffuse light-source glow per card (no hard
-drop-shadows); large radii; smooth gradients; matte — no gloss.
+## Performance — lightning fast (first-class requirement)
 
-## The startup splash (the headline complaint)
+Speed is a hard requirement, not a nice-to-have. The executive direction helps,
+not hurts, here:
 
-`StartupShell.tsx` hardcodes `bg-[#F7F9FF] text-[#0B35F1]` + a white logo ring +
-the literal `"elizaOS"`, and ignores branding. `firstRunTheme` exists in
-`BrandingConfig` but is **consumed nowhere**, so it is not the lever. Plan:
+- **First paint:** Milady's startup shell is dependency-light with its critical
+  CSS inlined. It **drops `CloudVideoBackground`** (an HQ 1080p MP4 decoded on
+  first paint) in favor of a pure-CSS velvet gradient — faster *and* on-brand.
+  Target: startup visible on first frame, no video/network on the critical path.
+- **Fonts (the main theme-perf risk):** self-hosted `woff2`, **subset** to used
+  glyphs, **only the weights actually used** (display + mono), `font-display: swap`,
+  and `<link rel="preload">` for the two faces. A system fallback stack paints text
+  immediately so there's no FOIT. No webfont network requests.
+- **Theme CSS:** one small sheet; velvet = pure CSS gradients (no image/video
+  textures). No runtime theme computation (static `:root`, no `branding.theme`
+  inline pass).
+- **Shell layer stays thin:** Milady's shell composes existing components and
+  preserves elizaOS's `React.lazy` route splitting — it adds no extra providers,
+  no extra re-renders, no heavy dependencies. Feature views stay lazy.
+- **Bundle discipline:** no new heavy deps; measure `apps/app` build output and
+  keep the Milady layer's added weight minimal (fonts subset, CSS small).
 
-1. **Committable recolor (ships in the real build):** a scoped block in
-   `milady-executive.css` targeting `[data-testid="startup-shell-loading"]` (and
-   the hardcoded-blue children — logo ring, status text, skeleton bars) recolors
-   the splash to velvet-black + champagne. These literal-hex Tailwind classes are
-   immune to token swaps but overridable by a scoped sheet. Fragile-by-nature
-   (couples to upstream class strings) — documented as a stopgap.
-2. **Committable mark:** replace the served `favicon.svg` (the splash logo) with a
-   minimal Milady mark (a champagne dot/monogram on velvet), so the elizaOS face
-   is gone from the splash committably.
-3. **The literal text `"elizaOS"`:** the only residue not fixable from
-   `apps/app`. Durable fix = **targeted upstream PR** making `StartupShell` read
-   `useBranding().appName` + theme tokens. Immediate dev visibility = a local
-   `eliza/` edit (non-committable; the clone is gitignored). Mark in the
-   component becomes the typographic wordmark `• Milady` in the condensed font.
+## Phasing
 
-Net: after this pass the splash is on-brand velvet **in the packaged build**; the
-upstream PR removes the last hardcoded string.
+### Phase 1 (this pass) — design system + own startup
+- **Committable now, immediate:** author `design.md`; ship `milady-executive.css`
+  (replaces the `brand-gold.css` import in `main.tsx`) + self-hosted fonts → the
+  whole token-driven body reskins to the executive look. As a committable stopgap
+  for the splash before the slot lands, a scoped recolor of
+  `[data-testid="pre-agent-cloud-shell"]` / `startup-shell-loading` + a Milady
+  `favicon.svg` make the front door velvet in the packaged build.
+- **The clean ownership:** `MiladyStartupShell.tsx` (Milady's own splash — `• Milady`
+  wordmark in the condensed font, executive palette, velvet) supplied via a new
+  `startupShell` boot-config slot. Upstream PR adds the slot at `App.tsx:1593`
+  (`bootConfig.startupShell ?? <StartupScreen/>`); works in local `eliza/` dev
+  immediately, reaches packaged builds after the alpha republish. Local `eliza/`
+  edit applied meanwhile so dev shows it now.
+
+### Phase 2 — own the app shell + chrome
+`MiladyApp.tsx` + `MiladyHeader`/sidebar/layout + a router that dispatches tabs to
+**composed** elizaOS views. Requires the upstream barrel exports of the views +
+state hooks. `main.tsx` mounts `MiladyApp` instead of `<App>`.
+
+### Phase 3+ — own individual screens only where the brand demands it.
 
 ## Verification
-
-- `bun run --cwd apps/app build` (production vite build the desktop shell loads).
-- Desktop dev render check via the dev observability endpoints
-  (`/api/dev/cursor-screenshot`, `/api/dev/console-log`) to confirm the executive
-  look + Milady splash render with no regressions.
-- `bun run verify` (typecheck + lint) for the touched `apps/app` files.
-- The full 5-loop `audit:cloud` visual review applies to `cloud-frontend` and to
-  the later all-screens re-skin pass — not gating this foundation pass.
+- `bun run --cwd apps/app build` (the production vite build the desktop shell loads).
+- Desktop dev render check via dev observability endpoints
+  (`/api/dev/cursor-screenshot`, `/api/dev/console-log`) — executive look + Milady
+  startup render, no regressions.
+- `bun run verify` (typecheck + lint) on touched `apps/app` files.
+- **Performance check:** measure startup first-paint (dev console timing +
+  screenshot timing) before/after; confirm no video/webfont on the critical path;
+  record `apps/app` build size delta and keep the Milady layer's added weight
+  minimal. A regression in first-paint or bundle size blocks "done."
+- Full 5-loop `audit:cloud` review applies to `cloud-frontend` / the later
+  all-screens pass — not gating Phase 1.
 
 ## Out of scope (this pass)
-
-- Per-screen editorial re-layout of every route.
-- A theme switcher / light-mode variant (we are replacing, single dark brand).
-- A bespoke Milady logo *glyph* beyond the minimal favicon mark + wordmark.
-- Touching `cloud-frontend` or the marketing homepage.
+- Phase 2/3 chrome + screen ownership (planned separately).
+- A theme switcher / light-mode variant (single dark executive brand).
+- A bespoke Milady logo *glyph* beyond a minimal favicon + the wordmark.
+- `cloud-frontend` and the marketing homepage.
 
 ## Risks
-
-- **Splash recolor couples to upstream class strings** — mitigated by the upstream
-  PR being the durable fix; the CSS stopgap is clearly marked and small.
-- **Stale alpha** — the upstream `StartupShell` PR won't reach a packaged Milady
-  build until elizaOS republishes `alpha` (gated on upstream green CI). The
-  committable recolor + favicon make the splash on-brand *without* waiting on that.
-- **Font weight** — bundling woff2 adds repo/bundle size; keep to the two weights
-  actually used (display + mono), subset if needed.
-- **`brand-gold.css` other importers** — confirm nothing else depends on it being
-  imported by `main.tsx`; it remains in `@elizaos/ui` for other consumers, we only
-  stop importing it here.
+- **Milady maintains its shell layer** — bounded (identity surfaces only; feature
+  views composed, not copied), but real ongoing work.
+- **Upstream-gated for packaged builds** — the `startupShell` slot + view/state
+  exports must merge upstream and republish to `alpha` to reach packaged Milady
+  builds. Committable theme + splash recolor + favicon give visible separation
+  meanwhile; local `eliza/` dev gets the full path immediately.
+- **Splash recolor stopgap couples to upstream class strings** — small, clearly
+  marked, retired once `MiladyStartupShell` lands via the slot.
+- **Export surface** — composing views needs `useApp`/`useBootConfig`/views on the
+  barrel; they are standalone files so the export is low-risk (confirm exact set
+  in the plan).
+- **Font weight** — bundle only the two weights used; subset if needed.

--- a/docs/superpowers/specs/2026-05-30-milady-whitelabel-client-design.md
+++ b/docs/superpowers/specs/2026-05-30-milady-whitelabel-client-design.md
@@ -1,0 +1,179 @@
+# Milady Whitelabel Client — Executive Design System (Foundation Pass)
+
+**Date:** 2026-05-30
+**Status:** Approved design — ready for implementation plan
+**Scope:** Foundation + chrome. Per-screen editorial re-layout is a later pass.
+
+## Problem
+
+`apps/app` is already the Milady client (its own `app.config.ts`, namespace, env
+aliases, character catalog, `appName: "Milady"`), but it still *looks* like
+elizaOS: it consumes the shared `@elizaos/app-core` + `@elizaos/ui` and inherits
+their chrome. The most visible offender is the startup splash, which hardcodes
+elizaOS blue-on-white and the literal string `"elizaOS"`. The user wants Milady
+to read as **its own white-labeled version** with an **executive** identity —
+flat velvet black, soft smooth textures, warm champagne/cream gold accents,
+condensed-display + monospace typography — in the spirit of the `.cache`
+gift-card reference, codified in a `design.md` (google-labs `DESIGN.md` format).
+
+## Decisions (locked with the user)
+
+1. **Whitelabel depth:** brand + theme layer. Keep consuming the shared runtime
+   UI; ship Milady's own complete design system + branding that reskins every
+   surface; close the spots where upstream hardcodes elizaOS. No fork.
+2. **Theme strategy:** replace. The executive look becomes *the* Milady identity;
+   retire the current `brand-gold.css` import. No theme switcher.
+3. **First increment:** foundation + chrome (design.md + theme tokens + branded
+   splash/chrome that renders Milady). Per-screen polish follows.
+4. **Fonts:** bundle self-hosted, open-licensed (offline-capable, fits
+   local-first/desktop).
+
+## Key architecture finding — the CSS-variable cascade (the spine)
+
+`@elizaos/ui` is fully token-driven: `styles.css` defines a Tailwind
+`@theme inline` map over CSS custom properties (`--bg`, `--accent`, `--card`,
+`--text`, `--border`, `--radius`, `--shadow-*`, fonts…); changing the vars
+reskins every component. There are two ways those vars get set:
+
+- **Static stylesheet** — `brand-gold.css` imported in `main.tsx` sets `:root`
+  tokens (it is already a flat-black + gold sheet; the gold is a *bright* yellow
+  `#f0b90b` and the font is Poppins).
+- **Inline at boot** — `AppContext.tsx:230-234` runs
+  `applyThemeToDocument(branding.theme, uiTheme)` **only when
+  `branding.theme` is set** (`if (!brandTheme) return;`). `applyThemeToDocument`
+  (`themes/apply-theme.ts`) sets **inline** `root.style.setProperty(...)`, which
+  beats any stylesheet `:root{}` rule for every token in `THEME_CSS_VAR_MAP`.
+
+**Consequence:** because Milady will **not** set `branding.theme`, nothing
+applies inline token overrides at boot — so a static stylesheet remains
+authoritative, exactly as `brand-gold.css` is today. We therefore deliver the
+Milady theme as **one CSS sheet**, not a parallel `ThemeDefinition` object. This
+is the least-complicated coherent design and keeps a single source of truth.
+
+> Trade-off considered: expressing colors as a `ThemeDefinition` via
+> `branding.theme`. Rejected for the foundation pass — it would force colors into
+> the inline path and split the brand across a TS object + a CSS sheet for the
+> non-token bits (velvet gradients, letter-spacing, `@font-face`), with no
+> benefit while we are *replacing* (not offering a user-pickable variant).
+
+## Architecture
+
+```
+apps/app/                      ← the Milady client (committable)
+  design.md                    ← NEW. Source of truth (DESIGN.md format)
+  src/main.tsx                 ← swap brand-gold.css import → milady-executive.css
+  src/styles/
+    milady-executive.css       ← NEW. The whole theme: :root tokens + @font-face
+                                  + velvet textures + letter-spacing + splash recolor
+    fonts/                      ← NEW. self-hosted woff2 (condensed display + mono)
+  public/brand/favicons/
+    favicon.svg                ← REPLACE elizaOS face → minimal Milady mark
+
+eliza/packages/ui/             ← upstream (non-committable here)
+  …/shell/StartupShell.tsx     ← targeted upstream PR: read useBranding().appName
+                                  + theme tokens instead of hardcoded hex + "elizaOS"
+```
+
+The whitelabel rides three existing, already-wired levers — no new app
+architecture:
+
+1. `BrandingConfig.appName` — already `"Milady"`; `{{appName}}` chrome already
+   says Milady via `useBranding()` / `appNameInterpolationVars`.
+2. The token-driven UI — one `:root` sheet reskins all body components.
+3. `<AppProvider branding={APP_BRANDING}>` is already passed in `main.tsx`.
+
+## The design system (`apps/app/design.md`)
+
+google-labs `DESIGN.md` format: YAML token front-matter (keyed to the real
+`ThemeColorSet` / CSS-var names) + prose sections in canonical order: **Overview ·
+Colors · Typography · Layout · Elevation & Depth · Shapes · Components · Do's &
+Don'ts**. `milady-executive.css` is the literal implementation of these tokens;
+they are kept in sync by review (no codegen step in this pass — YAGNI).
+
+### Colors (executive velvet, indicative — finalized in design.md)
+
+| Role | Value | Notes |
+|---|---|---|
+| `--bg` | `#0a0a0b` | velvet near-black, never pure `#000` |
+| `--bg-elevated` / `--card` | `#121214` → `#17171a` | smooth step up |
+| `--surface` glow | radial `rgba(201,179,140,0.06)` | the "velvet" sheen on cards |
+| `--text` | `#ece7df` | warm cream-white |
+| `--muted` | `#8d877c` | warm grey |
+| `--border` | `rgba(236,231,223,0.08)` | low-contrast hairline |
+| `--accent` | `#c9b38c` | **champagne/cream gold**, not bright `#f0b90b` |
+| `--accent-hover` | `#e8dcc0` | lighter champagne (resting→lighter, never →black) |
+| `--accent-foreground` | `#0a0a0b` | text on accent |
+
+Accent is **sparing** — editorial, not gilded. (Note: this brand is intentionally
+warm-gold; the cloud-frontend "no blue / orange-accent" rule in CLAUDE.md governs
+`packages/cloud-frontend`, a different surface, and does not bind this desktop
+client. Flag for confirmation if cloud-frontend must share the palette.)
+
+### Typography
+
+- **Display/headers:** self-hosted condensed grotesque (candidate: *Saira
+  Condensed* / *Archivo Narrow* — OFL). Drives `--font-display`.
+- **Labels/meta:** self-hosted monospace (candidate: *IBM Plex Mono* /
+  *JetBrains Mono* — OFL), uppercase + tracked for section labels (`01 / 03`,
+  `LIVE PREVIEW`). Drives `--font-mono`.
+- **Body:** keep a clean grotesque (mono or a neutral sans) per design.md.
+- Final family choices live in design.md; files bundled under `src/styles/fonts/`.
+
+### Elevation & textures ("soft velvet smooth")
+
+Single low, soft shadow + one diffuse light-source glow per card (no hard
+drop-shadows); large radii; smooth gradients; matte — no gloss.
+
+## The startup splash (the headline complaint)
+
+`StartupShell.tsx` hardcodes `bg-[#F7F9FF] text-[#0B35F1]` + a white logo ring +
+the literal `"elizaOS"`, and ignores branding. `firstRunTheme` exists in
+`BrandingConfig` but is **consumed nowhere**, so it is not the lever. Plan:
+
+1. **Committable recolor (ships in the real build):** a scoped block in
+   `milady-executive.css` targeting `[data-testid="startup-shell-loading"]` (and
+   the hardcoded-blue children — logo ring, status text, skeleton bars) recolors
+   the splash to velvet-black + champagne. These literal-hex Tailwind classes are
+   immune to token swaps but overridable by a scoped sheet. Fragile-by-nature
+   (couples to upstream class strings) — documented as a stopgap.
+2. **Committable mark:** replace the served `favicon.svg` (the splash logo) with a
+   minimal Milady mark (a champagne dot/monogram on velvet), so the elizaOS face
+   is gone from the splash committably.
+3. **The literal text `"elizaOS"`:** the only residue not fixable from
+   `apps/app`. Durable fix = **targeted upstream PR** making `StartupShell` read
+   `useBranding().appName` + theme tokens. Immediate dev visibility = a local
+   `eliza/` edit (non-committable; the clone is gitignored). Mark in the
+   component becomes the typographic wordmark `• Milady` in the condensed font.
+
+Net: after this pass the splash is on-brand velvet **in the packaged build**; the
+upstream PR removes the last hardcoded string.
+
+## Verification
+
+- `bun run --cwd apps/app build` (production vite build the desktop shell loads).
+- Desktop dev render check via the dev observability endpoints
+  (`/api/dev/cursor-screenshot`, `/api/dev/console-log`) to confirm the executive
+  look + Milady splash render with no regressions.
+- `bun run verify` (typecheck + lint) for the touched `apps/app` files.
+- The full 5-loop `audit:cloud` visual review applies to `cloud-frontend` and to
+  the later all-screens re-skin pass — not gating this foundation pass.
+
+## Out of scope (this pass)
+
+- Per-screen editorial re-layout of every route.
+- A theme switcher / light-mode variant (we are replacing, single dark brand).
+- A bespoke Milady logo *glyph* beyond the minimal favicon mark + wordmark.
+- Touching `cloud-frontend` or the marketing homepage.
+
+## Risks
+
+- **Splash recolor couples to upstream class strings** — mitigated by the upstream
+  PR being the durable fix; the CSS stopgap is clearly marked and small.
+- **Stale alpha** — the upstream `StartupShell` PR won't reach a packaged Milady
+  build until elizaOS republishes `alpha` (gated on upstream green CI). The
+  committable recolor + favicon make the splash on-brand *without* waiting on that.
+- **Font weight** — bundling woff2 adds repo/bundle size; keep to the two weights
+  actually used (display + mono), subset if needed.
+- **`brand-gold.css` other importers** — confirm nothing else depends on it being
+  imported by `main.tsx`; it remains in `@elizaos/ui` for other consumers, we only
+  stop importing it here.


### PR DESCRIPTION
## Problem
`bun run dev` never brought up the renderer (blank/broken UI) and stalled: vite's esbuild `optimizeDeps` dep-prebundle scanned `@elizaos/agent` against the **published alpha** (which lags develop and is missing newer subpaths like `runtime/plugin-collector`) and crashed with `Missing "./runtime/plugin-collector" specifier`, retrying 6× then giving up.

## Fix
`@elizaos/agent` is the **agent runtime — it runs in its own process** (the `eliza-api` server on :31337); the renderer talks to it over HTTP and already **stubs** it via `nativeModuleStubPlugin`. The only bug was the dep-prebundle scan hitting the stale package before the stub applied. Add `@elizaos/agent` to `optimizeDeps.exclude` so the scan skips it and the stub handles it at build time — the runtime is **not** bundled into the renderer.

## Verified
`bun run dev`: vite now serves on **:2138 with no agent crash**; the agent runtime still boots in its own **:31337** process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Exclude `@elizaos/agent` from Vite renderer dependency pre-bundling
> Adds `@elizaos/agent` to `optimizeDeps.exclude` in [vite.config.ts](https://github.com/milady-ai/milady/pull/2177/files#diff-0d80c2713ea1483c55bbc803b5d5d6a1f75654501e99a33c5d306cdbddd511e4) to prevent Vite from attempting to pre-bundle the agent runtime package in the renderer process.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 60f1be7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->