### PR TITLE
fix(homepage): resolve @elizaos base.css in published-package (Deploy Web) build

### DIFF
--- a/apps/homepage/vite.config.ts
+++ b/apps/homepage/vite.config.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import mdx from "@mdx-js/rollup";
@@ -13,6 +14,7 @@ import { defineConfig } from "vite";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, "../..");
+const requireFromHere = createRequire(import.meta.url);
 
 function shouldUseLocalElizaSource() {
   const mode = (
@@ -29,6 +31,30 @@ function shouldUseLocalElizaSource() {
 const localUiSourceRoot = shouldUseLocalElizaSource()
   ? path.join(repoRoot, "eliza", "packages", "ui", "src")
   : null;
+
+// The shared base stylesheet moved upstream from @elizaos/app-core (alpha /
+// published-package mode) to @elizaos/ui (beta / local-source mode). Resolve it
+// from whichever package actually ships it so both the local-source build (CI)
+// and the published-package build (Deploy Web) import a real stylesheet rather
+// than a missing export.
+function resolveElizaBaseCss() {
+  if (localUiSourceRoot) {
+    return path.join(localUiSourceRoot, "styles", "base.css");
+  }
+  for (const specifier of [
+    "@elizaos/app-core/styles/base.css",
+    "@elizaos/ui/styles/base.css",
+  ]) {
+    try {
+      return requireFromHere.resolve(specifier);
+    } catch {
+      // Try the next package.
+    }
+  }
+  throw new Error(
+    "Unable to resolve @elizaos base.css for the homepage build (checked @elizaos/app-core and @elizaos/ui).",
+  );
+}
 
 // Build-time Shiki highlighter shared across all MDX code blocks. Creating the
 // highlighter once and passing it into rehype keeps the Vite config hot-reload
@@ -93,18 +119,26 @@ export default defineConfig({
     react(),
   ],
   resolve: {
-    alias: localUiSourceRoot
-      ? [
-          {
-            find: /^@elizaos\/ui\//,
-            replacement: `${localUiSourceRoot}/`,
-          },
-          {
-            find: /^@elizaos\/ui$/,
-            replacement: path.join(localUiSourceRoot, "index.ts"),
-          },
-        ]
-      : [],
+    alias: [
+      // Most specific first: pin base.css to the package that ships it in the
+      // active mode (app-core when published, ui source when local).
+      {
+        find: /^@elizaos\/ui\/styles\/base\.css$/,
+        replacement: resolveElizaBaseCss(),
+      },
+      ...(localUiSourceRoot
+        ? [
+            {
+              find: /^@elizaos\/ui\//,
+              replacement: `${localUiSourceRoot}/`,
+            },
+            {
+              find: /^@elizaos\/ui$/,
+              replacement: path.join(localUiSourceRoot, "index.ts"),
+            },
+          ]
+        : []),
+    ],
   },
   build: {
     outDir: path.resolve(here, "dist"),


### PR DESCRIPTION
Follow-up to #2190. The merge of #2190 turned Deploy Web red: the homepage imported `@elizaos/ui/styles/base.css`, which resolves under local eliza source (CI builds the homepage in local mode) but 404s in the published-package Deploy Web build — alpha `@elizaos/ui` has no CSS export; the stylesheet ships in `@elizaos/app-core` there.

Fix: a mode-aware vite resolve alias in `apps/homepage/vite.config.ts` that pins `base.css` to whichever package actually ships it (app-core when published, ui source when local).

Verified locally: `cd apps/homepage && bunx vite build` exits 0 in **both** packages mode and local mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `@elizaos/ui/styles/base.css` resolution in published-package homepage builds
> The homepage Vite config previously only aliased `@elizaos/ui` when building from local source, causing `base.css` imports to fail in published-package builds.
>
> - Adds `resolveElizaBaseCss()` in [vite.config.ts](https://github.com/milady-ai/milady/pull/2191/files#diff-0469c7e1f030188451d6d8ab8639f1e865756ee5e5b08356467e2c2ba39d876c) to resolve `base.css` from the local UI source path, `@elizaos/app-core`, or `@elizaos/ui`, in that order.
> - The alias for `@elizaos/ui/styles/base.css` is now always registered, regardless of build mode.
> - Risk: if neither `@elizaos/app-core` nor `@elizaos/ui` provides `base.css`, Vite config evaluation throws and the build or dev server fails immediately.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 99a1523.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->