### PR TITLE
fix(ci): grant id-token:write in publish-npm (unbreak Release orchestrator startup)

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -44,6 +44,13 @@ concurrency:
 
 permissions:
   contents: read
+  # The publish job calls reusable-npm-publish.yml, which requests
+  # id-token: write for npm provenance/OIDC. A top-level permissions block
+  # resets unlisted scopes to `none`, so without this the whole release call
+  # graph (Release → release-orchestrator → publish-npm → reusable-npm-publish)
+  # fails GitHub's startup validation: "requesting id-token: write, but only
+  # allowed id-token: none".
+  id-token: write
 
 env:
   CI: "true"


### PR DESCRIPTION
Fixes the `Release` (agent-release.yml) **startup_failure** that fired on every PR-close to develop.

GitHub's verbatim error: `Invalid workflow file: publish-npm.yml ... requesting 'id-token: write', but is only allowed 'id-token: none'`. `publish-npm.yml`'s top-level `permissions` listed only `contents: read`, which resets `id-token` to `none`; its `publish` job calls `reusable-npm-publish.yml` (which needs `id-token: write` for npm OIDC provenance), so GitHub rejects the whole release call graph at startup. Grant `id-token: write` at the top level.

Chain: Release → release-orchestrator → publish-npm → reusable-npm-publish. This is the single narrowing point; every other `id-token: write` edge already has a granting parent.

⚠️ Note: merging this un-suppresses the auto-release pipeline (236 commits / 248 src changes since v2.0.0-alpha.140) — a release will fire on merge, as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Grant `id-token: write` permission in `publish-npm` workflow to fix Release orchestrator startup
> Adds a top-level `id-token: write` permission to [publish-npm.yml](.github/workflows/publish-npm.yml) so the workflow passes GitHub's permissions validation. Without this, jobs requiring OIDC (e.g. npm provenance) caused the Release orchestrator to fail at startup.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 80447b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->