### PR TITLE
fix(release): canary rides the alpha train (unblock Compute next version)

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -266,7 +266,11 @@ jobs:
 
           case "$CHANNEL" in
             canary)
-              PRE_ID="beta"
+              # Canary rides the alpha train (milady ships 2.0.0-alpha.N; the
+              # assertion below requires -alpha.N). PRE_ID must be "alpha" or the
+              # version compute picks the highest beta tag and fails the canary
+              # check ("canary releases must use an alpha version").
+              PRE_ID="alpha"
               NPM_DIST_TAG="canary"
               ANDROID_TRACK="internal"
               APPLE_TRACK="testflight"


### PR DESCRIPTION
Follow-up to #2192. With the startup_failure fixed, the Release run reached 'Compute next version' and failed: `canary releases must use an alpha version, got 2.0.11-beta.4`.

The canary case set `PRE_ID=beta`, so version-compute bumped the highest beta tag (a stray `v2.0.11-beta.3`) then failed the canary assertion (line 337) that requires `-alpha.N`. milady ships on the `2.0.0-alpha.N` train (npm `miladyai`=alpha.93, tags up to v2.0.0-alpha.140). Set `PRE_ID=alpha` so canary computes `2.0.0-alpha.141` and passes.

Merging re-fires the canary release (per the earlier decision to ship).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix canary release `PRE_ID` to use "alpha" instead of "beta"
> In [agent-release.yml](.github/workflows/agent-release.yml), the canary branch of the release workflow version computation now uses `PRE_ID=alpha`, producing `-alpha.N` versioned releases instead of `-beta.N`. This unblocks the Compute team's next version by preventing canary from colliding with the beta track.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 15fcc72.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->