### PR TITLE
fix(release): cloud-image logger/contracts + pre-check manifest refresh

### DIFF
--- a/.github/workflows/build-cloud-image.yml
+++ b/.github/workflows/build-cloud-image.yml
@@ -163,6 +163,17 @@ jobs:
           cd eliza/packages/agent
           bun run build:docker-dist
 
+      - name: Build @elizaos/logger and @elizaos/contracts
+        run: |
+          # core (src/logger.ts) and shared (src/contracts/*) import
+          # @elizaos/logger and @elizaos/contracts (workspace:*). Both packages
+          # default their "." export "types" to ./dist and only expose ./src
+          # under the eliza-source condition, which is not active in these
+          # per-package tsc builds — so their dist must exist first or the build
+          # fails with TS2307. (Same fix as build-docker.yml.)
+          (cd eliza/packages/logger && bun run build)
+          (cd eliza/packages/contracts && bun run build)
+
       - name: Build @elizaos/core (includes agent-orchestrator)
         run: |
           export PATH="$GITHUB_WORKSPACE/eliza/node_modules/.bin:$GITHUB_WORKSPACE/eliza/packages/schemas/node_modules/.bin:$PATH"

--- a/.github/workflows/release-electrobun.yml
+++ b/.github/workflows/release-electrobun.yml
@@ -470,6 +470,13 @@ jobs:
       - name: Align package-mode agent pins
         run: node scripts/align-eliza-agent-package-pins.mjs
 
+      # The release build rebuilds dist assets (with the resolved release
+      # version), so the committed static-asset manifest is stale relative to
+      # the freshly built tree. Regenerate it before release:check, matching
+      # run-release-contract-suite.mjs.
+      - name: Refresh static asset manifest
+        run: node scripts/generate-static-asset-manifest.mjs
+
       - name: Release readiness checks
         env:
           ELIZA_RELEASE_TAG: ${{ needs.prepare.outputs.tag }}


### PR DESCRIPTION
Follow-up to #2193. With version resolution fixed, the release reached the build matrix and surfaced two in-repo bugs:

1. **Cloud app image build** — `TS2307: Cannot find module '@elizaos/contracts' / '@elizaos/logger'`. build-cloud-image.yml builds core/shared without first building those new leaf packages (same fix already applied to build-docker.yml).
2. **Electrobun / Validate Release Inputs** — `release-check: static asset manifest is stale`. The release build rebuilds dist (new version), so the committed manifest is stale; regenerate it before `release:check` (matching run-release-contract-suite.mjs).

Merging re-fires the canary release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix cloud-image build by pre-building logger/contracts and refreshing the static asset manifest
> - Adds a pre-build step in [build-cloud-image.yml](.github/workflows/build-cloud-image.yml) to compile `@elizaos/logger` and `@elizaos/contracts` before `@elizaos/core` is built, fixing a missing dependency issue.
> - Adds a step in [release-electrobun.yml](.github/workflows/release-electrobun.yml) to regenerate the static asset manifest before release readiness checks run.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 694e022.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->