### PR TITLE
fix(ios): MoonCycles App Store build ships a working on-device agent

### DIFF
--- a/.github/workflows/apple-store-release.yml
+++ b/.github/workflows/apple-store-release.yml
@@ -133,8 +133,27 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.build_ios == 'true'
     runs-on: macos-15
-    timeout-minutes: 60
+    # The full-Bun engine + agent bundle + CocoaPods make this heavier than a
+    # thin cloud-only client, so allow more headroom than the bare-IPA budget.
+    timeout-minutes: 90
     env:
+      # Make this split build (web + cap sync + ios-overlay + fastlane) ship a
+      # working on-device agent, mirroring eliza's apple-store-release.yml /
+      # configureIosAppStoreBuildDefaults. Without these the IPA is a cloud-only
+      # thin client whose "start local agent" hard-fails ("the JSContext
+      # compatibility transport is disabled outside iOS development builds").
+      #   - ELIZA_BUILD_VARIANT/RELEASE_AUTHORITY: bake __ELIZA_BUILD_VARIANT__
+      #     ="store" (store CSP + isNativeIosStoreBuild()) and embed the engine.
+      #   - ELIZA_IOS_FULL_BUN_ENGINE=1: force the engine pod into the IPA.
+      #   - VITE_ELIZA_IOS_FULL_BUN_AVAILABLE=1: renderer uses the engine
+      #     (isFullBunRuntimeBuiltIn).
+      #   - VITE_ELIZA_IOS_RUNTIME_MODE=cloud-hybrid: App Store default; the user
+      #     switching to "local" persists to localStorage and wins.
+      ELIZA_BUILD_VARIANT: store
+      ELIZA_RELEASE_AUTHORITY: apple-app-store
+      ELIZA_IOS_FULL_BUN_ENGINE: "1"
+      VITE_ELIZA_IOS_FULL_BUN_AVAILABLE: "1"
+      VITE_ELIZA_IOS_RUNTIME_MODE: cloud-hybrid
       APPLE_ID: ${{ secrets.APPLE_ID }}
       APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
       ITC_TEAM_ID: ${{ secrets.ITC_TEAM_ID }}
@@ -224,6 +243,14 @@ jobs:
         run: bun run cap:sync:ios
         env:
           LANG: en_US.UTF-8
+
+      # Build the on-device agent bundle the embedded Bun engine executes, then
+      # the ios-overlay step below stages eliza/packages/agent/dist-mobile-ios
+      # into the app's public/agent. buildIos() does this via
+      # buildMobileAgentBundle(); this split workflow must run it explicitly.
+      - name: Build iOS agent bundle
+        if: steps.validate_ios.outputs.ready == 'true'
+        run: bun run --cwd eliza/packages/agent build:ios-bun
 
       - name: Overlay iOS native files (Fastlane, AppDelegate, entitlements)
         if: steps.validate_ios.outputs.ready == 'true'

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -2953,6 +2953,15 @@ export default defineConfig({
   publicDir: path.resolve(here, "public"),
   define: {
     global: "globalThis",
+    // Build variant baked into the renderer so @elizaos/ui/build-variant's
+    // isStoreBuild()/getBuildVariant() resolve at runtime (they read ONLY this
+    // define — no env fallback). Without it the iOS build is always detected as
+    // "direct": store CSP is skipped and isNativeIosStoreBuild() is false, so
+    // the embedded on-device agent is never used. Mirrors eliza
+    // packages/app/vite.config.ts.
+    __ELIZA_BUILD_VARIANT__: JSON.stringify(
+      process.env.ELIZA_BUILD_VARIANT === "store" ? "store" : "direct",
+    ),
     // Mirror the branded TTS debug env into the client bundle so one env
     // enables UI + server TTS logs in dev.
     [`import.meta.env.${BRANDED_ENV.ttsDebug}`]: JSON.stringify(


### PR DESCRIPTION
## Problem

The MoonCycles iOS App Store / TestFlight build shipped as a **cloud-only thin client with no on-device agent** — tapping "start local agent" hard-failed with *"the JSContext compatibility transport is disabled outside iOS development builds."* Same root cause as elizaOS/eliza#8860, with one extra milady-specific break.

## Root cause

The App Store workflow builds via `bun run build` (web) → `cap:sync:ios` → `run-mobile-build.mjs ios-overlay` → `fastlane`, which **bypasses `buildIos()`** (the function that assembles a working on-device agent). On top of that, milady's `apps/app/vite.config.ts` **never baked the `__ELIZA_BUILD_VARIANT__` define**, so `@elizaos/ui/build-variant`'s `isStoreBuild()` — which reads *only* that define, no env fallback — was always `"direct"`. So even with the right workflow env, store detection (`isNativeIosStoreBuild()`) was false and the embedded engine would never be used.

## Fix

- **`apps/app/vite.config.ts`**: bake the `__ELIZA_BUILD_VARIANT__` define from `process.env.ELIZA_BUILD_VARIANT` (mirrors eliza `packages/app/vite.config.ts`). This is the milady-specific piece — without it the workflow env alone wouldn't help.
- **`apple-store-release.yml` (`build-ios`)**: `ELIZA_BUILD_VARIANT=store` + `ELIZA_RELEASE_AUTHORITY=apple-app-store` + `ELIZA_IOS_FULL_BUN_ENGINE=1` + `VITE_ELIZA_IOS_FULL_BUN_AVAILABLE=1` + `VITE_ELIZA_IOS_RUNTIME_MODE=cloud-hybrid`; a **Build iOS agent bundle** step (`eliza/packages/agent build:ios-bun`) before the overlay; timeout 60→90m.

The `ios-overlay` agent-runtime staging + the engine `xcframework` come from the eliza clone (the fixes in elizaOS/eliza#8860 + the committed engine artifact), so once milady's pinned eliza ref includes #8860 this is complete.

## Verification

- Workflow YAML parses; env + step ordering (cap sync → agent bundle → overlay) asserted; vite define Biome-clean (same edit verified in the eliza PR).
- **Not** verified end-to-end: needs Apple signing secrets + a CI release run + a TestFlight install on a device — can't be done headless. A wrong wiring fails in CI (blocks the release; doesn't ship a broken app); TestFlight is the on-device gate before App Store promotion. Tracked alongside elizaOS/eliza#8861.

## Depends on
- elizaOS/eliza#8860 (shared `run-mobile-build.mjs` staging) being in milady's pinned eliza ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix MoonCycles App Store iOS build to ship a working on-device agent
> - Adds a 'Build iOS agent bundle' step in [apple-store-release.yml](.github/workflows/apple-store-release.yml) that runs `bun run build:ios-bun` before native file overlay, gated on the existing `validate_ios` output.
> - Sets store-specific env vars (`ELIZA_BUILD_VARIANT=store`, `ELIZA_IOS_FULL_BUN_ENGINE`, `VITE_ELIZA_IOS_RUNTIME_MODE=cloud-hybrid`) so the agent bundle and client code are built with correct runtime flags.
> - Injects a compile-time `__ELIZA_BUILD_VARIANT__` global in [vite.config.ts](https://github.com/milady-ai/milady/pull/2195/files#diff-0d80c2713ea1483c55bbc803b5d5d6a1f75654501e99a33c5d306cdbddd511e4), set to `'store'` or `'direct'` based on `ELIZA_BUILD_VARIANT` at build time.
> - Increases the iOS build job timeout from 60 to 90 minutes to accommodate the extra build step.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 76da39a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->